### PR TITLE
Skynet 3.1.5RP and a VeafSkynetHelper correction

### DIFF
--- a/src/scripts/community/skynet-iads-compiled.lua
+++ b/src/scripts/community/skynet-iads-compiled.lua
@@ -1,4 +1,4 @@
-env.info("--- SKYNET VERSION: 3.1.4RP | BUILD TIME: 20.11.2023 2049Z ---")
+env.info("--- SKYNET VERSION: 3.1.5RP | BUILD TIME: 14.12.2023 2228Z ---")
 do
 --this file contains the required units per sam type
 samTypesDB = {
@@ -45,6 +45,11 @@ samTypesDB = {
 			['S-300PS 64H6E sr'] = {
 				['name'] = {
 					['NATO'] = 'Big Bird',
+				},
+			},
+			['S-300PS 40B6MD sr_19J6'] = {
+				['name'] = {
+					['NATO'] = 'Tin Shield',
 				},
 			},
 		},
@@ -374,7 +379,7 @@ samTypesDB = {
 			},
 		},
 		['name'] = {
-			['NATO'] = 'Zues',
+			['NATO'] = 'Zeus',
 		},
 		['harm_detection_chance'] = 10
 	},
@@ -395,6 +400,23 @@ samTypesDB = {
 		},
 		['harm_detection_chance'] = 30
 	},
+	['HEMTT_C-RAM_Phalanx'] = {
+		['type'] = 'single',
+		['searchRadar'] = {
+			['HEMTT_C-RAM_Phalanx'] = {
+			},
+		},
+		['launchers'] = {
+			['HEMTT_C-RAM_Phalanx'] = {
+			},
+		},
+		['name'] = {
+			['NATO'] = 'C-RAM Phalanx',
+		},
+		['harm_detection_chance'] = 40,
+		['can_engage_harm'] = true
+	},
+
 --- Start of EW radars:
 	['1L13 EWR'] = {
 		['type'] = 'ewr',

--- a/src/scripts/veaf/veafSkynetIadsHelper.lua
+++ b/src/scripts/veaf/veafSkynetIadsHelper.lua
@@ -113,12 +113,15 @@ function veafSkynet.getStringSkynetElement(skynetElement)
 end
 
 function veafSkynet.getDcsGroupFromSkynetElement(skynetElement)
-    local category = getmetatable(skynetElement.dcsRepresentation)
-    if (category == Group) then
-        return skynetElement.dcsRepresentation
-    elseif (category == Unit) then
-        return Unit.getGroup(skynetElement.dcsRepresentation)
+    if (skynetElement.dcsRepresentation and skynetElement.dcsRepresentation:isExist()) then
+        local category = getmetatable(skynetElement.dcsRepresentation)
+        if (category == Group) then
+            return skynetElement.dcsRepresentation
+        elseif (category == Unit) then
+            return Unit.getGroup(skynetElement.dcsRepresentation)
+        end
     end
+    
     return nil
 end
 
@@ -144,11 +147,11 @@ function veafSkynet.getSkynetData(skynetElement)
 
         -- tracking and search radars can be used by multiple sites
         if(skynetDatabaseMatchType(skynetElement.trackingRadars, skynetData["trackingRadar"])) then
-            veaf.loggers.get(veafSkynet.Id):trace("Matched by launcher : " .. veafSkynet.getStringSkynetElement(skynetElement) .. " > " .. skynetDataName)
+            veaf.loggers.get(veafSkynet.Id):trace("Matched by TR : " .. veafSkynet.getStringSkynetElement(skynetElement) .. " > " .. skynetDataName)
             return skynetData
         end
         if(skynetDatabaseMatchType(skynetElement.searchRadars, skynetData["searchRadar"])) then
-            veaf.loggers.get(veafSkynet.Id):trace("Matched by launcher : " .. veafSkynet.getStringSkynetElement(skynetElement) .. " > " .. skynetDataName)
+            veaf.loggers.get(veafSkynet.Id):trace("Matched by SR : " .. veafSkynet.getStringSkynetElement(skynetElement) .. " > " .. skynetDataName)
             return skynetData
         end
     end


### PR DESCRIPTION
Skynet 3.1.5RP adds two new units in the database:
- S-300PS 40B6MD sr_19J6 (Tin Shield for S-300)
- HEMTT_C-RAM_Phalanx, with HARM detection=40 and capacity to intercept HARM

Also corrected an issue in `veafSkynet.getDcsGroupFromSkynetElement` that caused a script error if the group or unit linked to the Skynet element did not exist (was destroyed).