### PR TITLE
Added experimental Target selection and retention for the CTLD JTAC

### DIFF
--- a/src/scripts/community/CTLD.lua
+++ b/src/scripts/community/CTLD.lua
@@ -5069,13 +5069,104 @@ function ctld.addJTACRadioCommand(_side)
                 --   env.info("adding command for "..index)
                 if ctld.jtacRadioAdded[tostring(_groupId)] == nil then
                     -- env.info("about command for "..index)
-                    missionCommands.addCommandForGroup(_groupId, "JTAC Status", nil, ctld.getJTACStatus, { _playerUnit:getName() })
+                    local JTACpath = missionCommands.addSubMenuForGroup(_groupId, ctld.jtacMenuName)
+                    missionCommands.addCommandForGroup(_groupId, "JTAC Status", JTACpath, ctld.getJTACStatus, { _playerUnit:getName() })
                     ctld.jtacRadioAdded[tostring(_groupId)] = true
                     -- env.info("Added command for " .. index)
                 end
+
+                --build the path to the CTLD JTAC menu
+                local jtacCurrentPagePath = {[1]=ctld.jtacMenuName}
+                --build the path for the NextPage submenu on the first page of the CTLD JTAC menu
+                local NextPageText = "Next Page"
+                local MainNextPagePath = {[1]=ctld.jtacMenuName, [2]=NextPageText}
+                --remove it along with everything that's in it
+                missionCommands.removeItemForGroup(_groupId, MainNextPagePath)
+
+                --counter to know when to add the next page submenu to fit all of the JTAC group submenus
+                local jtacCounter = 0
+            
+                for _jtacGroupName,jtacUnit in pairs(ctld.jtacUnits) do
+
+                    --only bother removing the submenus on the first page of the CTLD JTAC menu as the other pages were deleted entirely above
+                    if ctld.jtacGroupSubMenuPath[_jtacGroupName] and #ctld.jtacGroupSubMenuPath[_jtacGroupName]==2 then
+                        missionCommands.removeItemForGroup(_groupId, ctld.jtacGroupSubMenuPath[_jtacGroupName])
+                    end
+
+                    ctld.logTrace(string.format("jtacTargetsList for %s is : %s", ctld.p(_jtacGroupName), ctld.p(ctld.jtacTargetsList[_jtacGroupName])))
+
+                    if #ctld.jtacTargetsList[_jtacGroupName] > 1 then
+
+                        local jtacGroupSubMenuName = string.format(_jtacGroupName .. " TGT Selection")
+
+                        jtacCounter = jtacCounter + 1
+                        --F2 through F10 makes 9 entries possible per page, with one being the NextMenu submenu
+                        if jtacCounter%9 == 0 then
+                            --recover the path to the current page with space available for JTAC group submenus
+                            jtacCurrentPagePath = missionCommands.addSubMenuForGroup(_groupId, NextPageText, jtacCurrentPagePath)
+                        end
+                        --add the JTAC group submenu to the current page
+                        ctld.jtacGroupSubMenuPath[_jtacGroupName] = missionCommands.addSubMenuForGroup(_groupId, jtacGroupSubMenuName, jtacCurrentPagePath)
+
+                        ctld.logTrace(string.format("jtacGroupSubMenuPath for %s is : %s", ctld.p(_jtacGroupName), ctld.p(ctld.jtacGroupSubMenuPath[_jtacGroupName])))
+
+                        --make a copy of the JTAC group submenu's path to insert the target's list on as many pages as required. The JTAC's group submenu path only leads to the first page
+                        local jtacTargetPagePath = mist.utils.deepCopy(ctld.jtacGroupSubMenuPath[_jtacGroupName])
+                        --add a reset targeting option to revert to automatic JTAC unit targeting
+                        missionCommands.addCommandForGroup(_groupId, "Reset TGT Selection", jtacTargetPagePath, ctld.setJTACTarget, {jtacGroupName = _jtacGroupName, targetName = "Reset"})
+                        
+                        --counter to know when to add the next page submenu to fit all of the targets in the JTAC's group submenu
+                        local itemCounter = 0
+
+                        --number of units for each unitType
+                        --this could definitely be integrated in the for loop below if the submenu and command creation happened all at once at the end, but not sure if the performance gain is really noticeable
+                        local typeNameAmount = {}
+                        for _,target in pairs(ctld.jtacTargetsList[_jtacGroupName]) do
+                            --check if the jtac has a current target before filtering it out if possible
+                            if (ctld.jtacCurrentTargets[_jtacGroupName] and target.unit:getName() ~= ctld.jtacCurrentTargets[_jtacGroupName].name) then
+                                local targetType_name = target.unit:getTypeName()
+
+                                if targetType_name then
+                                    if typeNameAmount[targetType_name] then
+                                        typeNameAmount[targetType_name] = typeNameAmount[targetType_name] + 1
+                                    else
+                                        typeNameAmount[targetType_name] = 1
+                                    end
+                                end
+                            end
+                        end
+
+                        --indicator table to know which unitType was already added to the radio submenu
+                        local radioAddedTypeNames = {}
+
+                        for _,target in pairs(ctld.jtacTargetsList[_jtacGroupName]) do
+                            --check if the JTAC has a current target, if so then do not add the current JTAC's target to the list or duplicate type names
+                            if (ctld.jtacCurrentTargets[_jtacGroupName] and target.unit:getName() ~= ctld.jtacCurrentTargets[_jtacGroupName].name) then
+                                local targetType_name = target.unit:getTypeName()
+
+                                if targetType_name and not radioAddedTypeNames[targetType_name] then
+
+                                    radioAddedTypeNames[targetType_name] = true
+
+                                    itemCounter = itemCounter + 1
+
+                                    --F2 through F10 makes 9 entries possible per page, with one being the NextMenu submenu. Pages other than the first would have 10 entires but worse case scenario is considered
+                                    if itemCounter%9 == 0 then
+                                        jtacTargetPagePath = missionCommands.addSubMenuForGroup(_groupId, NextPageText, jtacTargetPagePath)
+                                    end
+
+                                    local targetUnit_name = target.unit:getName()
+
+                                    ctld.logTrace(string.format("target selection command path for %s is : %s", ctld.p(targetUnit_name), ctld.p(jtacTargetPagePath)))
+
+                                    typeNameAmount[targetType_name] = typeNameAmount[targetType_name] or 1 --extra safety just in case, for some reason, that the getTypeName() method broke halfway through the above loop
+                                    missionCommands.addCommandForGroup(_groupId, string.format(targetType_name .. "(" .. typeNameAmount[targetType_name] .. ")"), jtacTargetPagePath, ctld.setJTACTarget, {jtacGroupName = _jtacGroupName, targetName = targetUnit_name})
+                                end
+                            end
+                        end
+                    end
+                end
             end
