### PR TITLE
CTLD JTAC Target selection and retention

### DIFF
--- a/src/scripts/community/mist.lua
+++ b/src/scripts/community/mist.lua
@@ -1529,7 +1529,8 @@ do -- the main scope
 					newGroup.units[unitIndex].name = newGroup.units[unitIndex].name
 				end
 			end
-			if newGroup.clone or not unitData.name then
+			--if the unit name was not given or already exists in the case of a clone, derive a new one from the group name
+			if (newGroup.clone and mist.DBs.unitsByName[unitData.name]) or not unitData.name then
 				newGroup.units[unitIndex].name = tostring(newGroup.name .. ' unit' .. unitIndex)
 			end
 

--- a/src/scripts/veaf/veafSkynetIadsHelper.lua
+++ b/src/scripts/veaf/veafSkynetIadsHelper.lua
@@ -31,7 +31,7 @@ veafSkynet.Id = "SKYNET"
 veafSkynet.Version = "1.2.1"
 
 -- trace level, specific to this module
--- veafSkynet.LogLevel = "trace"
+--veafSkynet.LogLevel = "trace"
 
 veaf.loggers.new(veafSkynet.Id, veafSkynet.LogLevel)
 
@@ -85,18 +85,25 @@ function veafSkynet.getNearestIADSSite(dcsUnit, currentGroup)
 
     local CoalitionSites = nil
 
-    local searchForGroup = function(CoalitionSites, pos, currentGroupName)
+    local searchForGroup = function(CoalitionSites, pos, currentGroupName, ewrFlag)
         local minDistance = veafSkynet.MaxPointDefenseDistanceFromSite
         local FoundGroup = nil
 
         for site, site_info in pairs(CoalitionSites) do
             local site_name = site_info.dcsName -- For EWRs it looks like this gives the unit's name which would need to be reversed to the group to get position data
+            
             veaf.loggers.get(veafSkynet.Id):trace(string.format("Checked Site groupName : %s", veaf.p(site_name))) 
             --for k,v in pairs(site_info) do 
             --    veaf.loggers.get(veafSkynet.Id):trace(string.format("Checked Site info key : %s", veaf.p(k))) --dump the skynet data structure
             --end
             
             if site_name and currentGroupName ~= site_name then
+                if ewrFlag then
+                    local unit = Unit.getByName(site_name)
+                    local group = Unit.getGroup(unit)
+                    site_name = Group.getName(group)
+                end
+
                 local groupAvgPosition = veaf.getAveragePosition(site_name)
                 veaf.loggers.get(veafSkynet.Id):trace(string.format("Checked Site groupAvgPosition : %s", veaf.p(groupAvgPosition)))
 
@@ -118,7 +125,7 @@ function veafSkynet.getNearestIADSSite(dcsUnit, currentGroup)
 
     --start by going through the EWRs
     CoalitionSites = iads:getEarlyWarningRadars()
-    nearestEWRname, minEWRDistance = searchForGroup(CoalitionSites, defensePos, currentGroup)
+    nearestEWRname, minEWRDistance = searchForGroup(CoalitionSites, defensePos, currentGroup, true)
 
     --search for SAM sites
     CoalitionSites = iads:getSAMSites()
