### PR TITLE
Multiple developpements and bug fixes

### DIFF
--- a/src/scripts/veaf/dcsUnits.lua
+++ b/src/scripts/veaf/dcsUnits.lua
@@ -23,7 +23,7 @@ dcsUnits = {}
 dcsUnits.Id = "DCSUNITS - "
 
 --- Version.
-dcsUnits.Version = "2021.04.22"
+dcsUnits.Version = "2022.07.03"
 
 -- trace level, specific to this module
 --dcsUnits.LogLevel = "trace"
@@ -34,6 +34,16 @@ dcsUnits.logger = veaf.loggers.new(dcsUnits.Id, dcsUnits.LogLevel)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Do not change anything below unless you know what you are doing!
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+--manually filled out list of all Naval statics, perhaps could be automated but did not find any patterns
+dcsUnits.NavalStatics = { 
+	["offshore WindTurbine"]=true,
+	["offshore WindTurbine2"]=true,
+	["Oil platform"]=true,
+	["Orca"]=true,
+	["Gas platform"]=true,
+	["Oil rig"]=true,
+}
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Utility methods
@@ -171,6 +181,36 @@ dcsUnits.DcsUnitsDatabase =
 	}, -- end of [4]
 	[5] = 
 	{
+		["type"] = "Allies_Director",
+		["name"] = "Allies_Director",
+		["category"] = "Air Defence",
+		["description"] = "Allies_Director",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			["Ground vehicles"] = true,
+			["Vehicles"] = true,
+			[26] = true,
+			[2] = true,
+			["AA_flak"] = true,
+			["All"] = true,
+			["Rocket Attack Valid AirDefence"] = true,
+			[16] = true,
+			["AAA"] = true,
+			["Armed Air Defence"] = true,
+			[330] = true,
+			["Air Defence"] = true,
+			["NonArmoredUnits"] = true,
+			["Static AAA"] = true,
+			["Ground Units"] = true,
+			["NonAndLightArmoredUnits"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [5]
+	[6] = 
+	{
 		["type"] = "bofors40",
 		["name"] = "AAA Bofors 40mm",
 		["category"] = "Air Defence",
@@ -198,8 +238,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [5]
-	[6] = 
+	}, -- end of [6]
+	[7] = 
 	{
 		["type"] = "Dog Ear radar",
 		["name"] = "MCC-SR Sborka \"Dog Ear\" SR",
@@ -228,8 +268,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [6]
-	[7] = 
+	}, -- end of [7]
+	[8] = 
 	{
 		["type"] = "flak18",
 		["name"] = "AAA 8,8cm Flak 18",
@@ -244,10 +284,10 @@ dcsUnits.DcsUnitsDatabase =
 			["NonArmoredUnits"] = true,
 			["AA_flak"] = true,
 			["All"] = true,
-			["AAA"] = true,
-			[16] = true,
-			[47] = true,
 			["Rocket Attack Valid AirDefence"] = true,
+			[16] = true,
+			["AAA"] = true,
+			[314] = true,
 			["NonAndLightArmoredUnits"] = true,
 			["Armed Air Defence"] = true,
 			["Air Defence"] = true,
@@ -258,8 +298,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [7]
-	[8] = 
+	}, -- end of [8]
+	[9] = 
 	{
 		["type"] = "flak30",
 		["name"] = "AAA Flak 38 20mm",
@@ -288,8 +328,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [8]
-	[9] = 
+	}, -- end of [9]
+	[10] = 
 	{
 		["type"] = "flak36",
 		["name"] = "AAA 8,8cm Flak 36",
@@ -318,8 +358,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [9]
-	[10] = 
+	}, -- end of [10]
+	[11] = 
 	{
 		["type"] = "flak37",
 		["name"] = "AAA 8,8cm Flak 37",
@@ -348,8 +388,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [10]
-	[11] = 
+	}, -- end of [11]
+	[12] = 
 	{
 		["type"] = "flak38",
 		["name"] = "AAA Flak-Vierling 38 Quad 20mm",
@@ -378,8 +418,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [11]
-	[12] = 
+	}, -- end of [12]
+	[13] = 
 	{
 		["type"] = "flak41",
 		["name"] = "AAA 8,8cm Flak 41",
@@ -408,8 +448,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [12]
-	[13] = 
+	}, -- end of [13]
+	[14] = 
 	{
 		["type"] = "Flakscheinwerfer_37",
 		["name"] = "SL Flakscheinwerfer 37",
@@ -437,8 +477,92 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [13]
-	[14] = 
+	}, -- end of [14]
+	[15] = 
+	{
+		["type"] = "FPS-117",
+		["name"] = "EWR AN/FPS-117 Radar",
+		["category"] = "Air Defence",
+		["description"] = "EWR AN/FPS-117 Radar",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			["Vehicles"] = true,
+			["Air Defence vehicles"] = true,
+			[2] = true,
+			["NonArmoredUnits"] = true,
+			["CustomAimPoint"] = true,
+			[101] = true,
+			["Ground vehicles"] = true,
+			[329] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["EWR"] = true,
+			["Air Defence"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			[16] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [15]
+	[16] = 
+	{
+		["type"] = "FPS-117 Dome",
+		["name"] = "EWR AN/FPS-117 Radar (domed)",
+		["category"] = "Air Defence",
+		["description"] = "EWR AN/FPS-117 Radar (domed)",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			["Vehicles"] = true,
+			["Air Defence vehicles"] = true,
+			["NonArmoredUnits"] = true,
+			[327] = true,
+			["CustomAimPoint"] = true,
+			[101] = true,
+			["Ground vehicles"] = true,
+			[2] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["EWR"] = true,
+			["Air Defence"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			[16] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [16]
+	[17] = 
+	{
+		["type"] = "FPS-117 ECS",
+		["name"] = "EWR AN/FPS-117 ECS",
+		["category"] = "Air Defence",
+		["description"] = "EWR AN/FPS-117 ECS",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			["Vehicles"] = true,
+			["SAM elements"] = true,
+			[2] = true,
+			["SAM related"] = true,
+			["Air Defence"] = true,
+			[16] = true,
+			[328] = true,
+			["NonArmoredUnits"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["Ground vehicles"] = true,
+			[101] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			["SAM CC"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [17]
+	[18] = 
 	{
 		["type"] = "FuMG-401",
 		["name"] = "EWR FuMG-401 Freya LZ",
@@ -465,8 +589,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [14]
-	[15] = 
+	}, -- end of [18]
+	[19] = 
 	{
 		["type"] = "FuSe-65",
 		["name"] = "EWR FuSe-65 Würzburg-Riese",
@@ -493,13 +617,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [15]
-	[16] = 
+	}, -- end of [19]
+	[20] = 
 	{
 		["type"] = "generator_5i57",
-		["name"] = "Gen Diesel Power Station 5157A",
+		["name"] = "Diesel Power Station 5I57A",
 		["category"] = "Air Defence",
-		["description"] = "Gen Diesel Power Station 5157A",
+		["description"] = "Diesel Power Station 5I57A",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -520,8 +644,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [16]
-	[17] = 
+	}, -- end of [20]
+	[21] = 
 	{
 		["type"] = "Gepard",
 		["name"] = "SPAAA Gepard",
@@ -555,8 +679,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [17]
-	[18] = 
+	}, -- end of [21]
+	[22] = 
 	{
 		["type"] = "Hawk cwar",
 		["name"] = "SAM Hawk CWAR AN/MPQ-55",
@@ -587,8 +711,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [18]
-	[19] = 
+	}, -- end of [22]
+	[23] = 
 	{
 		["type"] = "Hawk ln",
 		["name"] = "SAM Hawk LN M192",
@@ -619,8 +743,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "Hawk M192 LN",
 		}, -- end of ["aliases"]
-	}, -- end of [19]
-	[20] = 
+	}, -- end of [23]
+	[24] = 
 	{
 		["type"] = "Hawk pcp",
 		["name"] = "SAM Hawk Platoon Command Post (PCP)",
@@ -647,8 +771,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [20]
-	[21] = 
+	}, -- end of [24]
+	[25] = 
 	{
 		["type"] = "Hawk sr",
 		["name"] = "SAM Hawk SR (AN/MPQ-50)",
@@ -680,8 +804,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "Hawk AN/MPQ-50 SR",
 		}, -- end of ["aliases"]
-	}, -- end of [21]
-	[22] = 
+	}, -- end of [25]
+	[26] = 
 	{
 		["type"] = "Hawk tr",
 		["name"] = "SAM Hawk TR (AN/MPQ-46)",
@@ -712,40 +836,57 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "Hawk AN/MPQ-46 TR",
 		}, -- end of ["aliases"]
-	}, -- end of [22]
-	[23] = 
+	}, -- end of [26]
+	[27] = 
+	{
+		["type"] = "HL_ZU-23",
+		["name"] = "SPAAA HL with ZU-23",
+		["category"] = "Air Defence",
+		["description"] = "SPAAA HL with ZU-23",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			["Ground vehicles"] = true,
+			["Vehicles"] = true,
+			[26] = true,
+			["Ground Units"] = true,
+			["AA_flak"] = true,
+			[325] = true,
+			["All"] = true,
+			[16] = true,
+			["AAA"] = true,
+			["Rocket Attack Valid AirDefence"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			[2] = true,
+			["Air Defence"] = true,
+			["Armed Air Defence"] = true,
+			["Mobile AAA"] = true,
+			["NonArmoredUnits"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [27]
+	[28] = 
 	{
 		["type"] = "HQ-7_LN_SP",
 		["name"] = "HQ-7 Self-Propelled LN",
 		["category"] = "Air Defence",
 		["description"] = "HQ-7 Self-Propelled LN",
-		["vehicle"] = true,
 		["attribute"] = 
 		{
 			[2] = true,
-			["Vehicles"] = true,
-			["SAM elements"] = true,
-			[16] = true,
-			["SAM SR"] = true,
-			["Ground vehicles"] = true,
-			["RADAR_BAND1_FOR_ARM"] = true,
 			["AA_missile"] = true,
-			["NonArmoredUnits"] = true,
-			["Air Defence"] = true,
-			["SAM related"] = true,
-			[102] = true,
-			["NonAndLightArmoredUnits"] = true,
-			["SAM TR"] = true,
-			[277] = true,
-			["All"] = true,
-			["Ground Units"] = true,
 			["SR SAM"] = true,
+			[102] = true,
+			[16] = true,
+			[277] = true,
 		}, -- end of ["attribute"]
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [23]
-	[24] = 
+	}, -- end of [28]
+	[29] = 
 	{
 		["type"] = "HQ-7_STR_SP",
 		["name"] = "HQ-7 Self-Propelled STR",
@@ -776,8 +917,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [24]
-	[25] = 
+	}, -- end of [29]
+	[30] = 
 	{
 		["infantry"] = true,
 		["type"] = "Igla manpad INS",
@@ -812,37 +953,38 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [25]
-	[26] = 
+	}, -- end of [30]
+	[31] = 
 	{
 		["type"] = "KDO_Mod40",
-		["name"] = "AAA SP Kdo.G.40",
+		["name"] = "AAA Kdo.G.40",
 		["category"] = "Air Defence",
-		["description"] = "AAA SP Kdo.G.40",
+		["description"] = "AAA Kdo.G.40",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
 			["Ground vehicles"] = true,
-			[26] = true,
 			["Vehicles"] = true,
+			[26] = true,
 			["NonArmoredUnits"] = true,
-			[2] = true,
+			["AA_flak"] = true,
 			["All"] = true,
-			["Air Defence"] = true,
-			[47] = true,
-			["AAA"] = true,
-			["NonAndLightArmoredUnits"] = true,
 			["Rocket Attack Valid AirDefence"] = true,
+			[16] = true,
+			["AAA"] = true,
 			["Armed Air Defence"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			[316] = true,
+			["Air Defence"] = true,
 			["Static AAA"] = true,
 			["Ground Units"] = true,
-			[16] = true,
+			[2] = true,
 		}, -- end of ["attribute"]
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [26]
-	[27] = 
+	}, -- end of [31]
+	[32] = 
 	{
 		["type"] = "Kub 1S91 str",
 		["name"] = "SAM SA-6 Kub \"Straight Flush\" STR",
@@ -874,8 +1016,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "SA-6 Kub STR 9S91",
 		}, -- end of ["aliases"]
-	}, -- end of [27]
-	[28] = 
+	}, -- end of [32]
+	[33] = 
 	{
 		["type"] = "Kub 2P25 ln",
 		["name"] = "SAM SA-6 Kub \"Gainful\" TEL",
@@ -905,8 +1047,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "SA-6 Kub LN 2P25",
 		}, -- end of ["aliases"]
-	}, -- end of [28]
-	[29] = 
+	}, -- end of [33]
+	[34] = 
 	{
 		["type"] = "M1097 Avenger",
 		["name"] = "SAM Avenger (Stinger)",
@@ -938,8 +1080,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [29]
-	[30] = 
+	}, -- end of [34]
+	[35] = 
 	{
 		["type"] = "M1_37mm",
 		["name"] = "AAA M1 37mm",
@@ -968,8 +1110,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [30]
-	[31] = 
+	}, -- end of [35]
+	[36] = 
 	{
 		["type"] = "M45_Quadmount",
 		["name"] = "AAA M45 Quadmount HB 12.7mm",
@@ -998,8 +1140,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [31]
-	[32] = 
+	}, -- end of [36]
+	[37] = 
 	{
 		["type"] = "M48 Chaparral",
 		["name"] = "SAM Chaparral M48",
@@ -1030,8 +1172,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [32]
-	[33] = 
+	}, -- end of [37]
+	[38] = 
 	{
 		["type"] = "M6 Linebacker",
 		["name"] = "SAM Linebacker - Bradley M6",
@@ -1063,13 +1205,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [33]
-	[34] = 
+	}, -- end of [38]
+	[39] = 
 	{
 		["type"] = "Maschinensatz_33",
-		["name"] = "PU Maschinensatz_33",
+		["name"] = "Maschinensatz 33 Gen",
 		["category"] = "Air Defence",
-		["description"] = "PU Maschinensatz_33",
+		["description"] = "Maschinensatz 33 Gen",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -1090,8 +1232,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [34]
-	[35] = 
+	}, -- end of [39]
+	[40] = 
 	{
 		["type"] = "NASAMS_Command_Post",
 		["name"] = "SAM NASAMS C2",
@@ -1121,8 +1263,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [35]
-	[36] = 
+	}, -- end of [40]
+	[41] = 
 	{
 		["type"] = "NASAMS_LN_B",
 		["name"] = "SAM NASAMS LN AIM-120B",
@@ -1152,8 +1294,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [36]
-	[37] = 
+	}, -- end of [41]
+	[42] = 
 	{
 		["type"] = "NASAMS_LN_C",
 		["name"] = "SAM NASAMS LN AIM-120C",
@@ -1183,8 +1325,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [37]
-	[38] = 
+	}, -- end of [42]
+	[43] = 
 	{
 		["type"] = "NASAMS_Radar_MPQ64F1",
 		["name"] = "SAM NASAMS SR MPQ64F1",
@@ -1215,8 +1357,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [38]
-	[39] = 
+	}, -- end of [43]
+	[44] = 
 	{
 		["type"] = "Osa 9A33 ln",
 		["name"] = "SAM SA-8 Osa \"Gecko\" TEL",
@@ -1247,8 +1389,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [39]
-	[40] = 
+	}, -- end of [44]
+	[45] = 
 	{
 		["type"] = "p-19 s-125 sr",
 		["name"] = "SAM SA-2/3/5 P19 \"Flat Face\" SR ",
@@ -1278,8 +1420,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [40]
-	[41] = 
+	}, -- end of [45]
+	[46] = 
 	{
 		["type"] = "Patriot AMG",
 		["name"] = "SAM Patriot CR (AMG AN/MRC-137)",
@@ -1309,8 +1451,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [41]
-	[42] = 
+	}, -- end of [46]
+	[47] = 
 	{
 		["type"] = "Patriot cp",
 		["name"] = "SAM Patriot C2 ICC",
@@ -1340,8 +1482,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [42]
-	[43] = 
+	}, -- end of [47]
+	[48] = 
 	{
 		["type"] = "Patriot ECS",
 		["name"] = "SAM Patriot ECS",
@@ -1371,8 +1513,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [43]
-	[44] = 
+	}, -- end of [48]
+	[49] = 
 	{
 		["type"] = "Patriot EPP",
 		["name"] = "SAM Patriot EPP-III",
@@ -1402,8 +1544,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [44]
-	[45] = 
+	}, -- end of [49]
+	[50] = 
 	{
 		["type"] = "Patriot ln",
 		["name"] = "SAM Patriot LN",
@@ -1433,8 +1575,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [45]
-	[46] = 
+	}, -- end of [50]
+	[51] = 
 	{
 		["type"] = "Patriot str",
 		["name"] = "SAM Patriot STR",
@@ -1465,13 +1607,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [46]
-	[47] = 
+	}, -- end of [51]
+	[52] = 
 	{
 		["type"] = "QF_37_AA",
-		["name"] = "AAA QF 3,7\"",
+		["name"] = "AAA QF 3.7\"",
 		["category"] = "Air Defence",
-		["description"] = "AAA QF 3,7\"",
+		["description"] = "AAA QF 3.7\"",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -1495,8 +1637,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [47]
-	[48] = 
+	}, -- end of [52]
+	[53] = 
 	{
 		["type"] = "rapier_fsa_blindfire_radar",
 		["name"] = "SAM Rapier Blindfire TR",
@@ -1526,8 +1668,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [48]
-	[49] = 
+	}, -- end of [53]
+	[54] = 
 	{
 		["type"] = "rapier_fsa_launcher",
 		["name"] = "SAM Rapier LN",
@@ -1561,8 +1703,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [49]
-	[50] = 
+	}, -- end of [54]
+	[55] = 
 	{
 		["type"] = "rapier_fsa_optical_tracker_unit",
 		["name"] = "SAM Rapier Tracker",
@@ -1590,8 +1732,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [50]
-	[51] = 
+	}, -- end of [55]
+	[56] = 
 	{
 		["type"] = "RLS_19J6",
 		["name"] = "SAM SA-5 S-200 ST-68U \"Tin Shield\" SR",
@@ -1622,8 +1764,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [51]
-	[52] = 
+	}, -- end of [56]
+	[57] = 
 	{
 		["type"] = "Roland ADS",
 		["name"] = "SAM Roland ADS",
@@ -1657,8 +1799,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [52]
-	[53] = 
+	}, -- end of [57]
+	[58] = 
 	{
 		["type"] = "Roland Radar",
 		["name"] = "SAM Roland EWR",
@@ -1687,8 +1829,70 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [53]
-	[54] = 
+	}, -- end of [58]
+	[59] = 
+	{
+		["type"] = "RPC_5N62V",
+		["name"] = "SAM SA-5 S-200 \"Square Pair\" TR",
+		["category"] = "Air Defence",
+		["description"] = "SAM SA-5 S-200 \"Square Pair\" TR",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[2] = true,
+			["Vehicles"] = true,
+			["SAM elements"] = true,
+			[16] = true,
+			["Ground vehicles"] = true,
+			["RADAR_BAND1_FOR_ARM"] = true,
+			["RADAR_BAND2_FOR_ARM"] = true,
+			["LR SAM"] = true,
+			[313] = true,
+			["NonArmoredUnits"] = true,
+			["Air Defence"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["SAM TR"] = true,
+			["SAM related"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			[101] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [59]
+	[60] = 
+	{
+		["type"] = "S-200_Launcher",
+		["name"] = "SAM SA-5 S-200 \"Gammon\" LN",
+		["category"] = "Air Defence",
+		["description"] = "SAM SA-5 S-200 \"Gammon\" LN",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[2] = true,
+			["Vehicles"] = true,
+			["SAM elements"] = true,
+			[16] = true,
+			["Ground vehicles"] = true,
+			["AA_missile"] = true,
+			[74] = true,
+			["LR SAM"] = true,
+			["NonArmoredUnits"] = true,
+			["Air Defence"] = true,
+			["Armed Air Defence"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			[27] = true,
+			["SAM related"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			["SAM LL"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [60]
+	[61] = 
 	{
 		["type"] = "S-300PS 40B6M tr",
 		["name"] = "SAM SA-10 S-300 \"Grumble\" Flap Lid TR ",
@@ -1718,13 +1922,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [54]
-	[55] = 
+	}, -- end of [61]
+	[62] = 
 	{
 		["type"] = "S-300PS 40B6MD sr",
-		["name"] = "SAM SA-10 S-300 \"Grumble\" Clam Shell SR",
+		["name"] = "SAM SA-10 S-300PS Low Alt SR 5N66M",
 		["category"] = "Air Defence",
-		["description"] = "SAM SA-10 S-300 \"Grumble\" Clam Shell SR",
+		["description"] = "SAM SA-10 S-300PS Low Alt SR 5N66M",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -1749,8 +1953,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [55]
-	[56] = 
+	}, -- end of [62]
+	[63] = 
 	{
 		["type"] = "S-300PS 54K6 cp",
 		["name"] = "SAM SA-10 S-300 \"Grumble\" C2 ",
@@ -1778,8 +1982,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [56]
-	[57] = 
+	}, -- end of [63]
+	[64] = 
 	{
 		["type"] = "S-300PS 5P85C ln",
 		["name"] = "SAM SA-10 S-300 \"Grumble\" TEL D",
@@ -1808,8 +2012,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [57]
-	[58] = 
+	}, -- end of [64]
+	[65] = 
 	{
 		["type"] = "S-300PS 5P85D ln",
 		["name"] = "SAM SA-10 S-300 \"Grumble\" TEL C",
@@ -1838,8 +2042,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [58]
-	[59] = 
+	}, -- end of [65]
+	[66] = 
 	{
 		["type"] = "S-300PS 64H6E sr",
 		["name"] = "SAM SA-10 S-300 \"Grumble\" Big Bird SR ",
@@ -1869,8 +2073,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [59]
-	[60] = 
+	}, -- end of [66]
+	[67] = 
 	{
 		["type"] = "S-60_Type59_Artillery",
 		["name"] = "AAA S-60 57mm",
@@ -1899,8 +2103,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [60]
-	[61] = 
+	}, -- end of [67]
+	[68] = 
 	{
 		["type"] = "S_75M_Volhov",
 		["name"] = "SAM SA-2 S-75 \"Guideline\" LN",
@@ -1930,8 +2134,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [61]
-	[62] = 
+	}, -- end of [68]
+	[69] = 
 	{
 		["type"] = "SA-11 Buk CC 9S470M1",
 		["name"] = "SAM SA-11 Buk \"Gadfly\" C2 ",
@@ -1958,8 +2162,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [62]
-	[63] = 
+	}, -- end of [69]
+	[70] = 
 	{
 		["type"] = "SA-11 Buk LN 9A310M1",
 		["name"] = "SAM SA-11 Buk \"Gadfly\" Fire Dome TEL",
@@ -1992,8 +2196,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [63]
-	[64] = 
+	}, -- end of [70]
+	[71] = 
 	{
 		["type"] = "SA-11 Buk SR 9S18M1",
 		["name"] = "SAM SA-11 Buk \"Gadfly\" Snow Drift SR",
@@ -2022,8 +2226,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [64]
-	[65] = 
+	}, -- end of [71]
+	[72] = 
 	{
 		["description"] = "MANPADS SA-18 Igla \"Grouse\" C2",
 		["type"] = "SA-18 Igla comm",
@@ -2057,8 +2261,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [65]
-	[66] = 
+	}, -- end of [72]
+	[73] = 
 	{
 		["infantry"] = true,
 		["type"] = "SA-18 Igla manpad",
@@ -2093,8 +2297,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [66]
-	[67] = 
+	}, -- end of [73]
+	[74] = 
 	{
 		["description"] = "MANPADS SA-18 Igla-S \"Grouse\" C2",
 		["type"] = "SA-18 Igla-S comm",
@@ -2128,8 +2332,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [67]
-	[68] = 
+	}, -- end of [74]
+	[75] = 
 	{
 		["infantry"] = true,
 		["type"] = "SA-18 Igla-S manpad",
@@ -2164,39 +2368,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [68]
-	[69] = 
-	{
-		["type"] = "SA-8 Osa LD 9T217",
-		["name"] = "SAM SA-8 Osa LD 9T217",
-		["category"] = "Air Defence",
-		["description"] = "SAM SA-8 Osa LD 9T217",
-		["vehicle"] = true,
-		["attribute"] = 
-		{
-			[2] = true,
-			["Vehicles"] = true,
-			["SAM elements"] = true,
-			[17] = true,
-			["Trucks"] = true,
-			["Ground vehicles"] = true,
-			["SAM AUX"] = true,
-			["Ground Units Non Airdefence"] = true,
-			["NonArmoredUnits"] = true,
-			[25] = true,
-			["Air Defence"] = true,
-			["NonAndLightArmoredUnits"] = true,
-			[24] = true,
-			["SAM related"] = true,
-			["All"] = true,
-			["Ground Units"] = true,
-			["Unarmed vehicles"] = true,
-		}, -- end of ["attribute"]
-		["aliases"] = 
-		{
-		}, -- end of ["aliases"]
-	}, -- end of [69]
-	[70] = 
+	}, -- end of [75]
+	[76] = 
 	{
 		["type"] = "snr s-125 tr",
 		["name"] = "SAM SA-3 S-125 \"Low Blow\" TR",
@@ -2226,8 +2399,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [70]
-	[71] = 
+	}, -- end of [76]
+	[77] = 
 	{
 		["type"] = "SNR_75V",
 		["name"] = "SAM SA-2 S-75 \"Fan Song\" TR",
@@ -2257,8 +2430,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [71]
-	[72] = 
+	}, -- end of [77]
+	[78] = 
 	{
 		["infantry"] = true,
 		["type"] = "Soldier stinger",
@@ -2293,8 +2466,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [72]
-	[73] = 
+	}, -- end of [78]
+	[79] = 
 	{
 		["description"] = "MANPADS Stinger C2",
 		["type"] = "Stinger comm",
@@ -2328,8 +2501,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [73]
-	[74] = 
+	}, -- end of [79]
+	[80] = 
 	{
 		["description"] = "MANPADS Stinger C2 Desert",
 		["type"] = "Stinger comm dsr",
@@ -2363,8 +2536,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [74]
-	[75] = 
+	}, -- end of [80]
+	[81] = 
 	{
 		["type"] = "Strela-1 9P31",
 		["name"] = "SAM SA-9 Strela 1 \"Gaskin\" TEL",
@@ -2395,8 +2568,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "SA-9 Strela-1 9P31",
 		}, -- end of ["aliases"]
-	}, -- end of [75]
-	[76] = 
+	}, -- end of [81]
+	[82] = 
 	{
 		["type"] = "Strela-10M3",
 		["name"] = "SAM SA-13 Strela 10M3 \"Gopher\" TEL",
@@ -2429,8 +2602,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "SA-13 Strela-10M3 9A35M3",
 		}, -- end of ["aliases"]
-	}, -- end of [76]
-	[77] = 
+	}, -- end of [82]
+	[83] = 
 	{
 		["type"] = "Tor 9A331",
 		["name"] = "SAM SA-15 Tor \"Gauntlet\"",
@@ -2461,8 +2634,38 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [77]
-	[78] = 
+	}, -- end of [83]
+	[84] = 
+	{
+		["type"] = "tt_ZU-23",
+		["name"] = "SPAAA LC with ZU-23",
+		["category"] = "Air Defence",
+		["description"] = "SPAAA LC with ZU-23",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			["Ground vehicles"] = true,
+			["Vehicles"] = true,
+			[26] = true,
+			["Ground Units"] = true,
+			["AA_flak"] = true,
+			["All"] = true,
+			[326] = true,
+			[16] = true,
+			["AAA"] = true,
+			["Rocket Attack Valid AirDefence"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["NonArmoredUnits"] = true,
+			["Air Defence"] = true,
+			["Armed Air Defence"] = true,
+			["Mobile AAA"] = true,
+			[2] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [84]
+	[85] = 
 	{
 		["type"] = "Ural-375 ZU-23",
 		["name"] = "SPAAA ZU-23-2 Mounted Ural 375",
@@ -2491,8 +2694,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [78]
-	[79] = 
+	}, -- end of [85]
+	[86] = 
 	{
 		["type"] = "Ural-375 ZU-23 Insurgent",
 		["name"] = "SPAAA ZU-23-2 Insurgent Mounted Ural-375",
@@ -2521,8 +2724,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [79]
-	[80] = 
+	}, -- end of [86]
+	[87] = 
 	{
 		["type"] = "Vulcan",
 		["name"] = "SPAAA Vulcan M163",
@@ -2556,8 +2759,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "M163 Vulcan",
 		}, -- end of ["aliases"]
-	}, -- end of [80]
-	[81] = 
+	}, -- end of [87]
+	[88] = 
 	{
 		["type"] = "ZSU-23-4 Shilka",
 		["name"] = "SPAAA ZSU-23-4 Shilka \"Gun Dish\"",
@@ -2590,8 +2793,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [81]
-	[82] = 
+	}, -- end of [88]
+	[89] = 
 	{
 		["type"] = "ZSU_57_2",
 		["name"] = "SPAAA ZSU-57-2",
@@ -2620,8 +2823,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [82]
-	[83] = 
+	}, -- end of [89]
+	[90] = 
 	{
 		["type"] = "ZU-23 Closed Insurgent",
 		["name"] = "AAA ZU-23 Insurgent Closed Emplacement",
@@ -2650,8 +2853,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [83]
-	[84] = 
+	}, -- end of [90]
+	[91] = 
 	{
 		["type"] = "ZU-23 Emplacement",
 		["name"] = "AAA ZU-23 Emplacement",
@@ -2680,8 +2883,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [84]
-	[85] = 
+	}, -- end of [91]
+	[92] = 
 	{
 		["type"] = "ZU-23 Emplacement Closed",
 		["name"] = "AAA ZU-23 Closed Emplacement",
@@ -2710,8 +2913,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [85]
-	[86] = 
+	}, -- end of [92]
+	[93] = 
 	{
 		["type"] = "ZU-23 Insurgent",
 		["name"] = "AAA ZU-23 Insurgent Emplacement",
@@ -2740,8 +2943,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [86]
-	[87] = 
+	}, -- end of [93]
+	[94] = 
 	{
 		["type"] = "Cow",
 		["name"] = "Cow",
@@ -2756,8 +2959,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [87]
-	[88] = 
+	}, -- end of [94]
+	[95] = 
 	{
 		["type"] = "AAV7",
 		["name"] = "APC AAV-7 Amphibious",
@@ -2787,8 +2990,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [88]
-	[89] = 
+	}, -- end of [95]
+	[96] = 
 	{
 		["type"] = "BMD-1",
 		["name"] = "IFV BMD-1",
@@ -2820,8 +3023,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [89]
-	[90] = 
+	}, -- end of [96]
+	[97] = 
 	{
 		["type"] = "BMP-1",
 		["name"] = "IFV BMP-1",
@@ -2852,8 +3055,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [90]
-	[91] = 
+	}, -- end of [97]
+	[98] = 
 	{
 		["type"] = "BMP-2",
 		["name"] = "IFV BMP-2",
@@ -2884,8 +3087,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [91]
-	[92] = 
+	}, -- end of [98]
+	[99] = 
 	{
 		["type"] = "BMP-3",
 		["name"] = "IFV BMP-3",
@@ -2905,9 +3108,10 @@ dcsUnits.DcsUnitsDatabase =
 			["Infantry carriers"] = true,
 			["LightArmoredUnits"] = true,
 			["NonAndLightArmoredUnits"] = true,
+			["Armed vehicles"] = true,
 			[7] = true,
 			[104] = true,
-			["Armed vehicles"] = true,
+			["CustomAimPoint"] = true,
 			["IFV"] = true,
 			["All"] = true,
 			["Ground Units"] = true,
@@ -2916,8 +3120,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [92]
-	[93] = 
+	}, -- end of [99]
+	[100] = 
 	{
 		["type"] = "BRDM-2",
 		["name"] = "Scout BRDM-2",
@@ -2947,8 +3151,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [93]
-	[94] = 
+	}, -- end of [100]
+	[101] = 
 	{
 		["type"] = "BTR-80",
 		["name"] = "APC BTR-80",
@@ -2978,8 +3182,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [94]
-	[95] = 
+	}, -- end of [101]
+	[102] = 
 	{
 		["type"] = "BTR-82A",
 		["name"] = "IFV BTR-82A",
@@ -3009,8 +3213,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [95]
-	[96] = 
+	}, -- end of [102]
+	[103] = 
 	{
 		["type"] = "BTR_D",
 		["name"] = "APC BTR-RD",
@@ -3042,13 +3246,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [96]
-	[97] = 
+	}, -- end of [103]
+	[104] = 
 	{
 		["type"] = "Centaur_IV",
-		["name"] = "CT Centaur IV",
+		["name"] = "Tk Centaur IV CS",
 		["category"] = "Armor",
-		["description"] = "CT Centaur IV",
+		["description"] = "Tk Centaur IV CS",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -3072,8 +3276,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [97]
-	[98] = 
+	}, -- end of [104]
+	[105] = 
 	{
 		["type"] = "Challenger2",
 		["name"] = "MBT Challenger II",
@@ -3102,8 +3306,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [98]
-	[99] = 
+	}, -- end of [105]
+	[106] = 
 	{
 		["type"] = "Chieftain_mk3",
 		["name"] = "MBT Chieftain Mk.3",
@@ -3132,13 +3336,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [99]
-	[100] = 
+	}, -- end of [106]
+	[107] = 
 	{
 		["type"] = "Churchill_VII",
-		["name"] = "HIT Churchill VII",
+		["name"] = "Tk Churchill VII",
 		["category"] = "Armor",
-		["description"] = "HIT Churchill VII",
+		["description"] = "Tk Churchill VII",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -3162,8 +3366,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [100]
-	[101] = 
+	}, -- end of [107]
+	[108] = 
 	{
 		["type"] = "Cobra",
 		["name"] = "Scout Cobra",
@@ -3193,13 +3397,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [101]
-	[102] = 
+	}, -- end of [108]
+	[109] = 
 	{
 		["type"] = "Cromwell_IV",
-		["name"] = "CT Cromwell IV",
+		["name"] = "Tk Cromwell IV",
 		["category"] = "Armor",
-		["description"] = "CT Cromwell IV",
+		["description"] = "Tk Cromwell IV",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -3223,8 +3427,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [102]
-	[103] = 
+	}, -- end of [109]
+	[110] = 
 	{
 		["type"] = "Daimler_AC",
 		["name"] = "Car Daimler Armored",
@@ -3254,13 +3458,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [103]
-	[104] = 
+	}, -- end of [110]
+	[111] = 
 	{
 		["type"] = "Elefant_SdKfz_184",
-		["name"] = "SPG Sd.Kfz.184 Elefant",
+		["name"] = "SPG Elefant TD",
 		["category"] = "Armor",
-		["description"] = "SPG Sd.Kfz.184 Elefant",
+		["description"] = "SPG Elefant TD",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -3284,13 +3488,75 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [104]
-	[105] = 
+	}, -- end of [111]
+	[112] = 
+	{
+		["type"] = "HL_DSHK",
+		["name"] = "Scout HL with DSHK 12.7mm",
+		["category"] = "Armor",
+		["description"] = "Scout HL with DSHK 12.7mm",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[2] = true,
+			["Vehicles"] = true,
+			["Armored vehicles"] = true,
+			["AntiAir Armed Vehicles"] = true,
+			[17] = true,
+			["Ground vehicles"] = true,
+			["Armed ground units"] = true,
+			["APC"] = true,
+			["Ground Units Non Airdefence"] = true,
+			["Infantry carriers"] = true,
+			[26] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["LightArmoredUnits"] = true,
+			[321] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			["Armed vehicles"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [112]
+	[113] = 
+	{
+		["type"] = "HL_KORD",
+		["name"] = "Scout HL with KORD 12.7mm",
+		["category"] = "Armor",
+		["description"] = "Scout HL with KORD 12.7mm",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[2] = true,
+			["Vehicles"] = true,
+			["Armored vehicles"] = true,
+			["AntiAir Armed Vehicles"] = true,
+			[17] = true,
+			["Ground vehicles"] = true,
+			["Armed ground units"] = true,
+			["APC"] = true,
+			["Ground Units Non Airdefence"] = true,
+			["Infantry carriers"] = true,
+			[26] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["LightArmoredUnits"] = true,
+			[322] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			["Armed vehicles"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [113]
+	[114] = 
 	{
 		["type"] = "Jagdpanther_G1",
-		["name"] = "SPG Jagdpanther G1",
+		["name"] = "SPG Jagdpanther TD",
 		["category"] = "Armor",
-		["description"] = "SPG Jagdpanther G1",
+		["description"] = "SPG Jagdpanther TD",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -3314,13 +3580,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [105]
-	[106] = 
+	}, -- end of [114]
+	[115] = 
 	{
 		["type"] = "JagdPz_IV",
-		["name"] = "SPG Jagdpanzer IV",
+		["name"] = "SPG Jagdpanzer IV TD",
 		["category"] = "Armor",
-		["description"] = "SPG Jagdpanzer IV",
+		["description"] = "SPG Jagdpanzer IV TD",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -3344,8 +3610,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [106]
-	[107] = 
+	}, -- end of [115]
+	[116] = 
 	{
 		["type"] = "LAV-25",
 		["name"] = "IFV LAV-25",
@@ -3375,8 +3641,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [107]
-	[108] = 
+	}, -- end of [116]
+	[117] = 
 	{
 		["type"] = "Leclerc",
 		["name"] = "MBT Leclerc",
@@ -3405,8 +3671,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [108]
-	[109] = 
+	}, -- end of [117]
+	[118] = 
 	{
 		["type"] = "Leopard-2",
 		["name"] = "MBT Leopard-2A6M",
@@ -3435,8 +3701,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [109]
-	[110] = 
+	}, -- end of [118]
+	[119] = 
 	{
 		["type"] = "leopard-2A4",
 		["name"] = "MBT Leopard-2A4",
@@ -3465,8 +3731,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [110]
-	[111] = 
+	}, -- end of [119]
+	[120] = 
 	{
 		["type"] = "leopard-2A4_trs",
 		["name"] = "MBT Leopard-2A4 Trs",
@@ -3495,8 +3761,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [111]
-	[112] = 
+	}, -- end of [120]
+	[121] = 
 	{
 		["type"] = "Leopard-2A5",
 		["name"] = "MBT Leopard-2A5",
@@ -3525,8 +3791,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [112]
-	[113] = 
+	}, -- end of [121]
+	[122] = 
 	{
 		["type"] = "Leopard1A3",
 		["name"] = "MBT Leopard 1A3",
@@ -3556,8 +3822,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "LEO1A3",
 		}, -- end of ["aliases"]
-	}, -- end of [113]
-	[114] = 
+	}, -- end of [122]
+	[123] = 
 	{
 		["type"] = "M-1 Abrams",
 		["name"] = "MBT M1A2 Abrams",
@@ -3587,8 +3853,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [114]
-	[115] = 
+	}, -- end of [123]
+	[124] = 
 	{
 		["type"] = "M-113",
 		["name"] = "APC M113",
@@ -3619,8 +3885,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [115]
-	[116] = 
+	}, -- end of [124]
+	[125] = 
 	{
 		["type"] = "M-2 Bradley",
 		["name"] = "IFV M2A2 Bradley",
@@ -3653,8 +3919,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "M2A2 Bradley",
 		}, -- end of ["aliases"]
-	}, -- end of [116]
-	[117] = 
+	}, -- end of [125]
+	[126] = 
 	{
 		["type"] = "M-60",
 		["name"] = "MBT M60A3 Patton",
@@ -3683,8 +3949,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [117]
-	[118] = 
+	}, -- end of [126]
+	[127] = 
 	{
 		["type"] = "M1043 HMMWV Armament",
 		["name"] = "Scout HMMWV",
@@ -3715,8 +3981,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [118]
-	[119] = 
+	}, -- end of [127]
+	[128] = 
 	{
 		["type"] = "M1045 HMMWV TOW",
 		["name"] = "ATGM HMMWV",
@@ -3748,13 +4014,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [119]
-	[120] = 
+	}, -- end of [128]
+	[129] = 
 	{
 		["type"] = "M10_GMC",
-		["name"] = "SPG M10 GMC",
+		["name"] = "SPG M10 GMC TD",
 		["category"] = "Armor",
-		["description"] = "SPG M10 GMC",
+		["description"] = "SPG M10 GMC TD",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -3778,8 +4044,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [120]
-	[121] = 
+	}, -- end of [129]
+	[130] = 
 	{
 		["type"] = "M1126 Stryker ICV",
 		["name"] = "IFV M1126 Stryker ICV",
@@ -3810,8 +4076,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [121]
-	[122] = 
+	}, -- end of [130]
+	[131] = 
 	{
 		["type"] = "M1128 Stryker MGS",
 		["name"] = "SPG Stryker MGS",
@@ -3845,8 +4111,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [122]
-	[123] = 
+	}, -- end of [131]
+	[132] = 
 	{
 		["type"] = "M1134 Stryker ATGM",
 		["name"] = "ATGM Stryker",
@@ -3878,8 +4144,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [123]
-	[124] = 
+	}, -- end of [132]
+	[133] = 
 	{
 		["type"] = "M2A1_halftrack",
 		["name"] = "APC M2A1 Halftrack",
@@ -3909,8 +4175,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [124]
-	[125] = 
+	}, -- end of [133]
+	[134] = 
 	{
 		["type"] = "M4_Sherman",
 		["name"] = "Tk M4 Sherman",
@@ -3939,43 +4205,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [125]
-	[126] = 
+	}, -- end of [134]
+	[135] = 
 	{
-		["type"] = "M4A4_Sherman_FF",
-		["name"] = "MT M4A4 Sherman Firefly",
+		["type"] = "M4_Tractor",
+		["name"] = "Tractor M4 High Speed",
 		["category"] = "Armor",
-		["description"] = "MT M4A4 Sherman Firefly",
-		["vehicle"] = true,
-		["attribute"] = 
-		{
-			["HeavyArmoredUnits"] = true,
-			["Tanks"] = true,
-			[26] = true,
-			["Armed vehicles"] = true,
-			["Armored vehicles"] = true,
-			["AntiAir Armed Vehicles"] = true,
-			["Ground vehicles"] = true,
-			["Old Tanks"] = true,
-			[17] = true,
-			["Vehicles"] = true,
-			[2] = true,
-			["Ground Units Non Airdefence"] = true,
-			["Armed ground units"] = true,
-			["All"] = true,
-			["Ground Units"] = true,
-			[16] = true,
-		}, -- end of ["attribute"]
-		["aliases"] = 
-		{
-		}, -- end of ["aliases"]
-	}, -- end of [126]
-	[127] = 
-	{
-		["type"] = "M8_Greyhound",
-		["name"] = "Car M8 Greyhound Armored",
-		["category"] = "Armor",
-		["description"] = "Car M8 Greyhound Armored",
+		["description"] = "Tractor M4 High Speed",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -4000,8 +4236,69 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [127]
-	[128] = 
+	}, -- end of [135]
+	[136] = 
+	{
+		["type"] = "M4A4_Sherman_FF",
+		["name"] = "Tk M4A4 Sherman Firefly",
+		["category"] = "Armor",
+		["description"] = "Tk M4A4 Sherman Firefly",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			["HeavyArmoredUnits"] = true,
+			["Tanks"] = true,
+			[26] = true,
+			["Armed vehicles"] = true,
+			["Armored vehicles"] = true,
+			["AntiAir Armed Vehicles"] = true,
+			["Ground vehicles"] = true,
+			["Old Tanks"] = true,
+			[17] = true,
+			["Vehicles"] = true,
+			[2] = true,
+			["Ground Units Non Airdefence"] = true,
+			["Armed ground units"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			[16] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [136]
+	[137] = 
+	{
+		["type"] = "M8_Greyhound",
+		["name"] = "Scout M8 Greyhound AC",
+		["category"] = "Armor",
+		["description"] = "Scout M8 Greyhound AC",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[2] = true,
+			["Vehicles"] = true,
+			["Armored vehicles"] = true,
+			["AntiAir Armed Vehicles"] = true,
+			[17] = true,
+			["Ground vehicles"] = true,
+			["Armed ground units"] = true,
+			["Ground Units Non Airdefence"] = true,
+			["Infantry carriers"] = true,
+			[26] = true,
+			["LightArmoredUnits"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["IFV"] = true,
+			[7] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			["Armed vehicles"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [137]
+	[138] = 
 	{
 		["type"] = "Marder",
 		["name"] = "IFV Marder",
@@ -4032,8 +4329,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [128]
-	[129] = 
+	}, -- end of [138]
+	[139] = 
 	{
 		["type"] = "MCV-80",
 		["name"] = "IFV Warrior ",
@@ -4063,8 +4360,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [129]
-	[130] = 
+	}, -- end of [139]
+	[140] = 
 	{
 		["type"] = "Merkava_Mk4",
 		["name"] = "MBT Merkava IV",
@@ -4094,8 +4391,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [130]
-	[131] = 
+	}, -- end of [140]
+	[141] = 
 	{
 		["type"] = "MTLB",
 		["name"] = "APC MTLB",
@@ -4126,8 +4423,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [131]
-	[132] = 
+	}, -- end of [141]
+	[142] = 
 	{
 		["type"] = "PT_76",
 		["name"] = "LT PT-76",
@@ -4156,8 +4453,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [132]
-	[133] = 
+	}, -- end of [142]
+	[143] = 
 	{
 		["type"] = "Pz_IV_H",
 		["name"] = "Tk PzIV H",
@@ -4186,13 +4483,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [133]
-	[134] = 
+	}, -- end of [143]
+	[144] = 
 	{
 		["type"] = "Pz_V_Panther_G",
-		["name"] = "MT Pz.Kpfw.V Panther Ausf.G",
+		["name"] = "Tk Panther G (Pz V)",
 		["category"] = "Armor",
-		["description"] = "MT Pz.Kpfw.V Panther Ausf.G",
+		["description"] = "Tk Panther G (Pz V)",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -4216,13 +4513,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [134]
-	[135] = 
+	}, -- end of [144]
+	[145] = 
 	{
 		["type"] = "Sd_Kfz_234_2_Puma",
-		["name"] = "IFV Sd.Kfz.234/2 Puma",
+		["name"] = "Scout Puma AC",
 		["category"] = "Armor",
-		["description"] = "IFV Sd.Kfz.234/2 Puma",
+		["description"] = "Scout Puma AC",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -4247,8 +4544,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [135]
-	[136] = 
+	}, -- end of [145]
+	[146] = 
 	{
 		["type"] = "Sd_Kfz_251",
 		["name"] = "APC Sd.Kfz.251 Halftrack",
@@ -4278,13 +4575,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [136]
-	[137] = 
+	}, -- end of [146]
+	[147] = 
 	{
 		["type"] = "Stug_III",
-		["name"] = "SPG StuG III Ausf. G",
+		["name"] = "SPG StuG III G AG",
 		["category"] = "Armor",
-		["description"] = "SPG StuG III Ausf. G",
+		["description"] = "SPG StuG III G AG",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -4308,13 +4605,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [137]
-	[138] = 
+	}, -- end of [147]
+	[148] = 
 	{
 		["type"] = "Stug_IV",
-		["name"] = "SPG StuG IV",
+		["name"] = "SPG StuG IV AG",
 		["category"] = "Armor",
-		["description"] = "SPG StuG IV",
+		["description"] = "SPG StuG IV AG",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -4338,13 +4635,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [138]
-	[139] = 
+	}, -- end of [148]
+	[149] = 
 	{
 		["type"] = "SturmPzIV",
-		["name"] = "SPG Sturmpanzer IV Brummbar",
+		["name"] = "SPG Brummbaer AG",
 		["category"] = "Armor",
-		["description"] = "SPG Sturmpanzer IV Brummbar",
+		["description"] = "SPG Brummbaer AG",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -4367,8 +4664,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [139]
-	[140] = 
+	}, -- end of [149]
+	[150] = 
 	{
 		["type"] = "T-55",
 		["name"] = "MBT T-55",
@@ -4397,8 +4694,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [140]
-	[141] = 
+	}, -- end of [150]
+	[151] = 
 	{
 		["type"] = "T-72B",
 		["name"] = "MBT T-72B",
@@ -4428,8 +4725,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [141]
-	[142] = 
+	}, -- end of [151]
+	[152] = 
 	{
 		["type"] = "T-72B3",
 		["name"] = "MBT T-72B3",
@@ -4459,8 +4756,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [142]
-	[143] = 
+	}, -- end of [152]
+	[153] = 
 	{
 		["type"] = "T-80UD",
 		["name"] = "MBT T-80U",
@@ -4489,8 +4786,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [143]
-	[144] = 
+	}, -- end of [153]
+	[154] = 
 	{
 		["type"] = "T-90",
 		["name"] = "MBT T-90",
@@ -4520,13 +4817,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [144]
-	[145] = 
+	}, -- end of [154]
+	[155] = 
 	{
 		["type"] = "Tetrarch",
-		["name"] = "LT Mk VII Tetrarch",
+		["name"] = "Tk Tetrach",
 		["category"] = "Armor",
-		["description"] = "LT Mk VII Tetrarch",
+		["description"] = "Tk Tetrach",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -4551,13 +4848,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [145]
-	[146] = 
+	}, -- end of [155]
+	[156] = 
 	{
 		["type"] = "Tiger_I",
-		["name"] = "HT Pz.Kpfw.VI Tiger I",
+		["name"] = "Tk Tiger 1",
 		["category"] = "Armor",
-		["description"] = "HT Pz.Kpfw.VI Tiger I",
+		["description"] = "Tk Tiger 1",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -4581,13 +4878,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [146]
-	[147] = 
+	}, -- end of [156]
+	[157] = 
 	{
 		["type"] = "Tiger_II_H",
-		["name"] = "HT Pz.Kpfw.VI Ausf. B Tiger II",
+		["name"] = "Tk Tiger II",
 		["category"] = "Armor",
-		["description"] = "HT Pz.Kpfw.VI Ausf. B Tiger II",
+		["description"] = "Tk Tiger II",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -4611,8 +4908,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [147]
-	[148] = 
+	}, -- end of [157]
+	[158] = 
 	{
 		["type"] = "TPZ",
 		["name"] = "APC TPz Fuchs ",
@@ -4642,8 +4939,100 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [148]
-	[149] = 
+	}, -- end of [158]
+	[159] = 
+	{
+		["type"] = "tt_DSHK",
+		["name"] = "Scout LC with DSHK 12.7mm",
+		["category"] = "Armor",
+		["description"] = "Scout LC with DSHK 12.7mm",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[2] = true,
+			["Vehicles"] = true,
+			["Armed vehicles"] = true,
+			["AntiAir Armed Vehicles"] = true,
+			[17] = true,
+			["Ground vehicles"] = true,
+			["Armed ground units"] = true,
+			["APC"] = true,
+			["Ground Units Non Airdefence"] = true,
+			["Infantry carriers"] = true,
+			[26] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["LightArmoredUnits"] = true,
+			[323] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			["Armored vehicles"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [159]
+	[160] = 
+	{
+		["type"] = "tt_KORD",
+		["name"] = "Scout LC with KORD 12.7mm",
+		["category"] = "Armor",
+		["description"] = "Scout LC with KORD 12.7mm",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[2] = true,
+			["Vehicles"] = true,
+			["Armored vehicles"] = true,
+			["AntiAir Armed Vehicles"] = true,
+			[17] = true,
+			["Ground vehicles"] = true,
+			["Armed ground units"] = true,
+			["APC"] = true,
+			["Ground Units Non Airdefence"] = true,
+			["Infantry carriers"] = true,
+			[26] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["LightArmoredUnits"] = true,
+			["Armed vehicles"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			[324] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [160]
+	[161] = 
+	{
+		["type"] = "TYPE-59",
+		["name"] = "MT Type 59",
+		["category"] = "Armor",
+		["description"] = "MT Type 59",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			["HeavyArmoredUnits"] = true,
+			["Tanks"] = true,
+			[26] = true,
+			["Armed vehicles"] = true,
+			["Armored vehicles"] = true,
+			["AntiAir Armed Vehicles"] = true,
+			["Ground vehicles"] = true,
+			["Old Tanks"] = true,
+			[17] = true,
+			["Vehicles"] = true,
+			[2] = true,
+			["Ground Units Non Airdefence"] = true,
+			["Armed ground units"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			[16] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [161]
+	[162] = 
 	{
 		["type"] = "VAB_Mephisto",
 		["name"] = "ATGM VAB Mephisto",
@@ -4675,8 +5064,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [149]
-	[150] = 
+	}, -- end of [162]
+	[163] = 
 	{
 		["type"] = "ZBD04A",
 		["name"] = "ZBD-04A",
@@ -4708,8 +5097,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [150]
-	[151] = 
+	}, -- end of [163]
+	[164] = 
 	{
 		["type"] = "ZTZ96B",
 		["name"] = "ZTZ-96B",
@@ -4739,8 +5128,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [151]
-	[152] = 
+	}, -- end of [164]
+	[165] = 
 	{
 		["type"] = "2B11 mortar",
 		["name"] = "Mortar 2B11 120mm",
@@ -4768,8 +5157,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [152]
-	[153] = 
+	}, -- end of [165]
+	[166] = 
 	{
 		["type"] = "Grad-URAL",
 		["name"] = "MLRS BM-21 Grad 122mm",
@@ -4799,8 +5188,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "MLRS BM-21 Grad",
 		}, -- end of ["aliases"]
-	}, -- end of [153]
-	[154] = 
+	}, -- end of [166]
+	[167] = 
 	{
 		["type"] = "Grad_FDDM",
 		["name"] = "Grad MRL FDDM (FC)",
@@ -4831,8 +5220,68 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "Boman",
 		}, -- end of ["aliases"]
-	}, -- end of [154]
-	[155] = 
+	}, -- end of [167]
+	[168] = 
+	{
+		["type"] = "HL_B8M1",
+		["name"] = "MLRS HL with B8M1 80mm",
+		["category"] = "Artillery",
+		["description"] = "MLRS HL with B8M1 80mm",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[2] = true,
+			["Vehicles"] = true,
+			["Armed vehicles"] = true,
+			["LightArmoredUnits"] = true,
+			[17] = true,
+			["Ground vehicles"] = true,
+			["Armed ground units"] = true,
+			["</WSTYPE>"] = true,
+			["Artillery"] = true,
+			["Ground Units Non Airdefence"] = true,
+			["All"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			[63] = true,
+			["Indirect fire"] = true,
+			["MLRS"] = true,
+			["Ground Units"] = true,
+			[27] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [168]
+	[169] = 
+	{
+		["type"] = "LeFH_18-40-105",
+		["name"] = "FH LeFH-18 105mm",
+		["category"] = "Artillery",
+		["description"] = "FH LeFH-18 105mm",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			["Artillery"] = true,
+			["Ground Units Non Airdefence"] = true,
+			[26] = true,
+			[2] = true,
+			["LightArmoredUnits"] = true,
+			["Ground vehicles"] = true,
+			["Indirect fire"] = true,
+			[17] = true,
+			["Armed vehicles"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["Vehicles"] = true,
+			["Armed ground units"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			[319] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [169]
+	[170] = 
 	{
 		["type"] = "M-109",
 		["name"] = "SPH M109 Paladin 155mm",
@@ -4862,13 +5311,13 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "M109",
 		}, -- end of ["aliases"]
-	}, -- end of [155]
-	[156] = 
+	}, -- end of [170]
+	[171] = 
 	{
 		["type"] = "M12_GMC",
-		["name"] = "SPG M12 GMC 155mm",
+		["name"] = "SPH M12 GMC 155mm",
 		["category"] = "Artillery",
-		["description"] = "SPG M12 GMC 155mm",
+		["description"] = "SPH M12 GMC 155mm",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -4891,8 +5340,37 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [156]
-	[157] = 
+	}, -- end of [171]
+	[172] = 
+	{
+		["type"] = "M2A1-105",
+		["name"] = "FH M2A1 105mm",
+		["category"] = "Artillery",
+		["description"] = "FH M2A1 105mm",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[320] = true,
+			["Ground Units Non Airdefence"] = true,
+			[26] = true,
+			[2] = true,
+			["LightArmoredUnits"] = true,
+			["Ground vehicles"] = true,
+			["Indirect fire"] = true,
+			[17] = true,
+			["Armed vehicles"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["Vehicles"] = true,
+			["Armed ground units"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			["Artillery"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [172]
+	[173] = 
 	{
 		["type"] = "MLRS",
 		["name"] = "MLRS M270 227mm",
@@ -4923,8 +5401,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "M270 MLRS",
 		}, -- end of ["aliases"]
-	}, -- end of [157]
-	[158] = 
+	}, -- end of [173]
+	[174] = 
 	{
 		["type"] = "MLRS FDDM",
 		["name"] = "MRLS FDDM (FC)",
@@ -4955,8 +5433,37 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [158]
-	[159] = 
+	}, -- end of [174]
+	[175] = 
+	{
+		["type"] = "Pak40",
+		["name"] = "FH Pak 40 75mm",
+		["category"] = "Artillery",
+		["description"] = "FH Pak 40 75mm",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			["Artillery"] = true,
+			["Ground Units Non Airdefence"] = true,
+			[26] = true,
+			[2] = true,
+			["LightArmoredUnits"] = true,
+			["Ground vehicles"] = true,
+			["Indirect fire"] = true,
+			[17] = true,
+			["Armed vehicles"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["Vehicles"] = true,
+			["Armed ground units"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			[318] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [175]
+	[176] = 
 	{
 		["type"] = "PLZ05",
 		["name"] = "PLZ-05",
@@ -4984,8 +5491,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [159]
-	[160] = 
+	}, -- end of [176]
+	[177] = 
 	{
 		["type"] = "SAU 2-C9",
 		["name"] = "SPM 2S9 Nona 120mm M",
@@ -5013,8 +5520,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [160]
-	[161] = 
+	}, -- end of [177]
+	[178] = 
 	{
 		["type"] = "SAU Akatsia",
 		["name"] = "SPH 2S3 Akatsia 152mm",
@@ -5043,8 +5550,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "2S3 Akatsia",
 		}, -- end of ["aliases"]
-	}, -- end of [161]
-	[162] = 
+	}, -- end of [178]
+	[179] = 
 	{
 		["type"] = "SAU Gvozdika",
 		["name"] = "SPH 2S1 Gvozdika 122mm",
@@ -5072,8 +5579,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [162]
-	[163] = 
+	}, -- end of [179]
+	[180] = 
 	{
 		["type"] = "SAU Msta",
 		["name"] = "SPH 2S19 Msta 152mm",
@@ -5102,8 +5609,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "2S19 Msta",
 		}, -- end of ["aliases"]
-	}, -- end of [163]
-	[164] = 
+	}, -- end of [180]
+	[181] = 
 	{
 		["type"] = "Smerch",
 		["name"] = "MLRS 9A52 Smerch CM 300mm",
@@ -5132,8 +5639,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [164]
-	[165] = 
+	}, -- end of [181]
+	[182] = 
 	{
 		["type"] = "Smerch_HE",
 		["name"] = "MLRS 9A52 Smerch HE 300mm",
@@ -5162,8 +5669,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [165]
-	[166] = 
+	}, -- end of [182]
+	[183] = 
 	{
 		["type"] = "SpGH_Dana",
 		["name"] = "SPH Dana vz77 152mm",
@@ -5191,8 +5698,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [166]
-	[167] = 
+	}, -- end of [183]
+	[184] = 
 	{
 		["type"] = "T155_Firtina",
 		["name"] = "SPH T155 Firtina 155mm",
@@ -5221,8 +5728,39 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [167]
-	[168] = 
+	}, -- end of [184]
+	[185] = 
+	{
+		["type"] = "tt_B8M1",
+		["name"] = "MLRS LC with B8M1 80mm",
+		["category"] = "Artillery",
+		["description"] = "MLRS LC with B8M1 80mm",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[2] = true,
+			["Vehicles"] = true,
+			["Armed vehicles"] = true,
+			["LightArmoredUnits"] = true,
+			[17] = true,
+			["Ground vehicles"] = true,
+			["Armed ground units"] = true,
+			["</WSTYPE>"] = true,
+			["Artillery"] = true,
+			["Ground Units Non Airdefence"] = true,
+			["All"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			[63] = true,
+			["Indirect fire"] = true,
+			["MLRS"] = true,
+			["Ground Units"] = true,
+			[27] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [185]
+	[186] = 
 	{
 		["type"] = "Uragan_BM-27",
 		["name"] = "MLRS 9K57 Uragan BM-27 220mm",
@@ -5251,8 +5789,37 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [168]
-	[169] = 
+	}, -- end of [186]
+	[187] = 
+	{
+		["type"] = "Wespe124",
+		["name"] = "SPH Sd.Kfz.124 Wespe 105mm",
+		["category"] = "Artillery",
+		["description"] = "SPH Sd.Kfz.124 Wespe 105mm",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			["Artillery"] = true,
+			["Ground Units Non Airdefence"] = true,
+			[26] = true,
+			[2] = true,
+			["LightArmoredUnits"] = true,
+			["Ground vehicles"] = true,
+			["Indirect fire"] = true,
+			[17] = true,
+			["Armed vehicles"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["Vehicles"] = true,
+			[317] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			["Armed ground units"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [187]
+	[188] = 
 	{
 		["type"] = "ammo_cargo",
 		["name"] = "Ammo",
@@ -5265,8 +5832,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [169]
-	[170] = 
+	}, -- end of [188]
+	[189] = 
 	{
 		["type"] = "barrels_cargo",
 		["name"] = "Barrels",
@@ -5279,8 +5846,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [170]
-	[171] = 
+	}, -- end of [189]
+	[190] = 
 	{
 		["type"] = "container_cargo",
 		["name"] = "Container",
@@ -5293,8 +5860,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [171]
-	[172] = 
+	}, -- end of [190]
+	[191] = 
 	{
 		["type"] = "f_bar_cargo",
 		["name"] = "F-shape barrier",
@@ -5307,8 +5874,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [172]
-	[173] = 
+	}, -- end of [191]
+	[192] = 
 	{
 		["type"] = "fueltank_cargo",
 		["name"] = "Fueltank",
@@ -5321,8 +5888,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [173]
-	[174] = 
+	}, -- end of [192]
+	[193] = 
 	{
 		["type"] = "iso_container",
 		["name"] = "ISO container",
@@ -5335,8 +5902,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [174]
-	[175] = 
+	}, -- end of [193]
+	[194] = 
 	{
 		["type"] = "iso_container_small",
 		["name"] = "ISO container small",
@@ -5349,8 +5916,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [175]
-	[176] = 
+	}, -- end of [194]
+	[195] = 
 	{
 		["type"] = "m117_cargo",
 		["name"] = "M117 bombs",
@@ -5363,8 +5930,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [176]
-	[177] = 
+	}, -- end of [195]
+	[196] = 
 	{
 		["type"] = "oiltank_cargo",
 		["name"] = "Oiltank",
@@ -5377,8 +5944,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [177]
-	[178] = 
+	}, -- end of [196]
+	[197] = 
 	{
 		["type"] = "pipes_big_cargo",
 		["name"] = "Pipes big",
@@ -5391,8 +5958,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [178]
-	[179] = 
+	}, -- end of [197]
+	[198] = 
 	{
 		["type"] = "pipes_small_cargo",
 		["name"] = "Pipes small",
@@ -5405,8 +5972,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [179]
-	[180] = 
+	}, -- end of [198]
+	[199] = 
 	{
 		["type"] = "tetrapod_cargo",
 		["name"] = "Tetrapod",
@@ -5419,8 +5986,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [180]
-	[181] = 
+	}, -- end of [199]
+	[200] = 
 	{
 		["type"] = "trunks_long_cargo",
 		["name"] = "Trunks long",
@@ -5433,8 +6000,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [181]
-	[182] = 
+	}, -- end of [200]
+	[201] = 
 	{
 		["type"] = "trunks_small_cargo",
 		["name"] = "Trunks short",
@@ -5447,8 +6014,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [182]
-	[183] = 
+	}, -- end of [201]
+	[202] = 
 	{
 		["type"] = "uh1h_cargo",
 		["name"] = "UH-1H cargo",
@@ -5461,8 +6028,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [183]
-	[184] = 
+	}, -- end of [202]
+	[203] = 
 	{
 		["type"] = "Boxcartrinity",
 		["name"] = "Flatcar",
@@ -5488,8 +6055,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [184]
-	[185] = 
+	}, -- end of [203]
+	[204] = 
 	{
 		["type"] = "Coach a passenger",
 		["name"] = "Passenger Car",
@@ -5515,8 +6082,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [185]
-	[186] = 
+	}, -- end of [204]
+	[205] = 
 	{
 		["type"] = "Coach a platform",
 		["name"] = "Coach Platform",
@@ -5542,8 +6109,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [186]
-	[187] = 
+	}, -- end of [205]
+	[206] = 
 	{
 		["type"] = "Coach a tank blue",
 		["name"] = "Tank Car blue",
@@ -5569,8 +6136,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [187]
-	[188] = 
+	}, -- end of [206]
+	[207] = 
 	{
 		["type"] = "Coach a tank yellow",
 		["name"] = "Tank Car yellow",
@@ -5596,8 +6163,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [188]
-	[189] = 
+	}, -- end of [207]
+	[208] = 
 	{
 		["type"] = "Coach cargo",
 		["name"] = "Freight Van",
@@ -5623,8 +6190,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [189]
-	[190] = 
+	}, -- end of [208]
+	[209] = 
 	{
 		["type"] = "Coach cargo open",
 		["name"] = "Open Wagon",
@@ -5650,8 +6217,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [190]
-	[191] = 
+	}, -- end of [209]
+	[210] = 
 	{
 		["type"] = "DR_50Ton_Flat_Wagon",
 		["name"] = "DR 50-ton flat wagon",
@@ -5677,8 +6244,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [191]
-	[192] = 
+	}, -- end of [210]
+	[211] = 
 	{
 		["type"] = "German_covered_wagon_G10",
 		["name"] = "Wagon G10 (Germany)",
@@ -5704,8 +6271,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [192]
-	[193] = 
+	}, -- end of [211]
+	[212] = 
 	{
 		["type"] = "German_tank_wagon",
 		["name"] = "Tank Car (Germany)",
@@ -5730,8 +6297,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [193]
-	[194] = 
+	}, -- end of [212]
+	[213] = 
 	{
 		["type"] = "Tankcartrinity",
 		["name"] = "Tank Cartrinity",
@@ -5757,8 +6324,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [194]
-	[195] = 
+	}, -- end of [213]
+	[214] = 
 	{
 		["type"] = "Wellcarnsc",
 		["name"] = "Well Car",
@@ -5784,8 +6351,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [195]
-	[196] = 
+	}, -- end of [214]
+	[215] = 
 	{
 		["type"] = "big_smoke",
 		["name"] = "Big smoke",
@@ -5794,8 +6361,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [196]
-	[197] = 
+	}, -- end of [215]
+	[216] = 
 	{
 		["type"] = ".Command Center",
 		["name"] = "Command Center",
@@ -5804,43 +6371,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [197]
-	[198] = 
+	}, -- end of [216]
+	[217] = 
 	{
-		["type"] = "Airshow_Cone",
-		["name"] = "Airshow cone",
+		["type"] = "345 Excavator",
+		["name"] = "Excavator",
 		["category"] = "Fortification",
-		["description"] = "Airshow cone",
-		["aliases"] = 
-		{
-		}, -- end of ["aliases"]
-	}, -- end of [198]
-	[199] = 
-	{
-		["type"] = "Airshow_Crowd",
-		["name"] = "Airshow Crowd",
-		["category"] = "Fortification",
-		["description"] = "Airshow Crowd",
-		["aliases"] = 
-		{
-		}, -- end of ["aliases"]
-	}, -- end of [199]
-	[200] = 
-	{
-		["type"] = "Barracks 2",
-		["name"] = "Barracks 2",
-		["category"] = "Fortification",
-		["description"] = "Barracks 2",
-		["aliases"] = 
-		{
-		}, -- end of ["aliases"]
-	}, -- end of [200]
-	[201] = 
-	{
-		["type"] = "Beer Bomb",
-		["name"] = "\"Beer Bomb\"",
-		["category"] = "Fortification",
-		["description"] = "\"Beer Bomb\"",
+		["description"] = "Excavator",
 		["attribute"] = 
 		{
 			[5] = true,
@@ -5849,8 +6386,53 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [201]
-	[202] = 
+	}, -- end of [217]
+	[218] = 
+	{
+		["type"] = "Airshow_Cone",
+		["name"] = "Airshow cone",
+		["category"] = "Fortification",
+		["description"] = "Airshow cone",
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [218]
+	[219] = 
+	{
+		["type"] = "Airshow_Crowd",
+		["name"] = "Airshow Crowd",
+		["category"] = "Fortification",
+		["description"] = "Airshow Crowd",
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [219]
+	[220] = 
+	{
+		["type"] = "Barracks 2",
+		["name"] = "Barracks 2",
+		["category"] = "Fortification",
+		["description"] = "Barracks 2",
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [220]
+	[221] = 
+	{
+		["type"] = "Beer Bomb",
+		["name"] = "Barrel",
+		["category"] = "Fortification",
+		["description"] = "Barrel",
+		["attribute"] = 
+		{
+			[5] = true,
+			[9] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [221]
+	[222] = 
 	{
 		["type"] = "Belgian gate",
 		["name"] = "Belgian gate",
@@ -5864,8 +6446,23 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [202]
-	[203] = 
+	}, -- end of [222]
+	[223] = 
+	{
+		["type"] = "billboard_motorized",
+		["name"] = "Billboard Motorized",
+		["category"] = "Fortification",
+		["description"] = "Billboard Motorized",
+		["attribute"] = 
+		{
+			[5] = true,
+			[9] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [223]
+	[224] = 
 	{
 		["type"] = "Black_Tyre",
 		["name"] = "Mark Tyre Black",
@@ -5874,8 +6471,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [203]
-	[204] = 
+	}, -- end of [224]
+	[225] = 
 	{
 		["type"] = "Black_Tyre_RF",
 		["name"] = "Mark Tyre with Red Flag",
@@ -5884,8 +6481,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [204]
-	[205] = 
+	}, -- end of [225]
+	[226] = 
 	{
 		["type"] = "Black_Tyre_WF",
 		["name"] = "Mark Tyre with White Flag",
@@ -5894,8 +6491,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [205]
-	[206] = 
+	}, -- end of [226]
+	[227] = 
 	{
 		["type"] = "Boiler-house A",
 		["name"] = "Boiler-house A",
@@ -5904,8 +6501,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [206]
-	[207] = 
+	}, -- end of [227]
+	[228] = 
 	{
 		["type"] = "Bunker",
 		["name"] = "Bunker 2",
@@ -5929,8 +6526,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [207]
-	[208] = 
+	}, -- end of [228]
+	[229] = 
 	{
 		["type"] = "Cafe",
 		["name"] = "Cafe",
@@ -5939,8 +6536,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [208]
-	[209] = 
+	}, -- end of [229]
+	[230] = 
 	{
 		["type"] = "Chemical tank A",
 		["name"] = "Chemical tank A",
@@ -5949,8 +6546,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [209]
-	[210] = 
+	}, -- end of [230]
+	[231] = 
 	{
 		["type"] = "Comms tower M",
 		["name"] = "Comms tower M",
@@ -5959,8 +6556,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [210]
-	[211] = 
+	}, -- end of [231]
+	[232] = 
 	{
 		["type"] = "Concertina wire",
 		["name"] = "Concertina wire",
@@ -5974,8 +6571,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [211]
-	[212] = 
+	}, -- end of [232]
+	[233] = 
 	{
 		["type"] = "Container brown",
 		["name"] = "Container brown",
@@ -5984,8 +6581,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [212]
-	[213] = 
+	}, -- end of [233]
+	[234] = 
 	{
 		["type"] = "Container red 1",
 		["name"] = "Container red 1",
@@ -5994,8 +6591,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [213]
-	[214] = 
+	}, -- end of [234]
+	[235] = 
 	{
 		["type"] = "Container red 2",
 		["name"] = "Container red 2",
@@ -6004,8 +6601,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [214]
-	[215] = 
+	}, -- end of [235]
+	[236] = 
 	{
 		["type"] = "Container red 3",
 		["name"] = "Container red 3",
@@ -6014,8 +6611,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [215]
-	[216] = 
+	}, -- end of [236]
+	[237] = 
 	{
 		["type"] = "Container white",
 		["name"] = "Container white",
@@ -6024,8 +6621,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [216]
-	[217] = 
+	}, -- end of [237]
+	[238] = 
 	{
 		["type"] = "Czech hedgehogs 1",
 		["name"] = "Czech hedgehogs 1",
@@ -6039,8 +6636,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [217]
-	[218] = 
+	}, -- end of [238]
+	[239] = 
 	{
 		["type"] = "Czech hedgehogs 2",
 		["name"] = "Czech hedgehogs 2",
@@ -6054,8 +6651,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [218]
-	[219] = 
+	}, -- end of [239]
+	[240] = 
 	{
 		["type"] = "Dragonteeth 1",
 		["name"] = "Dragonteeth 1",
@@ -6069,8 +6666,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [219]
-	[220] = 
+	}, -- end of [240]
+	[241] = 
 	{
 		["type"] = "Dragonteeth 2",
 		["name"] = "Dragonteeth 2",
@@ -6084,8 +6681,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [220]
-	[221] = 
+	}, -- end of [241]
+	[242] = 
 	{
 		["type"] = "Dragonteeth 3",
 		["name"] = "Dragonteeth 3",
@@ -6099,8 +6696,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [221]
-	[222] = 
+	}, -- end of [242]
+	[243] = 
 	{
 		["type"] = "Dragonteeth 4",
 		["name"] = "Dragonteeth 4",
@@ -6114,8 +6711,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [222]
-	[223] = 
+	}, -- end of [243]
+	[244] = 
 	{
 		["type"] = "Dragonteeth 5",
 		["name"] = "Dragonteeth 5",
@@ -6129,8 +6726,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [223]
-	[224] = 
+	}, -- end of [244]
+	[245] = 
 	{
 		["type"] = "Electric power box",
 		["name"] = "Electric power box",
@@ -6139,8 +6736,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [224]
-	[225] = 
+	}, -- end of [245]
+	[246] = 
 	{
 		["type"] = "Farm A",
 		["name"] = "Farm A",
@@ -6149,8 +6746,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [225]
-	[226] = 
+	}, -- end of [246]
+	[247] = 
 	{
 		["type"] = "Farm B",
 		["name"] = "Farm B",
@@ -6159,8 +6756,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [226]
-	[227] = 
+	}, -- end of [247]
+	[248] = 
 	{
 		["type"] = "FARP Ammo Dump Coating",
 		["name"] = "FARP Ammo Storage",
@@ -6169,8 +6766,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [227]
-	[228] = 
+	}, -- end of [248]
+	[249] = 
 	{
 		["type"] = "FARP CP Blindage",
 		["name"] = "FARP Command Post",
@@ -6179,8 +6776,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [228]
-	[229] = 
+	}, -- end of [249]
+	[250] = 
 	{
 		["type"] = "FARP Fuel Depot",
 		["name"] = "FARP Fuel Depot",
@@ -6189,8 +6786,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [229]
-	[230] = 
+	}, -- end of [250]
+	[251] = 
 	{
 		["type"] = "FARP Tent",
 		["name"] = "FARP Tent",
@@ -6199,8 +6796,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [230]
-	[231] = 
+	}, -- end of [251]
+	[252] = 
 	{
 		["type"] = "Fire Control Bunker",
 		["name"] = "Fire control bunker",
@@ -6214,8 +6811,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [231]
-	[232] = 
+	}, -- end of [252]
+	[253] = 
 	{
 		["type"] = "fire_control",
 		["name"] = "Bunker with Fire Control Center",
@@ -6239,8 +6836,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [232]
-	[233] = 
+	}, -- end of [253]
+	[254] = 
 	{
 		["type"] = "Freya_Shelter_Brick",
 		["name"] = "Freya Shelter Brick",
@@ -6254,8 +6851,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [233]
-	[234] = 
+	}, -- end of [254]
+	[255] = 
 	{
 		["type"] = "Freya_Shelter_Concrete",
 		["name"] = "Freya Shelter Concrete",
@@ -6269,8 +6866,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [234]
-	[235] = 
+	}, -- end of [255]
+	[256] = 
 	{
 		["type"] = "Fuel tank",
 		["name"] = "Fuel tank",
@@ -6279,8 +6876,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [235]
-	[236] = 
+	}, -- end of [256]
+	[257] = 
 	{
 		["type"] = "Garage A",
 		["name"] = "Garage A",
@@ -6289,8 +6886,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [236]
-	[237] = 
+	}, -- end of [257]
+	[258] = 
 	{
 		["type"] = "Garage B",
 		["name"] = "Garage B",
@@ -6299,8 +6896,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [237]
-	[238] = 
+	}, -- end of [258]
+	[259] = 
 	{
 		["type"] = "Garage small A",
 		["name"] = "Garage small A",
@@ -6309,8 +6906,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [238]
-	[239] = 
+	}, -- end of [259]
+	[260] = 
 	{
 		["type"] = "Garage small B",
 		["name"] = "Garage small B",
@@ -6319,8 +6916,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [239]
-	[240] = 
+	}, -- end of [260]
+	[261] = 
 	{
 		["type"] = "GeneratorF",
 		["name"] = "GeneratorF",
@@ -6329,8 +6926,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [240]
-	[241] = 
+	}, -- end of [261]
+	[262] = 
 	{
 		["type"] = "Hangar A",
 		["name"] = "Hangar A",
@@ -6339,8 +6936,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [241]
-	[242] = 
+	}, -- end of [262]
+	[263] = 
 	{
 		["type"] = "Hangar B",
 		["name"] = "Hangar B",
@@ -6349,8 +6946,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [242]
-	[243] = 
+	}, -- end of [263]
+	[264] = 
 	{
 		["type"] = "Haystack 1",
 		["name"] = "Haystack 1",
@@ -6364,8 +6961,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [243]
-	[244] = 
+	}, -- end of [264]
+	[265] = 
 	{
 		["type"] = "Haystack 2",
 		["name"] = "Haystack 2",
@@ -6379,8 +6976,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [244]
-	[245] = 
+	}, -- end of [265]
+	[266] = 
 	{
 		["type"] = "Haystack 3",
 		["name"] = "Haystack 3",
@@ -6394,8 +6991,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [245]
-	[246] = 
+	}, -- end of [266]
+	[267] = 
 	{
 		["type"] = "Haystack 4",
 		["name"] = "Haystack 4",
@@ -6409,8 +7006,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [246]
-	[247] = 
+	}, -- end of [267]
+	[268] = 
 	{
 		["type"] = "Hemmkurvenhindernis",
 		["name"] = "Hemmkurvenhindernis",
@@ -6424,29 +7021,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [247]
-	[248] = 
-	{
-		["type"] = "Hercules_Container_Parachute_Static",
-		["name"] = "Hercules container with parachute",
-		["category"] = "Fortification",
-		["description"] = "Hercules container with parachute",
-		["attribute"] = 
-		{
-			["Fortifications"] = true,
-			["Ground Units Non Airdefence"] = true,
-			["HeavyArmoredUnits"] = true,
-			["AntiAir Armed Vehicles"] = true,
-			["Armed ground units"] = true,
-			["All"] = true,
-			[5] = true,
-			["Ground Units"] = true,
-		}, -- end of ["attribute"]
-		["aliases"] = 
-		{
-		}, -- end of ["aliases"]
-	}, -- end of [248]
-	[249] = 
+	}, -- end of [268]
+	[269] = 
 	{
 		["type"] = "house1arm",
 		["name"] = "Barracks armed",
@@ -6470,8 +7046,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [249]
-	[250] = 
+	}, -- end of [269]
+	[270] = 
 	{
 		["type"] = "house2arm",
 		["name"] = "Watch tower armed",
@@ -6495,8 +7071,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [250]
-	[251] = 
+	}, -- end of [270]
+	[271] = 
 	{
 		["type"] = "houseA_arm",
 		["name"] = "Building armed",
@@ -6519,8 +7095,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [251]
-	[252] = 
+	}, -- end of [271]
+	[272] = 
 	{
 		["type"] = "Landmine",
 		["name"] = "Landmine",
@@ -6529,8 +7105,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [252]
-	[253] = 
+	}, -- end of [272]
+	[273] = 
 	{
 		["type"] = "Log posts 1",
 		["name"] = "Log posts 1",
@@ -6544,8 +7120,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [253]
-	[254] = 
+	}, -- end of [273]
+	[274] = 
 	{
 		["type"] = "Log posts 2",
 		["name"] = "Log posts 2",
@@ -6559,8 +7135,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [254]
-	[255] = 
+	}, -- end of [274]
+	[275] = 
 	{
 		["type"] = "Log posts 3",
 		["name"] = "Log posts 3",
@@ -6574,8 +7150,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [255]
-	[256] = 
+	}, -- end of [275]
+	[276] = 
 	{
 		["type"] = "Log ramps 1",
 		["name"] = "Log ramps 1",
@@ -6589,8 +7165,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [256]
-	[257] = 
+	}, -- end of [276]
+	[277] = 
 	{
 		["type"] = "Log ramps 2",
 		["name"] = "Log ramps 2",
@@ -6604,8 +7180,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [257]
-	[258] = 
+	}, -- end of [277]
+	[278] = 
 	{
 		["type"] = "Log ramps 3",
 		["name"] = "Log ramps 3",
@@ -6619,8 +7195,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [258]
-	[259] = 
+	}, -- end of [278]
+	[279] = 
 	{
 		["type"] = "Military staff",
 		["name"] = "Military staff",
@@ -6629,8 +7205,38 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [259]
-	[260] = 
+	}, -- end of [279]
+	[280] = 
+	{
+		["type"] = "offshore WindTurbine",
+		["name"] = "offshore Wind Turbine",
+		["category"] = "Fortification",
+		["description"] = "offshore Wind Turbine",
+		["attribute"] = 
+		{
+			[5] = true,
+			[9] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [280]
+	[281] = 
+	{
+		["type"] = "offshore WindTurbine2",
+		["name"] = "offshore Wind Turbine2",
+		["category"] = "Fortification",
+		["description"] = "offshore Wind Turbine2",
+		["attribute"] = 
+		{
+			[5] = true,
+			[9] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [281]
+	[282] = 
 	{
 		["type"] = "Oil derrick",
 		["name"] = "Oil derrick",
@@ -6639,8 +7245,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [260]
-	[261] = 
+	}, -- end of [282]
+	[283] = 
 	{
 		["type"] = "Oil platform",
 		["name"] = "Oil platform",
@@ -6649,8 +7255,23 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [261]
-	[262] = 
+	}, -- end of [283]
+	[284] = 
+	{
+		["type"] = "Orca",
+		["name"] = "Orca Whale",
+		["category"] = "Fortification",
+		["description"] = "Orca Whale",
+		["attribute"] = 
+		{
+			[5] = true,
+			[9] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [284]
+	[285] = 
 	{
 		["type"] = "outpost",
 		["name"] = "Outpost",
@@ -6674,8 +7295,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [262]
-	[263] = 
+	}, -- end of [285]
+	[286] = 
 	{
 		["type"] = "outpost_road",
 		["name"] = "Road outpost",
@@ -6699,8 +7320,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [263]
-	[264] = 
+	}, -- end of [286]
+	[287] = 
 	{
 		["type"] = "Pump station",
 		["name"] = "Pump station",
@@ -6709,8 +7330,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [264]
-	[265] = 
+	}, -- end of [287]
+	[288] = 
 	{
 		["type"] = "Railway crossing A",
 		["name"] = "Railway crossing A",
@@ -6719,8 +7340,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [265]
-	[266] = 
+	}, -- end of [288]
+	[289] = 
 	{
 		["type"] = "Railway crossing B",
 		["name"] = "Railway crossing B",
@@ -6729,8 +7350,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [266]
-	[267] = 
+	}, -- end of [289]
+	[290] = 
 	{
 		["type"] = "Railway station",
 		["name"] = "Railway station",
@@ -6739,8 +7360,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [267]
-	[268] = 
+	}, -- end of [290]
+	[291] = 
 	{
 		["type"] = "Red_Flag",
 		["name"] = "Mark Flag Red",
@@ -6749,8 +7370,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [268]
-	[269] = 
+	}, -- end of [291]
+	[292] = 
 	{
 		["type"] = "Repair workshop",
 		["name"] = "Repair workshop",
@@ -6759,8 +7380,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [269]
-	[270] = 
+	}, -- end of [292]
+	[293] = 
 	{
 		["type"] = "Restaurant 1",
 		["name"] = "Restaurant 1",
@@ -6769,8 +7390,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [270]
-	[271] = 
+	}, -- end of [293]
+	[294] = 
 	{
 		["type"] = "Sandbox",
 		["name"] = "Bunker 1",
@@ -6794,8 +7415,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [271]
-	[272] = 
+	}, -- end of [294]
+	[295] = 
 	{
 		["type"] = "Shelter",
 		["name"] = "Shelter",
@@ -6804,8 +7425,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [272]
-	[273] = 
+	}, -- end of [295]
+	[296] = 
 	{
 		["type"] = "Shelter B",
 		["name"] = "Shelter B",
@@ -6814,8 +7435,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [273]
-	[274] = 
+	}, -- end of [296]
+	[297] = 
 	{
 		["type"] = "Shop",
 		["name"] = "Shop",
@@ -6824,8 +7445,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [274]
-	[275] = 
+	}, -- end of [297]
+	[298] = 
 	{
 		["type"] = "Siegfried Line",
 		["name"] = "Siegfried line",
@@ -6839,8 +7460,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [275]
-	[276] = 
+	}, -- end of [298]
+	[299] = 
 	{
 		["type"] = "SK_C_28_naval_gun",
 		["name"] = "Gun 15cm SK C/28 Naval in Bunker",
@@ -6871,8 +7492,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [276]
-	[277] = 
+	}, -- end of [299]
+	[300] = 
 	{
 		["type"] = "Small house 1A",
 		["name"] = "Small house 1A",
@@ -6881,8 +7502,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [277]
-	[278] = 
+	}, -- end of [300]
+	[301] = 
 	{
 		["type"] = "Small house 1A area",
 		["name"] = "Small house 1A area",
@@ -6891,8 +7512,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [278]
-	[279] = 
+	}, -- end of [301]
+	[302] = 
 	{
 		["type"] = "Small house 1B",
 		["name"] = "Small house 1B",
@@ -6901,8 +7522,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [279]
-	[280] = 
+	}, -- end of [302]
+	[303] = 
 	{
 		["type"] = "Small house 1B area",
 		["name"] = "Small house 1B area",
@@ -6911,8 +7532,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [280]
-	[281] = 
+	}, -- end of [303]
+	[304] = 
 	{
 		["type"] = "Small house 1C area",
 		["name"] = "Small house 1C area",
@@ -6921,8 +7542,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [281]
-	[282] = 
+	}, -- end of [304]
+	[305] = 
 	{
 		["type"] = "Small house 2C",
 		["name"] = "Small house 2C",
@@ -6931,8 +7552,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [282]
-	[283] = 
+	}, -- end of [305]
+	[306] = 
 	{
 		["type"] = "Small werehouse 1",
 		["name"] = "Small warehouse 1",
@@ -6941,8 +7562,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [283]
-	[284] = 
+	}, -- end of [306]
+	[307] = 
 	{
 		["type"] = "Small werehouse 2",
 		["name"] = "Small warehouse 2",
@@ -6951,8 +7572,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [284]
-	[285] = 
+	}, -- end of [307]
+	[308] = 
 	{
 		["type"] = "Small werehouse 3",
 		["name"] = "Small warehouse 3",
@@ -6961,8 +7582,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [285]
-	[286] = 
+	}, -- end of [308]
+	[309] = 
 	{
 		["type"] = "Small werehouse 4",
 		["name"] = "Small warehouse 4",
@@ -6971,8 +7592,38 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [286]
-	[287] = 
+	}, -- end of [309]
+	[310] = 
+	{
+		["type"] = "Small_LightHouse",
+		["name"] = "Small_LightHouse",
+		["category"] = "Fortification",
+		["description"] = "Small_LightHouse",
+		["attribute"] = 
+		{
+			[5] = true,
+			[9] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [310]
+	[311] = 
+	{
+		["type"] = "Stanley_LightHouse",
+		["name"] = "Stanley LightHouse",
+		["category"] = "Fortification",
+		["description"] = "Stanley LightHouse",
+		["attribute"] = 
+		{
+			[5] = true,
+			[9] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [311]
+	[312] = 
 	{
 		["type"] = "Subsidiary structure 1",
 		["name"] = "Subsidiary structure 1",
@@ -6981,8 +7632,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [287]
-	[288] = 
+	}, -- end of [312]
+	[313] = 
 	{
 		["type"] = "Subsidiary structure 2",
 		["name"] = "Subsidiary structure 2",
@@ -6991,8 +7642,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [288]
-	[289] = 
+	}, -- end of [313]
+	[314] = 
 	{
 		["type"] = "Subsidiary structure 3",
 		["name"] = "Subsidiary structure 3",
@@ -7001,8 +7652,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [289]
-	[290] = 
+	}, -- end of [314]
+	[315] = 
 	{
 		["type"] = "Subsidiary structure A",
 		["name"] = "Subsidiary structure A",
@@ -7011,8 +7662,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [290]
-	[291] = 
+	}, -- end of [315]
+	[316] = 
 	{
 		["type"] = "Subsidiary structure B",
 		["name"] = "Subsidiary structure B",
@@ -7021,8 +7672,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [291]
-	[292] = 
+	}, -- end of [316]
+	[317] = 
 	{
 		["type"] = "Subsidiary structure C",
 		["name"] = "Subsidiary structure C",
@@ -7031,8 +7682,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [292]
-	[293] = 
+	}, -- end of [317]
+	[318] = 
 	{
 		["type"] = "Subsidiary structure D",
 		["name"] = "Subsidiary structure D",
@@ -7041,8 +7692,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [293]
-	[294] = 
+	}, -- end of [318]
+	[319] = 
 	{
 		["type"] = "Subsidiary structure E",
 		["name"] = "Subsidiary structure E",
@@ -7051,8 +7702,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [294]
-	[295] = 
+	}, -- end of [319]
+	[320] = 
 	{
 		["type"] = "Subsidiary structure F",
 		["name"] = "Subsidiary structure F",
@@ -7061,8 +7712,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [295]
-	[296] = 
+	}, -- end of [320]
+	[321] = 
 	{
 		["type"] = "Subsidiary structure G",
 		["name"] = "Subsidiary structure G",
@@ -7071,8 +7722,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [296]
-	[297] = 
+	}, -- end of [321]
+	[322] = 
 	{
 		["type"] = "Supermarket A",
 		["name"] = "Supermarket A",
@@ -7081,8 +7732,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [297]
-	[298] = 
+	}, -- end of [322]
+	[323] = 
 	{
 		["type"] = "TACAN_beacon",
 		["name"] = "Beacon TACAN Portable TTS 3030",
@@ -7106,8 +7757,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [298]
-	[299] = 
+	}, -- end of [323]
+	[324] = 
 	{
 		["type"] = "Tech combine",
 		["name"] = "Tech combine",
@@ -7116,8 +7767,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [299]
-	[300] = 
+	}, -- end of [324]
+	[325] = 
 	{
 		["type"] = "Tech hangar A",
 		["name"] = "Tech hangar A",
@@ -7126,8 +7777,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [300]
-	[301] = 
+	}, -- end of [325]
+	[326] = 
 	{
 		["type"] = "Tetrahydra",
 		["name"] = "Tetrahydra",
@@ -7141,8 +7792,23 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [301]
-	[302] = 
+	}, -- end of [326]
+	[327] = 
+	{
+		["type"] = "Tower Crane",
+		["name"] = "TowerCrane",
+		["category"] = "Fortification",
+		["description"] = "TowerCrane",
+		["attribute"] = 
+		{
+			[5] = true,
+			[9] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [327]
+	[328] = 
 	{
 		["type"] = "TV tower",
 		["name"] = "TV tower",
@@ -7151,8 +7817,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [302]
-	[303] = 
+	}, -- end of [328]
+	[329] = 
 	{
 		["type"] = "warning_board_a",
 		["name"] = "Warning Board: Spy Cannot Escape!",
@@ -7166,8 +7832,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [303]
-	[304] = 
+	}, -- end of [329]
+	[330] = 
 	{
 		["type"] = "warning_board_b",
 		["name"] = "Warning Board: Catch Spy!",
@@ -7181,8 +7847,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [304]
-	[305] = 
+	}, -- end of [330]
+	[331] = 
 	{
 		["type"] = "Water tower A",
 		["name"] = "Water tower A",
@@ -7191,8 +7857,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [305]
-	[306] = 
+	}, -- end of [331]
+	[332] = 
 	{
 		["type"] = "WC",
 		["name"] = "WC",
@@ -7201,8 +7867,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [306]
-	[307] = 
+	}, -- end of [332]
+	[333] = 
 	{
 		["type"] = "White_Flag",
 		["name"] = "Mark Flag White",
@@ -7211,8 +7877,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [307]
-	[308] = 
+	}, -- end of [333]
+	[334] = 
 	{
 		["type"] = "White_Tyre",
 		["name"] = "Mark Tyre White",
@@ -7221,8 +7887,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [308]
-	[309] = 
+	}, -- end of [334]
+	[335] = 
 	{
 		["type"] = "Windsock",
 		["name"] = "Windsock",
@@ -7231,8 +7897,38 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [309]
-	[310] = 
+	}, -- end of [335]
+	[336] = 
+	{
+		["type"] = "WindTurbine",
+		["name"] = "Wind Turbine",
+		["category"] = "Fortification",
+		["description"] = "Wind Turbine",
+		["attribute"] = 
+		{
+			[5] = true,
+			[9] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [336]
+	[337] = 
+	{
+		["type"] = "WindTurbine_11",
+		["name"] = "Wind Turbine 11",
+		["category"] = "Fortification",
+		["description"] = "Wind Turbine 11",
+		["attribute"] = 
+		{
+			[5] = true,
+			[9] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [337]
+	[338] = 
 	{
 		["type"] = "Workshop A",
 		["name"] = "Workshop A",
@@ -7241,8 +7937,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [310]
-	[311] = 
+	}, -- end of [338]
+	[339] = 
 	{
 		["type"] = "GrassAirfield",
 		["name"] = "Grass Airfield",
@@ -7251,8 +7947,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [311]
-	[312] = 
+	}, -- end of [339]
+	[340] = 
 	{
 		["type"] = "Bridge",
 		["name"] = "Bridge",
@@ -7261,8 +7957,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [312]
-	[313] = 
+	}, -- end of [340]
+	[341] = 
 	{
 		["type"] = "Building",
 		["name"] = "Building",
@@ -7271,8 +7967,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [313]
-	[314] = 
+	}, -- end of [341]
+	[342] = 
 	{
 		["type"] = "Train",
 		["name"] = "Train",
@@ -7281,8 +7977,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [314]
-	[315] = 
+	}, -- end of [342]
+	[343] = 
 	{
 		["type"] = "Transport",
 		["name"] = "Transport",
@@ -7291,8 +7987,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [315]
-	[316] = 
+	}, -- end of [343]
+	[344] = 
 	{
 		["air"] = true,
 		["type"] = "AH-1W",
@@ -7315,8 +8011,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [316]
-	[317] = 
+	}, -- end of [344]
+	[345] = 
 	{
 		["air"] = true,
 		["type"] = "AH-64A",
@@ -7339,8 +8035,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [317]
-	[318] = 
+	}, -- end of [345]
+	[346] = 
 	{
 		["air"] = true,
 		["type"] = "AH-64D",
@@ -7363,8 +8059,32 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [318]
-	[319] = 
+	}, -- end of [346]
+	[347] = 
+	{
+		["air"] = true,
+		["type"] = "AH-64D_BLK_II",
+		["name"] = "AH-64D BLK.II",
+		["category"] = "Helicopter",
+		["description"] = "AH-64D BLK.II",
+		["attribute"] = 
+		{
+			[1] = true,
+			[2] = true,
+			[6] = true,
+			["Air"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			[300] = true,
+			["NonArmoredUnits"] = true,
+			["All"] = true,
+			["Helicopters"] = true,
+			["Attack helicopters"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [347]
+	[348] = 
 	{
 		["air"] = true,
 		["type"] = "CH-47D",
@@ -7387,8 +8107,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [319]
-	[320] = 
+	}, -- end of [348]
+	[349] = 
 	{
 		["air"] = true,
 		["type"] = "CH-53E",
@@ -7411,8 +8131,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [320]
-	[321] = 
+	}, -- end of [349]
+	[350] = 
 	{
 		["air"] = true,
 		["type"] = "Ka-27",
@@ -7435,8 +8155,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [321]
-	[322] = 
+	}, -- end of [350]
+	[351] = 
 	{
 		["air"] = true,
 		["type"] = "Ka-50",
@@ -7459,8 +8179,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [322]
-	[323] = 
+	}, -- end of [351]
+	[352] = 
 	{
 		["air"] = true,
 		["type"] = "Mi-24P",
@@ -7483,8 +8203,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [323]
-	[324] = 
+	}, -- end of [352]
+	[353] = 
 	{
 		["air"] = true,
 		["type"] = "Mi-24V",
@@ -7507,8 +8227,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [324]
-	[325] = 
+	}, -- end of [353]
+	[354] = 
 	{
 		["air"] = true,
 		["type"] = "Mi-26",
@@ -7531,8 +8251,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [325]
-	[326] = 
+	}, -- end of [354]
+	[355] = 
 	{
 		["air"] = true,
 		["type"] = "Mi-28N",
@@ -7555,8 +8275,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [326]
-	[327] = 
+	}, -- end of [355]
+	[356] = 
 	{
 		["air"] = true,
 		["type"] = "Mi-8MT",
@@ -7579,8 +8299,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [327]
-	[328] = 
+	}, -- end of [356]
+	[357] = 
 	{
 		["air"] = true,
 		["type"] = "OH-58D",
@@ -7603,8 +8323,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [328]
-	[329] = 
+	}, -- end of [357]
+	[358] = 
 	{
 		["air"] = true,
 		["type"] = "SA342L",
@@ -7627,8 +8347,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [329]
-	[330] = 
+	}, -- end of [358]
+	[359] = 
 	{
 		["air"] = true,
 		["type"] = "SA342M",
@@ -7651,8 +8371,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [330]
-	[331] = 
+	}, -- end of [359]
+	[360] = 
 	{
 		["air"] = true,
 		["type"] = "SA342Minigun",
@@ -7675,8 +8395,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [331]
-	[332] = 
+	}, -- end of [360]
+	[361] = 
 	{
 		["air"] = true,
 		["type"] = "SA342Mistral",
@@ -7699,8 +8419,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [332]
-	[333] = 
+	}, -- end of [361]
+	[362] = 
 	{
 		["air"] = true,
 		["type"] = "SH-3W",
@@ -7723,8 +8443,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [333]
-	[334] = 
+	}, -- end of [362]
+	[363] = 
 	{
 		["air"] = true,
 		["type"] = "SH-60B",
@@ -7747,8 +8467,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [334]
-	[335] = 
+	}, -- end of [363]
+	[364] = 
 	{
 		["air"] = true,
 		["type"] = "UH-1H",
@@ -7771,8 +8491,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [335]
-	[336] = 
+	}, -- end of [364]
+	[365] = 
 	{
 		["air"] = true,
 		["type"] = "UH-60A",
@@ -7795,8 +8515,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [336]
-	[337] = 
+	}, -- end of [365]
+	[366] = 
 	{
 		["type"] = "FARP",
 		["name"] = "FARP",
@@ -7805,8 +8525,23 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [337]
-	[338] = 
+	}, -- end of [366]
+	[367] = 
+	{
+		["type"] = "FARP_SINGLE_01",
+		["name"] = "PAD Single",
+		["category"] = "Heliport",
+		["description"] = "PAD Single",
+		["attribute"] = 
+		{
+			[5] = true,
+			[9] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [367]
+	[368] = 
 	{
 		["type"] = "Gas platform",
 		["name"] = "Gas platform",
@@ -7820,8 +8555,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [338]
-	[339] = 
+	}, -- end of [368]
+	[369] = 
 	{
 		["type"] = "Invisible FARP",
 		["name"] = "Invisible FARP",
@@ -7835,8 +8570,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [339]
-	[340] = 
+	}, -- end of [369]
+	[370] = 
 	{
 		["type"] = "Oil rig",
 		["name"] = "Oil rig",
@@ -7850,8 +8585,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [340]
-	[341] = 
+	}, -- end of [370]
+	[371] = 
 	{
 		["type"] = "SINGLE_HELIPAD",
 		["name"] = "Helipad Single",
@@ -7860,14 +8595,14 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [341]
-	[342] = 
+	}, -- end of [371]
+	[372] = 
 	{
 		["type"] = "Infantry AK",
-		["name"] = "Infantry AK-74 Rus",
+		["name"] = "Infantry AK-74 Rus ver1",
 		["category"] = "Infantry",
 		["infantry"] = true,
-		["description"] = "Infantry AK-74 Rus",
+		["description"] = "Infantry AK-74 Rus ver1",
 		["attribute"] = 
 		{
 			["Infantry"] = true,
@@ -7888,8 +8623,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [342]
-	[343] = 
+	}, -- end of [372]
+	[373] = 
 	{
 		["type"] = "Infantry AK Ins",
 		["name"] = "Insurgent AK-74",
@@ -7916,8 +8651,64 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [343]
-	[344] = 
+	}, -- end of [373]
+	[374] = 
+	{
+		["type"] = "Infantry AK ver2",
+		["name"] = "Infantry AK-74 Rus ver2",
+		["category"] = "Infantry",
+		["infantry"] = true,
+		["description"] = "Infantry AK-74 Rus ver2",
+		["attribute"] = 
+		{
+			["Infantry"] = true,
+			[26] = true,
+			[2] = true,
+			["NonArmoredUnits"] = true,
+			["CustomAimPoint"] = true,
+			["Skeleton_type_A"] = true,
+			[90] = true,
+			["New infantry"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["Ground Units Non Airdefence"] = true,
+			["Armed ground units"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			[17] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [374]
+	[375] = 
+	{
+		["type"] = "Infantry AK ver3",
+		["name"] = "Infantry AK-74 Rus ver3",
+		["category"] = "Infantry",
+		["infantry"] = true,
+		["description"] = "Infantry AK-74 Rus ver3",
+		["attribute"] = 
+		{
+			["Infantry"] = true,
+			[26] = true,
+			[2] = true,
+			["NonArmoredUnits"] = true,
+			["CustomAimPoint"] = true,
+			["Skeleton_type_A"] = true,
+			[90] = true,
+			["New infantry"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["Ground Units Non Airdefence"] = true,
+			["Armed ground units"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			[17] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [375]
+	[376] = 
 	{
 		["type"] = "Paratrooper AKS-74",
 		["name"] = "Paratrooper AKS",
@@ -7942,8 +8733,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [344]
-	[345] = 
+	}, -- end of [376]
+	[377] = 
 	{
 		["type"] = "Paratrooper RPG-16",
 		["name"] = "Paratrooper RPG-16",
@@ -7968,8 +8759,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [345]
-	[346] = 
+	}, -- end of [377]
+	[378] = 
 	{
 		["type"] = "Soldier AK",
 		["name"] = "Infantry AK-74",
@@ -7994,8 +8785,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [346]
-	[347] = 
+	}, -- end of [378]
+	[379] = 
 	{
 		["type"] = "Soldier M249",
 		["name"] = "Infantry M249",
@@ -8021,8 +8812,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [347]
-	[348] = 
+	}, -- end of [379]
+	[380] = 
 	{
 		["type"] = "Soldier M4",
 		["name"] = "Infantry M4",
@@ -8047,8 +8838,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [348]
-	[349] = 
+	}, -- end of [380]
+	[381] = 
 	{
 		["type"] = "Soldier M4 GRG",
 		["name"] = "Infantry M4 Georgia",
@@ -8074,8 +8865,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [349]
-	[350] = 
+	}, -- end of [381]
+	[382] = 
 	{
 		["type"] = "Soldier RPG",
 		["name"] = "Infantry RPG",
@@ -8100,8 +8891,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [350]
-	[351] = 
+	}, -- end of [382]
+	[383] = 
 	{
 		["type"] = "soldier_mauser98",
 		["name"] = "Infantry Mauser 98",
@@ -8128,8 +8919,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [351]
-	[352] = 
+	}, -- end of [383]
+	[384] = 
 	{
 		["type"] = "soldier_wwii_br_01",
 		["name"] = "Infantry SMLE No.4 Mk-1",
@@ -8156,8 +8947,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [352]
-	[353] = 
+	}, -- end of [384]
+	[385] = 
 	{
 		["type"] = "soldier_wwii_us",
 		["name"] = "Infantry M1 Garand",
@@ -8184,8 +8975,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [353]
-	[354] = 
+	}, -- end of [385]
+	[386] = 
 	{
 		["type"] = "DRG_Class_86",
 		["name"] = "Loco DRG Class 86",
@@ -8211,8 +9002,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [354]
-	[355] = 
+	}, -- end of [386]
+	[387] = 
 	{
 		["type"] = "Electric locomotive",
 		["name"] = "Loco VL80 Electric",
@@ -8237,8 +9028,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [355]
-	[356] = 
+	}, -- end of [387]
+	[388] = 
 	{
 		["type"] = "ES44AH",
 		["name"] = "Loco ES44AH",
@@ -8264,8 +9055,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [356]
-	[357] = 
+	}, -- end of [388]
+	[389] = 
 	{
 		["type"] = "Locomotive",
 		["name"] = "Loco CHME3T",
@@ -8291,8 +9082,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [357]
-	[358] = 
+	}, -- end of [389]
+	[390] = 
 	{
 		["type"] = "hy_launcher",
 		["name"] = "AShM SS-N-2 Silkworm",
@@ -8321,8 +9112,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [358]
-	[359] = 
+	}, -- end of [390]
+	[391] = 
 	{
 		["type"] = "Scud_B",
 		["name"] = "SSM SS-1C Scud-B",
@@ -8352,8 +9143,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [359]
-	[360] = 
+	}, -- end of [391]
+	[392] = 
 	{
 		["type"] = "Silkworm_SR",
 		["name"] = "AShM Silkworm SR",
@@ -8382,13 +9173,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [360]
-	[361] = 
+	}, -- end of [392]
+	[393] = 
 	{
 		["type"] = "v1_launcher",
-		["name"] = "SSM V-1 Launcher",
+		["name"] = "V-1 Launch Ramp",
 		["category"] = "MissilesSS",
-		["description"] = "SSM V-1 Launcher",
+		["description"] = "V-1 Launch Ramp",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -8412,8 +9203,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [361]
-	[362] = 
+	}, -- end of [393]
+	[394] = 
 	{
 		["type"] = "Carrier Airboss",
 		["name"] = "Carrier Airboss",
@@ -8427,8 +9218,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [362]
-	[363] = 
+	}, -- end of [394]
+	[395] = 
 	{
 		["type"] = "Carrier LSO Personell",
 		["name"] = "Carrier LSO 1",
@@ -8442,8 +9233,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [363]
-	[364] = 
+	}, -- end of [395]
+	[396] = 
 	{
 		["type"] = "Carrier LSO Personell 1",
 		["name"] = "Carrier LSO 2",
@@ -8457,8 +9248,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [364]
-	[365] = 
+	}, -- end of [396]
+	[397] = 
 	{
 		["type"] = "Carrier LSO Personell 2",
 		["name"] = "Carrier LSO 3",
@@ -8472,8 +9263,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [365]
-	[366] = 
+	}, -- end of [397]
+	[398] = 
 	{
 		["type"] = "Carrier LSO Personell 3",
 		["name"] = "Carrier LSO 4",
@@ -8487,8 +9278,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [366]
-	[367] = 
+	}, -- end of [398]
+	[399] = 
 	{
 		["type"] = "Carrier LSO Personell 4",
 		["name"] = "Carrier LSO 5",
@@ -8502,8 +9293,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [367]
-	[368] = 
+	}, -- end of [399]
+	[400] = 
 	{
 		["type"] = "Carrier LSO Personell 5",
 		["name"] = "Carrier LSO 6",
@@ -8517,8 +9308,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [368]
-	[369] = 
+	}, -- end of [400]
+	[401] = 
 	{
 		["type"] = "Carrier Seaman",
 		["name"] = "Carrier Seaman",
@@ -8532,8 +9323,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [369]
-	[370] = 
+	}, -- end of [401]
+	[402] = 
 	{
 		["type"] = "us carrier shooter",
 		["name"] = "Carrier Shooter",
@@ -8547,8 +9338,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [370]
-	[371] = 
+	}, -- end of [402]
+	[403] = 
 	{
 		["type"] = "us carrier tech",
 		["name"] = "Carrier Technician",
@@ -8562,8 +9353,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [371]
-	[372] = 
+	}, -- end of [403]
+	[404] = 
 	{
 		["air"] = true,
 		["type"] = "A-10A",
@@ -8587,8 +9378,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [372]
-	[373] = 
+	}, -- end of [404]
+	[405] = 
 	{
 		["air"] = true,
 		["type"] = "A-10C",
@@ -8614,8 +9405,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [373]
-	[374] = 
+	}, -- end of [405]
+	[406] = 
 	{
 		["air"] = true,
 		["type"] = "A-10C_2",
@@ -8641,8 +9432,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [374]
-	[375] = 
+	}, -- end of [406]
+	[407] = 
 	{
 		["air"] = true,
 		["type"] = "A-20G",
@@ -8666,8 +9457,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [375]
-	[376] = 
+	}, -- end of [407]
+	[408] = 
 	{
 		["air"] = true,
 		["type"] = "A-4E-C",
@@ -8678,20 +9469,20 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = true,
 			["Air"] = true,
-			["NonArmoredUnits"] = true,
+			["Refuelable"] = true,
 			["Multirole fighters"] = true,
 			["Battle airplanes"] = true,
 			["NonAndLightArmoredUnits"] = true,
-			[297] = true,
+			[301] = true,
 			["All"] = true,
 			["Planes"] = true,
-			["Refuelable"] = true,
+			["NonArmoredUnits"] = true,
 		}, -- end of ["attribute"]
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [376]
-	[377] = 
+	}, -- end of [408]
+	[409] = 
 	{
 		["air"] = true,
 		["type"] = "A-50",
@@ -8714,8 +9505,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [377]
-	[378] = 
+	}, -- end of [409]
+	[410] = 
 	{
 		["air"] = true,
 		["type"] = "AJS37",
@@ -8737,8 +9528,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [378]
-	[379] = 
+	}, -- end of [410]
+	[411] = 
 	{
 		["air"] = true,
 		["type"] = "An-26B",
@@ -8760,8 +9551,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [379]
-	[380] = 
+	}, -- end of [411]
+	[412] = 
 	{
 		["air"] = true,
 		["type"] = "An-30M",
@@ -8783,8 +9574,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [380]
-	[381] = 
+	}, -- end of [412]
+	[413] = 
 	{
 		["air"] = true,
 		["type"] = "AV8BNA",
@@ -8808,8 +9599,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [381]
-	[382] = 
+	}, -- end of [413]
+	[414] = 
 	{
 		["air"] = true,
 		["type"] = "B-17G",
@@ -8833,8 +9624,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [382]
-	[383] = 
+	}, -- end of [414]
+	[415] = 
 	{
 		["air"] = true,
 		["type"] = "B-1B",
@@ -8861,8 +9652,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [383]
-	[384] = 
+	}, -- end of [415]
+	[416] = 
 	{
 		["air"] = true,
 		["type"] = "B-52H",
@@ -8889,8 +9680,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [384]
-	[385] = 
+	}, -- end of [416]
+	[417] = 
 	{
 		["air"] = true,
 		["type"] = "Bf-109K-4",
@@ -8912,8 +9703,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [385]
-	[386] = 
+	}, -- end of [417]
+	[418] = 
 	{
 		["air"] = true,
 		["type"] = "C-101CC",
@@ -8936,8 +9727,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [386]
-	[387] = 
+	}, -- end of [418]
+	[419] = 
 	{
 		["air"] = true,
 		["type"] = "C-101EB",
@@ -8960,8 +9751,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [387]
-	[388] = 
+	}, -- end of [419]
+	[420] = 
 	{
 		["air"] = true,
 		["type"] = "C-130",
@@ -8983,8 +9774,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [388]
-	[389] = 
+	}, -- end of [420]
+	[421] = 
 	{
 		["air"] = true,
 		["type"] = "C-17A",
@@ -9007,8 +9798,31 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [389]
-	[390] = 
+	}, -- end of [421]
+	[422] = 
+	{
+		["air"] = true,
+		["type"] = "C-47",
+		["name"] = "C-47",
+		["category"] = "Plane",
+		["description"] = "C-47",
+		["attribute"] = 
+		{
+			[1] = true,
+			["Air"] = true,
+			["Planes"] = true,
+			[299] = true,
+			["NonArmoredUnits"] = true,
+			["Transports"] = true,
+			["All"] = true,
+			[5] = true,
+			["NonAndLightArmoredUnits"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [422]
+	[423] = 
 	{
 		["air"] = true,
 		["type"] = "Christen Eagle II",
@@ -9030,8 +9844,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [390]
-	[391] = 
+	}, -- end of [423]
+	[424] = 
 	{
 		["air"] = true,
 		["type"] = "E-2C",
@@ -9055,8 +9869,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [391]
-	[392] = 
+	}, -- end of [424]
+	[425] = 
 	{
 		["air"] = true,
 		["type"] = "E-3A",
@@ -9081,8 +9895,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [392]
-	[393] = 
+	}, -- end of [425]
+	[426] = 
 	{
 		["air"] = true,
 		["type"] = "F-117A",
@@ -9106,8 +9920,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [393]
-	[394] = 
+	}, -- end of [426]
+	[427] = 
 	{
 		["air"] = true,
 		["type"] = "F-14A",
@@ -9130,8 +9944,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [394]
-	[395] = 
+	}, -- end of [427]
+	[428] = 
 	{
 		["air"] = true,
 		["type"] = "F-14A-135-GR",
@@ -9155,8 +9969,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [395]
-	[396] = 
+	}, -- end of [428]
+	[429] = 
 	{
 		["air"] = true,
 		["type"] = "F-14B",
@@ -9180,8 +9994,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [396]
-	[397] = 
+	}, -- end of [429]
+	[430] = 
 	{
 		["air"] = true,
 		["type"] = "F-15C",
@@ -9206,8 +10020,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [397]
-	[398] = 
+	}, -- end of [430]
+	[431] = 
 	{
 		["air"] = true,
 		["type"] = "F-15E",
@@ -9232,8 +10046,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [398]
-	[399] = 
+	}, -- end of [431]
+	[432] = 
 	{
 		["air"] = true,
 		["type"] = "F-16A",
@@ -9256,8 +10070,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [399]
-	[400] = 
+	}, -- end of [432]
+	[433] = 
 	{
 		["air"] = true,
 		["type"] = "F-16A MLU",
@@ -9280,8 +10094,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [400]
-	[401] = 
+	}, -- end of [433]
+	[434] = 
 	{
 		["air"] = true,
 		["type"] = "F-16C bl.50",
@@ -9306,8 +10120,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [401]
-	[402] = 
+	}, -- end of [434]
+	[435] = 
 	{
 		["air"] = true,
 		["type"] = "F-16C bl.52d",
@@ -9332,8 +10146,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [402]
-	[403] = 
+	}, -- end of [435]
+	[436] = 
 	{
 		["air"] = true,
 		["type"] = "F-16C_50",
@@ -9358,8 +10172,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [403]
-	[404] = 
+	}, -- end of [436]
+	[437] = 
 	{
 		["air"] = true,
 		["type"] = "F-4E",
@@ -9381,8 +10195,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [404]
-	[405] = 
+	}, -- end of [437]
+	[438] = 
 	{
 		["air"] = true,
 		["type"] = "F-5E",
@@ -9404,8 +10218,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [405]
-	[406] = 
+	}, -- end of [438]
+	[439] = 
 	{
 		["air"] = true,
 		["type"] = "F-5E-3",
@@ -9427,8 +10241,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [406]
-	[407] = 
+	}, -- end of [439]
+	[440] = 
 	{
 		["air"] = true,
 		["type"] = "F-86F Sabre",
@@ -9450,8 +10264,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [407]
-	[408] = 
+	}, -- end of [440]
+	[441] = 
 	{
 		["air"] = true,
 		["type"] = "F/A-18A",
@@ -9474,8 +10288,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [408]
-	[409] = 
+	}, -- end of [441]
+	[442] = 
 	{
 		["air"] = true,
 		["type"] = "F/A-18C",
@@ -9500,8 +10314,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [409]
-	[410] = 
+	}, -- end of [442]
+	[443] = 
 	{
 		["air"] = true,
 		["type"] = "FA-18C_hornet",
@@ -9511,23 +10325,25 @@ dcsUnits.DcsUnitsDatabase =
 		["attribute"] = 
 		{
 			[1] = true,
-			["Air"] = true,
+			["Link4"] = true,
 			["Refuelable"] = true,
-			[280] = true,
+			["ACLS"] = true,
 			["Link16"] = true,
 			["Multirole fighters"] = true,
+			["Planes"] = true,
 			["Battle airplanes"] = true,
 			["NonAndLightArmoredUnits"] = true,
-			["Planes"] = true,
+			["Air"] = true,
+			["NonArmoredUnits"] = true,
 			["All"] = true,
 			["Datalink"] = true,
-			["NonArmoredUnits"] = true,
+			[280] = true,
 		}, -- end of ["attribute"]
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [410]
-	[411] = 
+	}, -- end of [443]
+	[444] = 
 	{
 		["air"] = true,
 		["type"] = "FW-190A8",
@@ -9549,8 +10365,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [411]
-	[412] = 
+	}, -- end of [444]
+	[445] = 
 	{
 		["air"] = true,
 		["type"] = "FW-190D9",
@@ -9572,8 +10388,34 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [412]
-	[413] = 
+	}, -- end of [445]
+	[446] = 
+	{
+		["air"] = true,
+		["type"] = "H-6J",
+		["name"] = "H-6J",
+		["category"] = "Plane",
+		["description"] = "H-6J",
+		["attribute"] = 
+		{
+			[1] = true,
+			[2] = true,
+			["Air"] = true,
+			["NonArmoredUnits"] = true,
+			["Strategic bombers"] = true,
+			[298] = true,
+			["Battle airplanes"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["Bombers"] = true,
+			["All"] = true,
+			["Datalink"] = true,
+			["Planes"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [446]
+	[447] = 
 	{
 		["air"] = true,
 		["type"] = "Hawk",
@@ -9595,31 +10437,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [413]
-	[414] = 
-	{
-		["air"] = true,
-		["type"] = "Hercules",
-		["name"] = "Hercules",
-		["category"] = "Plane",
-		["description"] = "Hercules",
-		["attribute"] = 
-		{
-			[1] = true,
-			["Air"] = true,
-			[298] = true,
-			["NonAndLightArmoredUnits"] = true,
-			["Planes"] = true,
-			["Transports"] = true,
-			["All"] = true,
-			[5] = true,
-			["NonArmoredUnits"] = true,
-		}, -- end of ["attribute"]
-		["aliases"] = 
-		{
-		}, -- end of ["aliases"]
-	}, -- end of [414]
-	[415] = 
+	}, -- end of [447]
+	[448] = 
 	{
 		["air"] = true,
 		["type"] = "I-16",
@@ -9641,8 +10460,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [415]
-	[416] = 
+	}, -- end of [448]
+	[449] = 
 	{
 		["air"] = true,
 		["type"] = "IL-76MD",
@@ -9664,14 +10483,14 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [416]
-	[417] = 
+	}, -- end of [449]
+	[450] = 
 	{
 		["air"] = true,
 		["type"] = "IL-78M",
-		["name"] = "IL-78M",
+		["name"] = "IL-78M Tanker",
 		["category"] = "Plane",
-		["description"] = "IL-78M",
+		["description"] = "IL-78M Tanker",
 		["attribute"] = 
 		{
 			[1] = true,
@@ -9687,8 +10506,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [417]
-	[418] = 
+	}, -- end of [450]
+	[451] = 
 	{
 		["air"] = true,
 		["type"] = "J-11A",
@@ -9710,8 +10529,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [418]
-	[419] = 
+	}, -- end of [451]
+	[452] = 
 	{
 		["air"] = true,
 		["type"] = "JF-17",
@@ -9736,8 +10555,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [419]
-	[420] = 
+	}, -- end of [452]
+	[453] = 
 	{
 		["air"] = true,
 		["type"] = "Ju-88A4",
@@ -9761,8 +10580,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [420]
-	[421] = 
+	}, -- end of [453]
+	[454] = 
 	{
 		["air"] = true,
 		["type"] = "KC-135",
@@ -9785,8 +10604,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [421]
-	[422] = 
+	}, -- end of [454]
+	[455] = 
 	{
 		["air"] = true,
 		["type"] = "KC130",
@@ -9809,14 +10628,14 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [422]
-	[423] = 
+	}, -- end of [455]
+	[456] = 
 	{
 		["air"] = true,
 		["type"] = "KC135MPRS",
-		["name"] = "KC-135MPRS",
+		["name"] = "KC-135MPRS Tanker",
 		["category"] = "Plane",
-		["description"] = "KC-135MPRS",
+		["description"] = "KC-135MPRS Tanker",
 		["attribute"] = 
 		{
 			[1] = true,
@@ -9833,8 +10652,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [423]
-	[424] = 
+	}, -- end of [456]
+	[457] = 
 	{
 		["air"] = true,
 		["type"] = "KJ-2000",
@@ -9858,8 +10677,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [424]
-	[425] = 
+	}, -- end of [457]
+	[458] = 
 	{
 		["air"] = true,
 		["type"] = "L-39C",
@@ -9882,8 +10701,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [425]
-	[426] = 
+	}, -- end of [458]
+	[459] = 
 	{
 		["air"] = true,
 		["type"] = "L-39ZA",
@@ -9906,8 +10725,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [426]
-	[427] = 
+	}, -- end of [459]
+	[460] = 
 	{
 		["air"] = true,
 		["type"] = "M-2000C",
@@ -9930,8 +10749,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [427]
-	[428] = 
+	}, -- end of [460]
+	[461] = 
 	{
 		["air"] = true,
 		["type"] = "MiG-15bis",
@@ -9953,8 +10772,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [428]
-	[429] = 
+	}, -- end of [461]
+	[462] = 
 	{
 		["air"] = true,
 		["type"] = "MiG-19P",
@@ -9976,8 +10795,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [429]
-	[430] = 
+	}, -- end of [462]
+	[463] = 
 	{
 		["air"] = true,
 		["type"] = "MiG-21Bis",
@@ -9999,8 +10818,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [430]
-	[431] = 
+	}, -- end of [463]
+	[464] = 
 	{
 		["air"] = true,
 		["type"] = "MiG-23MLD",
@@ -10021,8 +10840,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [431]
-	[432] = 
+	}, -- end of [464]
+	[465] = 
 	{
 		["air"] = true,
 		["type"] = "MiG-25PD",
@@ -10045,8 +10864,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [432]
-	[433] = 
+	}, -- end of [465]
+	[466] = 
 	{
 		["air"] = true,
 		["type"] = "MiG-25RBT",
@@ -10068,8 +10887,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [433]
-	[434] = 
+	}, -- end of [466]
+	[467] = 
 	{
 		["air"] = true,
 		["type"] = "MiG-27K",
@@ -10091,8 +10910,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [434]
-	[435] = 
+	}, -- end of [467]
+	[468] = 
 	{
 		["air"] = true,
 		["type"] = "MiG-29A",
@@ -10114,8 +10933,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [435]
-	[436] = 
+	}, -- end of [468]
+	[469] = 
 	{
 		["air"] = true,
 		["type"] = "MiG-29G",
@@ -10137,8 +10956,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [436]
-	[437] = 
+	}, -- end of [469]
+	[470] = 
 	{
 		["air"] = true,
 		["type"] = "MiG-29S",
@@ -10160,8 +10979,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [437]
-	[438] = 
+	}, -- end of [470]
+	[471] = 
 	{
 		["air"] = true,
 		["type"] = "MiG-31",
@@ -10185,8 +11004,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [438]
-	[439] = 
+	}, -- end of [471]
+	[472] = 
 	{
 		["air"] = true,
 		["type"] = "Mirage 2000-5",
@@ -10211,8 +11030,32 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [439]
-	[440] = 
+	}, -- end of [472]
+	[473] = 
+	{
+		["air"] = true,
+		["type"] = "MosquitoFBMkVI",
+		["name"] = "Mosquito FB Mk. VI",
+		["category"] = "Plane",
+		["description"] = "Mosquito FB Mk. VI",
+		["attribute"] = 
+		{
+			[1] = true,
+			["Air"] = true,
+			["Battleplanes"] = true,
+			["NonArmoredUnits"] = true,
+			[4] = true,
+			[297] = true,
+			["Battle airplanes"] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["All"] = true,
+			["Planes"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [473]
+	[474] = 
 	{
 		["air"] = true,
 		["type"] = "MQ-9 Reaper",
@@ -10235,8 +11078,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [440]
-	[441] = 
+	}, -- end of [474]
+	[475] = 
 	{
 		["air"] = true,
 		["type"] = "P-47D-30",
@@ -10258,8 +11101,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [441]
-	[442] = 
+	}, -- end of [475]
+	[476] = 
 	{
 		["air"] = true,
 		["type"] = "P-47D-30bl1",
@@ -10281,8 +11124,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [442]
-	[443] = 
+	}, -- end of [476]
+	[477] = 
 	{
 		["air"] = true,
 		["type"] = "P-47D-40",
@@ -10304,8 +11147,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [443]
-	[444] = 
+	}, -- end of [477]
+	[478] = 
 	{
 		["air"] = true,
 		["type"] = "P-51D",
@@ -10327,8 +11170,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [444]
-	[445] = 
+	}, -- end of [478]
+	[479] = 
 	{
 		["air"] = true,
 		["type"] = "P-51D-30-NA",
@@ -10350,8 +11193,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [445]
-	[446] = 
+	}, -- end of [479]
+	[480] = 
 	{
 		["air"] = true,
 		["type"] = "RQ-1A Predator",
@@ -10373,8 +11216,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [446]
-	[447] = 
+	}, -- end of [480]
+	[481] = 
 	{
 		["air"] = true,
 		["type"] = "S-3B",
@@ -10396,8 +11239,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [447]
-	[448] = 
+	}, -- end of [481]
+	[482] = 
 	{
 		["air"] = true,
 		["type"] = "S-3B Tanker",
@@ -10421,8 +11264,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [448]
-	[449] = 
+	}, -- end of [482]
+	[483] = 
 	{
 		["air"] = true,
 		["type"] = "SpitfireLFMkIX",
@@ -10444,8 +11287,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [449]
-	[450] = 
+	}, -- end of [483]
+	[484] = 
 	{
 		["air"] = true,
 		["type"] = "SpitfireLFMkIXCW",
@@ -10467,8 +11310,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [450]
-	[451] = 
+	}, -- end of [484]
+	[485] = 
 	{
 		["air"] = true,
 		["type"] = "Su-17M4",
@@ -10490,8 +11333,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [451]
-	[452] = 
+	}, -- end of [485]
+	[486] = 
 	{
 		["air"] = true,
 		["type"] = "Su-24M",
@@ -10514,8 +11357,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [452]
-	[453] = 
+	}, -- end of [486]
+	[487] = 
 	{
 		["air"] = true,
 		["type"] = "Su-24MR",
@@ -10537,8 +11380,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [453]
-	[454] = 
+	}, -- end of [487]
+	[488] = 
 	{
 		["air"] = true,
 		["type"] = "Su-25",
@@ -10561,8 +11404,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [454]
-	[455] = 
+	}, -- end of [488]
+	[489] = 
 	{
 		["air"] = true,
 		["type"] = "Su-25T",
@@ -10585,8 +11428,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [455]
-	[456] = 
+	}, -- end of [489]
+	[490] = 
 	{
 		["air"] = true,
 		["type"] = "Su-25TM",
@@ -10609,8 +11452,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [456]
-	[457] = 
+	}, -- end of [490]
+	[491] = 
 	{
 		["air"] = true,
 		["type"] = "Su-27",
@@ -10632,8 +11475,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [457]
-	[458] = 
+	}, -- end of [491]
+	[492] = 
 	{
 		["air"] = true,
 		["type"] = "Su-30",
@@ -10655,8 +11498,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [458]
-	[459] = 
+	}, -- end of [492]
+	[493] = 
 	{
 		["air"] = true,
 		["type"] = "Su-33",
@@ -10679,8 +11522,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [459]
-	[460] = 
+	}, -- end of [493]
+	[494] = 
 	{
 		["air"] = true,
 		["type"] = "Su-34",
@@ -10703,32 +11546,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [460]
-	[461] = 
-	{
-		["air"] = true,
-		["type"] = "T-45",
-		["name"] = "T-45",
-		["category"] = "Plane",
-		["description"] = "T-45",
-		["attribute"] = 
-		{
-			[1] = true,
-			["Air"] = true,
-			["Fighters"] = true,
-			["NonArmoredUnits"] = true,
-			[299] = true,
-			["NonAndLightArmoredUnits"] = true,
-			["Battle airplanes"] = true,
-			["All"] = true,
-			["Planes"] = true,
-			["Refuelable"] = true,
-		}, -- end of ["attribute"]
-		["aliases"] = 
-		{
-		}, -- end of ["aliases"]
-	}, -- end of [461]
-	[462] = 
+	}, -- end of [494]
+	[495] = 
 	{
 		["air"] = true,
 		["type"] = "TF-51D",
@@ -10750,8 +11569,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [462]
-	[463] = 
+	}, -- end of [495]
+	[496] = 
 	{
 		["air"] = true,
 		["type"] = "Tornado GR4",
@@ -10777,8 +11596,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "Tornado GR3",
 		}, -- end of ["aliases"]
-	}, -- end of [463]
-	[464] = 
+	}, -- end of [496]
+	[497] = 
 	{
 		["air"] = true,
 		["type"] = "Tornado IDS",
@@ -10789,21 +11608,22 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = true,
 			["Air"] = true,
-			["NonArmoredUnits"] = true,
+			["Refuelable"] = true,
 			[56] = true,
 			["Link16"] = true,
 			["Battle airplanes"] = true,
-			["NonAndLightArmoredUnits"] = true,
+			["Bombers"] = true,
 			["Planes"] = true,
+			["NonArmoredUnits"] = true,
 			["All"] = true,
 			["Datalink"] = true,
-			["Bombers"] = true,
+			["NonAndLightArmoredUnits"] = true,
 		}, -- end of ["attribute"]
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [464]
-	[465] = 
+	}, -- end of [497]
+	[498] = 
 	{
 		["air"] = true,
 		["type"] = "Tu-142",
@@ -10828,8 +11648,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [465]
-	[466] = 
+	}, -- end of [498]
+	[499] = 
 	{
 		["air"] = true,
 		["type"] = "Tu-160",
@@ -10854,8 +11674,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [466]
-	[467] = 
+	}, -- end of [499]
+	[500] = 
 	{
 		["air"] = true,
 		["type"] = "Tu-22M3",
@@ -10878,8 +11698,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [467]
-	[468] = 
+	}, -- end of [500]
+	[501] = 
 	{
 		["air"] = true,
 		["type"] = "Tu-95MS",
@@ -10904,8 +11724,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [468]
-	[469] = 
+	}, -- end of [501]
+	[502] = 
 	{
 		["air"] = true,
 		["type"] = "WingLoong-I",
@@ -10928,8 +11748,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [469]
-	[470] = 
+	}, -- end of [502]
+	[503] = 
 	{
 		["air"] = true,
 		["type"] = "Yak-40",
@@ -10951,8 +11771,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [470]
-	[471] = 
+	}, -- end of [503]
+	[504] = 
 	{
 		["air"] = true,
 		["type"] = "Yak-52",
@@ -10974,8 +11794,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [471]
-	[472] = 
+	}, -- end of [504]
+	[505] = 
 	{
 		["type"] = "ALBATROS",
 		["name"] = "Corvette 1124.4 Grisha",
@@ -11002,8 +11822,36 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [472]
-	[473] = 
+	}, -- end of [505]
+	[506] = 
+	{
+		["type"] = "CastleClass_01",
+		["name"] = "Castle Class",
+		["category"] = "Ship",
+		["naval"] = true,
+		["description"] = "Castle Class",
+		["attribute"] = 
+		{
+			["Heavy armed ships"] = true,
+			[14] = true,
+			["HeavyArmoredUnits"] = true,
+			["Ships"] = true,
+			["Armed Air Defence"] = true,
+			["Armed ships"] = true,
+			["RADAR_BAND2_FOR_ARM"] = true,
+			["Naval"] = true,
+			["HelicopterCarrier"] = true,
+			["Armed Ship"] = true,
+			[3] = true,
+			["All"] = true,
+			["Corvettes"] = true,
+			[12] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [506]
+	[507] = 
 	{
 		["type"] = "CV_1143_5",
 		["name"] = "CV 1143.5 Admiral Kuznetsov(2017)",
@@ -11036,8 +11884,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [473]
-	[474] = 
+	}, -- end of [507]
+	[508] = 
 	{
 		["type"] = "CVN_71",
 		["name"] = "CVN-71 Theodore Roosevelt",
@@ -11048,29 +11896,32 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			["Aircraft Carriers"] = true,
 			["AircraftCarrier"] = true,
-			["Arresting Gear"] = true,
+			["ACLS"] = true,
 			["RADAR_BAND1_FOR_ARM"] = true,
 			["RADAR_BAND2_FOR_ARM"] = true,
 			[265] = true,
 			["AircraftCarrier With Arresting Gear"] = true,
+			["Link4"] = true,
 			[3] = true,
 			[12] = true,
-			["AircraftCarrier With Catapult"] = true,
 			["Heavy armed ships"] = true,
-			["Ships"] = true,
+			["AircraftCarrier With Catapult"] = true,
+			["Naval"] = true,
 			["Armed Air Defence"] = true,
 			["Armed ships"] = true,
+			["Ships"] = true,
+			["Arresting Gear"] = true,
 			["Armed Ship"] = true,
 			["HeavyArmoredUnits"] = true,
 			["All"] = true,
 			["catapult"] = true,
-			["Naval"] = true,
+			["Datalink"] = true,
 		}, -- end of ["attribute"]
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [474]
-	[475] = 
+	}, -- end of [508]
+	[509] = 
 	{
 		["type"] = "CVN_72",
 		["name"] = "CVN-72 Abraham Lincoln",
@@ -11081,29 +11932,32 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			["Aircraft Carriers"] = true,
 			["AircraftCarrier"] = true,
-			["Arresting Gear"] = true,
+			["ACLS"] = true,
 			["RADAR_BAND1_FOR_ARM"] = true,
 			["RADAR_BAND2_FOR_ARM"] = true,
 			["AircraftCarrier With Arresting Gear"] = true,
+			["Link4"] = true,
 			[3] = true,
-			[12] = true,
-			["AircraftCarrier With Catapult"] = true,
 			["Heavy armed ships"] = true,
-			[266] = true,
+			[12] = true,
+			["Arresting Gear"] = true,
+			["AircraftCarrier With Catapult"] = true,
 			["Armed Air Defence"] = true,
 			["Armed ships"] = true,
 			["Ships"] = true,
+			[266] = true,
+			["Naval"] = true,
 			["Armed Ship"] = true,
 			["HeavyArmoredUnits"] = true,
 			["All"] = true,
 			["catapult"] = true,
-			["Naval"] = true,
+			["Datalink"] = true,
 		}, -- end of ["attribute"]
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [475]
-	[476] = 
+	}, -- end of [509]
+	[510] = 
 	{
 		["type"] = "CVN_73",
 		["name"] = "CVN-73 George Washington",
@@ -11114,18 +11968,21 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			["Aircraft Carriers"] = true,
 			["AircraftCarrier"] = true,
-			["Arresting Gear"] = true,
+			["ACLS"] = true,
 			["RADAR_BAND1_FOR_ARM"] = true,
 			["RADAR_BAND2_FOR_ARM"] = true,
 			["AircraftCarrier With Arresting Gear"] = true,
+			["Link4"] = true,
 			[3] = true,
-			[12] = true,
-			["AircraftCarrier With Catapult"] = true,
 			["Heavy armed ships"] = true,
-			["Naval"] = true,
+			[12] = true,
+			["Arresting Gear"] = true,
+			["AircraftCarrier With Catapult"] = true,
 			["Armed Air Defence"] = true,
 			["Armed ships"] = true,
 			["Ships"] = true,
+			["Datalink"] = true,
+			["Naval"] = true,
 			["Armed Ship"] = true,
 			["HeavyArmoredUnits"] = true,
 			["All"] = true,
@@ -11135,8 +11992,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [476]
-	[477] = 
+	}, -- end of [510]
+	[511] = 
 	{
 		["type"] = "CVN_75",
 		["name"] = "CVN-75 Harry S. Truman",
@@ -11147,29 +12004,32 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			["Aircraft Carriers"] = true,
 			["AircraftCarrier"] = true,
-			["Arresting Gear"] = true,
+			["ACLS"] = true,
 			["RADAR_BAND1_FOR_ARM"] = true,
 			["RADAR_BAND2_FOR_ARM"] = true,
 			["AircraftCarrier With Arresting Gear"] = true,
+			["Link4"] = true,
 			[3] = true,
-			[12] = true,
-			["AircraftCarrier With Catapult"] = true,
 			["Heavy armed ships"] = true,
-			["Ships"] = true,
+			[12] = true,
+			["Naval"] = true,
+			["AircraftCarrier With Catapult"] = true,
 			["Armed Air Defence"] = true,
-			[268] = true,
 			["Armed ships"] = true,
+			["Ships"] = true,
+			[268] = true,
+			["Arresting Gear"] = true,
 			["Armed Ship"] = true,
 			["HeavyArmoredUnits"] = true,
 			["All"] = true,
 			["catapult"] = true,
-			["Naval"] = true,
+			["Datalink"] = true,
 		}, -- end of ["attribute"]
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [477]
-	[478] = 
+	}, -- end of [511]
+	[512] = 
 	{
 		["type"] = "Dry-cargo ship-1",
 		["name"] = "Bulker Yakushev",
@@ -11191,8 +12051,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [478]
-	[479] = 
+	}, -- end of [512]
+	[513] = 
 	{
 		["type"] = "Dry-cargo ship-2",
 		["name"] = "Cargo Ivanov",
@@ -11214,8 +12074,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [479]
-	[480] = 
+	}, -- end of [513]
+	[514] = 
 	{
 		["type"] = "ELNYA",
 		["name"] = "Tanker Elnya 160",
@@ -11237,8 +12097,44 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [480]
-	[481] = 
+	}, -- end of [514]
+	[515] = 
+	{
+		["type"] = "Forrestal",
+		["name"] = "CV-59 Forrestal",
+		["category"] = "Ship",
+		["naval"] = true,
+		["description"] = "CV-59 Forrestal",
+		["attribute"] = 
+		{
+			["Aircraft Carriers"] = true,
+			["AircraftCarrier"] = true,
+			["ACLS"] = true,
+			["RADAR_BAND1_FOR_ARM"] = true,
+			["RADAR_BAND2_FOR_ARM"] = true,
+			["AircraftCarrier With Arresting Gear"] = true,
+			["Link4"] = true,
+			[3] = true,
+			["Heavy armed ships"] = true,
+			[12] = true,
+			["Arresting Gear"] = true,
+			["AircraftCarrier With Catapult"] = true,
+			["Armed Air Defence"] = true,
+			["Armed ships"] = true,
+			["Ships"] = true,
+			["Datalink"] = true,
+			["Naval"] = true,
+			["Armed Ship"] = true,
+			["HeavyArmoredUnits"] = true,
+			["All"] = true,
+			["catapult"] = true,
+			[315] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [515]
+	[516] = 
 	{
 		["type"] = "HandyWind",
 		["name"] = "Bulker Handy Wind",
@@ -11262,8 +12158,25 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [481]
-	[482] = 
+	}, -- end of [516]
+	[517] = 
+	{
+		["type"] = "HarborTug",
+		["name"] = "Harbor Tug",
+		["category"] = "Ship",
+		["description"] = "Harbor Tug",
+		["attribute"] = 
+		{
+			[3] = true,
+			[5] = true,
+			[12] = true,
+			[15] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [517]
+	[518] = 
 	{
 		["type"] = "Higgins_boat",
 		["name"] = "Boat LCVP Higgins",
@@ -11290,8 +12203,40 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [482]
-	[483] = 
+	}, -- end of [518]
+	[519] = 
+	{
+		["type"] = "hms_invincible",
+		["name"] = "HMS Invincible (R05)",
+		["category"] = "Ship",
+		["naval"] = true,
+		["description"] = "HMS Invincible (R05)",
+		["attribute"] = 
+		{
+			["Aircraft Carriers"] = true,
+			["AircraftCarrier With Tramplin"] = true,
+			["AircraftCarrier"] = true,
+			["Ships"] = true,
+			["RADAR_BAND1_FOR_ARM"] = true,
+			["RADAR_BAND2_FOR_ARM"] = true,
+			["DetectionByAWACS"] = true,
+			["ski_jump"] = true,
+			[3] = true,
+			[12] = true,
+			["Heavy armed ships"] = true,
+			["Armed ships"] = true,
+			["Armed Air Defence"] = true,
+			["Armed Ship"] = true,
+			["HeavyArmoredUnits"] = true,
+			["All"] = true,
+			["Naval"] = true,
+			[331] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [519]
+	[520] = 
 	{
 		["type"] = "IMPROVED_KILO",
 		["name"] = "SSK 636 Improved Kilo",
@@ -11317,8 +12262,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [483]
-	[484] = 
+	}, -- end of [520]
+	[521] = 
 	{
 		["type"] = "KILO",
 		["name"] = "SSK 877V Kilo",
@@ -11344,8 +12289,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [484]
-	[485] = 
+	}, -- end of [521]
+	[522] = 
 	{
 		["type"] = "KUZNECOW",
 		["name"] = "CV 1143.5 Admiral Kuznetsov",
@@ -11378,8 +12323,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [485]
-	[486] = 
+	}, -- end of [522]
+	[523] = 
 	{
 		["type"] = "La_Combattante_II",
 		["name"] = "FAC La Combattante IIa",
@@ -11407,8 +12352,153 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [486]
-	[487] = 
+	}, -- end of [523]
+	[524] = 
+	{
+		["type"] = "leander-gun-achilles",
+		["name"] = "HMS Achilles (F12)",
+		["category"] = "Ship",
+		["naval"] = true,
+		["description"] = "HMS Achilles (F12)",
+		["attribute"] = 
+		{
+			["Heavy armed ships"] = true,
+			["HeavyArmoredUnits"] = true,
+			[14] = true,
+			["Armed Air Defence"] = true,
+			["Ships"] = true,
+			["Armed ships"] = true,
+			["Naval"] = true,
+			["Cruisers"] = true,
+			["RADAR_BAND1_FOR_ARM"] = true,
+			["HelicopterCarrier"] = true,
+			["Armed Ship"] = true,
+			[3] = true,
+			["All"] = true,
+			["DetectionByAWACS"] = true,
+			[12] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [524]
+	[525] = 
+	{
+		["type"] = "leander-gun-andromeda",
+		["name"] = "HMS Andromeda (F57)",
+		["category"] = "Ship",
+		["naval"] = true,
+		["description"] = "HMS Andromeda (F57)",
+		["attribute"] = 
+		{
+			["Heavy armed ships"] = true,
+			["HeavyArmoredUnits"] = true,
+			[14] = true,
+			["Armed Air Defence"] = true,
+			["Ships"] = true,
+			["Armed ships"] = true,
+			["Naval"] = true,
+			["Cruisers"] = true,
+			["RADAR_BAND1_FOR_ARM"] = true,
+			["HelicopterCarrier"] = true,
+			["Armed Ship"] = true,
+			[3] = true,
+			["All"] = true,
+			["DetectionByAWACS"] = true,
+			[12] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [525]
+	[526] = 
+	{
+		["type"] = "leander-gun-ariadne",
+		["name"] = "HMS Ariadne (F72)",
+		["category"] = "Ship",
+		["naval"] = true,
+		["description"] = "HMS Ariadne (F72)",
+		["attribute"] = 
+		{
+			["Heavy armed ships"] = true,
+			["HeavyArmoredUnits"] = true,
+			[14] = true,
+			["Armed Air Defence"] = true,
+			["Ships"] = true,
+			["Armed ships"] = true,
+			["Naval"] = true,
+			["Cruisers"] = true,
+			["RADAR_BAND1_FOR_ARM"] = true,
+			["HelicopterCarrier"] = true,
+			["Armed Ship"] = true,
+			[3] = true,
+			["All"] = true,
+			["DetectionByAWACS"] = true,
+			[12] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [526]
+	[527] = 
+	{
+		["type"] = "leander-gun-condell",
+		["name"] = "CNS Almirante Condell (PFG-06)",
+		["category"] = "Ship",
+		["naval"] = true,
+		["description"] = "CNS Almirante Condell (PFG-06)",
+		["attribute"] = 
+		{
+			["Heavy armed ships"] = true,
+			["HeavyArmoredUnits"] = true,
+			[14] = true,
+			["Armed Air Defence"] = true,
+			["Ships"] = true,
+			["Armed ships"] = true,
+			["Naval"] = true,
+			["Cruisers"] = true,
+			["RADAR_BAND1_FOR_ARM"] = true,
+			["HelicopterCarrier"] = true,
+			["Armed Ship"] = true,
+			[3] = true,
+			["All"] = true,
+			["DetectionByAWACS"] = true,
+			[12] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [527]
+	[528] = 
+	{
+		["type"] = "leander-gun-lynch",
+		["name"] = "CNS Almirante Lynch (PFG-07)",
+		["category"] = "Ship",
+		["naval"] = true,
+		["description"] = "CNS Almirante Lynch (PFG-07)",
+		["attribute"] = 
+		{
+			["Heavy armed ships"] = true,
+			["HeavyArmoredUnits"] = true,
+			[14] = true,
+			["Armed Air Defence"] = true,
+			["Ships"] = true,
+			["Armed ships"] = true,
+			["Naval"] = true,
+			["Cruisers"] = true,
+			["RADAR_BAND1_FOR_ARM"] = true,
+			["HelicopterCarrier"] = true,
+			["Armed Ship"] = true,
+			[3] = true,
+			["All"] = true,
+			["DetectionByAWACS"] = true,
+			[12] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [528]
+	[529] = 
 	{
 		["type"] = "LHA_Tarawa",
 		["name"] = "LHA-1 Tarawa",
@@ -11439,8 +12529,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [487]
-	[488] = 
+	}, -- end of [529]
+	[530] = 
 	{
 		["type"] = "LST_Mk2",
 		["name"] = "LST Mk.II",
@@ -11467,8 +12557,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [488]
-	[489] = 
+	}, -- end of [530]
+	[531] = 
 	{
 		["type"] = "MOLNIYA",
 		["name"] = "Corvette 1241.1 Molniya",
@@ -11496,8 +12586,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [489]
-	[490] = 
+	}, -- end of [531]
+	[532] = 
 	{
 		["type"] = "MOSCOW",
 		["name"] = "Cruiser 1164 Moskva",
@@ -11525,8 +12615,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [490]
-	[491] = 
+	}, -- end of [532]
+	[533] = 
 	{
 		["type"] = "NEUSTRASH",
 		["name"] = "Frigate 11540 Neustrashimy",
@@ -11554,8 +12644,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [491]
-	[492] = 
+	}, -- end of [533]
+	[534] = 
 	{
 		["type"] = "PERRY",
 		["name"] = "FFG Oliver Hazard Perry",
@@ -11584,8 +12674,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [492]
-	[493] = 
+	}, -- end of [534]
+	[535] = 
 	{
 		["type"] = "PIOTR",
 		["name"] = "Battlecruiser 1144.2 Pyotr Velikiy",
@@ -11614,8 +12704,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [493]
-	[494] = 
+	}, -- end of [535]
+	[536] = 
 	{
 		["type"] = "REZKY",
 		["name"] = "Frigate 1135M Rezky",
@@ -11641,8 +12731,36 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [494]
-	[495] = 
+	}, -- end of [536]
+	[537] = 
+	{
+		["type"] = "santafe",
+		["name"] = "ARA Santa Fe S-21",
+		["category"] = "Ship",
+		["naval"] = true,
+		["description"] = "ARA Santa Fe S-21",
+		["attribute"] = 
+		{
+			["Submarines"] = true,
+			["Heavy armed ships"] = true,
+			["HeavyArmoredUnits"] = true,
+			["Ships"] = true,
+			["Armed Air Defence"] = true,
+			[16] = true,
+			["Armed ships"] = true,
+			["RADAR_BAND1_FOR_ARM"] = true,
+			[12] = true,
+			[332] = true,
+			[3] = true,
+			["All"] = true,
+			["DetectionByAWACS"] = true,
+			["Naval"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [537]
+	[538] = 
 	{
 		["type"] = "Schnellboot_type_S130",
 		["name"] = "Boat Schnellboot type S130",
@@ -11668,8 +12786,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [495]
-	[496] = 
+	}, -- end of [538]
+	[539] = 
 	{
 		["type"] = "Seawise_Giant",
 		["name"] = "Tanker Seawise Giant",
@@ -11693,8 +12811,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [496]
-	[497] = 
+	}, -- end of [539]
+	[540] = 
 	{
 		["type"] = "SOM",
 		["name"] = "SSK 641B Tango",
@@ -11720,8 +12838,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [497]
-	[498] = 
+	}, -- end of [540]
+	[541] = 
 	{
 		["type"] = "speedboat",
 		["name"] = "Boat Armed Hi-speed",
@@ -11748,8 +12866,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [498]
-	[499] = 
+	}, -- end of [541]
+	[542] = 
 	{
 		["type"] = "Stennis",
 		["name"] = "CVN-74 John C. Stennis",
@@ -11760,29 +12878,32 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			["Aircraft Carriers"] = true,
 			["AircraftCarrier"] = true,
-			["Arresting Gear"] = true,
+			["ACLS"] = true,
 			["RADAR_BAND1_FOR_ARM"] = true,
 			["RADAR_BAND2_FOR_ARM"] = true,
 			["AircraftCarrier With Arresting Gear"] = true,
+			["Link4"] = true,
 			[3] = true,
-			[12] = true,
-			["AircraftCarrier With Catapult"] = true,
 			["Heavy armed ships"] = true,
+			[12] = true,
 			[264] = true,
+			["AircraftCarrier With Catapult"] = true,
 			["Armed Air Defence"] = true,
 			["Armed ships"] = true,
 			["Ships"] = true,
+			["Arresting Gear"] = true,
+			["Naval"] = true,
 			["Armed Ship"] = true,
 			["HeavyArmoredUnits"] = true,
 			["All"] = true,
 			["catapult"] = true,
-			["Naval"] = true,
+			["Datalink"] = true,
 		}, -- end of ["attribute"]
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [499]
-	[500] = 
+	}, -- end of [542]
+	[543] = 
 	{
 		["type"] = "TICONDEROG",
 		["name"] = "CG Ticonderoga",
@@ -11811,8 +12932,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [500]
-	[501] = 
+	}, -- end of [543]
+	[544] = 
 	{
 		["type"] = "Type_052B",
 		["name"] = "Type 052B Destroyer",
@@ -11842,8 +12963,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [501]
-	[502] = 
+	}, -- end of [544]
+	[545] = 
 	{
 		["type"] = "Type_052C",
 		["name"] = "Type 052C Destroyer",
@@ -11873,8 +12994,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [502]
-	[503] = 
+	}, -- end of [545]
+	[546] = 
 	{
 		["type"] = "Type_054A",
 		["name"] = "Type 054A Frigate",
@@ -11904,8 +13025,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [503]
-	[504] = 
+	}, -- end of [546]
+	[547] = 
 	{
 		["type"] = "Type_071",
 		["name"] = "Type 071 Amphibious Transport Dock",
@@ -11928,6 +13049,7 @@ dcsUnits.DcsUnitsDatabase =
 			["Heavy armed ships"] = true,
 			["Armed ships"] = true,
 			["Armed Air Defence"] = true,
+			["HelicopterCarrier"] = true,
 			["Armed Ship"] = true,
 			["HeavyArmoredUnits"] = true,
 			["All"] = true,
@@ -11937,8 +13059,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [504]
-	[505] = 
+	}, -- end of [547]
+	[548] = 
 	{
 		["type"] = "Type_093",
 		["name"] = "Type 093 Attack Submarine",
@@ -11967,8 +13089,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [505]
-	[506] = 
+	}, -- end of [548]
+	[549] = 
 	{
 		["type"] = "Uboat_VIIC",
 		["name"] = "U-boat VIIC U-flak",
@@ -11996,8 +13118,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [506]
-	[507] = 
+	}, -- end of [549]
+	[550] = 
 	{
 		["type"] = "USS_Arleigh_Burke_IIa",
 		["name"] = "DDG Arleigh Burke IIa",
@@ -12026,8 +13148,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [507]
-	[508] = 
+	}, -- end of [550]
+	[551] = 
 	{
 		["type"] = "USS_Samuel_Chase",
 		["name"] = "LS Samuel Chase",
@@ -12054,8 +13176,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [508]
-	[509] = 
+	}, -- end of [551]
+	[552] = 
 	{
 		["type"] = "VINSON",
 		["name"] = "CVN-70 Carl Vinson",
@@ -12087,8 +13209,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [509]
-	[510] = 
+	}, -- end of [552]
+	[553] = 
 	{
 		["type"] = "ZWEZDNY",
 		["name"] = "Boat Zvezdny type",
@@ -12111,8 +13233,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [510]
-	[511] = 
+	}, -- end of [553]
+	[554] = 
 	{
 		["type"] = "AA8",
 		["name"] = "Firefighter Vehicle AA-7.2/60",
@@ -12138,8 +13260,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [511]
-	[512] = 
+	}, -- end of [554]
+	[555] = 
 	{
 		["type"] = "ATMZ-5",
 		["name"] = "Refueler ATMZ-5",
@@ -12165,8 +13287,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [512]
-	[513] = 
+	}, -- end of [555]
+	[556] = 
 	{
 		["type"] = "ATZ-10",
 		["name"] = "Refueler ATZ-10",
@@ -12193,8 +13315,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "ATZ-10 Fuel Truck",
 		}, -- end of ["aliases"]
-	}, -- end of [513]
-	[514] = 
+	}, -- end of [556]
+	[557] = 
 	{
 		["type"] = "ATZ-5",
 		["name"] = "Refueler ATZ-5",
@@ -12220,8 +13342,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [514]
-	[515] = 
+	}, -- end of [557]
+	[558] = 
 	{
 		["type"] = "ATZ-60_Maz",
 		["name"] = "Refueler ATZ-60 Tractor",
@@ -12247,8 +13369,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [515]
-	[516] = 
+	}, -- end of [558]
+	[559] = 
 	{
 		["type"] = "Bedford_MWD",
 		["name"] = "Truck Bedford",
@@ -12274,8 +13396,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [516]
-	[517] = 
+	}, -- end of [559]
+	[560] = 
 	{
 		["type"] = "Blitz_36-6700A",
 		["name"] = "Truck Opel Blitz",
@@ -12301,13 +13423,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [517]
-	[518] = 
+	}, -- end of [560]
+	[561] = 
 	{
 		["type"] = "CCKW_353",
-		["name"] = "Truck GMC \"Jimmy\" 6x6 Truck",
+		["name"] = "Truck GMC \"Jimmy\" 6x6",
 		["category"] = "Unarmed",
-		["description"] = "Truck GMC \"Jimmy\" 6x6 Truck",
+		["description"] = "Truck GMC \"Jimmy\" 6x6",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -12328,8 +13450,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [518]
-	[519] = 
+	}, -- end of [561]
+	[562] = 
 	{
 		["type"] = "GAZ-3307",
 		["name"] = "Truck GAZ-3307",
@@ -12355,8 +13477,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [519]
-	[520] = 
+	}, -- end of [562]
+	[563] = 
 	{
 		["type"] = "GAZ-3308",
 		["name"] = "Truck GAZ-3308",
@@ -12382,8 +13504,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [520]
-	[521] = 
+	}, -- end of [563]
+	[564] = 
 	{
 		["type"] = "GAZ-66",
 		["name"] = "Truck GAZ-66",
@@ -12409,8 +13531,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [521]
-	[522] = 
+	}, -- end of [564]
+	[565] = 
 	{
 		["type"] = "HEMTT TFFT",
 		["name"] = "Firefighter HEMMT TFFT",
@@ -12436,8 +13558,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [522]
-	[523] = 
+	}, -- end of [565]
+	[566] = 
 	{
 		["type"] = "Horch_901_typ_40_kfz_21",
 		["name"] = "LUV Horch 901 Staff Car",
@@ -12463,8 +13585,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [523]
-	[524] = 
+	}, -- end of [566]
+	[567] = 
 	{
 		["type"] = "Hummer",
 		["name"] = "LUV HMMWV Jeep",
@@ -12497,8 +13619,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "M1025 HMMWV",
 		}, -- end of ["aliases"]
-	}, -- end of [524]
-	[525] = 
+	}, -- end of [567]
+	[568] = 
 	{
 		["type"] = "IKARUS Bus",
 		["name"] = "Bus IKARUS-280",
@@ -12524,8 +13646,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [525]
-	[526] = 
+	}, -- end of [568]
+	[569] = 
 	{
 		["type"] = "KAMAZ Truck",
 		["name"] = "Truck KAMAZ 43101",
@@ -12552,8 +13674,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "KAMAZ-43101",
 		}, -- end of ["aliases"]
-	}, -- end of [526]
-	[527] = 
+	}, -- end of [569]
+	[570] = 
 	{
 		["type"] = "KrAZ6322",
 		["name"] = "Truck KrAZ-6322 6x6",
@@ -12580,13 +13702,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [527]
-	[528] = 
+	}, -- end of [570]
+	[571] = 
 	{
 		["type"] = "Kubelwagen_82",
-		["name"] = "LUV Kubelwagen 82",
+		["name"] = "LUV Kubelwagen Jeep",
 		["category"] = "Unarmed",
-		["description"] = "LUV Kubelwagen 82",
+		["description"] = "LUV Kubelwagen Jeep",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -12607,8 +13729,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [528]
-	[529] = 
+	}, -- end of [571]
+	[572] = 
 	{
 		["type"] = "Land_Rover_101_FC",
 		["name"] = "Truck Land Rover 101 FC",
@@ -12634,8 +13756,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [529]
-	[530] = 
+	}, -- end of [572]
+	[573] = 
 	{
 		["type"] = "Land_Rover_109_S3",
 		["name"] = "LUV Land Rover 109",
@@ -12661,8 +13783,39 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [530]
-	[531] = 
+	}, -- end of [573]
+	[574] = 
+	{
+		["type"] = "LARC-V",
+		["name"] = "LARC-V",
+		["category"] = "Unarmed",
+		["description"] = "LARC-V",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[2] = true,
+			["Vehicles"] = true,
+			["Armored vehicles"] = true,
+			["AntiAir Armed Vehicles"] = true,
+			[333] = true,
+			["Ground vehicles"] = true,
+			[10] = true,
+			["Armed ground units"] = true,
+			["APC"] = true,
+			["Ground Units Non Airdefence"] = true,
+			["Infantry carriers"] = true,
+			[26] = true,
+			["NonAndLightArmoredUnits"] = true,
+			["LightArmoredUnits"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			["Armed vehicles"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [574]
+	[575] = 
 	{
 		["type"] = "LAZ Bus",
 		["name"] = "Bus LAZ-695",
@@ -12688,8 +13841,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [531]
-	[532] = 
+	}, -- end of [575]
+	[576] = 
 	{
 		["type"] = "LiAZ Bus",
 		["name"] = "Bus LiAZ-677",
@@ -12715,8 +13868,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [532]
-	[533] = 
+	}, -- end of [576]
+	[577] = 
 	{
 		["type"] = "M 818",
 		["name"] = "Truck M939 Heavy",
@@ -12744,13 +13897,13 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "M818",
 		}, -- end of ["aliases"]
-	}, -- end of [533]
-	[534] = 
+	}, -- end of [577]
+	[578] = 
 	{
 		["type"] = "M30_CC",
-		["name"] = "Carrier M30 Cargo",
+		["name"] = "Ammo M30 Cargo Carrier",
 		["category"] = "Unarmed",
-		["description"] = "Carrier M30 Cargo",
+		["description"] = "Ammo M30 Cargo Carrier",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -12775,39 +13928,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [534]
-	[535] = 
-	{
-		["type"] = "M4_Tractor",
-		["name"] = "Tractor M4 Hi-Speed",
-		["category"] = "Unarmed",
-		["description"] = "Tractor M4 Hi-Speed",
-		["vehicle"] = true,
-		["attribute"] = 
-		{
-			[2] = true,
-			["Vehicles"] = true,
-			["Armored vehicles"] = true,
-			["AntiAir Armed Vehicles"] = true,
-			[17] = true,
-			["Ground vehicles"] = true,
-			["Armed ground units"] = true,
-			["Ground Units Non Airdefence"] = true,
-			["Infantry carriers"] = true,
-			[26] = true,
-			["LightArmoredUnits"] = true,
-			["NonAndLightArmoredUnits"] = true,
-			["IFV"] = true,
-			[7] = true,
-			["All"] = true,
-			["Ground Units"] = true,
-			["Armed vehicles"] = true,
-		}, -- end of ["attribute"]
-		["aliases"] = 
-		{
-		}, -- end of ["aliases"]
-	}, -- end of [535]
-	[536] = 
+	}, -- end of [578]
+	[579] = 
 	{
 		["type"] = "M978 HEMTT Tanker",
 		["name"] = "Refueler M978 HEMTT",
@@ -12833,8 +13955,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [536]
-	[537] = 
+	}, -- end of [579]
+	[580] = 
 	{
 		["type"] = "MAZ-6303",
 		["name"] = "Truck MAZ-6303",
@@ -12860,8 +13982,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [537]
-	[538] = 
+	}, -- end of [580]
+	[581] = 
 	{
 		["type"] = "Predator GCS",
 		["name"] = "MCC Predator UAV CP & GCS",
@@ -12888,8 +14010,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [538]
-	[539] = 
+	}, -- end of [581]
+	[582] = 
 	{
 		["type"] = "Predator TrojanSpirit",
 		["name"] = "MCC-COMM Predator UAV CL",
@@ -12915,8 +14037,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [539]
-	[540] = 
+	}, -- end of [582]
+	[583] = 
 	{
 		["type"] = "Sd_Kfz_2",
 		["name"] = "LUV Kettenrad",
@@ -12946,13 +14068,13 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [540]
-	[541] = 
+	}, -- end of [583]
+	[584] = 
 	{
 		["type"] = "Sd_Kfz_7",
-		["name"] = "Carrier Sd.Kfz.7 Tractor",
+		["name"] = "Tractor Sd.Kfz.7 Art'y Tractor",
 		["category"] = "Unarmed",
-		["description"] = "Carrier Sd.Kfz.7 Tractor",
+		["description"] = "Tractor Sd.Kfz.7 Art'y Tractor",
 		["vehicle"] = true,
 		["attribute"] = 
 		{
@@ -12977,8 +14099,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [541]
-	[542] = 
+	}, -- end of [584]
+	[585] = 
 	{
 		["type"] = "SKP-11",
 		["name"] = "Truck SKP-11 Mobile ATC",
@@ -13005,8 +14127,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "SKP-11 Mobile Command Post",
 		}, -- end of ["aliases"]
-	}, -- end of [542]
-	[543] = 
+	}, -- end of [585]
+	[586] = 
 	{
 		["type"] = "Suidae",
 		["name"] = "Suidae",
@@ -13032,8 +14154,39 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [543]
-	[544] = 
+	}, -- end of [586]
+	[587] = 
+	{
+		["type"] = "tacr2a",
+		["name"] = "RAF Rescue",
+		["category"] = "Unarmed",
+		["description"] = "RAF Rescue",
+		["vehicle"] = true,
+		["attribute"] = 
+		{
+			[2] = true,
+			["Vehicles"] = true,
+			["Armored vehicles"] = true,
+			["AntiAir Armed Vehicles"] = true,
+			[17] = true,
+			["Ground vehicles"] = true,
+			["Armed ground units"] = true,
+			["APC"] = true,
+			["Ground Units Non Airdefence"] = true,
+			["Infantry carriers"] = true,
+			[25] = true,
+			["NonAndLightArmoredUnits"] = true,
+			[14] = true,
+			["LightArmoredUnits"] = true,
+			["All"] = true,
+			["Ground Units"] = true,
+			["Armed vehicles"] = true,
+		}, -- end of ["attribute"]
+		["aliases"] = 
+		{
+		}, -- end of ["aliases"]
+	}, -- end of [587]
+	[588] = 
 	{
 		["type"] = "Tigr_233036",
 		["name"] = "LUV Tigr",
@@ -13064,8 +14217,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [544]
-	[545] = 
+	}, -- end of [588]
+	[589] = 
 	{
 		["type"] = "Trolley bus",
 		["name"] = "Bus ZIU-9 Trolley",
@@ -13091,8 +14244,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [545]
-	[546] = 
+	}, -- end of [589]
+	[590] = 
 	{
 		["type"] = "TZ-22_KrAZ",
 		["name"] = "Refueler TZ-22 Tractor",
@@ -13118,8 +14271,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [546]
-	[547] = 
+	}, -- end of [590]
+	[591] = 
 	{
 		["type"] = "UAZ-469",
 		["name"] = "LUV UAZ-469 Jeep",
@@ -13146,8 +14299,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [547]
-	[548] = 
+	}, -- end of [591]
+	[592] = 
 	{
 		["type"] = "Ural ATsP-6",
 		["name"] = "Firefighter Ural ATsP-6",
@@ -13173,8 +14326,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [548]
-	[549] = 
+	}, -- end of [592]
+	[593] = 
 	{
 		["type"] = "Ural-375",
 		["name"] = "Truck Ural-375",
@@ -13200,8 +14353,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [549]
-	[550] = 
+	}, -- end of [593]
+	[594] = 
 	{
 		["type"] = "Ural-375 PBU",
 		["name"] = "Truck Ural-375 Mobile C2",
@@ -13227,8 +14380,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [550]
-	[551] = 
+	}, -- end of [594]
+	[595] = 
 	{
 		["type"] = "Ural-4320 APA-5D",
 		["name"] = "GPU APA-5D on Ural 4320",
@@ -13255,8 +14408,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "Ural-4320 APA-5D Ground Power Unit",
 		}, -- end of ["aliases"]
-	}, -- end of [551]
-	[552] = 
+	}, -- end of [595]
+	[596] = 
 	{
 		["type"] = "Ural-4320-31",
 		["name"] = "Truck Ural-4320-31 Arm'd",
@@ -13282,8 +14435,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [552]
-	[553] = 
+	}, -- end of [596]
+	[597] = 
 	{
 		["type"] = "Ural-4320T",
 		["name"] = "Truck Ural-4320T",
@@ -13309,8 +14462,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [553]
-	[554] = 
+	}, -- end of [597]
+	[598] = 
 	{
 		["type"] = "VAZ Car",
 		["name"] = "Car VAZ-2109",
@@ -13336,8 +14489,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [554]
-	[555] = 
+	}, -- end of [598]
+	[599] = 
 	{
 		["type"] = "Willys_MB",
 		["name"] = "Car Willys Jeep",
@@ -13363,8 +14516,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [555]
-	[556] = 
+	}, -- end of [599]
+	[600] = 
 	{
 		["type"] = "ZiL-131 APA-80",
 		["name"] = "GPU APA-80 on ZIL-131",
@@ -13391,8 +14544,8 @@ dcsUnits.DcsUnitsDatabase =
 		{
 			[1] = "ZiL-131 APA-80 Ground Power Unit",
 		}, -- end of ["aliases"]
-	}, -- end of [556]
-	[557] = 
+	}, -- end of [600]
+	[601] = 
 	{
 		["type"] = "ZIL-131 KUNG",
 		["name"] = "Truck ZIL-131 (C2)",
@@ -13418,8 +14571,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [557]
-	[558] = 
+	}, -- end of [601]
+	[602] = 
 	{
 		["type"] = "ZIL-135",
 		["name"] = "Truck ZIL-135",
@@ -13445,8 +14598,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [558]
-	[559] = 
+	}, -- end of [602]
+	[603] = 
 	{
 		["type"] = "ZIL-4331",
 		["name"] = "Truck ZIL-4331",
@@ -13472,8 +14625,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [559]
-	[560] = 
+	}, -- end of [603]
+	[604] = 
 	{
 		["type"] = ".Ammunition depot",
 		["name"] = "Ammunition depot",
@@ -13482,8 +14635,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [560]
-	[561] = 
+	}, -- end of [604]
+	[605] = 
 	{
 		["type"] = "Tank",
 		["name"] = "Tank 1",
@@ -13492,8 +14645,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [561]
-	[562] = 
+	}, -- end of [605]
+	[606] = 
 	{
 		["type"] = "Tank 2",
 		["name"] = "Tank 2",
@@ -13502,8 +14655,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [562]
-	[563] = 
+	}, -- end of [606]
+	[607] = 
 	{
 		["type"] = "Tank 3",
 		["name"] = "Tank 3",
@@ -13512,8 +14665,8 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [563]
-	[564] = 
+	}, -- end of [607]
+	[608] = 
 	{
 		["type"] = "Warehouse",
 		["name"] = "Warehouse",
@@ -13522,56 +14675,6 @@ dcsUnits.DcsUnitsDatabase =
 		["aliases"] = 
 		{
 		}, -- end of ["aliases"]
-	}, -- end of [564]
+	}, -- end of [608]
 } -- end of units
-
--- appending custom cargoes
-function dcsUnits.addCargoUnit( name, displayName, shape, shapeDstr, life, canExplode, rate, mass, attribute, minMass, maxMass, topdown_view)
-    local res = {}
-    res.desc = {}
-    
-    res.desc.typeName = name
-    res.desc.displayName = displayName
-    res.desc.attributes = {}
-    res.desc.attributes.Cargos = true
-    res.desc.minMass = minMass
-    res.desc.maxMass = maxMass
-    res.desc.category = 'Cargo'
-
-    veaf.loggers.get(dcsUnits.Id):debug("Adding custom cargo "..displayName)
-    dcsUnits.DcsUnitsDatabase[name] = res
-end
-
-veaf.loggers.get(dcsUnits.Id):info(string.format("Loading version %s", dcsUnits.Version))
-
--- dcsUnits.addCargoUnit( "jeep_cargo", "jeep_cargo", "jeep_cargo", "jeep_cargo",10,false, 100, 1200,  {"Cargos"}, 100, 4000 );
--- dcsUnits.addCargoUnit( "bambi_bucket", "bambi_bucket", "bambi_bucket","bambi_bucket",5,false, 1000, 1500,  {"Cargos"}, 1000, 2000 );
--- dcsUnits.addCargoUnit( "zu23_cargo", "zu23_cargo", "zu23_cargo","zu23_cargo",15,false, 100, 1500,  {"Cargos"}, 1000, 2000 ); --zu23_cargo
--- dcsUnits.addCargoUnit( "blu82_cargo", "blu82_cargo", "blu82_cargo","blu82_cargo",10,true,100, 2400,{"Cargos"},800,5000); --blu82_cargo
--- dcsUnits.addCargoUnit( "generator_cargo", "generator_cargo", "generator_cargo","generator_cargo",10,false, 100, 1500,  {"Cargos"}, 1000, 2000 ); --generator_cargo
--- dcsUnits.addCargoUnit( "Tschechenigel_cargo", "Tschechenigel_cargo", "reiter_cargo","reiter_cargo",20,false, 100, 1000,  {"Cargos"}, 100, 10000 ); --reiter_cargo
--- dcsUnits.addCargoUnit( "sandbag", "sandbag", "sandbag","sandbag", 100, 1000,  {"Cargos"},10,false, 100, 10000 ); --sandbag
--- dcsUnits.addCargoUnit( "booth_container", "booth_container", "booth_container","booth_container",10,false, 100, 3200,  {"Cargos"}, 2200, 10000 );--booth_container
--- dcsUnits.addCargoUnit( "antenne", "antenne", "antenne","antenne",10,false, 100, 3200,  {"Cargos"}, 2200, 10000 );--antenne
--- dcsUnits.addCargoUnit( "mast", "mast", "mast","mast",10,false, 100, 3200,  {"Cargos"}, 2200, 10000 );--mast
--- dcsUnits.addCargoUnit( "uh1_weapons", "uh1_weapons", "uh1_weapons","uh1_weapons",10,false, 100, 1000,  {"Cargos"}, 100, 10000 );--uh1_weapons
--- dcsUnits.addCargoUnit( "panzergranaten", "panzergranaten", "panzergranaten","panzergranaten",10,false, 100, 1500,  {"Cargos"}, 1000, 2000 );--panzergranaten
--- dcsUnits.addCargoUnit( "pz2000_shell", "pz2000_shell", "pz2000_shell","pz2000_shell",10,false, 100, 1500,  {"Cargos"}, 1000, 2000 );--pz2000_shell
--- dcsUnits.addCargoUnit( "sandbag_box", "sandbag_box", "sandbag_box","sandbag_box",10,false, 100, 1500,  {"Cargos"}, 1000, 2000 );--sandbag_box
--- dcsUnits.addCargoUnit( "fir_tree", "fir_tree", "fir_tree","fir_tree",100, 1000,  {"Cargos"},10,false, 100, 10000 );--fir_tree
--- dcsUnits.addCargoUnit( "hmvee_cargo", "hmvee_cargo", "hmvee_cargo","hmvee_cargo",10,false, 100, 3200,  {"Cargos"}, 2200, 10000 );--hmvee_cargo
--- dcsUnits.addCargoUnit( "eurotainer", "eurotainer", "eurotainer","eurotainer",10,false,100, 2400,{"Cargos"},800,5000);--eurotainer
--- dcsUnits.addCargoUnit( "MK6", "MK6", "MK6","MK6",10,true,100, 2400,{"Cargos"},800,5000);--MK6
--- dcsUnits.addCargoUnit( "concrete_pipe_duo", "concrete_pipe_duo", "concrete_pipe_duo","concrete_pipe_duo",10,false,100, 823,  {"Cargos"}, 823, 823 );--concrete_pipe_duo
--- dcsUnits.addCargoUnit( "concrete_pipe", "concrete_pipe", "concrete_pipe","concrete_pipe",10,false,100, 823,  {"Cargos"}, 823, 823 );--concrete_pipe
--- dcsUnits.addCargoUnit( "gaz66_cargo", "gaz66_cargo", "gaz66_cargo","gaz66_cargo",15,false, 100, 3200,  {"Cargos"}, 2200, 10000 );--gaz66_cargo
--- dcsUnits.addCargoUnit( "uaz_cargo", "uaz_cargo", "uaz_cargo","uaz_cargo",15,false, 100, 3200,  {"Cargos"}, 2200, 10000 );--uaz_cargo
--- dcsUnits.addCargoUnit( "stretcher_body", "stretcher_body", "stretcher_body","stretcher_body",5,false,100, 1000,  {"Cargos"}, 100, 10000 );--stretcher_body
--- dcsUnits.addCargoUnit( "stretcher_empty", "stretcher_empty", "stretcher_empty","stretcher_empty",10,false,100, 1000,  {"Cargos"}, 100, 10000 );--stretcher_empty
--- dcsUnits.addCargoUnit( "san_container", "san_container", "san_container","san_container",15,false, 100, 3200,  {"Cargos"}, 2200, 10000 );--san_container
--- dcsUnits.addCargoUnit( "biwak_cargo", "biwak_cargo", "biwak_cargo","biwak_cargo", 15,false,100, 3200,  {"Cargos"}, 2200, 10000 );--biwak_cargo
--- dcsUnits.addCargoUnit( "wolf_cargo", "wolf_cargo", "wolf_cargo","wolf_cargo",15,false, 100, 3200,  {"Cargos"}, 2200, 10000 );--wolf_cargo
--- dcsUnits.addCargoUnit( "biwak_timber", "biwak_timber", "biwak_timber","biwak_timber",15,false, 100, 480,  {"Cargos"}, 100, 480);--biwak_timber
--- dcsUnits.addCargoUnit( "biwak_metal", "biwak_metal", "biwak_metal","biwak_metal",15,false, 100, 480,  {"Cargos"}, 100, 480);--biwak_metal
-
 

--- a/src/scripts/veaf/veaf.lua
+++ b/src/scripts/veaf/veaf.lua
@@ -32,7 +32,7 @@ veaf = {}
 veaf.Id = "VEAF"
 
 --- Version.
-veaf.Version = "1.21.0"
+veaf.Version = "1.21.1"
 
 --- Development version ?
 veaf.Development = true
@@ -1205,14 +1205,14 @@ function veaf.moveGroupAt(groupName, leadUnitName, heading, speed, timeInSeconds
     return true
 end
 
-function veaf.readyForCombat(group)
+function veaf.readyForCombat(group, alarm)
     if type(group) == 'string' then
         group = Group.getByName(group)
     end
     if group then
         local cont = group:getController()
         cont:setOnOff(true)
-        cont:setOption(AI.Option.Ground.id.ALARM_STATE, AI.Option.Ground.val.ALARM_STATE.RED)	
+        cont:setOption(AI.Option.Ground.id.ALARM_STATE, alarm)	
         cont:setOption(AI.Option.Air.id.ROE, AI.Option.Air.val.ROE.WEAPON_FREE)
     end
 end
@@ -2087,6 +2087,38 @@ function veaf.getPolygonFromUnits(unitNames)
     return polygon
 end
 
+function veaf.laserCodeToDigit(code)
+    local codeDigit = {}
+    codeDigit.units=code%10
+    codeDigit.tens=(code%100-codeDigit.units)/10
+    codeDigit.hundreds=(code%1000-codeDigit.tens*10-codeDigit.units)/100
+    codeDigit.thousands=(code-codeDigit.hundreds*100-codeDigit.tens*10-codeDigit.units)/1000
+
+    veaf.loggers.get(veaf.Id):debug(string.format("laser code : %s", veaf.p(code)))
+    veaf.loggers.get(veaf.Id):debug(string.format("laser code digits : %s", veaf.p(codeDigit)))
+    
+    return codeDigit
+end
+
+--computes the heading between two points in radians
+function veaf.headingBetweenPoints(point1, point2)
+
+    local hdg
+
+    if point1 and point2 and point1.x and point1.y and point2.x and point2.y then
+        -- if hdg is not set, compute heading between point2 and point3
+        hdg = math.floor(math.deg(math.atan2(point2.y - point1.y, point2.x - point1.x)))
+        if hdg < 0 then
+            hdg = hdg + 360
+        end
+    end
+
+    -- convert heading to radians
+    hdg = hdg * math.pi / 180
+
+    return hdg
+
+end
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Logging
 -------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/scripts/veaf/veaf.lua
+++ b/src/scripts/veaf/veaf.lua
@@ -39,7 +39,7 @@ veaf.Development = true
 veaf.SecurityDisabled = true
 
 -- trace level, specific to this module
-veaf.LogLevel = "trace"
+--veaf.LogLevel = "trace"
 --veaf.LogLevel = "debug"
 --veaf.ForcedLogLevel = "trace"
 

--- a/src/scripts/veaf/veafCarrierOperations.lua
+++ b/src/scripts/veaf/veafCarrierOperations.lua
@@ -48,10 +48,10 @@ veafCarrierOperations = {}
 veafCarrierOperations.Id = "CARRIER"
 
 --- Version.
-veafCarrierOperations.Version = "1.11.0"
+veafCarrierOperations.Version = "1.11.1"
 
 -- trace level, specific to this module
-veafCarrierOperations.LogLevel = "trace"
+--veafCarrierOperations.LogLevel = "trace"
 
 veaf.loggers.new(veafCarrierOperations.Id, veafCarrierOperations.LogLevel)
 
@@ -61,15 +61,15 @@ veafCarrierOperations.RadioMenuNameRed = "CARRIER OPS - RED"
 
 veafCarrierOperations.AllCarriers = 
 {
-    ["LHA_Tarawa"] = { runwayAngleWithBRC = 0, desiredWindSpeedOnDeck = 20},
+    ["LHA_Tarawa"] = { runwayAngleWithBRC = -1, desiredWindSpeedOnDeck = 20},
     ["Stennis"] = { runwayAngleWithBRC = 9.05, desiredWindSpeedOnDeck = 25},
     ["CVN_71"] = { runwayAngleWithBRC = 9.05, desiredWindSpeedOnDeck = 25},
     ["CVN_72"] = { runwayAngleWithBRC = 9.05, desiredWindSpeedOnDeck = 25},
     ["CVN_73"] = { runwayAngleWithBRC = 9.05, desiredWindSpeedOnDeck = 25},
     ["CVN_75"] = { runwayAngleWithBRC = 9.05, desiredWindSpeedOnDeck = 25},
     ["Forrestal"] = { runwayAngleWithBRC = 9.05, desiredWindSpeedOnDeck = 25},
-    ["KUZNECOW"] ={ runwayAngleWithBRC = 0, desiredWindSpeedOnDeck = 25},
-    ["CV_1143_5"] ={ runwayAngleWithBRC = 0, desiredWindSpeedOnDeck = 25}
+    ["KUZNECOW"] ={ runwayAngleWithBRC = 9, desiredWindSpeedOnDeck = 25},
+    ["CV_1143_5"] ={ runwayAngleWithBRC = 9, desiredWindSpeedOnDeck = 25}
 }
 
 veafCarrierOperations.ALT_FOR_MEASURING_WIND = 30 -- wind is measured at 30 meters, 10 meters above deck
@@ -488,7 +488,9 @@ function veafCarrierOperations.continueCarrierOperations(groupName)
                     local vars = {}
                     vars.gpName = carrier.tankerUnitName
                     vars.action = 'respawn'
-                    vars.point = startPosition
+                    vars.point = {}
+                    vars.point.x = startPosition.x
+                    vars.point.z = startPosition.z
                     vars.point.y = 2500
                     vars.radius = 500
                     mist.teleportToPoint(vars)
@@ -561,7 +563,7 @@ function veafCarrierOperations.continueCarrierOperations(groupName)
                                         }, -- end of ["task"]
                                         ["type"] = "Turning Point",
                                         ["ETA"] = 0,
-                                        ["ETA_locked"] = true,
+                                        ["ETA_locked"] = false,
                                         ["x"] = startPosition.x,
                                         ["y"] = startPosition.z,
                                         ["speed_locked"] = true,
@@ -763,14 +765,14 @@ function veafCarrierOperations.rebuildRadioMenu()
         
         -- remove the submenu
         veaf.loggers.get(veafCarrierOperations.Id):trace("remove the submenu")
-        veafRadio.delSubmenu(carrier.menuPath, veafCarrierOperations.rootPath)
-
-        -- create the submenu
-        veaf.loggers.get(veafCarrierOperations.Id):trace("create the submenu")
         local menuRoot = veafCarrierOperations.rootPathRed
         if carrier.side == coalition.side.BLUE then
             menuRoot = veafCarrierOperations.rootPathBlue
         end
+        veafRadio.delSubmenu(carrier.menuPath, menuRoot)
+
+        -- create the submenu
+        veaf.loggers.get(veafCarrierOperations.Id):trace("create the submenu")
 
         carrier.menuPath = veafRadio.addSubMenu(name, menuRoot)
 

--- a/src/scripts/veaf/veafCasMission.lua
+++ b/src/scripts/veaf/veafCasMission.lua
@@ -72,7 +72,7 @@ veafCasMission = {}
 veafCasMission.Id = "CASMISSION"
 
 --- Version.
-veafCasMission.Version = "1.11.0"
+veafCasMission.Version = "1.11.1"
 
 -- trace level, specific to this module
 --veafCasMission.LogLevel = "trace"
@@ -692,7 +692,7 @@ function veafCasMission.generateInfantryGroup(groupName, defense, armor, side, s
     return group
 end
 
-function veafCasMission.placeGroup(groupDefinition, spawnPosition, spacing, resultTable)
+function veafCasMission.placeGroup(groupDefinition, spawnPosition, spacing, resultTable, hasDest)
     if spawnPosition ~= nil and groupDefinition ~= nil then
         veaf.loggers.get(veafCasMission.Id):trace(string.format("veafCasMission.placeGroup(#groupDefinition.units=%d)",#groupDefinition.units))
 
@@ -703,7 +703,7 @@ function veafCasMission.placeGroup(groupDefinition, spawnPosition, spacing, resu
         -- place its units
         groupPosition = { x = spawnPosition.x, z = spawnPosition.y }
         local hdg = math.random(359)
-        local group, cells = veafUnits.placeGroup(group, veaf.placePointOnLand(groupPosition), spacing+3, hdg)
+        local group, cells = veafUnits.placeGroup(group, veaf.placePointOnLand(groupPosition), spacing+3, hdg, hasDest)
         if veaf.Trace then 
             veafUnits.traceGroup(group, cells)
         end

--- a/src/scripts/veaf/veafGrass.lua
+++ b/src/scripts/veaf/veafGrass.lua
@@ -45,7 +45,7 @@ veafGrass = {}
 veafGrass.Id = "GRASS"
 
 --- Version.
-veafGrass.Version = "2.2.0"
+veafGrass.Version = "2.2.1"
 
 -- trace level, specific to this module
 --veafGrass.LogLevel = "trace"
@@ -414,7 +414,7 @@ function veafGrass.buildFarpUnits(farp, grassRunwayUnits, groupName)
     }
 
 	if ctld then
-		local _beaconInfo = ctld.createRadioBeacon(beaconPoint, 2, "USA", farp.unitName or farp.name, -1, true)
+		local _beaconInfo = ctld.createRadioBeacon(beaconPoint, farpCoalition, farp.country, farp.unitName or farp.name, -1, true)
 		if _beaconInfo ~= nil then
 			farpNamedPoint.tacan = string.format("ADF : %.2f KHz - %.2f MHz - %.2f MHz", _beaconInfo.vhf / 1000, _beaconInfo.uhf / 1000000, _beaconInfo.fm / 1000000)
 			veaf.loggers.get(veafGrass.Id):trace(string.format("farpNamedPoint.tacan=%s", veaf.p(farpNamedPoint.tacan)))

--- a/src/scripts/veaf/veafMove.lua
+++ b/src/scripts/veaf/veafMove.lua
@@ -68,7 +68,7 @@ veafMove = {}
 veafMove.Id = "MOVE"
 
 --- Version.
-veafMove.Version = "1.8.0"
+veafMove.Version = "1.9.0"
 
 -- trace level, specific to this module
 --veafMove.LogLevel = "trace"
@@ -84,29 +84,29 @@ veafMove.tankerMissionParameters = {
     ["A-10C"] = {speed=250, alt=12000},
     ["A-10C_2"] = {speed=250, alt=12000},
     ["AV8BNA"] = {speed=350, alt=18000},
-    ["F-14A"] = {speed=450, alt=22000},
-    ["F-14A-135-GR"] = {speed=450, alt=22000},
-    ["F-14B"] = {speed=450, alt=22000},
-    ["F-15C"] = {speed=450, alt=22000},
-    ["F-15E"] = {speed=450, alt=22000},
-    ["F-16A"] = {speed=450, alt=22000},
-    ["F-16A MLU"] = {speed=450, alt=22000},
-    ["F-16C bl.50"] = {speed=450, alt=22000},
-    ["F-16C bl.52d"] = {speed=450, alt=22000},
-    ["F-16C_50"] = {speed=450, alt=22000},
-    ["F/A-18A"] = {speed=450, alt=22000},
-    ["F/A-18C"] = {speed=450, alt=22000},
-    ["FA-18C_hornet"] = {speed=450, alt=22000},
-    ["JF-17"] = {speed=450, alt=22000},
-    ["M-2000C"] = {speed=450, alt=22000},
-    ["MiG-29K"] = {speed=450, alt=22000},
-    ["MiG-31"] = {speed=450, alt=22000},
-    ["Mirage 2000-5"] = {speed=450, alt=22000},
-    ["Su-24M"] = {speed=450, alt=22000},
-    ["Su-24MR"] = {speed=450, alt=22000},
-    ["Su-33"] = {speed=450, alt=22000},
-    ["Su-34"] = {speed=450, alt=22000},
-    ["Tornado GR4"] = {speed=450, alt=22000},
+    ["F-14A"] = {speed=400, alt=22000},
+    ["F-14A-135-GR"] = {speed=400, alt=22000},
+    ["F-14B"] = {speed=400, alt=22000},
+    ["F-15C"] = {speed=400, alt=22000},
+    ["F-15E"] = {speed=400, alt=22000},
+    ["F-16A"] = {speed=400, alt=22000},
+    ["F-16A MLU"] = {speed=400, alt=22000},
+    ["F-16C bl.50"] = {speed=400, alt=22000},
+    ["F-16C bl.52d"] = {speed=400, alt=22000},
+    ["F-16C_50"] = {speed=400, alt=22000},
+    ["F/A-18A"] = {speed=400, alt=22000},
+    ["F/A-18C"] = {speed=400, alt=22000},
+    ["FA-18C_hornet"] = {speed=400, alt=22000},
+    ["JF-17"] = {speed=400, alt=22000},
+    ["M-2000C"] = {speed=400, alt=22000},
+    ["MiG-29K"] = {speed=400, alt=22000},
+    ["MiG-31"] = {speed=400, alt=22000},
+    ["Mirage 2000-5"] = {speed=400, alt=22000},
+    ["Su-24M"] = {speed=400, alt=22000},
+    ["Su-24MR"] = {speed=400, alt=22000},
+    ["Su-33"] = {speed=400, alt=22000},
+    ["Su-34"] = {speed=400, alt=22000},
+    ["Tornado GR4"] = {speed=400, alt=22000},
 }
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Do not change anything below unless you know what you are doing!
@@ -158,7 +158,7 @@ function veafMove.executeCommand(eventPos, eventText, bypassSecurity)
             elseif options.changeTanker then
                 result = veafMove.changeTanker(eventPos, options.speed, options.altitude)
             elseif options.moveAfac then
-                result = veafMove.moveAfac(eventPos, options.groupName, options.speed, options.altitude)
+                result = veafMove.moveAfac(eventPos, options.groupName, options.speed, options.altitude, options.hdg, options.immortal)
             end
         else
             -- None of the keywords matched.
@@ -194,6 +194,9 @@ function veafMove.markTextAnalysis(text)
     -- tanker refuel leg heading in degrees
     switch.hdg = nil -- defaults to original heading
 
+    -- option to set AFAC to immortal
+    switch.immortal = false
+
     -- tanker refuel leg distance in degrees
     switch.distance = nil -- defaults to original distance
 
@@ -217,7 +220,7 @@ function veafMove.markTextAnalysis(text)
         switch.altitude = -1
     elseif text:lower():find(veafMove.Keyphrase .. " afac") then
         switch.moveAfac = true
-        switch.speed = 300
+        switch.speed = 150
         switch.altitude = 15000
     else
         return nil
@@ -274,6 +277,11 @@ function veafMove.markTextAnalysis(text)
         if key:lower() == "silent" then
             veaf.loggers.get(veafMove.Id):trace("Keyword silent found")
             switch.silent = true
+        end
+
+        if key:lower() == "immortal" then
+            veaf.loggers.get(veafMove.Id):trace("Keyword immortal found")
+            switch.immortal = true
         end
 
     end
@@ -356,7 +364,6 @@ function veafMove.changeTanker(eventPos, speed, alt)
         -- point1 is the point where the tanker mission starts ; we'll change the speed and altitude
         local point1 = points[idxPoint1]
         veaf.loggers.get(veafMove.Id):trace("found point1")
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "point1", point1, debugMarkers)
         -- set speed
         if speed > -1 then 
             point1.speed = speed/1.94384  -- in m/s
@@ -370,24 +377,22 @@ function veafMove.changeTanker(eventPos, speed, alt)
             alt = point1.alt / 0.3048 -- in feet
         end
         veaf.loggers.get(veafMove.Id):trace(string.format("newPoint1=%s",veaf.p(point1)))
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "newPoint1", point1, debugMarkers)
 
         -- point 2 is the start of the tanking Orbit ; we'll change the speed and altitude
         local point2 = points[idxPoint2]
         veaf.loggers.get(veafMove.Id):trace("found point2")
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "point2", point2, debugMarkers)
         local foundOrbit = false
         local task1 = veaf.findInTable(point2, "task")
         if task1 then
             local tasks = task1.params.tasks
             if (tasks) then
-                veaf.mainLogTrace("found " .. #tasks .. " tasks")
+                veaf.loggers.get(veafMove.Id):trace("found %s tasks", veaf.p(#tasks))
                 for j, task in pairs(tasks) do
-                    veaf.mainLogTrace("found task #" .. j)
+                    veaf.loggers.get(veafMove.Id):trace("found task #%s", veaf.p(j))
                     if task.params then
-                        veaf.mainLogTrace("has .params")
+                        veaf.loggers.get(veafMove.Id):trace("has .params")
                         if task.id and task.id == "Orbit" then
-                            veaf.mainLogDebug("Found a ORBIT task for tanker " .. tankerGroupName)
+                            veaf.loggers.get(veafMove.Id):debug("Found a ORBIT task for tanker " .. tankerGroupName)
                             foundOrbit = true
                             if speed > -1 then 
                                 task.params.speed = speed/1.94384  -- in m/s
@@ -408,12 +413,10 @@ function veafMove.changeTanker(eventPos, speed, alt)
             trigger.action.outText(text)
             return
         end
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "newPoint2", point2, debugMarkers)
 
         -- point 3 is the end of the tanking Orbit ; we'll change the speed and altitude
         local point3 = points[idxPoint3]
         veaf.loggers.get(veafMove.Id):trace("found point3")
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "point3", point3, debugMarkers)
         -- change speed
         if speed > -1 then 
             point3.speed = speed/1.94384  -- in m/s
@@ -423,7 +426,6 @@ function veafMove.changeTanker(eventPos, speed, alt)
             point3.alt = alt * 0.3048 -- in meters
         end
         veaf.loggers.get(veafMove.Id):trace("newpoint3="..veaf.p(point3))
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "newpoint3", point3, debugMarkers)
 
         -- replace whole mission
         veaf.loggers.get(veafMove.Id):debug("Resetting changed tanker mission")
@@ -463,6 +465,7 @@ function veafMove.moveTanker(eventPos, groupName, speed, alt, hdg, distance, tel
 		return false
     end
     
+    local unitGroup_Id = nil
     local tankerData = veaf.getGroupData(groupName)
     if not(tankerData) then
         local text = "Cannot move tanker " .. groupName .. " ; cannot find group"
@@ -470,6 +473,7 @@ function veafMove.moveTanker(eventPos, groupName, speed, alt, hdg, distance, tel
         trigger.action.outText(text)
         return false
     end
+    unitGroup_Id = Group.getID(unitGroup) --this and only this serves as a groupID, what is given in tankerData and EscortData does not correspond on the DCS side
 
     local route = veaf.findInTable(tankerData, "route")
     local points = veaf.findInTable(route, "points")
@@ -482,15 +486,12 @@ function veafMove.moveTanker(eventPos, groupName, speed, alt, hdg, distance, tel
 
         local point1 = points[idxPoint1]
         veaf.loggers.get(veafMove.Id):trace(string.format("point1=%s",veaf.p(point1)))
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "point1", point1, debugMarkers)
 
         local point2 = points[idxPoint2]
         veaf.loggers.get(veafMove.Id):trace(string.format("point2=%s",veaf.p(point2)))
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "point2", point2, debugMarkers)
 
         local point3 = points[idxPoint3]
         veaf.loggers.get(veafMove.Id):trace(string.format("point3=%s",veaf.p(point3)))
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "point3", point3, debugMarkers)
 
         -- if distance is not set, compute distance between point2 and point3
         local distance = distance
@@ -504,13 +505,10 @@ function veafMove.moveTanker(eventPos, groupName, speed, alt, hdg, distance, tel
         -- if hdg is not set, compute heading between point2 and point3
         local hdg = hdg
         if hdg == nil then
-            hdg = math.floor(math.deg(math.atan2(point3.y - point2.y, point3.x - point2.x)))
-            if hdg < 0 then
-                hdg = hdg + 360
-            end
+            hdg = veaf.headingBetweenPoints(point2, point3)
+        else
+            hdg = hdg * math.pi/180
         end
-        -- convert heading to radians
-        hdg = hdg * math.pi / 180
 
         -- if speed is not set, use point2 speed
         local speed = speed
@@ -573,7 +571,6 @@ function veafMove.moveTanker(eventPos, groupName, speed, alt, hdg, distance, tel
         point1.alt = movePoint.alt
         point1.speed = movePoint.speed
         veaf.loggers.get(veafMove.Id):trace(string.format("newPoint1=%s",veaf.p(point1)))
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "newPoint1", point1, debugMarkers)
 
         -- set point2 to the start of the tanking Orbit (startLegPoint)
         local foundOrbit = false
@@ -581,13 +578,13 @@ function veafMove.moveTanker(eventPos, groupName, speed, alt, hdg, distance, tel
         if task1 then
             local tasks = task1.params.tasks
             if (tasks) then
-                veaf.mainLogTrace("found " .. #tasks .. " tasks")
+                veaf.loggers.get(veafMove.Id):trace("found " .. #tasks .. " tasks")
                 for j, task in pairs(tasks) do
-                    veaf.mainLogTrace("found task #" .. j)
+                    veaf.loggers.get(veafMove.Id):trace(string.format("found task #%s", veaf.p(j)))
                     if task.params then
-                        veaf.mainLogTrace("has .params")
+                        veaf.loggers.get(veafMove.Id):trace("has .params")
                         if task.id and task.id == "Orbit" then
-                            veaf.mainLogDebug("Found a ORBIT task for tanker " .. groupName)
+                            veaf.loggers.get(veafMove.Id):debug("Found a ORBIT task for tanker " .. groupName)
                             foundOrbit = true
                             task.params.speed = speed
                             task.params.altitude = alt
@@ -607,7 +604,6 @@ function veafMove.moveTanker(eventPos, groupName, speed, alt, hdg, distance, tel
         point2.alt = startLegPoint.alt
         point2.speed = startLegPoint.speed
         veaf.loggers.get(veafMove.Id):trace(string.format("newPoint2=%s",veaf.p(point2)))
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "newPoint2", point2, debugMarkers)
 
         -- set point2 to the end of the tanking Orbit (endLegPoint)
         point3.x = endLegPoint.x
@@ -615,32 +611,133 @@ function veafMove.moveTanker(eventPos, groupName, speed, alt, hdg, distance, tel
         point3.alt = endLegPoint.alt
         point3.speed = endLegPoint.speed
         veaf.loggers.get(veafMove.Id):trace("newpoint3="..veaf.p(point3))
-        traceMarkerId = veaf.loggers.get(veafMove.Id)(traceMarkerId, "newpoint3", point3, debugMarkers)
 
+
+        --verify escort existence and correct configuration
+        local groupName_escort = groupName.." escort"
+        local unitGroup_escort = Group.getByName(groupName_escort)
+        local escort_flag = false
+        local route_escort = {}
+        local points_escort = {}
+        local idxPoint1_escort = nil
+        local idxPoint2_escort = nil
+        local point1_escort = {}
+        local point2_escort = {}
+        local task2_escort = {}
+        local tasks_escort = {}
+        local task_escort = {}
+        local EscortData = {}
+        if unitGroup_escort ~= nil then  
+            EscortData = veaf.getGroupData(groupName_escort)
+            if not(EscortData) then
+                local text = "Cannot move Escort " .. groupName_escort .. " ; cannot find group"
+                veaf.loggers.get(veafMove.Id):info(text)
+            else
+                route_escort = veaf.findInTable(EscortData, "route")
+                points_escort = veaf.findInTable(route_escort, "points")
+    
+                if points_escort then
+                    veaf.loggers.get(veafMove.Id):debug("Escort has WP")
+                    idxPoint1_escort = #points_escort-1 --second to last waypoint
+                    idxPoint2_escort = #points_escort --last waypoint where the escort has to be set up in the editor
+                    point1_escort = points_escort[idxPoint1_escort]
+                    point2_escort = points_escort[idxPoint2_escort]
+                    task2_escort = veaf.findInTable(point2_escort, "task")
+                    if task2_escort.params.tasks then
+                        veaf.loggers.get(veafMove.Id):debug("Last escort WP has tasks")
+                        tasks_escort = task2_escort.params.tasks
+                        for k, task in pairs(tasks_escort) do
+                            --if task.enabled and task.id and task.id == "Escort" and task.params and task.params.groupId == unitGroup_Id then --this line should be used to verify proper configuration of the escort but as it turns out the groupId stored in params has nothing to do with the groupId DCS needs for the escort task, use Group.getID(groupClass) instead
+                            if task.enabled and task.id and task.id == "Escort" and task.params then
+                                veaf.loggers.get(veafMove.Id):trace("Found correct escort Tasking ! Escorted ID : %s", unitGroup_Id)
+                                escort_flag=true --esort exists and is correctly configured
+                                task_escort=task --recover the escort task table to insert the "new" escorted ID, even though it's the same but it seems DCS destroys it after the escorted group respawns
+                            end
+                        end
+                    end
+                end
+            end
+        else
+            veaf.loggers.get(veafMove.Id):info(groupName_escort .. ' not found for move tanker escort command')
+        end
+        
+        local teleportPoint_escort = {}
+        teleportPoint_escort.x = teleportPoint.x
+        teleportPoint_escort.y = teleportPoint.y
+        teleportPoint_escort.alt = teleportPoint.alt
+        if escort_flag then
+            --distances by which the escort is offseted from the escorted group in the map's referential, task_escort provides relative spacing
+            local escort_offset = {}
+            escort_offset.x = (task_escort.params.pos.x*math.cos(hdg) - task_escort.params.pos.z*math.sin(hdg))
+            escort_offset.z = (task_escort.params.pos.x*math.sin(hdg) + task_escort.params.pos.z*math.cos(hdg))
+
+            teleportPoint_escort.x = teleportPoint.x + escort_offset.x
+            teleportPoint_escort.y = teleportPoint.y + escort_offset.z
+            teleportPoint_escort.alt = teleportPoint.alt + task_escort.params.pos.y
+            teleportPoint_escort.speed = teleportPoint.speed
+
+            --Effectively waypoint 0, the AI will have to fly over it and in the editor it never poses a problem but in scripting the AI will do orbits to try and reach it
+            --so it has to be offseted
+            point1_escort.x = (teleportPoint.x + movePoint.x)/2 + escort_offset.x
+            point1_escort.y = (teleportPoint.y + movePoint.y)/2 + escort_offset.z
+            point1_escort.alt = movePoint.alt + task_escort.params.pos.y
+            point1_escort.speed = movePoint.speed
+
+            --Waypoint 1 where the escort tasking will come into play
+            point2_escort.x = 2*point1_escort.x - teleportPoint.x - escort_offset.x
+            point2_escort.y =  2*point1_escort.y - teleportPoint.y - escort_offset.z
+            point2_escort.alt = movePoint.alt + task_escort.params.pos.y
+            point2_escort.speed = movePoint.speed
+        end
+
+
+        --actually move the group
         local delay = 0
 
         -- teleport if the option is set
         if teleport then
-            veaf.loggers.get(veafMove.Id):debug("Teleport the group")   
-            local vars = { groupName = groupName, point = teleportPoint, action = "respawn" }
+            veaf.loggers.get(veafMove.Id):debug("Teleport the tanker")   
+            local vars = { groupName = groupName, point = teleportPoint, action = "teleport"}
             local grp = mist.teleportToPoint(vars)
             unitGroup = Group.getByName(groupName)
+            unitGroup_Id = Group.getID(unitGroup) --get the new groupID which has now changed
+
+            if escort_flag then
+                veaf.loggers.get(veafMove.Id):debug("Teleport the escort")   
+                task_escort.params.groupId = unitGroup_Id --assign the new groupID within the old escort mission, only necessary after teleporting as the tanker's ID will have changed
+                local vars_escort = { groupName = groupName_escort, point = teleportPoint_escort, action = "teleport"}
+                local grp_escort = mist.teleportToPoint(vars_escort)
+                unitGroup_escort = Group.getByName(groupName_escort)
+            end
+
             delay = 1
         end
 
-        veaf.loggers.get(veafMove.Id):debug(string.format("Resetting moved tanker mission in %d seconds", delay))
-        local replaceMission = function(unitGroup, tankerData)
+        veaf.loggers.get(veafMove.Id):debug(string.format("Resetting moved tanker/escort mission in %d seconds", delay))
+        local replaceMission = function(unitGroup, tankerData, escort_flag, unitGroup_escort, EscortData)
             veaf.loggers.get(veafMove.Id):debug(string.format("Resetting moved tanker %s mission", unitGroup:getName()))
             veaf.loggers.get(veafMove.Id):debug(string.format("tankerData=%s", veaf.p(tankerData)))
-            -- replace the mission
+            -- replace the mission ... for the tanker
             local mission = { 
                 id = 'Mission', 
                 params = tankerData
             }
             local controller = unitGroup:getController()
             controller:setTask(mission)
+
+            if escort_flag then
+                veaf.loggers.get(veafMove.Id):debug(string.format("Resetting moved Tanker Escort %s mission", unitGroup_escort:getName()))
+                veaf.loggers.get(veafMove.Id):debug(string.format("EscortData=%s", veaf.p(EscortData)))
+                --... for the escort, necessary to re assign the mission wether the tanker was teleported (== changed ID) or not because DCS
+                local escort_mission = { 
+                    id = 'Mission', 
+                    params = EscortData  
+                }
+                local escort_controller = unitGroup_escort:getController()
+                escort_controller:setTask(escort_mission)
+            end
         end
-        mist.scheduleFunction(replaceMission, {unitGroup, tankerData}, timer.getTime()+delay)
+        mist.scheduleFunction(replaceMission, {unitGroup, tankerData, escort_flag, unitGroup_escort, EscortData}, timer.getTime()+delay)
         return true
     else
         return false
@@ -652,19 +749,21 @@ end
 -- @param point eventPos
 -- @param string groupName 
 -- @param float speed in knots
--- @param float hdg heading (0-359)
--- @param float distance in Nm
 -- @param float alt in feet
+-- @param float hdg in degrees
+-- @param boolean immortal
 ------------------------------------------------------------------------------
-function veafMove.moveAfac(eventPos, groupName, speed, alt)
+function veafMove.moveAfac(eventPos, groupName, speed, alt, heading, immortal)
     if not speed then
-        speed = 300
+        speed = 150
     end
     if not alt then
         alt = 20000
     end
     veaf.loggers.get(veafMove.Id):debug("veafMove.moveAfac(groupName = " .. groupName .. ", speed = " .. speed .. ", alt = " .. alt)
     veaf.loggers.get(veafMove.Id):debug(string.format("veafMove.moveAfac: eventPos  x=%.1f z=%.1f", eventPos.x, eventPos.z))
+
+    local distanceFromTeleport = 3000 --distance between the orbit point and the teleport point in meters
 
 	local unitGroup = Group.getByName(groupName)
 	if unitGroup == nil then
@@ -673,93 +772,142 @@ function veafMove.moveAfac(eventPos, groupName, speed, alt)
 		return false
 	end
 
-	-- teleport position
-	local teleportPosition = {
-		["x"] = eventPos.x + 5 * 1852 * math.cos(mist.utils.toRadian(180)),
-        ["y"] = eventPos.z + 5 * 1852 * math.sin(mist.utils.toRadian(180)),
-        ["alt"] = alt * 0.3048 -- in meters
-	}
+    local afacData = veaf.getGroupData(groupName)
+    if not afacData then
+        for number, dynAFACcallsign in pairs(veafSpawn.AFAC.callsigns) do
+            if groupName:find(dynAFACcallsign) then
+                veaf.loggers.get(veafMove.Id):trace("AFAC is dynamically spawned (Move command WIP)")
+                trigger.action.outText("Dynamically spawned AFACs can not be moved yet (WIP)", 10)
+                return false
+                --afacData = veafSpawn.AFAC.missionData[number] --Does not work to recover the mission data of the dynamically spawned afac for movie command later on, for mist the group simply does not exist so it has no data
+            end
+        end
+    end
+    veaf.loggers.get(veafMove.Id):trace("Found AFAC named " .. groupName .. " for move command")
+    veaf.loggers.get(veafMove.Id):debug(string.format("AFAC mission data is : %s", veaf.p(afacData)))
 
-    -- starting position
-	local fromPosition = {
-		["x"] = eventPos.x,
-		["y"] = eventPos.z
-	}
-	
-	local mission = { 
-		id = 'Mission', 
-		params = { 
-			["communication"] = true,
-			["start_time"] = 0,
-			["task"] = "AFAC",
-			route = { 
-				points = { 
-					-- first point
-					[1] = { 
-						["type"] = "Turning Point",
-						["action"] = "Turning Point",
-						["x"] = fromPosition.x,
-						["y"] = fromPosition.y,
-						["alt"] = alt * 0.3048, -- in meters
-						["alt_type"] = "BARO", 
-						["speed"] = speed/1.94384,  -- speed in m/s
-						["speed_locked"] = boolean, 
-						["task"] = 
-						{
-							["id"] = "ComboTask",
-							["params"] = 
-							{
-                                ["tasks"] = 
-                                {
-                                    [1] = 
-                                    {
-                                        ["number"] = 1,
-                                        ["auto"] = false,
-                                        ["id"] = "Orbit",
-                                        ["enabled"] = true,
-                                        ["params"] = 
-                                        {
-                                            ["altitude"] = alt * 0.3048, -- in meters,
-                                            ["pattern"] = "Circle",
-                                            ["speed"] = speed/1.94384,  -- speed in m/s
-                                            ["altitudeEdited"] = true,
-                                            ["speedEdited"] = true,
-                                        }, -- end of ["params"]
-                                    }, -- end of [1]
-                                }, -- end of ["tasks"]
-                            }, -- end of ["params"]
-						}, -- end of ["task"]
-					}, -- enf of [1]
-				}, 
-			} 
-		} 
-	}
+    local route_afac = veaf.findInTable(afacData, "route")
+    local points_afac = veaf.findInTable(route_afac, "points")
+    if points_afac then
 
-    local vars = { groupName = groupName, point = teleportPosition, action = "teleport" }
-    local grp = mist.teleportToPoint(vars)
-
-    -- JTAC needs to be invisible and immortal
-    local _setImmortal = {
-        id = 'SetImmortal',
-        params = {
-            value = true
-        }
-    }
-    -- invisible to AI, Shagrat
-    local _setInvisible = {
-        id = 'SetInvisible',
-        params = {
-            value = true
-        }
-    }
-
-    -- replace whole mission
-    local controller = unitGroup:getController()
-	controller:setTask(mission)
-    Controller.setCommand(controller, _setImmortal)
-    Controller.setCommand(controller, _setInvisible)
+        veaf.loggers.get(veafMove.Id):trace("Found AFAC waypoints")
+        local idxPoint1_afac = #points_afac-1 --second to last waypoint
+        local idxPoint2_afac = #points_afac --last waypoint
+        local point1_afac = points_afac[idxPoint1_afac]
+        local point2_afac = points_afac[idxPoint2_afac]
+        local FACflag = false
+        local OrbitFlag = false
     
-    return true
+        -- if hdg is not set, compute heading between point1 and point2
+        local hdg = heading
+        if hdg == nil then
+            hdg = veaf.headingBetweenPoints(point1_afac, point2_afac)
+        else
+            hdg = heading * math.pi/180
+        end
+        
+        -- teleport position
+        local teleportPosition = {
+            ["x"] = eventPos.x - distanceFromTeleport*math.cos(hdg), --teleport 3km south of orbit point
+            ["y"] = eventPos.z - distanceFromTeleport*math.sin(hdg),
+            ["alt"] = alt * 0.3048 -- in meters
+        }
+
+        -- orbit position
+        local fromPosition = {
+            ["x"] = eventPos.x,
+            ["y"] = eventPos.z
+        }
+
+        --check valid configuration of the AFAC
+        if point1_afac and point2_afac then
+            veaf.loggers.get(veafMove.Id):debug("AFAC has at least the two waypoints required")
+            local tasks1_afac=point1_afac.task.params.tasks
+            local tasks2_afac=point2_afac.task.params.tasks
+            if tasks1_afac and tasks2_afac then
+                for _, task in pairs(tasks1_afac) do
+                    if task.id == "FAC" then
+                        veaf.loggers.get(veafMove.Id):trace("FAC configuration valid on second to last WP")
+                        FACflag = true
+                    end
+                end
+
+                for _, task in pairs(tasks2_afac) do
+                    if task.id == "Orbit" then
+                        veaf.loggers.get(veafMove.Id):trace("AFAC Orbit configuration valid on last WP")
+                        OrbitFlag = true
+                    end
+                end
+            end
+        end
+
+        if FACflag == false or OrbitFlag == false then
+            veaf.loggers.get(veafMove.Id):info(groupName .. ' has an invalid FAC/Orbit configuration')
+            trigger.action.outText(groupName .. ' has an invalid FAC/Orbit configuration' , 10)
+            return false
+        end
+
+        --edit the last two waypoints of the AFAC's flight plan with the new requested position,speed and alt info
+        point1_afac.speed=speed
+        point1_afac.alt=teleportPosition.alt
+        point1_afac.x=teleportPosition.x + distanceFromTeleport*math.cos(hdg)/2
+        point1_afac.y=teleportPosition.y + distanceFromTeleport*math.sin(hdg)/2
+    
+        point2_afac.speed=speed
+        point2_afac.alt=teleportPosition.alt
+        point2_afac.x=eventPos.x
+        point2_afac.y=eventPos.z
+
+        --teleport the group south of the requested location
+        veaf.loggers.get(veafMove.Id):trace("AFAC ".. groupName .. " teleported")
+        local vars = { groupName = groupName, point = teleportPosition, action = "teleport" }
+        local grp = mist.teleportToPoint(vars)
+        unitGroup = Group.getByName(groupName) --refresh group class after respawn, not necessary but safer considering at least the groupId changes
+    
+        --necessary delay for the following code to not be ignored
+        local delay=1
+    
+        -- replace whole mission
+        local setMission = function(unitGroup, afacData, immortal)
+            veaf.loggers.get(veafMove.Id):trace("AFAC retasked with modified mission")
+
+            local mission = {
+                id = 'Mission',
+                params = afacData
+            }
+    
+            local controller = unitGroup:getController()
+            controller:setTask(mission)
+
+            if immortal then
+                -- JTAC needs to be invisible and immortal
+                veaf.loggers.get(veafMove.Id):trace("AFAC immortalized")
+                local _setImmortal = {
+                    id = 'SetImmortal',
+                    params = {
+                        value = true
+                    }
+                }
+                -- invisible to AI, Shagrat
+                local _setInvisible = {
+                    id = 'SetInvisible',
+                    params = {
+                        value = true
+                    }
+                }
+
+                Controller.setCommand(controller, _setImmortal)
+                Controller.setCommand(controller, _setInvisible)
+            end
+        end
+    
+        mist.scheduleFunction(setMission, {unitGroup, afacData, immortal}, timer.getTime()+delay)
+        
+        return true
+    else
+        return false
+    end
+
 end
 
 -- prepare tanker units
@@ -862,5 +1010,3 @@ function veafMove.initialize()
 end
 
 veaf.loggers.get(veafMove.Id):info(string.format("Loading version %s", veafMove.Version))
-
-

--- a/src/scripts/veaf/veafShortcuts.lua
+++ b/src/scripts/veaf/veafShortcuts.lua
@@ -27,7 +27,7 @@ veafShortcuts = {}
 veafShortcuts.Id = "SHORTCUTS"
 
 --- Version.
-veafShortcuts.Version = "1.26.0"
+veafShortcuts.Version = "1.27.0"
 
 -- trace level, specific to this module
 --veafShortcuts.LogLevel = "trace"
@@ -694,9 +694,30 @@ function veafShortcuts.buildDefaultList()
     -- specific air defenses groups and units  
     veafShortcuts.AddAlias(
         VeafAlias:new()
+            :setName("-hq7")
+            :setDescription("HQ-7 Red Banner battery")
+            :setVeafCommand("_spawn group, name hq7, skynet true")
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-hq7noew")
+            :setDescription("HQ-7 Red Banner battery without EWR")
+            :setVeafCommand("_spawn group, name hq7-noew, skynet true")
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
             :setName("-sa2")
             :setDescription("SA-2 Guideline (S-75 Dvina) battery")
             :setVeafCommand("_spawn group, name sa2, skynet true")
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-sa5")
+            :setDescription("SA-5 Gammon (S-200 Dubna) battery")
+            :setVeafCommand("_spawn group, name sa5, skynet true")
             :setBypassSecurity(false)
     )
     veafShortcuts.AddAlias(
@@ -757,9 +778,23 @@ function veafShortcuts.buildDefaultList()
     )
     veafShortcuts.AddAlias(
         VeafAlias:new()
+            :setName("-insurgent_manpad")
+            :setDescription("Insurgent SA-18 manpad squad")
+            :setVeafCommand("_spawn group, name ins_manpad")
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
             :setName("-sa18")
-            :setDescription("SA-18 manpad soldier")
-            :setVeafCommand("_spawn unit, name SA-18 Igla-S manpad")
+            :setDescription("SA-18 manpad squad")
+            :setVeafCommand("_spawn group, name sa18_squad")
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-sa18s")
+            :setDescription("SA-18S manpad squad")
+            :setVeafCommand("_spawn group, name sa18s_squad")
             :setBypassSecurity(false)
     )
     veafShortcuts.AddAlias(
@@ -786,7 +821,7 @@ function veafShortcuts.buildDefaultList()
     veafShortcuts.AddAlias(
         VeafAlias:new()
             :setName("-manpads")
-            :setDescription("mutiple SA-18 manpad soldier peppered in a wide radius")
+            :setDescription("mutiple SA-18S manpad soldier peppered in a wide radius")
             :setVeafCommand("_spawn unit, name SA-18 Igla-S manpad, radius 5000, skynet true")
             :addRandomParameter("multiplier", 3, 6)
             :setBypassSecurity(false)
@@ -807,9 +842,51 @@ function veafShortcuts.buildDefaultList()
     )
     veafShortcuts.AddAlias(
         VeafAlias:new()
+            :setName("-nasams")
+            :setDescription("NASAMS battery with 120C (US by default)")
+            :setVeafCommand("_spawn group, name nasams_c, country USA, skynet true")
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-nasams_b")
+            :setDescription("NASAMS battery with 120B (US by default)")
+            :setVeafCommand("_spawn group, name nasams_b, country USA, skynet true")
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
             :setName("-patriot")
             :setDescription("Patriot battery (US by default)")
             :setVeafCommand("_spawn group, name patriot, country USA, skynet true")
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-stinger")
+            :setDescription("Stinger manpad squad (US by default)")
+            :setVeafCommand("_spawn group, name stinger_squad, country USA")
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-dogear")
+            :setDescription("Dogear Radar")
+            :setVeafCommand("_spawn unit, name dogear, skynet true, ewr")
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-blue_ewr")
+            :setDescription("F-117 Domed EWR (US by default)")
+            :setVeafCommand("_spawn group, name blue_ewr, country USA, skynet true")
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-ewr")
+            :setDescription("55G6 Mast EWR")
+            :setVeafCommand("_spawn group, name ewr, skynet true")
             :setBypassSecurity(false)
     )
     veafShortcuts.AddAlias(
@@ -845,6 +922,28 @@ function veafShortcuts.buildDefaultList()
             :setName("-pyotr")
             :setDescription("CGN 1144.2 Pyotr Velikiy (RU by default)")
             :setVeafCommand("_spawn unit, name PIOTR, country RUSSIA, skynet true")
+            :setBypassSecurity(false)
+    )
+    -- convoys
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-hv_convoy_red")
+            :setDescription("Red High Value Attack convoy")
+            :setVeafCommand("_spawn group, name hv_convoy_red, country RUSSIA, skynet false, alarm 0") --skynet is set to false as Radar SAMs will not move otherwise (AI turned off). Alarm is set to 0, meaning Alarm state 0 for proper movement of the scud
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-attack_convoy_red")
+            :setDescription("Red Attack convoy")
+            :setVeafCommand("_spawn group, name convoy_red, country RUSSIA, skynet false") --skynet is set to false as Radar SAMs will not move otherwise (AI turned off). Alarm is set to 0, meaning Alarm state 0 for proper movement of the scud
+            :setBypassSecurity(false)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-civilian_convoy_red")
+            :setDescription("Red Civilian convoy")
+            :setVeafCommand("_spawn group, name civilian_convoy_red, country RUSSIA") --skynet is set to false as Radar SAMs will not move otherwise (AI turned off). Alarm is set to 0, meaning Alarm state 0 for proper movement of the scud
             :setBypassSecurity(false)
     )
 
@@ -998,6 +1097,13 @@ function veafShortcuts.buildDefaultList()
             :setName("-jtac")
             :setDescription("JTAC humvee")
             :setVeafCommand("_spawn jtac")
+            :setBypassSecurity(true)
+    )
+    veafShortcuts.AddAlias(
+        VeafAlias:new()
+            :setName("-afac")
+            :setDescription("AFAC MQ-9 Reaper")
+            :setVeafCommand("_spawn afac")
             :setBypassSecurity(true)
     )
     veafShortcuts.AddAlias(

--- a/src/scripts/veaf/veafSkynetIadsHelper.lua
+++ b/src/scripts/veaf/veafSkynetIadsHelper.lua
@@ -200,8 +200,8 @@ function veafSkynet.addGroupToNetwork(dcsGroup, forceEwr, pointDefense, alreadyA
                 trigger.action.outText("Point Defense added",5)
                 iads:getSAMSiteByGroupName(nearestSAMSite_name):addPointDefence(addedSite)
             else
-                veaf.loggers.get(veafSkynet.Id):info("Could not find SAM site within range to add point defense to (WIP)")
-                trigger.action.outText("Could not find SAM site within range to add point defense to (WIP)", 10)
+                veaf.loggers.get(veafSkynet.Id):info("Could not find SAM site within range to add point defense to (adding for EWR is WIP)")
+                trigger.action.outText("Could not find SAM site within range to add point defense to (adding for EWR is WIP)", 10)
             end
         elseif forceEwr then
             veaf.loggers.get(veafSkynet.Id):trace(string.format("SAM/EWR is forced EWR"))

--- a/src/scripts/veaf/veafSpawn.lua
+++ b/src/scripts/veaf/veafSpawn.lua
@@ -667,9 +667,13 @@ function veafSpawn.markTextAnalysis(text)
         end
 
         if key:lower() == "pointdefense" then
-            -- Set force IADS EWR toggle for unit spawn
+            -- Tells IADS to add the spawned SAM to the point defenses of the specified site or to the nearest site
             veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword pointdefense found"))
             options.pointDefense = true
+            if val ~= "" then
+                veaf.loggers.get(veafSpawn.Id):trace(string.format("groupName specified : %s", tostring(val)))
+                options.pointDefense = tostring(val) 
+            end
         end
 
         --to be placed after the skynet input, SAMs in the skynet network work better if set to AlarmState RED, so AlarmState is equal to 2 if skynet is enabled

--- a/src/scripts/veaf/veafUnits.lua
+++ b/src/scripts/veaf/veafUnits.lua
@@ -448,7 +448,7 @@ function veafUnits.placeGroup(group, spawnPoint, spacing, hdg, hasDest)
     local fixedUnits = {}
     local freeUnits = {}
     for _, unit in pairs(group.units) do
-        if unit.cell and not hasDest then
+        if unit.cell and not hasDest then --if the convoy has a destination, programmer defined patterns do not apply anymore as the convoy is spawned in a line
             table.insert(fixedUnits, unit)
         else
             table.insert(freeUnits, unit)
@@ -461,19 +461,17 @@ function veafUnits.placeGroup(group, spawnPoint, spacing, hdg, hasDest)
         allCells[cellNum] = cellNum
     end
         
-    if not hasDest then --if the convoy has a destination, programmer defined patterns do not apply anymore as the convoy is spawned in a line
-        -- place fixed units in their designated cells
-        for i = 1, #fixedUnits do 
-            local unit = fixedUnits[i]
-            cells[unit.cell] = {}
-            cells[unit.cell].unit = unit
-            
-            -- remove this cell from the list of available cells
-            for cellNum = 1, #allCells do
-                if allCells[cellNum] == unit.cell then
-                    table.remove(allCells, cellNum)
-                    break
-                end
+    -- place fixed units in their designated cells
+    for i = 1, #fixedUnits do 
+        local unit = fixedUnits[i]
+        cells[unit.cell] = {}
+        cells[unit.cell].unit = unit
+        
+        -- remove this cell from the list of available cells
+        for cellNum = 1, #allCells do
+            if allCells[cellNum] == unit.cell then
+                table.remove(allCells, cellNum)
+                break
             end
         end
     end


### PR DESCRIPTION
--------------------------------------------------------------------------------------------------------------------------------
Fixes
--------------------------------------------------------------------------------------------------------------------------------
-Carrier operations radio menu duplication bug fixed

-Move command restored for tankers

-AFAC moving fixed 

-TACANs spawning as blue on FARPs despite the FARP being red, fixed


--------------------------------------------------------------------------------------------------------------------------------
Additions
--------------------------------------------------------------------------------------------------------------------------------
-AFAC dynamic spawning added (->issue, can't move dynamically spawned AFACs). The spawn limit is set to 8 as otherwise their DCS callsigns will overlap causing confusion in the native JTAC radio menu.

-tanker escort teleportation added (->bug, the escort doesn't really work anymore when teleported but does follow the tanker)

-static spawning added through _spawn units command, added the _**"static" option**_ to force the desired unit to be a static. This also means that aircrafts and helicopters can now be spawned, as statics through the _spawn unit command with the forceStatic option. (->issue, more complex statics such as FARPs, smokes and fires (list TBD) can not be spawned through this command)

-manually added a navalStatic list for the checkUnitPosition command to know if a static is allowed to spawn in water or not.
-added the _**"alarm" option**_ to set the alarmState of spawned units/groups (whatever the command)

-group in-Line spawning for convoys added, works with -sam, -convoy, -armor, -transport and _spawn group. (unverified issue -> convoys no longer fan out at arrival)

-**_"heading" option_** added for -sam, -convoy and -transport (in order for users to align groups with the road when they have a destination for faster departures)

-IADS added _**"pointdefense" option**_ when spawning SAMs added. This will add the new SAM to the pointDefenses of the nearest SAM site/EWR site or to the specified site (by groupName). 
(->bug, you can add pointdefences to IADS networks of the other coalition or technically to any IADS network other than the one that the defending SAM was added to, seems to be a skynet bug)
(->issue, currently it is not possible to add pointdefences to the nearest EWR as skynet does not store the group name of the EWR but rather it's unit name)

-IADS added _**"ewr" option**_ when spawning SAMs/EWRs to force them to act as EWRs (always on, feeding the network)


--------------------------------------------------------------------------------------------------------------------------------
Shortcut changes and additions / Groups update and additions
--------------------------------------------------------------------------------------------------------------------------------
-added multiple groups : sa5, hq7, hq7-noew, red_ewr, blue_ewr, stinger, nasams_c, nasams_b, stinger_squad, insurgent_manpad_squad, sa18_squad, sa18s_squad (as in the Igla-S more modern version), hv_convoy_red, attack_convoy_red and civilian_convoy_red
-reworked some groups to have correct launcher headings, their SR spawned first (to counter an IADS bug) etc.

added the following shortcuts : 
-afac
-nasams
-nasams_b
-sa5
-hq7
-hq7noew
-dogear
-ewr
-hv_convoy_red
-attack_convoy_red
-civilian_convoy_red
-sa18s
-insurgent_manpad
-stinger

reworked the following shortcuts :
-sa18 now spawns an sa-18 squad with some infantry and a transport vehicle (Tigr 4x4)