-
-
         end
     end
 end
@@ -5107,14 +5198,17 @@ end
 
 ------------ JTAC -----------
 
-
+ctld.jtacMenuName = "JTAC" --name of the CTLD JTAC radio menu
 ctld.jtacLaserPoints = {}
 ctld.jtacIRPoints = {}
 ctld.jtacSmokeMarks = {}
 ctld.jtacUnits = {} -- list of JTAC units for f10 command
 ctld.jtacStop = {} -- jtacs to tell to stop lasing
 ctld.jtacCurrentTargets = {}
+ctld.jtacTargetsList = {} --current available targets to each JTAC for lasing (targets from other JTACs are filtered out). Contains DCS unit objects with their methods and the distance to the JTAC {unit, dist}
+ctld.jtacSelectedTarget = {} --currently user selected target if it contains a unit's name, otherwise contains 1 or nil (if not initialized)
 ctld.jtacRadioAdded = {} --keeps track of who's had the radio command added
+ctld.jtacGroupSubMenuPath = {} --keeps track of which submenu contains each JTAC's target selection menu
 ctld.jtacGeneratedLaserCodes = {} -- keeps track of generated codes, cycles when they run out
 ctld.jtacLaserPointCodes = {}
 ctld.jtacRadioData = {}
@@ -5151,10 +5245,8 @@ function ctld.JTACAutoLase(_jtacGroupName, _laserCode, _smoke, _lock, _colour, _
     end
 
     if _lock == nil then
-
         _lock = ctld.JTAC_lock
     end
-
 
     ctld.jtacLaserPointCodes[_jtacGroupName] = _laserCode
     ctld.jtacRadioData[_jtacGroupName] = _radio
@@ -5190,7 +5282,6 @@ function ctld.JTACAutoLase(_jtacGroupName, _laserCode, _smoke, _lock, _colour, _
             end
         end
 
-
         if ctld.jtacUnits[_jtacGroupName] ~= nil then
             ctld.notifyCoalition("JTAC Group " .. _jtacGroupName .. " KIA!", 10, ctld.jtacUnits[_jtacGroupName].side, _radio)
         end
@@ -5206,6 +5297,15 @@ function ctld.JTACAutoLase(_jtacGroupName, _laserCode, _smoke, _lock, _colour, _
         _jtacUnit = _jtacGroup[1]
         --add to list
         ctld.jtacUnits[_jtacGroupName] = { name = _jtacUnit:getName(), side = _jtacUnit:getCoalition(), radio = _radio }
+        
+        --Targets list and Selected target initialization
+        if not ctld.jtacTargetsList[_jtacGroupName] then
+            ctld.jtacTargetsList[_jtacGroupName] = {}
+        end
+
+        if not ctld.jtacSelectedTarget[_jtacGroupName] then
+            ctld.jtacSelectedTarget[_jtacGroupName] = 1
+        end
 
         -- work out smoke colour
         if _colour == nil then
@@ -5242,6 +5342,38 @@ function ctld.JTACAutoLase(_jtacGroupName, _laserCode, _smoke, _lock, _colour, _
     end
 
     local _enemyUnit = ctld.getCurrentUnit(_jtacUnit, _jtacGroupName)
+    --update targets list and store the next potential target if the selected one was lost
+    local _defaultEnemyUnit = ctld.findNearestVisibleEnemy(_jtacUnit, _lock) 
+
+    --search for the current target in the targets list which should contain it if the JTAC has visual (except that all of the targeted units are omitted from the list so that's not going to work)
+    -- if ctld.jtacTargetsList[_jtacGroupName] and ctld.jtacCurrentTargets[_jtacGroupName] then
+    --     for _,target in pairs(ctld.jtacTargetsList[_jtacGroupName]) do
+    --         if target.unit:getName() == ctld.jtacCurrentTargets[_jtacGroupName].name then
+    --             _enemyUnit = target.unit
+    --         end
+    --     end
+    -- end
+
+    -- if the JTAC sees a unit and a target was selected by users but is not the current unit, check if the selected target is in the targets list, if it is, then it's been reacquired
+    if _enemyUnit and ctld.jtacSelectedTarget[_jtacGroupName] ~= 1 and ctld.jtacSelectedTarget[_jtacGroupName] ~= _enemyUnit:getName() then
+        for _,target in pairs(ctld.jtacTargetsList[_jtacGroupName]) do
+            if target then
+                local targetUnit = target.unit
+                local targetName = targetUnit:getName()
+
+                if ctld.jtacSelectedTarget[_jtacGroupName] == targetName then
+
+                    ctld.jtacCurrentTargets[_jtacGroupName] = { name = targetName, unitType = targetUnit:getTypeName(), unitId = targetUnit:getID() }
+                    _enemyUnit = targetUnit
+
+                    local message = _jtacGroupName .. ", selected target reacquired, " .. _enemyUnit:getTypeName()
+                    local fullMessage = message .. '. CODE: ' .. _laserCode .. ". POSITION: " .. ctld.getPositionString(_enemyUnit)
+                    ctld.notifyCoalition(fullMessage, 10, _jtacUnit:getCoalition(), _radio, message)
+                end
+            end
+        end
+    end
+
     local targetDestroyed = false
     local targetLost = false
 
@@ -5271,23 +5403,21 @@ function ctld.JTACAutoLase(_jtacGroupName, _laserCode, _smoke, _lock, _colour, _
 
 
     if _enemyUnit == nil then
-        _enemyUnit = ctld.findNearestVisibleEnemy(_jtacUnit, _lock)
-
-        if _enemyUnit ~= nil then
+        if _defaultEnemyUnit ~= nil then
 
             -- store current target for easy lookup
-            ctld.jtacCurrentTargets[_jtacGroupName] = { name = _enemyUnit:getName(), unitType = _enemyUnit:getTypeName(), unitId = _enemyUnit:getID() }
+            ctld.jtacCurrentTargets[_jtacGroupName] = { name = _defaultEnemyUnit:getName(), unitType = _defaultEnemyUnit:getTypeName(), unitId = _defaultEnemyUnit:getID() }
             local action = ", lasing new target, "
             if targetLost then
-                action = ", target lost " .. action
+                action = ", target lost" .. action
                 targetLost = false
             elseif targetDestroyed then
-                action = ", target destroyed " .. action
+                action = ", target destroyed" .. action
                 targetDestroyed = false
             end
         
-            local message = _jtacGroupName .. action .. _enemyUnit:getTypeName()
-            local fullMessage = message .. '. CODE: ' .. _laserCode .. ". POSITION: " .. ctld.getPositionString(_enemyUnit)
+            local message = _jtacGroupName .. action .. _defaultEnemyUnit:getTypeName()
+            local fullMessage = message .. '. CODE: ' .. _laserCode .. ". POSITION: " .. ctld.getPositionString(_defaultEnemyUnit)
             ctld.notifyCoalition(fullMessage, 10, _jtacUnit:getCoalition(), _radio, message)
 
             -- create smoke
@@ -5349,11 +5479,35 @@ function ctld.cleanupJTAC(_jtacGroupName)
     ctld.cancelLase(_jtacGroupName)
 
     -- Cleanup
-    ctld.jtacUnits[_jtacGroupName] = nil
-
     ctld.jtacCurrentTargets[_jtacGroupName] = nil
 
+    ctld.jtacTargetsList[_jtacGroupName] = {}
+
+    ctld.jtacSelectedTarget[_jtacGroupName] = nil
+
     ctld.jtacRadioData[_jtacGroupName] = nil
+
+    --remove the JTAC's group submenu and all of the target pages it potentially contained if the JTAC has or had a menu
+    --using ctld.jtacUnits[_jtacGroupName].side seems less reliable
+    for i=1,2 do
+        local _players = coalition.getPlayers(i)
+
+        if _players ~= nil then
+
+            for _, _playerUnit in pairs(_players) do
+
+                local _groupId = ctld.getGroupId(_playerUnit)
+
+                if _groupId and ctld.jtacGroupSubMenuPath[_jtacGroupName] then
+                    missionCommands.removeItemForGroup(_groupId, ctld.jtacGroupSubMenuPath[_jtacGroupName])
+                end
+            end
+        end
+    end
+
+    ctld.jtacUnits[_jtacGroupName] = nil
+
+    ctld.jtacGroupSubMenuPath[_jtacGroupName] = nil
 end
 
 
@@ -5485,7 +5639,6 @@ end
 -- get currently selected unit and check they're still in range
 function ctld.getCurrentUnit(_jtacUnit, _jtacGroupName)
 
-
     local _unit = nil
 
     if ctld.jtacCurrentTargets[_jtacGroupName] ~= nil then
@@ -5531,6 +5684,7 @@ function ctld.findNearestVisibleEnemy(_jtacUnit, _targetType,_distance)
 
     local _nearestDistance = _maxDistance
 
+    local _jtacGroupName = _jtacUnit:getName()
     local _jtacPoint = _jtacUnit:getPoint()
     local _coa =    _jtacUnit:getCoalition()
 
@@ -5587,9 +5741,13 @@ function ctld.findNearestVisibleEnemy(_jtacUnit, _targetType,_distance)
     -- vehicle
     -- unit
 
+
+    ctld.jtacTargetsList[_jtacGroupName] = _unitList
+    --from the units in range, build the targets list, unsorted as to keep consistency between radio menu refreshes
+
     local _sort = function( a,b ) return a.dist < b.dist end
     table.sort(_unitList,_sort)
-    -- sort list
+    -- sort list 
 
     -- check for hpriority
     for _, _enemyUnit in ipairs(_unitList) do
@@ -5779,7 +5937,18 @@ function ctld.getJTACStatus(_args)
             end
 
             if _enemyUnit ~= nil and _enemyUnit:getLife() > 0 and _enemyUnit:isActive() == true then
-                _message = _message .. "" .. _start .. " targeting " .. _enemyUnit:getTypeName() .. " CODE: " .. _laserCode .. ctld.getPositionString(_enemyUnit) .. "\n"
+
+                local action = " targeting "
+
+                if ctld.jtacSelectedTarget[_jtacGroupName] == _enemyUnit:getName() then 
+                    action = " targeting selected unit "
+                else
+                    if ctld.jtacSelectedTarget[_jtacGroupName] ~= 1 then
+                        action = " attempting to find selected unit, temporarily targeting "
+                    end
+                end
+
+                _message = _message .. "" .. _start .. action .. _enemyUnit:getTypeName() .. " CODE: " .. _laserCode .. ctld.getPositionString(_enemyUnit) .. "\n"
 
                 local _list = ctld.listNearbyEnemies(_jtacUnit)
 
@@ -5806,7 +5975,42 @@ function ctld.getJTACStatus(_args)
     ctld.notifyCoalition(_message, 10, _side)
 end
 
+function ctld.setJTACTarget(_args)
+    if _args then
+        local _jtacGroupName = _args.jtacGroupName
+        local targetName = _args.targetName
 
+        if _jtacGroupName and targetName ~= "Reset" and ctld.jtacSelectedTarget[_jtacGroupName] and ctld.jtacTargetsList[_jtacGroupName] then
+            
+            --look for the unit's (target) name in the Targets List, create the required data structure for jtacCurrentTargets and then assign it to the JTAC called _jtacGroupName
+            for _, target in pairs(ctld.jtacTargetsList[_jtacGroupName]) do
+
+                if target then
+
+                    local ListedTargetUnit = target.unit
+                    local ListedTargetName = ListedTargetUnit:getName()
+
+                    if ListedTargetName == targetName then
+
+                        ctld.jtacSelectedTarget[_jtacGroupName] = targetName
+                        ctld.jtacCurrentTargets[_jtacGroupName] = { name = targetName, unitType = ListedTargetUnit:getTypeName(), unitId = ListedTargetUnit:getID() }
+            
+                        local message = _jtacGroupName .. ", targeting selected unit, " .. ListedTargetUnit:getTypeName()
+                        local fullMessage = message .. '. CODE: ' .. ctld.jtacLaserPointCodes[_jtacGroupName] .. ". POSITION: " .. ctld.getPositionString(ListedTargetUnit)
+                        ctld.notifyCoalition(fullMessage, 10, ctld.jtacUnits[_jtacGroupName].side, ctld.jtacRadioData[_jtacGroupName], message)
+                    end
+                end
+            end
+            
+        elseif targetName == "Reset" and ctld.jtacSelectedTarget[_jtacGroupName] ~= 1 then
+            ctld.jtacSelectedTarget[_jtacGroupName] = 1
+            ctld.jtacCurrentTargets[_jtacGroupName] = nil
+
+            local message = _jtacGroupName .. ", target selection reset."
+            ctld.notifyCoalition(message, 10, ctld.jtacUnits[_jtacGroupName].side, ctld.jtacRadioData[_jtacGroupName])
+        end
+    end
+end
 
 function ctld.isInfantry(_unit)
 

--- a/src/scripts/community/mist.lua
+++ b/src/scripts/community/mist.lua
@@ -1529,7 +1529,8 @@ do -- the main scope
 					newGroup.units[unitIndex].name = newGroup.units[unitIndex].name
 				end
 			end
-			if newGroup.clone or not unitData.name then
+			--if the unit name was not given or already exists in the case of a clone, derive a new one from the group name
+			if (newGroup.clone and mist.DBs.unitsByName[unitData.name]) or not unitData.name then
 				newGroup.units[unitIndex].name = tostring(newGroup.name .. ' unit' .. unitIndex)
 			end
 

--- a/src/scripts/veaf/veafSpawn.lua
+++ b/src/scripts/veaf/veafSpawn.lua
@@ -136,14 +136,14 @@ veafSpawn.AFAC.maximumAmount = 8
 veafSpawn.AFAC.baseAFACfrequency = 226300000 -- 226.300000 MHz otherwise known as 226300000 Hz
 -- callsign list of the AFACs
 veafSpawn.AFAC.callsigns = {
-    [1] = "Enfield 9",
-    [2] = "Springfield 9",
-    [3] = "Uzi 9",
-    [4] = "Colt 9",
-    [5] = "Dodge 9",
-    [6] = "Ford 9",
-    [7] = "Chevy 9",
-    [8] = "Pontiac 9",
+    [1] = "Enfield 9 1",
+    [2] = "Springfield 9 1",
+    [3] = "Uzi 9 1",
+    [4] = "Colt 9 1",
+    [5] = "Dodge 9 1",
+    [6] = "Ford 9 1",
+    [7] = "Chevy 9 1",
+    [8] = "Pontiac 9 1",
 }
 -- AFAC mission data as MIST isn't able to recover it from dynamically spawned aircrafts
 veafSpawn.AFAC.missionData = {}
@@ -2367,7 +2367,7 @@ function veafSpawn.spawnAFAC(spawnSpot, name, country, altitude, speed, hdg, fre
     local codeDigit = {}
     codeDigit = veaf.laserCodeToDigit(code)
 
-    local newGroupName = string.format("%s - %01d %01d %01d %01d", veafSpawn.AFAC.callsigns[veafSpawn.AFAC.numberSpawned], codeDigit.thousands, codeDigit.hundreds, codeDigit.tens, codeDigit.units)
+    local newGroupName = veafSpawn.AFAC.callsigns[veafSpawn.AFAC.numberSpawned]
     veaf.loggers.get(veafSpawn.Id):trace("newGroupName=%s",newGroupName)
     
     local altitude = altitude 
@@ -2506,19 +2506,19 @@ function veafSpawn.spawnAFAC(spawnSpot, name, country, altitude, speed, hdg, fre
     --newGroup.task = "AFAC"
     veaf.loggers.get(veafSpawn.Id):trace("newGroup=%s", veaf.p(newGroup, nil, {"route", "payload"}))
 
-    for _, unit in pairs(newGroup.units) do
-        unit.skill = "Excellent"
-    end
+    --setup of the new group
+    local unit = newGroup.units[1]
+    unit.skill = "Excellent"
     newGroup.hidden=false
     newGroup.name = newGroupName
-    for _, unit in pairs(newGroup.units) do
-        local unitName = unit.unitName or unit.name
-        veaf.loggers.get(veafSpawn.Id):trace("unitName=%s",unitName)
-        local spawnedUnitName = string.format("%s #%04d", unitName, veafSpawn.spawnedNamesIndex[groupName])
-        unit.name = spawnedUnitName
-        unit.alt = teleportSpot.alt
-        veaf.loggers.get(veafSpawn.Id):trace("spawnedUnitName=%s",spawnedUnitName)
-    end
+
+    local unitName = newGroupName
+    veaf.loggers.get(veafSpawn.Id):trace("unitName=%s",unitName)
+    unit.unitName = unitName
+    unit.name = unitName
+
+    unit.alt = teleportSpot.alt
+
     veaf.loggers.get(veafSpawn.Id):trace("newGroup=%s", veaf.p(newGroup, nil, {"route", "payload"}))
     local _spawnedGroup = mist.dynAdd(newGroup)
 
@@ -2527,7 +2527,8 @@ function veafSpawn.spawnAFAC(spawnSpot, name, country, altitude, speed, hdg, fre
         veaf.loggers.get(veafSpawn.Id):trace("_spawnedGroup.name=%s",_spawnedGroup.name)
         mist.goRoute(_spawnedGroup.name, newRoute)
 
-        --veafSpawn.AFAC.missionData[veafSpawn.spawnedNamesIndex[groupName]] = veaf.getGroupData(_spawnedGroup.name) --Does not work to recover the mission data of the dynamically spawned afac for movie command later on, for mist the group simply does not exist so it has no data
+        --veaf.loggers.get(veafSpawn.Id):trace("_spawnedGroup=%s", veaf.p(_spawnedGroup))
+        --veafSpawn.AFAC.missionData[veafSpawn.spawnedNamesIndex[groupName]] = _spawnedGroup --Does not work to recover the mission data of the dynamically spawned afac for movie command later on, for mist the group simply does not exist anyways
 
         -- start lasing 
         if ctld then 
@@ -2544,7 +2545,7 @@ function veafSpawn.spawnAFAC(spawnSpot, name, country, altitude, speed, hdg, fre
         end
 
         local humanFrequency = dcsFrequency/1000000
-        local text = "AFAC " .. string.format(veafSpawn.AFAC.numberSpawned) .. "/" .. string.format(veafSpawn.AFAC.maximumAmount) .. " - " .. string.format(_spawnedGroup.name) .. " (" .. string.format(country) .. ") - on " .. string.format(humanFrequency) .. "AM (DCS) or " .. string.format(frequency) .. string.upper(mod) .. " (SRS)"
+        local text = "AFAC " .. string.format(veafSpawn.AFAC.numberSpawned) .. "/" .. string.format(veafSpawn.AFAC.maximumAmount) .. " - " .. string.format(_spawnedGroup.name) .. " (" .. string.format(country) .. ") - on " .. string.format(humanFrequency) .. "AM (DCS AFAC) or " .. string.format(frequency) .. string.upper(mod) .. " (SRS)"
         veaf.loggers.get(veafSpawn.Id):info(text)
         trigger.action.outText(text, 15)
  


### PR DESCRIPTION
-CTLD JTAC Experimental User Target Selection and Target Selection retention (will try to acquire selected target if possible after losing it)
->This needs extensive testing, at least to verify proper operation without interacting with the target selection. So far most "potential" issues are with the radio menu refresh, if the unit dies at the wrong time, will it delete the entries correctly ? etc.

-MIST tweak to clone single unit groups with the their groupName=unitName (for CTLD JTAC compatibility)
->Breaking change unless a specific option is added, to be discussed

-spawnAFAC command optimized slightly (originally modified due to previously listed compatibility issue)
->Still haven't managed to fix the moveAFAC command for dynamically spawned AFACs, MIST just doesn't know the group even exists...