@@ -227,15 +234,15 @@ function veafSkynet.addGroupToNetwork(dcsGroup, forceEwr, pointDefense, alreadyA
             if defended_name then
                 local text = string.format("Point Defense added to site : %s", string.format(defended_name))
                 veaf.loggers.get(veafSkynet.Id):info(text)
-                trigger.action.outText(text,5)
+                trigger.action.outText(text,10)
                 if iads:getSAMSiteByGroupName(defended_name) then
                     iads:getSAMSiteByGroupName(defended_name):addPointDefence(addedSite)
                 else
                     iads:getEarlyWarningRadars(defended_name):addPointDefence(addedSite)
                 end
             else
-                veaf.loggers.get(veafSkynet.Id):info("Could not find SAM site within range to add point defense to (adding for nearest EWR is WIP)")
-                trigger.action.outText("Could not find SAM site within range to add point defense to (adding for nearest EWR is WIP)", 10)
+                veaf.loggers.get(veafSkynet.Id):info("Could not find SAM site within range to add point defense")
+                trigger.action.outText("Could not find SAM site within range to add point defense", 15)
             end
         elseif forceEwr then
             veaf.loggers.get(veafSkynet.Id):trace(string.format("SAM/EWR is forced EWR"))

--- a/src/scripts/veaf/veafSpawn.lua
+++ b/src/scripts/veaf/veafSpawn.lua
@@ -136,14 +136,14 @@ veafSpawn.AFAC.maximumAmount = 8
 veafSpawn.AFAC.baseAFACfrequency = 226300000 -- 226.300000 MHz otherwise known as 226300000 Hz
 -- callsign list of the AFACs
 veafSpawn.AFAC.callsigns = {
-    [1] = "Enfield 9",
-    [2] = "Springfield 9",
-    [3] = "Uzi 9",
-    [4] = "Colt 9",
-    [5] = "Dodge 9",
-    [6] = "Ford 9",
-    [7] = "Chevy 9",
-    [8] = "Pontiac 9",
+    [1] = "Enfield 9 1",
+    [2] = "Springfield 9 1",
+    [3] = "Uzi 9 1",
+    [4] = "Colt 9 1",
+    [5] = "Dodge 9 1",
+    [6] = "Ford 9 1",
+    [7] = "Chevy 9 1",
+    [8] = "Pontiac 9 1",
 }
 -- AFAC mission data as MIST isn't able to recover it from dynamically spawned aircrafts
 veafSpawn.AFAC.missionData = {}
@@ -2367,7 +2367,7 @@ function veafSpawn.spawnAFAC(spawnSpot, name, country, altitude, speed, hdg, fre
     local codeDigit = {}
     codeDigit = veaf.laserCodeToDigit(code)
 
-    local newGroupName = string.format("%s - %01d %01d %01d %01d", veafSpawn.AFAC.callsigns[veafSpawn.AFAC.numberSpawned], codeDigit.thousands, codeDigit.hundreds, codeDigit.tens, codeDigit.units)
+    local newGroupName = veafSpawn.AFAC.callsigns[veafSpawn.AFAC.numberSpawned]
     veaf.loggers.get(veafSpawn.Id):trace("newGroupName=%s",newGroupName)
     
     local altitude = altitude 
@@ -2506,19 +2506,19 @@ function veafSpawn.spawnAFAC(spawnSpot, name, country, altitude, speed, hdg, fre
     --newGroup.task = "AFAC"
     veaf.loggers.get(veafSpawn.Id):trace("newGroup=%s", veaf.p(newGroup, nil, {"route", "payload"}))
 
-    for _, unit in pairs(newGroup.units) do
-        unit.skill = "Excellent"
-    end
+    --setup of the new group
+    local unit = newGroup.units[1]
+    unit.skill = "Excellent"
     newGroup.hidden=false
     newGroup.name = newGroupName
-    for _, unit in pairs(newGroup.units) do
-        local unitName = unit.unitName or unit.name
-        veaf.loggers.get(veafSpawn.Id):trace("unitName=%s",unitName)
-        local spawnedUnitName = string.format("%s #%04d", unitName, veafSpawn.spawnedNamesIndex[groupName])
-        unit.name = spawnedUnitName
-        unit.alt = teleportSpot.alt
-        veaf.loggers.get(veafSpawn.Id):trace("spawnedUnitName=%s",spawnedUnitName)
-    end
+
+    local unitName = newGroupName
+    veaf.loggers.get(veafSpawn.Id):trace("unitName=%s",unitName)
+    unit.unitName = unitName
+    unit.name = unitName
+
+    unit.alt = teleportSpot.alt
+
     veaf.loggers.get(veafSpawn.Id):trace("newGroup=%s", veaf.p(newGroup, nil, {"route", "payload"}))
     local _spawnedGroup = mist.dynAdd(newGroup)
 
@@ -2527,7 +2527,8 @@ function veafSpawn.spawnAFAC(spawnSpot, name, country, altitude, speed, hdg, fre
         veaf.loggers.get(veafSpawn.Id):trace("_spawnedGroup.name=%s",_spawnedGroup.name)
         mist.goRoute(_spawnedGroup.name, newRoute)
 
-        --veafSpawn.AFAC.missionData[veafSpawn.spawnedNamesIndex[groupName]] = veaf.getGroupData(_spawnedGroup.name) --Does not work to recover the mission data of the dynamically spawned afac for movie command later on, for mist the group simply does not exist so it has no data
+        --veaf.loggers.get(veafSpawn.Id):trace("_spawnedGroup=%s", veaf.p(_spawnedGroup))
+        --veafSpawn.AFAC.missionData[veafSpawn.spawnedNamesIndex[groupName]] = _spawnedGroup --Does not work to recover the mission data of the dynamically spawned afac for movie command later on, for mist the group simply does not exist anyways
 
         -- start lasing 
         if ctld then 
@@ -2544,7 +2545,7 @@ function veafSpawn.spawnAFAC(spawnSpot, name, country, altitude, speed, hdg, fre
         end
 
         local humanFrequency = dcsFrequency/1000000
-        local text = "AFAC " .. string.format(veafSpawn.AFAC.numberSpawned) .. "/" .. string.format(veafSpawn.AFAC.maximumAmount) .. " - " .. string.format(_spawnedGroup.name) .. " (" .. string.format(country) .. ") - on " .. string.format(humanFrequency) .. "AM (DCS) or " .. string.format(frequency) .. string.upper(mod) .. " (SRS)"
+        local text = "AFAC " .. string.format(veafSpawn.AFAC.numberSpawned) .. "/" .. string.format(veafSpawn.AFAC.maximumAmount) .. " - " .. string.format(_spawnedGroup.name) .. " (" .. string.format(country) .. ") - on " .. string.format(humanFrequency) .. "AM (DCS AFAC) or " .. string.format(frequency) .. string.upper(mod) .. " (SRS)"
         veaf.loggers.get(veafSpawn.Id):info(text)
         trigger.action.outText(text, 15)
  


### PR DESCRIPTION
-CTLD JTAC Experimental User Target Selection and Target Selection retention (will try to acquire selected target if possible after losing it)
->This needs extensive testing, at least to verify proper operation without interacting with the target selection. So far most "potential" issues are with the radio menu refresh, if the unit dies at the wrong time, will it delete the entries correctly ? etc.

-MIST tweak to clone single unit groups with the their groupName=unitName (for CTLD JTAC compatibility)
->Breaking change unless a specific option is added, to be discussed

-spawnAFAC command optimized slightly
->Still haven't managed to fix the moveAFAC command for dynamically spawned AFACs, MIST just doesn't know the group even exists...
