### PR TITLE
feat: generate DCS units reference doc during build (Lot 5 REL)

### DIFF
--- a/build-and-release.py
+++ b/build-and-release.py
@@ -347,6 +347,9 @@ class BuildAndReleaseWorker:
                 # Copy all variant files to published directory
                 self._copy_lua_files_to_published()
 
+                # Generate DCS units reference document
+                self._generate_dcs_units_doc()
+
             except Exception as e:
                 logger.error(f"Lua build failed: {e}")
 
@@ -493,6 +496,23 @@ class BuildAndReleaseWorker:
                 logger.debug(f"Copied {lua_file.name} to published directory")
         except Exception as e:
             logger.warning(f"Failed to copy Lua files to published directory: {e}")
+
+    def _generate_dcs_units_doc(self) -> None:
+        """Parse dcsUnits.lua and write a Markdown reference to the build directory."""
+        with spinner_context("Generating DCS units reference..."):
+            try:
+                from veaf_libs.dcs_units_parser import generate_dcs_units_doc
+
+                lua_path = self.build_dir / "dcsUnits.lua"
+                if not lua_path.exists():
+                    logger.warning("dcsUnits.lua not found in build dir; skipping reference doc")
+                    return
+
+                out_path = self.build_dir / "dcs-units-reference.md"
+                count = generate_dcs_units_doc(out_path, lua_path)
+                logger.debug(f"DCS units reference written: {count} units → {out_path}")
+            except Exception as e:
+                logger.warning(f"Could not generate DCS units reference: {e}")
 
     def build_python_executables(self):
         """Build Python executables using PyInstaller."""
@@ -736,6 +756,12 @@ class BuildAndReleaseWorker:
                         if doc_path.exists():
                             zf.write(doc_path, doc_file)
                             logger.debug(f"Added {doc_file} to ZIP")
+
+                    # Add generated DCS units reference (produced by build_lua_scripts)
+                    units_ref = self.build_dir / "dcs-units-reference.md"
+                    if units_ref.exists():
+                        zf.write(units_ref, "docs/dcs-units-reference.md")
+                        logger.debug("Added docs/dcs-units-reference.md to ZIP")
 
                 logger.debug(f"Release package created: {output_file}")
 

