### PR TITLE
Skynet debug mode adjustment

### DIFF
--- a/src/scripts/veaf/veafSkynetIadsHelper.lua
+++ b/src/scripts/veaf/veafSkynetIadsHelper.lua
@@ -28,7 +28,7 @@ veafSkynet = {}
 veafSkynet.Id = "SKYNET"
 
 --- Version.
-veafSkynet.Version = "2.0.1"
+veafSkynet.Version = "2.0.2"
 
 -- trace level, specific to this module
 --veafSkynet.LogLevel = "trace"

--- a/src/scripts/veaf/veafSkynetIadsHelper.lua
+++ b/src/scripts/veaf/veafSkynetIadsHelper.lua
@@ -329,7 +329,7 @@ local function initializeIADS(networkName, coa, inRadio, debug)
         veaf.loggers.get(veafSkynet.Id):debug("adding debug information")
         local iadsDebug = iads:getDebugSettings()
         iadsDebug.IADSStatus = true
-        iadsDebug.samWentDark = true
+        iadsDebug.radarWentDark = true -- FG iadsDebug.samWentDark = true
         iadsDebug.contacts = true
         iadsDebug.radarWentLive = true
         iadsDebug.noWorkingCommmandCenter = false


### PR DESCRIPTION
Bien qu'initialisée dans le create du logger, la variable _samWentDark_ n'est pas utilisée par Skynet. La bonne variable est _radarWentDark_.