### PR TITLE
Fixed routes for delayed group spawns, added delayed option for _spawn commands, reworked skynet helper, other fixes

### DIFF
--- a/src/scripts/veaf/veaf.lua
+++ b/src/scripts/veaf/veaf.lua
@@ -32,7 +32,7 @@ veaf = {}
 veaf.Id = "VEAF"
 
 --- Version.
-veaf.Version = "1.21.2"
+veaf.Version = "1.21.3"
 
 --- Development version ?
 veaf.Development = true
@@ -2518,6 +2518,7 @@ VeafQRA.STATUS_DEAD = 3
 
 VeafQRA.WATCHDOG_DELAY = 5
 
+VeafQRA.AllSilence = false --value to set all spawned QRAs to silent if true. By default it's false but this value can be set in the missionConfig
 VeafQRA.DEFAULT_MESSAGE_START = "%s is deployed"
 VeafQRA.DEFAULT_MESSAGE_DESTROYED = "%s has been destroyed"
 VeafQRA.DEFAULT_MESSAGE_READY = "%s is ready"
@@ -2536,7 +2537,7 @@ function VeafQRA:new()
     self.messageStart = VeafQRA.DEFAULT_MESSAGE_START
     self.messageDestroyed = VeafQRA.DEFAULT_MESSAGE_DESTROYED
     self.messageReady = VeafQRA.DEFAULT_MESSAGE_READY
-    self.silent = false
+    self.silent = VeafQRA.AllSilence
     self.respawnRadius = 250
     self.reactOnHelicopters = false
     self.delayBeforeRearming = -1

--- a/src/scripts/veaf/veaf.lua
+++ b/src/scripts/veaf/veaf.lua
@@ -2523,6 +2523,14 @@ VeafQRA.DEFAULT_MESSAGE_START = "%s is deployed"
 VeafQRA.DEFAULT_MESSAGE_DESTROYED = "%s has been destroyed"
 VeafQRA.DEFAULT_MESSAGE_READY = "%s is ready"
 
+function VeafQRA.ToggleAllSilence()
+    if VeafQRA.AllSilence == true then
+        VeafQRA.AllSilence = false
+    else
+        VeafQRA.AllSilence = true
+    end
+end
+
 function VeafQRA:new()
     veaf.loggers.get(VeafQRA.Id):trace(string.format("VeafQRA:new()"))
     local self = setmetatable({}, VeafQRA)

--- a/src/scripts/veaf/veafCarrierOperations.lua
+++ b/src/scripts/veaf/veafCarrierOperations.lua
@@ -48,7 +48,7 @@ veafCarrierOperations = {}
 veafCarrierOperations.Id = "CARRIER"
 
 --- Version.
-veafCarrierOperations.Version = "1.11.2"
+veafCarrierOperations.Version = "1.11.3"
 
 -- trace level, specific to this module
 --veafCarrierOperations.LogLevel = "trace"
@@ -772,13 +772,16 @@ function veafCarrierOperations.rebuildRadioMenu()
     for name, carrier in pairs(veafCarrierOperations.carriers) do
         veaf.loggers.get(veafCarrierOperations.Id):trace("rebuildRadioMenu processing "..name)
         
-        -- remove the submenu
-        veaf.loggers.get(veafCarrierOperations.Id):trace("remove the submenu")
         local menuRoot = veafCarrierOperations.rootPathRed
         if carrier.side == coalition.side.BLUE then
             menuRoot = veafCarrierOperations.rootPathBlue
         end
-        veafRadio.delSubmenu(carrier.menuPath, menuRoot)
+
+        -- remove the submenu if it exists
+        if carrier.menuPath then
+            veafRadio.delSubmenu(carrier.menuPath, menuRoot)
+            veaf.loggers.get(veafCarrierOperations.Id):trace("remove the submenu")
+        end
 
         -- create the submenu
         veaf.loggers.get(veafCarrierOperations.Id):trace("create the submenu")