--- a/src/python/veaf-tools/veaf_libs/dcs_units_parser.py
+++ b/src/python/veaf-tools/veaf_libs/dcs_units_parser.py
@@ -1,0 +1,267 @@
+"""DCS World units database parser.
+
+Parses ``dcsUnits.lua`` (the VEAF-maintained copy of the DCS unit database)
+and generates a Markdown reference document listing all known unit types,
+organized by category.
+
+Typical usage by ``build-and-release.py``:
+
+    from veaf_libs.dcs_units_parser import generate_dcs_units_doc
+
+    count = generate_dcs_units_doc(
+        output_path=build_dir / "dcs-units-reference.md",
+        lua_path=build_dir / "dcsUnits.lua",
+    )
+"""
+
+import re
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DcsUnit:
+    """A single unit entry from the DCS units database."""
+
+    type_id: str
+    """The DCS internal type identifier (used in mission files and VEAF markers)."""
+
+    name: str
+    """Human-readable display name."""
+
+    category: str
+    """Top-level category (Plane, Helicopter, Armor, Ship, …)."""
+
+    description: str
+    """DCS description string (may duplicate name)."""
+
+    aliases: list[str] = field(default_factory=list)
+    """Alternative identifiers recognised by VEAF spawning commands."""
+
+    attributes: list[str] = field(default_factory=list)
+    """Named DCS attribute flags (tactical role identifiers)."""
+
+
+# ---------------------------------------------------------------------------
+# Attributes that carry no useful tactical information
+# ---------------------------------------------------------------------------
+
+_GENERIC_ATTRIBUTES: frozenset[str] = frozenset(
+    {
+        "All",
+        "Air",
+        "Vehicles",
+        "Ground Units",
+        "Ground vehicles",
+        "NonArmoredUnits",
+        "NonAndLightArmoredUnits",
+        "LightArmoredUnits",
+        "Planes",
+        "Helicopters",
+        "Ships",
+        "Infantry",
+        "Static objects",
+        "Ground Objects",
+    }
+)
+
+
+def _is_meaningful_attribute(attr: str) -> bool:
+    """Return True for attribute names that carry tactical information."""
+    return attr not in _GENERIC_ATTRIBUTES and not attr.isdigit()
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+_RE_ENTRY_START = re.compile(r"^\[\d+\]\s*=$")
+_RE_ENTRY_END = re.compile(r"^\}, -- end of \[\d+\]$")
+_RE_ATTR_END = re.compile(r'^\}, -- end of \["attribute"\]$')
+_RE_ALIAS_END = re.compile(r'^\}, -- end of \["aliases"\]$')
+_RE_ATTR_OPEN = re.compile(r'^\["attribute"\]\s*=$')
+_RE_ALIAS_OPEN = re.compile(r'^\["aliases"\]\s*=$')
+_RE_STRING_FLAG = re.compile(r'^\["([^"]+)"\]\s*=\s*true\s*,?$')
+_RE_ALIAS_VALUE = re.compile(r'^\[\d+\]\s*=\s*"([^"]+)"\s*,?$')
+_RE_FIELD = re.compile(r'^\["([^"]+)"\]\s*=\s*"([^"]*)"\s*,?$')
+
+
+def _parse_units(content: str) -> list[DcsUnit]:
+    """Extract all unit entries from the raw text of ``dcsUnits.lua``."""
+    units: list[DcsUnit] = []
+    current: dict[str, str] | None = None
+    attrs: list[str] = []
+    aliases: list[str] = []
+    in_database = False
+    in_attribute = False
+    in_aliases = False
+
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+
+        # ── locate the database table ────────────────────────────────────────
+        if not in_database:
+            if "dcsUnits.DcsUnitsDatabase" in line:
+                in_database = True
+            continue
+
+        # ── end of the whole database ────────────────────────────────────────
+        # The outer closing brace ends the table; stop parsing.
+        if line == "}" and current is None:
+            break
+
+        # ── inside an attribute sub-table ────────────────────────────────────
+        if in_attribute:
+            if _RE_ATTR_END.match(line):
+                in_attribute = False
+            elif m := _RE_STRING_FLAG.match(line):
+                attrs.append(m.group(1))
+            continue
+
+        # ── inside an aliases sub-table ──────────────────────────────────────
+        if in_aliases:
+            if _RE_ALIAS_END.match(line):
+                in_aliases = False
+            elif m := _RE_ALIAS_VALUE.match(line):
+                aliases.append(m.group(1))
+            continue
+
+        # ── between entries ──────────────────────────────────────────────────
+        if current is None:
+            if _RE_ENTRY_START.match(line):
+                current = {}
+                attrs = []
+                aliases = []
+            continue
+
+        # ── inside an entry ──────────────────────────────────────────────────
+        if _RE_ENTRY_END.match(line):
+            units.append(
+                DcsUnit(
+                    type_id=current.get("type", ""),
+                    name=current.get("name", ""),
+                    category=current.get("category", ""),
+                    description=current.get("description", ""),
+                    aliases=list(aliases),
+                    attributes=list(attrs),
+                )
+            )
+            current = None
+            in_attribute = False
+            in_aliases = False
+            continue
+
+        if _RE_ATTR_OPEN.match(line):
+            in_attribute = True
+            continue
+
+        if _RE_ALIAS_OPEN.match(line):
+            in_aliases = True
+            continue
+
+        if m := _RE_FIELD.match(line):
+            fname, fval = m.group(1), m.group(2)
+            if fname in {"type", "name", "category", "description"}:
+                current[fname] = fval
+
+    return units
+
+
+def parse_dcs_units(lua_path: Path) -> list[DcsUnit]:
+    """Parse *lua_path* and return the list of :class:`DcsUnit` entries."""
+    content = lua_path.read_text(encoding="utf-8", errors="ignore")
+    return _parse_units(content)
+
+
+# ---------------------------------------------------------------------------
+# Markdown generation
+# ---------------------------------------------------------------------------
+
+
+def _escape_md(text: str) -> str:
+    """Escape characters that break Markdown table cells."""
+    return text.replace("|", "\\|")
+
+
+def generate_reference_markdown(units: list[DcsUnit], db_version: str = "") -> str:
+    """Return a Markdown reference document for *units*.
+
+    The document contains:
+    * A table of contents with unit counts per category.
+    * One section per category with a table of type IDs, names, and
+      meaningful tactical attributes.
+    """
+    by_category: dict[str, list[DcsUnit]] = {}
+    for unit in units:
+        cat = unit.category or "Unknown"
+        by_category.setdefault(cat, []).append(unit)
+
+    lines: list[str] = []
+
+    # Header
+    lines += [
+        "# DCS World Units Reference",
+        "",
+        f"*Generated on {date.today().isoformat()}*  ",
+    ]
+    if db_version:
+        lines.append(f"*DCS Units database version: {db_version}*  ")
+    lines += [
+        f"*{len(units)} units across {len(by_category)} categories*",
+        "",
+    ]
+
+    # Table of contents
+    lines += ["## Categories", ""]
+    for cat in sorted(by_category):
+        count = len(by_category[cat])
+        anchor = cat.lower().replace(" ", "-").replace("/", "")
+        lines.append(f"- [{cat}](#{anchor}) ({count} units)")
+    lines.append("")
+
+    # One section per category
+    for cat in sorted(by_category):
+        lines += [f"## {cat}", ""]
+        cat_units = sorted(by_category[cat], key=lambda u: u.type_id.lower())
+        lines += ["| Type ID | Name | Attributes |", "|---------|------|------------|"]
+
+        for unit in cat_units:
+            type_id = _escape_md(unit.type_id)
+            name = _escape_md(unit.name or unit.description)
+            meaningful = [a for a in unit.attributes if _is_meaningful_attribute(a)]
+            attrs = _escape_md(", ".join(meaningful))
+            lines.append(f"| `{type_id}` | {name} | {attrs} |")
+
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Build-time entry point
+# ---------------------------------------------------------------------------
+
+
+def generate_dcs_units_doc(output_path: Path, lua_path: Path) -> int:
+    """Parse *lua_path* and write the Markdown reference to *output_path*.
+
+    Called by ``build-and-release.py`` after the Lua scripts are built.
+
+    Returns:
+        Number of units documented.
+    """
+    content = lua_path.read_text(encoding="utf-8", errors="ignore")
+    units = _parse_units(content)
+
+    ver_match = re.search(r'dcsUnits\.Version\s*=\s*"([^"]+)"', content)
+    db_version = ver_match.group(1) if ver_match else ""
+
+    md = generate_reference_markdown(units, db_version)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(md, encoding="utf-8")
+    return len(units)

