### PR TITLE
Log for QRA with non existant zone

### DIFF
--- a/src/scripts/veaf/veaf.lua
+++ b/src/scripts/veaf/veaf.lua
@@ -19,7 +19,7 @@ veaf = {}
 veaf.Id = "VEAF"
 
 --- Version.
-veaf.Version = "1.46.0"
+veaf.Version = "1.46.1"
 
 --- Development version ?
 veaf.Development = true
@@ -590,6 +590,10 @@ function veaf.ifnns(o, fields)
         end
     end
     return result
+end
+
+function veaf.isNullOrEmpty(s)
+    return (s == nil or (type(s) == "string" and s == ""))
 end
 
 function veaf.p(o, level, skip)

--- a/src/scripts/veaf/veafQraManager.lua
+++ b/src/scripts/veaf/veafQraManager.lua
@@ -21,7 +21,7 @@ veafQraManager = {}
 veafQraManager.Id = "QRA"
 
 --- Version.
-veafQraManager.Version = "1.2.1"
+veafQraManager.Version = "1.2.2"
 
 -- trace level, specific to this module
 --veafQraManager.LogLevel = "trace"
@@ -610,6 +610,11 @@ function VeafQRA:check()
                 local unitNames = self:_getEnemyHumanUnits()
                 local unitsInZone = nil
                 local triggerZone = veaf.getTriggerZone(self.triggerZoneName)
+
+                if (not veaf.isNullOrEmpty(self.triggerZoneName) and triggerZone == nil) then
+                    veaf.loggers.get(veafQraManager.Id):error("QRA has a non-existant zone: " .. self.triggerZoneName)
+                end
+
                 if triggerZone then
                     if triggerZone.type == 0 then -- circular
                         unitsInZone = mist.getUnitsInZones(unitNames, {self.triggerZoneName})


### PR DESCRIPTION
Added a log in `VeafQRA:check()` to notify of a QRA based on a non-existant zone.
Added the tool function `veaf.isNullOrEmpty(s)` to check if an object is nil or an empty string.