### PR TITLE
Fix logout alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veaf-mission-creation-tools",
-  "version": "4.49.0",
+  "version": "4.50.0",
   "description": "A set of tools that help set up a and run dynamic missions",
   "main": "src/nodejs/app.js",
   "bin": {

--- a/src/scripts/veaf/veafShortcuts.lua
+++ b/src/scripts/veaf/veafShortcuts.lua
@@ -1057,7 +1057,8 @@ function veafShortcuts.buildDefaultList()
             :setDescription("Lock the system")
             :setHidden(true)
             :setVeafCommand("_auth logout")
-            :setBypassSecurity(true)
+            :dontEndWithComma()
+            :setBypassSecurity(false)
     )
     -- shortcuts to specific groups
     veafShortcuts.AddAlias(


### PR DESCRIPTION
Configuration of `-logout` alias (trailing comma, bypassSecurity true) coupled to the code [here](https://github.com/VEAF/VEAF-Mission-Creation-Tools/blob/master/src/scripts/veaf/veafSecurity.lua#L519-L525) was causing markers with this command to login.