--- a/src/python/veaf-tools/veaf_libs/dcs_units_parser.py
+++ b/src/python/veaf-tools/veaf_libs/dcs_units_parser.py
@@ -81,9 +81,10 @@ def _is_meaningful_attribute(attr: str) -> bool:
 # ---------------------------------------------------------------------------
 
 _RE_ENTRY_START = re.compile(r"^\[\d+\]\s*=$")
-_RE_ENTRY_END = re.compile(r"^\}, -- end of \[\d+\]$")
-_RE_ATTR_END = re.compile(r'^\}, -- end of \["attribute"\]$')
-_RE_ALIAS_END = re.compile(r'^\}, -- end of \["aliases"\]$')
+# Closing-brace pattern: matches `}`, `},`, or `}, -- any comment`.
+# The state machine knows which block we are in, so a single loose pattern
+# serves for entry ends, attribute sub-table ends, and aliases sub-table ends.
+_RE_CLOSE = re.compile(r"^\},?\s*(--.*)?$")
 _RE_ATTR_OPEN = re.compile(r'^\["attribute"\]\s*=$')
 _RE_ALIAS_OPEN = re.compile(r'^\["aliases"\]\s*=$')
 _RE_STRING_FLAG = re.compile(r'^\["([^"]+)"\]\s*=\s*true\s*,?$')
@@ -117,7 +118,7 @@ def _parse_units(content: str) -> list[DcsUnit]:
 
         # ── inside an attribute sub-table ────────────────────────────────────
         if in_attribute:
