### PR TITLE
Fix skynet deactivate

### DIFF
--- a/src/scripts/veaf/veafSkynetIadsHelper.lua
+++ b/src/scripts/veaf/veafSkynetIadsHelper.lua
@@ -1095,6 +1095,9 @@ function veafSkynet.deactivateNetwork(veafSkynetNetwork, elementStates)
     veaf.loggers.get(veafSkynet.Id):trace("Deactivating network " .. iads:getCoalitionString() .. ". Network elements will go " .. sElementState)
 
     local function setGroupState(skynetElement)
+        skynetElement:finishHarmDefence()
+        skynetElement:cleanUp()
+
         veafSkynet.removePointDefencesFromSkynetElement(skynetElement)
         if (elementState == veafSkynet.SkynetElementStates.Autonomous) then
             skynetElement:resetAutonomousState()
@@ -1106,6 +1109,7 @@ function veafSkynet.deactivateNetwork(veafSkynetNetwork, elementStates)
         end
     end
 
+    veafSkynet.monitorDynamicSpawn(false)
     iads:deactivate()
 
     local ewrs = iads:getEarlyWarningRadars()

--- a/src/scripts/veaf/veafSkynetIadsHelper.lua
+++ b/src/scripts/veaf/veafSkynetIadsHelper.lua
@@ -19,7 +19,7 @@ veafSkynet = {}
 veafSkynet.Id = "SKYNET"
 
 --- Version.
-veafSkynet.Version = "3.1.0"
+veafSkynet.Version = "3.1.1"
 
 -- trace level, specific to this module
 --veafSkynet.LogLevel = "trace"


### PR DESCRIPTION
Problems identified during live use:
- SAM sites did not return to live if defending HARM during IADS shutdown.
- IADS was reactivated when dynamic spawn was active, if an eligible unit was spawned in the mission.

This PR addresses both.