### PR TITLE
**bug correction** - when a DCS group and its single unit had the same name, the code got the group first and wrongly called "getTypeName" on the Group object.

### DIFF
--- a/src/scripts/veaf/veaf.lua
+++ b/src/scripts/veaf/veaf.lua
@@ -19,7 +19,7 @@ veaf = {}
 veaf.Id = "VEAF"
 
 --- Version.
-veaf.Version = "1.52.1"
+veaf.Version = "1.53.0"
 
 --- Development version ?
 veaf.Development = false
@@ -3128,6 +3128,33 @@ function veaf.startsWith(aString, aPrefix, caseSensitive)
     end
     return string.sub(aString,1,string.len(aPrefix))==aPrefix
 end
+
+function veaf.getDcsTypeName(dcsElementName)
+    veaf.loggers.get(veaf.Id):debug("veaf.getDcsTypeName(dcsElementName=%s", veaf.p(dcsElementName))
+
+    local result = "unknown"
+
+    if (not veaf.isNullOrEmpty(dcsElementName)) then
+        -- first check for a unit named like this, because the group and its units may have the same name
+        local dcsUnit = Unit.getByName(dcsElementName)
+        veaf.loggers.get(veaf.Id):trace("Unit.getByName(dcsElementName)=%s", veaf.p(dcsUnit))
+        if not dcsUnit then
+            -- then check for a group named like that
+            local dcsGroup = Group.getByName(dcsElementName)
+            veaf.loggers.get(veaf.Id):trace("Group.getByName(dcsElementName)=%s", veaf.p(dcsGroup))
+            dcsUnit = dcsGroup and dcsGroup:getUnit(1)
+        end
+        if (dcsUnit) then
+            veaf.loggers.get(veaf.Id):trace("dcsUnit=%s", veaf.p(dcsUnit, nil, nil, true, false))
+            result = dcsUnit:getTypeName()
+        end
+    end
+
+    veaf.loggers.get(veaf.Id):trace("result=%s", veaf.p(result))
+
+    return result
+end
+
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Logging
 -------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/scripts/veaf/veafWeather.lua
+++ b/src/scripts/veaf/veafWeather.lua
@@ -17,10 +17,10 @@ veafWeather = {}
 veafWeather.Id = "WEATHER"
 
 --- Version.
-veafWeather.Version = "1.4.2"
+veafWeather.Version = "1.4.3"
 
 -- trace level, specific to this module
---veafWeather.LogLevel = "trace"
+veafWeather.LogLevel = "trace"
 veaf.loggers.new(veafWeather.Id, veafWeather.LogLevel)
 
 --- Key phrase to look for in the mark text which triggers the command.
@@ -317,23 +317,7 @@ veafWeatherUnitSystem.Aircrafts.FaaMetric =
 
 ---------------------------------------------------------------------------------------------------
 ---  Methods
-function veafWeatherUnitSystem.defaultForElementName(dcsElementName)
-    --veaf.loggers.get(veafWeather.Id):trace(">>> veafWeatherUnitSystem:defaultForGroup - " .. dcsElementName)
-
-    local sTypeName = "unknown"
-    if (not veaf.isNullOrEmpty(dcsElementName)) then
-        local dcsElement = Group.getByName(dcsElementName)
-        if (dcsElement == nil) then
-            dcsElement = Unit.getByName(dcsElementName)
-        end
-        if (dcsElement) then
-            sTypeName = dcsElement:getTypeName()
-        end
-    end
-
-    --veaf.loggers.get(veafWeather.Id):trace(">>> veafWeatherUnitSystem:defaultForGroup - " .. sTypeName)
-    return veafWeatherUnitSystem.defaultForTypeName(sTypeName)
-end
+--- 
 
 function veafWeatherUnitSystem.defaultForTypeName(sTypeName)
     if (veaf.tableContains(veafWeatherUnitSystem.Aircrafts.Faa, sTypeName)) then
@@ -479,18 +463,9 @@ end
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Static methods
 function veafWeatherData.getWeatherString(vec3, dcsElementName, unitSystem)
-    local sTypeName = "unknown"
     local bWithLaste = false
 
-    if (not veaf.isNullOrEmpty(dcsElementName)) then
-        local dcsElement = Group.getByName(dcsElementName)
-        if (dcsElement == nil) then
-            dcsElement = Unit.getByName(dcsElementName)
-        end
-        if (dcsElement) then
-            sTypeName = dcsElement:getTypeName()
-        end
-    end
+    local sTypeName = veaf.getDcsTypeName(dcsElementName)
 
     if (unitSystem == nil) then
         unitSystem = veafWeatherUnitSystem.defaultForTypeName(sTypeName)


### PR DESCRIPTION
I moved the type check to the veaf.getDcsTypename() function and reveresed the order (unit first, if nil then group -> first unit).