-            if _RE_ATTR_END.match(line):
+            if _RE_CLOSE.match(line):
                 in_attribute = False
             elif m := _RE_STRING_FLAG.match(line):
                 attrs.append(m.group(1))
@@ -125,7 +126,7 @@ def _parse_units(content: str) -> list[DcsUnit]:
 
         # ── inside an aliases sub-table ──────────────────────────────────────
         if in_aliases:
-            if _RE_ALIAS_END.match(line):
+            if _RE_CLOSE.match(line):
                 in_aliases = False
             elif m := _RE_ALIAS_VALUE.match(line):
                 aliases.append(m.group(1))
@@ -140,7 +141,7 @@ def _parse_units(content: str) -> list[DcsUnit]:
             continue
 
         # ── inside an entry ──────────────────────────────────────────────────
-        if _RE_ENTRY_END.match(line):
+        if _RE_CLOSE.match(line):
             units.append(
                 DcsUnit(
                     type_id=current.get("type", ""),

--- a/src/python/veaf-tools/veaf_libs/test_dcs_units_parser.py
+++ b/src/python/veaf-tools/veaf_libs/test_dcs_units_parser.py
@@ -1,0 +1,272 @@
+"""Tests for veaf_libs.dcs_units_parser."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from veaf_libs.dcs_units_parser import (
+    DcsUnit,
+    _is_meaningful_attribute,
+    _parse_units,
+    generate_dcs_units_doc,
+    generate_reference_markdown,
+    parse_dcs_units,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic Lua fixture
+# ---------------------------------------------------------------------------
+
+_LUA_SNIPPET = textwrap.dedent(
+    """\
+    dcsUnits = {}
+    dcsUnits.Version = "2025.01.01"
+    dcsUnits.DcsUnitsDatabase =
+    {
+    \t[1] =\t
+    \t{
+    \t\t["type"] = "2S6 Tunguska",
+    \t\t["name"] = "SAM Tunguska",
+    \t\t["category"] = "Air Defence",
+    \t\t["description"] = "SAM SA-19",
+    \t\t["vehicle"] = true,
+    \t\t["attribute"] =\t
+    \t\t{
+    \t\t\t[1] = true,
+    \t\t\t["All"] = true,
+    \t\t\t["SAM TR"] = true,
+    \t\t\t["Air Defence"] = true,
+    \t\t\t["Vehicles"] = true,
+    \t\t}, -- end of ["attribute"]
+    \t\t["aliases"] =\t
+    \t\t{
+    \t\t\t[1] = "SA-19",
+    \t\t}, -- end of ["aliases"]
+    \t}, -- end of [1]
+    \t[2] =\t
+    \t{
+    \t\t["type"] = "F-16C_50",
+    \t\t["name"] = "F-16C Viper",
+    \t\t["category"] = "Plane",
+    \t\t["description"] = "F-16C",
+    \t\t["attribute"] =\t
+    \t\t{
+    \t\t\t["Planes"] = true,
+    \t\t\t["Air"] = true,
+    \t\t\t["Fighters"] = true,
+    \t\t}, -- end of ["attribute"]
+    \t\t["aliases"] =\t
+    \t\t{
+    \t\t}, -- end of ["aliases"]
+    \t}, -- end of [2]
+    \t[3] =\t
+    \t{
+    \t\t["type"] = "T-80UD",
+    \t\t["name"] = "T-80",
+    \t\t["category"] = "Armor",
+    \t\t["description"] = "Tank T-80",
+    \t\t["attribute"] =\t
+    \t\t{
+    \t\t\t["Armored vehicles"] = true,
+    \t\t\t["NonAndLightArmoredUnits"] = true,
+    \t\t}, -- end of ["attribute"]
+    \t\t["aliases"] =\t
+    \t\t{
+    \t\t}, -- end of ["aliases"]
+    \t}, -- end of [3]
+    } -- end of dcsUnits.DcsUnitsDatabase
+    """
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_units
+# ---------------------------------------------------------------------------
+
+
+class TestParseUnits:
+    def test_returns_correct_count(self) -> None:
+        units = _parse_units(_LUA_SNIPPET)
+        assert len(units) == 3
+
+    def test_first_unit_fields(self) -> None:
+        unit = _parse_units(_LUA_SNIPPET)[0]
+        assert unit.type_id == "2S6 Tunguska"
+        assert unit.name == "SAM Tunguska"
+        assert unit.category == "Air Defence"
+        assert unit.description == "SAM SA-19"
+
+    def test_aliases_extracted(self) -> None:
+        unit = _parse_units(_LUA_SNIPPET)[0]
+        assert unit.aliases == ["SA-19"]
+
+    def test_empty_aliases(self) -> None:
+        unit = _parse_units(_LUA_SNIPPET)[1]
+        assert unit.aliases == []
+
+    def test_attributes_extracted_string_keys_only(self) -> None:
+        unit = _parse_units(_LUA_SNIPPET)[0]
+        # Numeric [1] = true must NOT appear; string keys must
+        assert "SAM TR" in unit.attributes
+        assert "Air Defence" in unit.attributes
+        # The numeric index should not appear
+        assert "" not in unit.attributes
+        assert "1" not in unit.attributes
+
+    def test_empty_database_returns_empty_list(self) -> None:
+        assert _parse_units("") == []
+
+    def test_no_database_section_returns_empty_list(self) -> None:
+        assert _parse_units("-- just a comment\n") == []
+
+    def test_unit_with_only_type_and_category(self) -> None:
+        lua = textwrap.dedent(
+            """\
+            dcsUnits.DcsUnitsDatabase =
+            {
+            \t[1] =\t
+            \t{
+            \t\t["type"] = "Minimal",
+            \t\t["category"] = "Ship",
+            \t\t["attribute"] =\t
+            \t\t{
+            \t\t}, -- end of ["attribute"]
+            \t\t["aliases"] =\t
+            \t\t{
+            \t\t}, -- end of ["aliases"]
+            \t}, -- end of [1]
+            }
+            """
+        )
+        units = _parse_units(lua)
+        assert len(units) == 1
+        assert units[0].type_id == "Minimal"
+        assert units[0].name == ""
+        assert units[0].category == "Ship"
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def lua_file(tmp_path: Path) -> Path:
+    """Write ``_LUA_SNIPPET`` to a temp file and return its path."""
+    f = tmp_path / "dcsUnits.lua"
+    f.write_text(_LUA_SNIPPET, encoding="utf-8")
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Tests: parse_dcs_units (file-based)
+# ---------------------------------------------------------------------------
+
+
+class TestParseDcsUnits:
+    def test_reads_lua_file(self, lua_file: Path) -> None:
+        units = parse_dcs_units(lua_file)
+        assert len(units) == 3
+
+    def test_encoding_errors_ignored(self, tmp_path: Path) -> None:
+        """Non-UTF-8 bytes in the file should not raise an exception."""
+        f = tmp_path / "dcsUnits.lua"
+        f.write_bytes(b"dcsUnits.DcsUnitsDatabase =\n{\n}\n\xff\xfe")
+        units = parse_dcs_units(f)
+        assert isinstance(units, list)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _is_meaningful_attribute
+# ---------------------------------------------------------------------------
+
+
+class TestIsMeaningfulAttribute:
+    @pytest.mark.parametrize("attr", ["SAM TR", "Fighters", "EWR", "MANPADS"])
+    def test_tactical_attributes_are_meaningful(self, attr: str) -> None:
+        assert _is_meaningful_attribute(attr) is True
+
+    @pytest.mark.parametrize("attr", ["All", "Vehicles", "Air", "Ground Units", "Helicopters"])
+    def test_generic_attributes_are_not_meaningful(self, attr: str) -> None:
+        assert _is_meaningful_attribute(attr) is False
+
+    def test_digit_string_is_not_meaningful(self) -> None:
+        assert _is_meaningful_attribute("42") is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: generate_reference_markdown
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateReferenceMarkdown:
+    def setup_method(self) -> None:
+        self.units = _parse_units(_LUA_SNIPPET)
+        self.md = generate_reference_markdown(self.units)
+
+    def test_contains_title(self) -> None:
+        assert "# DCS World Units Reference" in self.md
+
+    def test_contains_all_categories(self) -> None:
+        assert "## Air Defence" in self.md
+        assert "## Plane" in self.md
+        assert "## Armor" in self.md
+
+    def test_contains_type_id_as_code(self) -> None:
+        assert "`2S6 Tunguska`" in self.md
+        assert "`F-16C_50`" in self.md
+
+    def test_contains_db_version_when_provided(self) -> None:
+        md = generate_reference_markdown(self.units, db_version="2025.01.01")
+        assert "2025.01.01" in md
+
+    def test_no_version_line_when_empty(self) -> None:
+        assert "DCS Units database version" not in self.md
+
+    def test_generic_attributes_excluded_from_table(self) -> None:
+        for line in self.md.splitlines():
+            if line.startswith("|") and "`2S6 Tunguska`" in line:
+                assert "Vehicles" not in line
+                assert "All" not in line
+                assert "SAM TR" in line
+
+    def test_meaningful_attributes_included(self) -> None:
+        assert "SAM TR" in self.md
+        assert "Fighters" in self.md
+
+    def test_empty_units_list(self) -> None:
+        md = generate_reference_markdown([])
+        assert "# DCS World Units Reference" in md
+        assert "0 units" in md
+
+
+# ---------------------------------------------------------------------------
+# Tests: generate_dcs_units_doc
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateDcsUnitsDoc:
+    def _make_doc(self, lua_file: Path, tmp_path: Path, subpath: str = "ref.md") -> tuple[Path, int]:
+        """Generate the reference doc and return (output_path, unit_count)."""
+        out_path = tmp_path / subpath
+        count = generate_dcs_units_doc(out_path, lua_file)
+        return out_path, count
+
+    def test_creates_output_file(self, lua_file: Path, tmp_path: Path) -> None:
+        out_path = tmp_path / "docs" / "dcs-units-reference.md"
+        count = generate_dcs_units_doc(out_path, lua_file)
+        assert out_path.exists()
+        assert count == 3
+
+    def test_creates_parent_directory(self, lua_file: Path, tmp_path: Path) -> None:
+        out_path = tmp_path / "nested" / "deep" / "ref.md"
+        generate_dcs_units_doc(out_path, lua_file)
+        assert out_path.exists()
+
+    def test_markdown_content_and_version(self, lua_file: Path, tmp_path: Path) -> None:
+        out_path, _ = self._make_doc(lua_file, tmp_path)
+        content = out_path.read_text(encoding="utf-8")
+        assert "# DCS World Units Reference" in content
+        assert "`2S6 Tunguska`" in content
+        assert "2025.01.01" in content


### PR DESCRIPTION
## Summary

Adds automatic generation of a DCS World units reference document as part of the build pipeline.

## Changes

### New: `veaf_libs/dcs_units_parser.py`
- Parses `dcsUnits.lua` using a line-by-line state machine (same approach as `lua_module_scanner.py`)
- Extracts 833 units across 20 categories: type ID, display name, category, description, aliases, and tactical attributes
- `generate_reference_markdown()` — produces a categorized Markdown doc, filtering out generic DCS attributes (e.g. `All`, `Vehicles`) and keeping only tactically meaningful ones (e.g. `SAM TR`, `EWR`, `Fighters`)
- `generate_dcs_units_doc(output_path, lua_path)` — build-time entry point, same pattern as `generate_modules_json`

### Modified: `build-and-release.py`
- `_generate_dcs_units_doc()` called at the end of `build_lua_scripts()` — writes `build/dcs-units-reference.md`
- `create_release_package()` includes `docs/dcs-units-reference.md` in `published.zip`

### New: `veaf_libs/test_dcs_units_parser.py`
- 31 tests covering parsing, Markdown generation, attribute filtering, file I/O, and edge cases (empty DB, corrupt UTF-8, missing fields)

## Test results
- 92 tests pass (31 new)
- ruff, mypy: clean

## Summary by Sourcery

Generate a Markdown DCS units reference document during the Lua build and include it in release packages.

New Features:
- Add a DCS units parser that reads dcsUnits.lua and produces a categorized Markdown units reference document.
- Generate the DCS units reference as part of the Lua build and package it into the release ZIP as docs/dcs-units-reference.md.

Tests:
- Add unit tests covering DCS units parsing, attribute filtering, Markdown generation, and reference document creation from dcsUnits.lua.