### PR TITLE
SKYNET VERSION: 3.1.3RP

### DIFF
--- a/src/scripts/community/skynet-iads-compiled.lua
+++ b/src/scripts/community/skynet-iads-compiled.lua
@@ -1,4 +1,4 @@
-env.info("--- SKYNET VERSION: 3.1.3RP | BUILD TIME: 18.09.2023 1943Z ---")
+env.info("--- SKYNET VERSION: 3.1.4RP | BUILD TIME: 20.11.2023 2049Z ---")
 do
 --this file contains the required units per sam type
 samTypesDB = {
@@ -3154,8 +3154,10 @@ function SkynetIADSContact:getTypeName()
 	if self:isIdentifiedAsHARM() then
 		return SkynetIADSContact.HARM
 	end
-	local category = self:getDCSRepresentation():getCategory()
+	local category = Object.getCategory(self:getDCSRepresentation()) -- getCategory changed in DCS 2.9.1.48111 see https://forum.dcs.world/topic/337957-patch-notes-discussion-november-2023/#comment-5330539
 	if category == Object.Category.UNIT then
+		return self.typeName
+	elseif category == Object.Category.WEAPON then
 		return self.typeName
 	end
 	return "UNKNOWN"

--- a/src/scripts/veaf/veafCombatZone.lua
+++ b/src/scripts/veaf/veafCombatZone.lua
@@ -937,11 +937,6 @@ function VeafCombatZone:desactivate()
     end
     self:clearSpawnedGroups()
 
-    -- reset the IADS', if the module is active
-    if veafSkynet then
-        veafSkynet.reinitialize()
-    end
-
     -- refresh the radio menu
     self:updateRadioMenu()
 

--- a/src/scripts/veaf/veafSkynetIadsHelper.lua
+++ b/src/scripts/veaf/veafSkynetIadsHelper.lua
@@ -1191,7 +1191,7 @@ function veafSkynet.addCommandCenterOfCoalition(iCoalitionId, sCommandCenterName
         
         veafSkynet.addCommandCenter(veafSkynetNetwork, sCommandCenterName)  
     else
-        veaf.loggers.get(veafSkynet.Id):trace("Veaf skynet not initialized. Command center []" .. sCommandCenterName .. "] stored to be added later for [" .. iCoalitionId .. "]")
+        veaf.loggers.get(veafSkynet.Id):trace("Veaf skynet not initialized. Command center [" .. sCommandCenterName .. "] stored to be added later for [" .. iCoalitionId .. "]")
         table.insert (veafSkynet.CommandCentersPreinitialize, {CoalitionId = iCoalitionId, CommandCenterName = sCommandCenterName})
     end
 end


### PR DESCRIPTION
This Skynet version accounts for the getCategory changed in DCS 2.9.1.48111 see https://forum.dcs.world/topic/337957-patch-notes-discussion-november-2023/#comment-5330539

Also added in Skynet: the display of the type of weapon contacts.

Additional update to the VEAF scripts: https://github.com/VEAF/VEAF-Mission-Creation-Tools/issues/250




