### PR TITLE
Fix get nearest airbase list error

### DIFF
--- a/src/scripts/veaf/veafAirbases.lua
+++ b/src/scripts/veaf/veafAirbases.lua
@@ -16,7 +16,7 @@ veafAirbases = {}
 veafAirbases.Id = "AIRBASES"
 
 --- Version.
-veafAirbases.Version = "1.1.0"
+veafAirbases.Version = "1.1.1"
 
 -- trace level, specific to this module
 --veafAirbases.LogLevel = "trace"

--- a/src/scripts/veaf/veafAirbases.lua
+++ b/src/scripts/veaf/veafAirbases.lua
@@ -122,34 +122,35 @@ function veafAirbases.getNearestAirbaseList(dcsUnit, iCount)
     end
 
     for _, veafAirbase in pairs(veafAirbases.Airbases) do
-        local vec3Airbase = veafAirbase.DcsAirbase:getPoint()
-        local iDistance = mist.utils.get2DDist(vec3Unit, vec3Airbase)
-        local bAdded = false
+        if (veafAirbase and veafAirbase.DcsAirbase and veafAirbase.DcsAirbase:isExist()) then
+            local vec3Airbase = veafAirbase.DcsAirbase:getPoint()
+            local iDistance = mist.utils.get2DDist(vec3Unit, vec3Airbase)
+            local bAdded = false
 
-        -- first fill all the nil positions
-        for i = 1, iCount, 1 do
-            if (nearestList[i] == nil) then
-                nearestList[i] = { veafAirbase, iDistance }
-                bAdded = true
-                break
-            end
-        end
-
-        if (not bAdded) then
-            -- then, replace the farthest one if the current one is closer
-            for i = iCount, 1, -1 do
-                if (iDistance < nearestList[i][2]) then
-                    nearestList[i] = { veafAirbase, iDistance}
+            -- first fill all the nil positions
+            for i = 1, iCount, 1 do
+                if (nearestList[i] == nil) then
+                    nearestList[i] = { veafAirbase, iDistance }
                     bAdded = true
                     break
                 end
             end
-        end
 
-        if (bAdded) then
-            table.sort(nearestList, Sort)
+            if (not bAdded) then
+                -- then, replace the farthest one if the current one is closer
+                for i = iCount, 1, -1 do
+                    if (iDistance < nearestList[i][2]) then
+                        nearestList[i] = { veafAirbase, iDistance}
+                        bAdded = true
+                        break
+                    end
+                end
+            end
+
+            if (bAdded) then
+                table.sort(nearestList, Sort)
+            end
         end
-        
     end
 
     return nearestList

--- a/src/scripts/veaf/veafWeather.lua
+++ b/src/scripts/veaf/veafWeather.lua
@@ -1096,6 +1096,7 @@ function veafWeatherAtis.getAtis(veafAirbase)
             veaf.loggers.get(veafWeather.Id):trace(string.format("Failed to create ATIS for airbase %s", veafAirbase.Name))
         else
             veaf.loggers.get(veafWeather.Id):trace(string.format("New ATIS in effect for airbase %s: %s %s", veafAirbase.Name, atisInEffect.Letter, veafTime.toStringTime(atisInEffect.DateTimeZulu, false)))      
+        end
         
         veafWeatherAtis.ListInEffect[veafAirbase.Name] = atisInEffect
     end
@@ -1110,6 +1111,7 @@ function veafWeatherAtis.getAtisString(veafAirbase)
         return "No ATIS message for airbase " .. veafAirbase.Name
     else
         return atisInEffect.Message
+    end
 end
 
 function veafWeatherAtis.getAtisStringFromVeafPoint(sPointName, iAbsTime)

--- a/src/scripts/veaf/veafWeather.lua
+++ b/src/scripts/veaf/veafWeather.lua
@@ -993,6 +993,10 @@ veafWeatherAtis.ListInEffect = {}
 ---------------------------------------------------------------------------------------------------
 ---  CTORS
 function veafWeatherAtis:Create(veafAirbase, dateTimeZulu)
+    if (veafAirbase == nil or veafAirbase.DcsAirbase == nil or not veafAirbase.DcsAirbase:isExist()) then
+        return nil
+    end
+
     local iHoursSinceMidnight = dateTimeZulu.hour
     local sLetter = string.char(math.floor(iHoursSinceMidnight) + string.byte("A"))
 
@@ -1087,7 +1091,12 @@ function veafWeatherAtis.getAtis(veafAirbase)
 
     if (atisInEffect == nil) then
         atisInEffect = veafWeatherAtis:Create(veafAirbase, dateTimeZulu)
-        veaf.loggers.get(veafWeather.Id):trace(string.format("New ATIS in effect for airbase %s: %s %s", veafAirbase.Name, atisInEffect.Letter, veafTime.toStringTime(atisInEffect.DateTimeZulu, false)))  
+        
+        if (atisInEffect == nil) then
+            veaf.loggers.get(veafWeather.Id):trace(string.format("Failed to create ATIS for airbase %s", veafAirbase.Name))
+        else
+            veaf.loggers.get(veafWeather.Id):trace(string.format("New ATIS in effect for airbase %s: %s %s", veafAirbase.Name, atisInEffect.Letter, veafTime.toStringTime(atisInEffect.DateTimeZulu, false)))      
+        
         veafWeatherAtis.ListInEffect[veafAirbase.Name] = atisInEffect
     end
 
@@ -1096,7 +1105,11 @@ end
 
 function veafWeatherAtis.getAtisString(veafAirbase)
     local atisInEffect = veafWeatherAtis.getAtis(veafAirbase)
-    return atisInEffect.Message
+
+    if (atisInEffect == nil) then
+        return "No ATIS message for airbase " .. veafAirbase.Name
+    else
+        return atisInEffect.Message
 end
 
 function veafWeatherAtis.getAtisStringFromVeafPoint(sPointName, iAbsTime)

--- a/src/scripts/veaf/veafWeather.lua
+++ b/src/scripts/veaf/veafWeather.lua
@@ -17,7 +17,7 @@ veafWeather = {}
 veafWeather.Id = "WEATHER"
 
 --- Version.
-veafWeather.Version = "1.5.1"
+veafWeather.Version = "1.5.2"
 
 -- trace level, specific to this module
 --veafWeather.LogLevel = "trace"


### PR DESCRIPTION
Fix for issue #302

## Summary by Sourcery

Fix nearest airbase lookup and ATIS generation when airbases are missing or no longer exist.

Bug Fixes:
- Guard against non-existent or invalid airbases when building the nearest airbase list to avoid runtime errors.
- Prevent ATIS creation and access for invalid or non-existent airbases, returning a fallback message instead of failing.

Enhancements:
- Add logging to trace failed ATIS creation attempts for specific airbases.
- Bump veafAirbases and veafWeather module version numbers to reflect the changes.