### PR TITLE
feat: Skynet-IADS release 3.4.0RP

### DIFF
--- a/src/scripts/community/skynet-iads-compiled.lua
+++ b/src/scripts/community/skynet-iads-compiled.lua
@@ -1,4 +1,4 @@
-env.info("--- SKYNET VERSION: 3.3.2RP | BUILD TIME: 02.02.2024 1951Z ---")
+env.info("--- SKYNET VERSION: 3.4.0RP | BUILD TIME: 10.09.2025 2045Z ---")
 do
 --this file contains the required units per sam type
 samTypesDB = {	
@@ -387,6 +387,22 @@ samTypesDB = {
 		},
 		['harm_detection_chance'] = 10
 	},
+	['Phalanx'] = {
+		['type'] = 'single',
+		['searchRadar'] = {
+			['HEMTT_C-RAM_Phalanx'] = {
+			},
+		},
+		['launchers'] = {
+			['HEMTT_C-RAM_Phalanx'] = {
+			},
+		},
+		['name'] = {
+			['NATO'] = 'Phalanx',
+		},
+		['harm_detection_chance'] = 10,
+		['can_engage_harm'] = true
+	},	
 	['HQ-7'] = {
 		['searchRadar'] = {
 			['HQ-7_STR_SP'] = {
@@ -404,22 +420,72 @@ samTypesDB = {
 		},
 		['harm_detection_chance'] = 30
 	},	
-	['Phalanx'] = {
+	['Tor M2'] = {
 		['type'] = 'single',
 		['searchRadar'] = {
-			['HEMTT_C-RAM_Phalanx'] = {
+			['CHAP_TorM2'] = {
 			},
 		},
 		['launchers'] = {
-			['HEMTT_C-RAM_Phalanx'] = {
+			['CHAP_TorM2'] = {
 			},
 		},
 		['name'] = {
-			['NATO'] = 'Phalanx',
+			['NATO'] = 'SA-15 Gauntlet M2',
+		},
+		['harm_detection_chance'] = 90,
+		['can_engage_harm'] = true
+	},	
+	['Pantsir S1'] = {
+		['type'] = 'single',
+		['searchRadar'] = {
+			['CHAP_PantsirS1'] = {
+			},
+		},
+		['launchers'] = {
+			['CHAP_PantsirS1'] = {
+			},
+		},
+		['name'] = {
+			['NATO'] = 'SA-22 Greyhound',
 		},
 		['harm_detection_chance'] = 10,
 		['can_engage_harm'] = true
 	},	
+	['Iris-T SLM'] = {
+		['type'] = 'complex',
+		['searchRadar'] = {
+			['CHAP_IRISTSLM_STR'] = {
+				['name'] = {
+					['NATO'] = 'Hensoldt TRML-4D',
+				},
+			},
+		},
+		['launchers'] = {
+			['CHAP_IRISTSLM_LN'] = {
+			},
+		},
+		['name'] = {
+			['NATO'] = 'Iris-T SLM',
+		},
+		['harm_detection_chance'] = 90,
+		['can_engage_harm'] = true
+	},
+	['Buk Solo'] = {
+		['type'] = 'single',
+		['searchRadar'] = {
+			['SA-11 Buk LN 9A310M1'] = {
+			},
+		},
+		['launchers'] = {
+			['SA-11 Buk LN 9A310M1'] = {
+			},
+		},
+		['name'] = {
+			['NATO'] = 'SA-11 Gadfly Solo',
+		},
+		['harm_detection_chance'] = 70
+	},
 -- Start of RED EW radars:	
 	['1L13 EWR'] = {
 		['type'] = 'ewr',


### PR DESCRIPTION
As requested by Sharko, Skynet-IADS upgraded to 3.4.0RP, which adds to the database :
- Tor M2
- Pantsir S1
- Iris-T SLM
- SA-11 solo (w/o the Snowdrift)

## Summary by Sourcery

Upgrade Skynet-IADS to 3.4.0RP and expand the SAM database with new systems.

New Features:
- Add Phalanx C-RAM air defense type
- Add Tor M2 (SA-15 Gauntlet) battery
- Add Pantsir S1 (SA-22 Greyhound) battery
- Add Iris-T SLM (Hensoldt TRML-4D) system
- Add Buk Solo (SA-11 Gadfly Solo) battery

Enhancements:
- Bump Skynet-IADS version to 3.4.0RP with updated build timestamp