--- a/src/scripts/veaf/veafCasMission.lua
+++ b/src/scripts/veaf/veafCasMission.lua
@@ -832,7 +832,7 @@ function veafCasMission.generateCasMission(spawnSpot, size, defense, armor, spac
     if coalition.side.RED ~= side then
         opposing_side = coalition.side.RED
     end
-    veafSpawn.spawnAFAC(spawnSpot, "mq9", veaf.getCountryForCoalition(opposing_side), nil, nil, nil, veaf.convertLaserToFreq(1688), "FM", 1688, true, false)
+    veafSpawn.spawnAFAC(spawnSpot, "mq9", veaf.getCountryForCoalition(opposing_side), nil, nil, nil, veafSpawn.convertLaserToFreq(1688), "FM", 1688, true, false)
 
     -- build menu for each player
     veafRadio.addCommandToSubmenu('Target information', veafCasMission.rootPath, veafCasMission.reportTargetInformation, nil, veafRadio.USAGE_ForGroup)

--- a/src/scripts/veaf/veafCasMission.lua
+++ b/src/scripts/veaf/veafCasMission.lua
@@ -72,7 +72,7 @@ veafCasMission = {}
 veafCasMission.Id = "CASMISSION"
 
 --- Version.
-veafCasMission.Version = "1.12.0"
+veafCasMission.Version = "1.13.0"
 
 -- trace level, specific to this module
 --veafCasMission.LogLevel = "trace"
@@ -827,8 +827,12 @@ function veafCasMission.generateCasMission(spawnSpot, size, defense, armor, spac
     controller:setOption(9, 2) -- set alarm state to red
     controller:setOption(AI.Option.Ground.id.DISPERSE_ON_ATTACK, disperseOnAttack) -- set disperse on attack according to the option
 
-    -- Move reaper
-    -- TODO
+    -- Spawn Reaper
+    local opposing_side = coalition.side.BLUE
+    if coalition.side.RED ~= side then
+        opposing_side = coalition.side.RED
+    end
+    veafSpawn.spawnAFAC(spawnSpot, "mq9", veaf.getCountryForCoalition(opposing_side), nil, nil, nil, veaf.convertLaserToFreq(1688), "FM", 1688, true, false)
 
     -- build menu for each player
     veafRadio.addCommandToSubmenu('Target information', veafCasMission.rootPath, veafCasMission.reportTargetInformation, nil, veafRadio.USAGE_ForGroup)

--- a/src/scripts/veaf/veafCasMission.lua
+++ b/src/scripts/veaf/veafCasMission.lua
@@ -346,7 +346,7 @@ local function _addDefenseForGroups(group, side, defense, multiple, forInfantry)
                 else
                     table.insert(group.units, { veaf.randomlyChooseFrom({"Strela-1 9P31", "Strela-10M3"}), random=true })
                     table.insert(group.units, { "Tor 9A331", random=true })
-                    table.insert(group.units, { "2S6 Tunguska", random=true })
+                    table.insert(group.units, { "ZSU-23-4 Shilka", random=true })
                 end
             end
         elseif _actualDefense == 5 then

--- a/src/scripts/veaf/veafInterpreter.lua
+++ b/src/scripts/veaf/veafInterpreter.lua
@@ -54,7 +54,7 @@ veafInterpreter = {}
 veafInterpreter.Id = "INTERPRETER"
 
 --- Version.
-veafInterpreter.Version = "1.3.0"
+veafInterpreter.Version = "1.4.0"
 
 -- trace level, specific to this module
 --veafInterpreter.LogLevel = "trace"
@@ -105,38 +105,25 @@ function veafInterpreter.execute(command, position, coalition, route, spawnedGro
     local commandExecuted = false
     spawnedGroups = spawnedGroups or {}
 
-    if logDebug("checking in veafShortcuts") and veafShortcuts.executeCommand(position, command, coalition, nil, true, spawnedGroups) then
-        commandExecuted = true
-    elseif logDebug("checking in veafSpawn") and veafSpawn.executeCommand(position, command, coalition, nil, true, spawnedGroups) then
-        commandExecuted = true
+    if logDebug("checking in veafShortcuts") and veafShortcuts.executeCommand(position, command, coalition, nil, true, spawnedGroups, route) then
+        return true
+    elseif logDebug("checking in veafSpawn") and veafSpawn.executeCommand(position, command, coalition, nil, true, spawnedGroups, nil, nil, route, true) then
+        return true
     elseif logDebug("checking in veafNamedPoints") and veafNamedPoints.executeCommand(position, {text=command, coalition=-1}, true) then
-        commandExecuted = true
+        return true
     elseif logDebug("checking in veafCasMission") and veafCasMission.executeCommand(position, command, coalition, true) then
-        commandExecuted = true
+        return true
     elseif logDebug("checking in veafSecurity") and veafSecurity.executeCommand(position, command, true) then
-        commandExecuted = true
+        return true
     elseif logDebug("checking in veafMove") and veafMove.executeCommand(position, command, true) then
-        commandExecuted = true
+        return true
     elseif logDebug("checking in veafRadio") and veafRadio.executeCommand(position, command, coalition, true) then
-        commandExecuted = true
+        return true
     elseif logDebug("checking in veafRemote") and veafRemote.executeCommand(position, command, coalition) then
-        commandExecuted = true
+        return true
     else
-        commandExecuted = false
+        return false
     end
-
-    if commandExecuted then
-        veaf.loggers.get(veafInterpreter.Id):trace(string.format("spawnedGroups = [%s]", veaf.p(spawnedGroups)))
-        if route and spawnedGroups then
-            for _, newGroup in pairs(spawnedGroups) do
-                veaf.loggers.get(veafInterpreter.Id):trace(string.format("newGroup = [%s]", veaf.p(newGroup)))
-                mist.goRoute(newGroup, route)
-            end
-        end
-    end
-
-    return commandExecuted
-
 end
 
 function veafInterpreter.executeCommandOnUnit(unitName, command)

--- a/src/scripts/veaf/veafSkynetIadsHelper.lua
+++ b/src/scripts/veaf/veafSkynetIadsHelper.lua
@@ -28,7 +28,7 @@ veafSkynet = {}
 veafSkynet.Id = "SKYNET"
 
 --- Version.
-veafSkynet.Version = "1.2.1"
+veafSkynet.Version = "2.0.0"
 
 -- trace level, specific to this module
 --veafSkynet.LogLevel = "trace"
@@ -49,10 +49,22 @@ veafSkynet.MaxPointDefenseDistanceFromSite = 10000
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 veafSkynet.initialized = false
-veafSkynet.redIADS = nil
-veafSkynet.blueIADS = nil
+--flag to know if all units present on the map should be loaded at init or not into their team's main IADS network
+veafSkynet.loadAllAtInit = {
+    [tostring(coalition.side.BLUE)] = true,
+    [tostring(coalition.side.RED)] = true
+}
+--table containing the default IADS network names initialized for each coalition
+veafSkynet.defaultIADS = {
+    [tostring(coalition.side.BLUE)] = "blue iads",
+    [tostring(coalition.side.RED)] = "red iads",
+}
 veafSkynet.iadsSamUnitsTypes = {}
 veafSkynet.iadsEwrUnitsTypes = {}
+
+--table containing the structure of each IADS network, first level is accessed with the IADS name. This contains the .coalitionID of the network, the IADS network (.iads), the groups added to the network (.groups) stored by groupName, 
+--wether this network should appear on the radio menu (.includeInRadio) and lastly if this network is in debug mode (.debugFlag). The groups store whether the group was .forceEwr or .pointDefense.
+veafSkynet.structure = {}
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Utility methods
@@ -62,22 +74,36 @@ veafSkynet.iadsEwrUnitsTypes = {}
 -- core functions
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-function veafSkynet.getIadsOfCoalition(coa)
+function veafSkynet.getIadsOfCoalition(networkName, coa)
     local iads = nil
-    if coa == coalition.side.RED then
-        iads = veafSkynet.redIADS
-    elseif coa == coalition.side.BLUE then
-        iads = veafSkynet.blueIADS
+    if veafSkynet.structure[networkName] and coa == veafSkynet.structure[networkName].coalitionID then
+        iads = veafSkynet.structure[networkName].iads
     end
     return iads
 end
 
-function veafSkynet.getNearestIADSSite(dcsUnit, currentGroup)
-    local coa = dcsUnit:getCoalition()
-    veaf.loggers.get(veafSkynet.Id):trace(string.format("coalition of pointDefense : %s", veaf.p(coa))) 
-    local defensePos = dcsUnit:getPosition()
-    veaf.loggers.get(veafSkynet.Id):debug(string.format("pointDefense Position : %s", veaf.p(defensePos))) 
-    local iads = veafSkynet.getIadsOfCoalition(coa)
+function veafSkynet.getNearestIADSSite(networkName, dcsGroup)
+    
+    if not dcsGroup then
+        veaf.loggers.get(veafSkynet.Id):trace("No group to find the nearest IADS site for")
+        return false
+    end
+
+    local coa = dcsGroup:getCoalition()
+    veaf.loggers.get(veafSkynet.Id):trace(string.format("Ref coalition : %s", veaf.p(coa))) 
+
+    local iads = veafSkynet.getIadsOfCoalition(networkName, coa)
+    if not iads then
+        veaf.loggers.get(veafSkynet.Id):trace(string.format("IADS named %s for the coalition of the group %s does not exist", veaf.p(networkName), tostring(dcsUnit:getName())))
+        return false
+    end
+    
+    local currentGroup = dcsGroup:getName()
+    veaf.loggers.get(veafSkynet.Id):trace(string.format("networkName : %s", veaf.p(networkName))) 
+    local groupPos = veaf.getAveragePosition(dcsGroup)
+    veaf.loggers.get(veafSkynet.Id):debug(string.format("Ref Position : %s", veaf.p(groupPos))) 
+
+
     local nearestEWRname = nil
     local minEWRDistance = veafSkynet.MaxPointDefenseDistanceFromSite
     local nearestSAMname = nil
@@ -105,7 +131,7 @@ function veafSkynet.getNearestIADSSite(dcsUnit, currentGroup)
                 veaf.loggers.get(veafSkynet.Id):debug(string.format("Checked Site groupAvgPosition : %s", veaf.p(groupAvgPosition)))
 
                 if groupAvgPosition then
-                    local distance = math.sqrt((pos.p.x-groupAvgPosition.x)^2+(pos.p.z-groupAvgPosition.z)^2)
+                    local distance = math.sqrt((pos.x-groupAvgPosition.x)^2+(pos.z-groupAvgPosition.z)^2)
                     veaf.loggers.get(veafSkynet.Id):trace(string.format("Distance between checked site and pointDefense : %s", veaf.p(distance)))
 
                     if distance <= minDistance then
@@ -122,11 +148,11 @@ function veafSkynet.getNearestIADSSite(dcsUnit, currentGroup)
 
     --start by going through the EWRs
     CoalitionSites = iads:getEarlyWarningRadars()
-    nearestEWRname, minEWRDistance = searchForGroup(CoalitionSites, defensePos, currentGroup, true)
+    nearestEWRname, minEWRDistance = searchForGroup(CoalitionSites, groupPos, currentGroup, true)
 
     --search for SAM sites
     CoalitionSites = iads:getSAMSites()
-    nearestSAMname, minSAMDistance = searchForGroup(CoalitionSites, defensePos, currentGroup)    
+    nearestSAMname, minSAMDistance = searchForGroup(CoalitionSites, groupPos, currentGroup)    
 
     if minEWRDistance <= minSAMDistance then
         return nearestEWRname
@@ -135,21 +161,30 @@ function veafSkynet.getNearestIADSSite(dcsUnit, currentGroup)
 end
 
 
-function veafSkynet.addGroupToNetwork(dcsGroup, forceEwr, pointDefense, alreadyAddedGroups)
+function veafSkynet.addGroupToNetwork(networkName, dcsGroup, forceEwr, pointDefense, alreadyAddedGroups, silent)
     if not veafSkynet.initialized then 
         return false 
     end
 
+    if not dcsGroup then
+        veaf.loggers.get(veafSkynet.Id):error("No group to find to add to network")
+        return false
+    end
+
     local forceEwr = false or forceEwr
     local pointDefense = false or pointDefense
+    local silent = false or silent
 
     local batchMode = (alreadyAddedGroups ~= nil)
     local alreadyAddedGroups = alreadyAddedGroups or {}
     local groupName = dcsGroup:getName()
     local coa = dcsGroup:getCoalition()
-    local iads = veafSkynet.getIadsOfCoalition(coa)
+    veaf.loggers.get(veafSkynet.Id):trace(string.format("networkName= %s", tostring(networkName)))
+    veaf.loggers.get(veafSkynet.Id):trace(string.format("groupName= %s", tostring(groupName)))
+    veaf.loggers.get(veafSkynet.Id):trace(string.format("Coalition= %s", tostring(coa)))
+    local iads = veafSkynet.getIadsOfCoalition(networkName, coa)
     if not(iads) then
-        veaf.loggers.get(veafSkynet.Id):trace(string.format("no IADS for the coalition of %s", tostring(groupName)))
+        veaf.loggers.get(veafSkynet.Id):trace(string.format("IADS named %s for the coalition of the group %s does not exist", veaf.p(networkName), tostring(groupName)))
         return false
     end
     local didSomething = false
@@ -157,6 +192,39 @@ function veafSkynet.addGroupToNetwork(dcsGroup, forceEwr, pointDefense, alreadyA
     veaf.loggers.get(veafSkynet.Id):trace(string.format("batchMode = %s", tostring(batchMode)))
     veaf.loggers.get(veafSkynet.Id):trace(string.format("forceEwr = %s", tostring(forceEwr)))
     veaf.loggers.get(veafSkynet.Id):trace(string.format("PointDefense= %s", tostring(pointDefense)))
+
+    local defended_name = nil
+    if pointDefense and not(forceEwr) then
+        veaf.loggers.get(veafSkynet.Id):trace(string.format("SAM is pointDefense"))
+        
+        if pointDefense == true then 
+            veaf.loggers.get(veafSkynet.Id):trace(string.format("Find nearest site to defend"))
+            defended_name = veafSkynet.getNearestIADSSite(networkName, dcsGroup)
+        else
+            defended_name = pointDefense
+            local defended_SAM = iads:getSAMSiteByGroupName(defended_name)
+            local defended_EWR = iads:getEarlyWarningRadars(defended_name)
+
+            local defended_site = defended_EWR
+            if defended_SAM then
+                defended_site = defended_SAM
+            end
+
+            if defended_site then
+                local defended_pos = veaf.getAvgGroupPos(defended_name)
+                local dcsGroup_pos = veaf.getAvgGroupPos(groupName)
+                local distance = math.sqrt((dcsGroup_pos.x-defended_pos.x)^2+(dcsGroup_pos.z-defended_pos.z)^2)
+                veaf.loggers.get(veafSkynet.Id):trace(string.format("Distance between requested site and pointDefense : %s", veaf.p(distance)))
+
+                if distance > veafSkynet.MaxPointDefenseDistanceFromSite then
+                    defended_name = nil
+                    veaf.loggers.get(veafSkynet.Id):info("User requested SAM Site out of reach for point defense")
+                end
+            else
+                defended_name = nil
+            end 
+        end
+    end
 
     for _, dcsUnit in pairs(dcsGroup:getUnits()) do
         local unitName = dcsUnit:getName()
@@ -196,42 +264,11 @@ function veafSkynet.addGroupToNetwork(dcsGroup, forceEwr, pointDefense, alreadyA
         end
 
         --user requested configuration
-        if addedSite and pointDefense and not(forceEwr) and not(ewrFlag) then
-            veaf.loggers.get(veafSkynet.Id):trace(string.format("SAM is pointDefense"))
-
-            local defended_name = nil
-            if pointDefense == true then 
-                veaf.loggers.get(veafSkynet.Id):trace(string.format("Find nearest site to defend"))
-                defended_name = veafSkynet.getNearestIADSSite(dcsUnit, groupName)
-            else
-                defended_name = pointDefense
-                local defended_SAM = iads:getSAMSiteByGroupName(defended_name)
-                local defended_EWR = iads:getEarlyWarningRadars(defended_name)
-
-                local defended_site = defended_EWR
-                if defended_SAM then
-                    defended_site = defended_SAM
-                end
-
-                if defended_site then
-                    local defended_pos = veaf.getAvgGroupPos(defended_name)
-                    local dcsUnit_pos = dcsUnit:getPosition()
-                    local distance = math.sqrt((dcsUnit_pos.p.x-defended_pos.x)^2+(dcsUnit_pos.p.z-defended_pos.z)^2)
-                    veaf.loggers.get(veafSkynet.Id):trace(string.format("Distance between requested site and pointDefense : %s", veaf.p(distance)))
-
-                    if distance > veafSkynet.MaxPointDefenseDistanceFromSite then
-                        defended_name = nil
-                        veaf.loggers.get(veafSkynet.Id):info("User requested SAM Site out of reach for point defense")
-                    end
-                else
-                    defended_name = nil
-                end 
-            end
-            
+        if addedSite and pointDefense and not(forceEwr) and not(ewrFlag) then            
             if defended_name then
                 local text = string.format("Point Defense added to site : %s", string.format(defended_name))
                 veaf.loggers.get(veafSkynet.Id):info(text)
-                trigger.action.outText(text,10)
+                if not silent then trigger.action.outText(text,10) end
                 if iads:getSAMSiteByGroupName(defended_name) then
                     veaf.loggers.get(veafSkynet.Id):trace(string.format("adding pointDefense to SAM -> OK"))
                     iads:getSAMSiteByGroupName(defended_name):addPointDefence(addedSite)
@@ -247,7 +284,7 @@ function veafSkynet.addGroupToNetwork(dcsGroup, forceEwr, pointDefense, alreadyA
                 end
             else
                 veaf.loggers.get(veafSkynet.Id):info("Could not find SAM site within range to add point defenses to")
-                trigger.action.outText("Could not find SAM site within range to add point defenses to", 15)
+                if not silent then trigger.action.outText("Could not find SAM site within range to add point defenses to", 15) end
             end
         elseif forceEwr then
             veaf.loggers.get(veafSkynet.Id):trace(string.format("SAM/EWR is forced EWR"))
@@ -274,14 +311,21 @@ function veafSkynet.addGroupToNetwork(dcsGroup, forceEwr, pointDefense, alreadyA
         end       
         -- reactivate the IADS after a warmup delay
         iads:setupSAMSitesAndThenActivate(veafSkynet.DelayForRestart)
+
+        --add the added site to the structure of the network it was added to
+        veafSkynet.structure[networkName].groups[groupName] = { forceEwr = forceEwr, pointDefense = defended_name }
     end
 
     return didSomething
 end
 
-local function initializeIADS(coa, inRadio, debug)
-    local iads = veafSkynet.getIadsOfCoalition(coa)
-    veaf.loggers.get(veafSkynet.Id):debug(string.format("initializeIADS %s",tostring(iads:getCoalitionString())))
+local function initializeIADS(networkName, coa, inRadio, debug)
+    local iads = veafSkynet.getIadsOfCoalition(networkName, coa)
+    if not(iads) then
+        veaf.loggers.get(veafSkynet.Id):trace(string.format("IADS named %s for coalition %s does not exist", veaf.p(networkName), veaf.p(coa)))
+        return false
+    end
+    veaf.loggers.get(veafSkynet.Id):trace(string.format("initializeIADS %s",tostring(iads:getCoalitionString())))
 
     if debug then
         veaf.loggers.get(veafSkynet.Id):debug("adding debug information")
@@ -304,9 +348,32 @@ local function initializeIADS(coa, inRadio, debug)
     local alreadyAddedGroups = {}
     local dcsGroups = coalition.getGroups(coa)
     for _, dcsGroup in pairs(dcsGroups) do
-        veafSkynet.addGroupToNetwork(dcsGroup, alreadyAddedGroups)
+        if veafSkynet.structure[networkName] then
+            local groupName = dcsGroup:getName()
+            if groupName then
+                local structureData = veafSkynet.structure[networkName].groups[groupName]
+                local forceEwr = false
+                local pointDefense = false
+                if structureData then
+                    if structureData.forceEwr then
+                        forceEwr = structureData.forceEwr
+                    end
+                    if structureData.pointDefense then
+                        pointDefense = structureData.pointDefense
+                    end
+                end
+                if veafSkynet.loadAllAtInit[tostring(coa)] or structureData then 
+                    veafSkynet.addGroupToNetwork(networkName, dcsGroup, forceEwr, pointDefense, alreadyAddedGroups, true)
+                end 
+            end 
+        end
     end
 
+    if veafSkynet.loadAllAtInit[tostring(coa)] then
+        veafSkynet.loadAllAtInit[tostring(coa)] = false
+    end
+
+    veaf.loggers.get(veafSkynet.Id):trace("Specific configuration applied")
     -- specific configurations, for each SAM type
     iads:getSAMSitesByNatoName('SA-10'):setActAsEW(false)
     iads:getSAMSitesByNatoName('SA-6'):setActAsEW(false)
@@ -329,15 +396,77 @@ end
 -- initialisation
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-local function createNetworks(loadUnits)
-    veafSkynet.redIADS = SkynetIADS:create("RED IADS")
-    veafSkynet.redIADS.coalitionID = coalition.side.RED
-    veafSkynet.blueIADS = SkynetIADS:create("BLUE IADS")
-    veafSkynet.blueIADS.coalitionID = coalition.side.BLUE
-    if loadUnits then
-        initializeIADS(coalition.side.RED, veafSkynet.includeRedInRadio, veafSkynet.debugRed)
-        initializeIADS(coalition.side.BLUE, veafSkynet.includeBlueInRadio, veafSkynet.debugBlue)
+local function createNetworks(networkName, coa, loadUnits, UserAdd)
+   
+    local UserAdd = UserAdd or false
+    local loadUnits = loadUnits or false
+
+    local networkName = networkName
+    if networkName then 
+        networkName = tostring(networkName) 
+    else
+        veaf.loggers.get(veafSkynet.Id):error("networkName is of invalid format")
+        return false
     end
+    local coa = coa
+    if coa then 
+        coa = tonumber(coa) 
+    else
+        veaf.loggers.get(veafSkynet.Id):error("Coalition specified is of invalid format")
+        return false
+    end
+    veaf.loggers.get(veafSkynet.Id):trace("networkName= %s", veaf.p(networkName))
+    veaf.loggers.get(veafSkynet.Id):trace("CoalitionID= %s", veaf.p(coa))
+    veaf.loggers.get(veafSkynet.Id):trace("loadUnits= %s", veaf.p(loadUnits))
+    veaf.loggers.get(veafSkynet.Id):trace("UserAdd= %s", veaf.p(UserAdd))
+
+    if networkName and coa then
+        if (UserAdd and not veafSkynet.structure[networkName]) or not UserAdd then
+            local debugFlag = veafSkynet.debugBlue
+            local includeInRadio = veafSkynet.includeBlueInRadio
+
+            if coa == coalition.side.RED then
+                debugFlag = veafSkynet.debugRed
+                includeInRadio = veafSkynet.includeRedInRadio
+            end
+
+            veaf.loggers.get(veafSkynet.Id):trace("creating network...")
+            local iads = SkynetIADS:create(networkName)
+            iads.coalitionID = coa
+            if iads then
+                if not veafSkynet.structure[networkName] then
+                    veaf.loggers.get(veafSkynet.Id):trace("network is new")
+                    veafSkynet.structure[networkName] = {}
+                    veafSkynet.structure[networkName].coalitionID = coa
+                    veafSkynet.structure[networkName].includeInRadio = includeInRadio
+                    veafSkynet.structure[networkName].debugFlag = debugFlag
+                    veafSkynet.structure[networkName].groups = {}
+                end
+                veafSkynet.structure[networkName].iads = iads
+
+                veaf.loggers.get(veafSkynet.Id):trace("Stored structure for network named %s :", veaf.p(networkName))
+                for index,_ in pairs(veafSkynet.structure[networkName]) do
+                    veaf.loggers.get(veafSkynet.Id):trace("-> %s", veaf.p(index))
+                end
+                veaf.loggers.get(veafSkynet.Id):trace("Stored IADS structure for network named %s :", veaf.p(networkName))
+                for index,_ in pairs(veafSkynet.structure[networkName].iads) do
+                    veaf.loggers.get(veafSkynet.Id):trace("-> %s", veaf.p(index))
+                end
+                veaf.loggers.get(veafSkynet.Id):trace("CoalitionID for network named %s :", veaf.p(networkName))
+                veaf.loggers.get(veafSkynet.Id):trace("-> %s", veaf.p(veafSkynet.structure[networkName].iads.coalitionID))
+                veaf.loggers.get(veafSkynet.Id):trace("-> %s", veaf.p(veafSkynet.structure[networkName].iads:getCoalitionString()))
+
+                if loadUnits then
+                    initializeIADS(networkName, coa, includeInRadio, debugFlag)
+                end
+                return true
+            end
+        else
+            local text = string.format("The network name \"%s\" already exists", veaf.p(networkName))
+            veaf.loggers.get(veafSkynet.Id):info(text)
+        end
+    end
+    return false
 end
 
 -- reset the IADS networks and rebuild them. Useful when a dynamic combat zone is deactivated
@@ -346,19 +475,17 @@ function veafSkynet.reinitialize()
         return false 
     end
 
-    if veafSkynet.redIADS then
-        if veafSkynet.includeRedInRadio then 
-            veafSkynet.redIADS:removeRadioMenu()
+    for networkName, networkStructure in pairs(veafSkynet.structure) do
+        if networkStructure.iads then
+            veaf.loggers.get(veafSkynet.Id):trace("Stored structure for network named %s has IADS, deactivating", veaf.p(networkName))
+            if networkStructure.includeInRadio then 
+                veaf.loggers.get(veafSkynet.Id):trace("Removing radio menu...")
+                networkStructure.iads:removeRadioMenu()
+            end
+            networkStructure.iads:deactivate()
         end
-        veafSkynet.redIADS:deactivate()
+        createNetworks(networkName, networkStructure.coalitionID, true)
     end
-    if veafSkynet.blueIADS then
-        if veafSkynet.includeBlueInRadio then 
-            veafSkynet.blueIADS:removeRadioMenu()
-        end
-        veafSkynet.blueIADS:deactivate()
-    end
-    createNetworks(true)
 end
 
 function veafSkynet.initialize(includeRedInRadio, debugRed, includeBlueInRadio, debugBlue)
@@ -381,6 +508,7 @@ function veafSkynet.initialize(includeRedInRadio, debugRed, includeBlueInRadio, 
                 local list = groupData[listName]
                 if list then 
                     for unitType, _ in pairs(list) do
+                        veaf.loggers.get(veafSkynet.Id):trace(string.format("-> SAM"))
                         veafSkynet.iadsSamUnitsTypes[unitType] = true
                     end
                 end
@@ -410,7 +538,8 @@ function veafSkynet.initialize(includeRedInRadio, debugRed, includeBlueInRadio, 
     end
     veaf.loggers.get(veafSkynet.Id):trace(string.format("veafSkynet.iadsEwrUnitsTypes=%s",veaf.p(veafSkynet.iadsEwrUnitsTypes)))
     
-    createNetworks(false)
+    createNetworks(veafSkynet.defaultIADS[tostring(coalition.side.BLUE)], coalition.side.BLUE, false)
+    createNetworks(veafSkynet.defaultIADS[tostring(coalition.side.RED)], coalition.side.RED, false)
 
     veaf.loggers.get(veafSkynet.Id):info(string.format("Loading units in %s seconds", tostring(veafSkynet.DelayForStartup)))
     mist.scheduleFunction(veafSkynet.reinitialize,{}, timer.getTime()+veafSkynet.DelayForStartup)

--- a/src/scripts/veaf/veafSkynetIadsHelper.lua
+++ b/src/scripts/veaf/veafSkynetIadsHelper.lua
@@ -31,7 +31,7 @@ veafSkynet.Id = "SKYNET"
 veafSkynet.Version = "2.0.0"
 
 -- trace level, specific to this module
---veafSkynet.LogLevel = "trace"
+veafSkynet.LogLevel = "trace"
 
 veaf.loggers.new(veafSkynet.Id, veafSkynet.LogLevel)
 
@@ -469,13 +469,14 @@ local function createNetworks(networkName, coa, loadUnits, UserAdd)
     return false
 end
 
--- reset the IADS networks and rebuild them. Useful when a dynamic combat zone is deactivated
-function veafSkynet.reinitialize()
+-- reset an IADS network, useful when many additions are made at once to harmonize the structure
+function veafSkynet.reinitializeNetwork(networkName)
     if not veafSkynet.initialized then 
         return false 
     end
 
-    for networkName, networkStructure in pairs(veafSkynet.structure) do
+    if networkName and veafSkynet.structure[networkName] then
+        local networkStructure = veafSkynet.structure[networkName]
         if networkStructure.iads then
             veaf.loggers.get(veafSkynet.Id):trace("Stored structure for network named %s has IADS, deactivating", veaf.p(networkName))
             if networkStructure.includeInRadio then 
@@ -485,6 +486,17 @@ function veafSkynet.reinitialize()
             networkStructure.iads:deactivate()
         end
         createNetworks(networkName, networkStructure.coalitionID, true)
+    end
+end
+
+-- reset an IADS networks, useful when many additions/destructions are made at once to harmonize the structures on the skynet side
+function veafSkynet.reinitialize()
+    if not veafSkynet.initialized then 
+        return false 
+    end
+
+    for networkName,_ in pairs(veafSkynet.structure) do
+        veafSkynet.reinitializeNetwork(networkName)
     end
 end
 

--- a/src/scripts/veaf/veafUnits.lua
+++ b/src/scripts/veaf/veafUnits.lua
@@ -39,7 +39,7 @@ veafUnits = {}
 veafUnits.Id = "UNITS"
 
 --- Version.
-veafUnits.Version = "1.11.0"
+veafUnits.Version = "1.11.1"
 
 -- trace level, specific to this module
 --veafUnits.LogLevel = "trace"
@@ -1884,7 +1884,7 @@ veafUnits.GroupsDatabase = {
         },
     },
     {
-        aliases = {"RU-SAM-SA13-Battery", "sa19-battery"},
+        aliases = {"RU-SAM-SA13-Battery", "sa13-battery"},
         group = {
             disposition = { h= 5, w= 5},
             units = {


### PR DESCRIPTION
(-Delayed the init of veafInterpreter within the associated missionConfig in such a way that spawned groups and units do not get added to an IADS network despite them being set to "skynet false" by default or forced as. The change will be ported to the mission tools side as soon as it is confirmed that a specific delay works in any scenario, in the mean time, keep this in mind) 

-Reworked the skynet helper to allow for the creation of and the addition to an unlimited number of IADS networks. To keep track of what exists or not, a structure was made, referencing (by name) each IADS network object along with complementary informations such as the coalitionID and the groups contained within the network.
At mission start, all of the SAMs/EWRs present on the map (not interpreter spawned, see fix above) will added to the "main" IADS of each team (which correspond to the only IADS networks that were available before). Then, groups can be added as before to these main networks through shortcuts and _spawn commands using skynet true or skynet <name of the network>.
This also allowed for the reinitialize function to be improved. When the networks are deactivated then recreated, only the previously stored groups in each network will be loaded again instead of any compatible SAM/EWR group on the map. This fixes the bug where deactivating combat zones adds every SAM/EWR to skynet, even the ones set to skynet false.
->Also added a function to reintialize one network only by networkName.

-tweaked the skynet option to be able to receive the name of IADS network you want to add the spawned group to.

-Added an AFAC spawn in CAS missions.

-Added an AFAC watchdog function to remove the AFAC mark when it dies.

-Fixed groups spawned by the interpreter not receiving the route that was set for them in the editor if they were delayed or spawned multiple times through a repeat/delay options.

-Added the option "delayed" for all of the _spawn commands. This allows to match the similar form "-<shortcut>!<delay in seconds>" for shortcuts.

-Minor addition for convenience to QRAs, added the global variable VearQRA.AllSilence which if set to true will silence the messages to players. This option is by default set to false and it is best set in the missionConfig through the use of VeafQRA.ToggleAllSilence() which will alternate between VeafQRA.AllSilence true and then false in that order. 

-Minor fix to the spawnAFAC function, took into account the <silent> parameter to not push messages to players when it is not desired

-tweaked "defense 5" setting for red coalition, spawns a shilka instead of a tunguska.