### PR TITLE
fix(lua): Lot 7 — Lua runtime safety and dynamic slot fixes

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -320,12 +320,12 @@ In `build-and-release.py`, before publish: parse `src/scripts/veaf/dcsUnits.lua`
 
 | # | Ticket | Issue | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| LUA-FIX-001 | Fix `math.atan` wind direction calculation (Lua 5.1 compat) | #287 | fix | 30 min | [ ] |
-| LUA-FIX-002 | Fix stale DCS object ref in `getNearestAirbaseList` | #302 | fix | 45 min | [ ] |
-| LUA-FIX-003 | Fix dynamic slots breaking QRA, Radio, AirWaves, Sanctuary, Grass | #293 | fix | 90 min | [ ] |
-| LUA-FIX-004 | Fix QRA not triggered by dynamic slot aircraft | #299 | fix | 45 min | [ ] |
-| LUA-FIX-005 | Fix CasMission/CombatZone always using Blue bullseye | #304 | fix | 30 min | [ ] |
-| LUA-FIX-006 | Update unit list for DCS 2.9.19.13478 new assets | #295, #296 | chore | 60 min | [ ] |
+| LUA-FIX-001 | Fix `math.atan` wind direction calculation (Lua 5.1 compat) | #287 | fix | 30 min | [x] |
+| LUA-FIX-002 | Fix stale DCS object ref in `getNearestAirbaseList` | #302 | fix | 45 min | [x] |
+| LUA-FIX-003 | Fix dynamic slots breaking QRA, Radio, AirWaves, Sanctuary, Grass | #293 | fix | 90 min | [x] |
+| LUA-FIX-004 | Fix QRA not triggered by dynamic slot aircraft | #299 | fix | 45 min | [x] |
+| LUA-FIX-005 | Fix CasMission/CombatZone always using Blue bullseye | #304 | fix | 30 min | [x] |
+| LUA-FIX-006 | Update unit list for DCS 2.9.19.13478 new assets | #295, #296 | chore | 60 min | [x] |
 
 **Raw total: 300 min → estimated (×1.15): ~345 min (~5h45)**
 
@@ -342,7 +342,7 @@ In `build-and-release.py`, before publish: parse `src/scripts/veaf/dcsUnits.lua`
 | Lot 4 — LUA-CONFIG | ~6h | [ ] |
 | Lot 5 — RELEASE | ~1h30 | [ ] |
 | Lot 6 — BONUS | ~3h30 | [ ] |
-| Lot 7 — LUA FIXES | ~5h45 | [ ] |
+| Lot 7 — LUA FIXES | ~5h45 | [x] |
 | **Total** | **~29h** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*

--- a/src/scripts/veaf/veafAirWaves.lua
+++ b/src/scripts/veaf/veafAirWaves.lua
@@ -752,26 +752,58 @@ function AirWaveZone:handleCrippledEnemyUnit(waveNumber, unit)
 end
 
 function AirWaveZone:getPlayerUnitsNames()
-  if not self.playerHumanUnitsNames then
-    self.playerHumanUnitsNames = {}
-    for _, unit in pairs(mist.DBs.humansByName) do
-      local coalitionId = 0
-      if unit.coalition then
-        if unit.coalition:lower() == "red" then
-          coalitionId = coalition.side.RED
-        elseif unit.coalition:lower() == "blue" then
-          coalitionId = coalition.side.BLUE
+  -- Rebuild each time to include dynamic slot players not tracked by mist
+  self.playerHumanUnitsNames = {}
+
+  -- Static slot players from mist DB
+  for _, unit in pairs(mist.DBs.humansByName) do
+    local coalitionId = 0
+    if unit.coalition then
+      if unit.coalition:lower() == "red" then
+        coalitionId = coalition.side.RED
+      elseif unit.coalition:lower() == "blue" then
+        coalitionId = coalition.side.BLUE
+      end
+    end
+    if self.playerCoalitions[coalitionId] then
+      if unit.category then
+        if unit.category == "plane" then
+          table.insert(self.playerHumanUnitsNames, unit.unitName)
         end
       end
-      if self.playerCoalitions[coalitionId] then
-        if unit.category then
-          if unit.category == "plane" then
-            table.insert(self.playerHumanUnitsNames, unit.unitName)
+    end
+  end
+
+  -- Dynamic slot players via DCS coalition API (not tracked by mist)
+  for _, checkCoalitionId in pairs({ coalition.side.RED, coalition.side.BLUE }) do
+    if self.playerCoalitions[checkCoalitionId] then
+      local groups = coalition.getGroups(checkCoalitionId, Group.Category.AIRPLANE)
+      if groups then
+        for _, grp in pairs(groups) do
+          local units = grp:getUnits()
+          if units then
+            for _, dcsUnit in pairs(units) do
+              if dcsUnit:getPlayerName() then
+                local dynamicUnitName = dcsUnit:getName()
+                -- Only add if not already present from mist DB
+                local alreadyAdded = false
+                for _, existingName in pairs(self.playerHumanUnitsNames) do
+                  if existingName == dynamicUnitName then
+                    alreadyAdded = true
+                    break
+                  end
+                end
+                if not alreadyAdded then
+                  table.insert(self.playerHumanUnitsNames, dynamicUnitName)
+                end
+              end
+            end
           end
         end
       end
     end
   end
+
   return self.playerHumanUnitsNames
 end
 

--- a/src/scripts/veaf/veafAirWaves.lua
+++ b/src/scripts/veaf/veafAirWaves.lua
@@ -756,6 +756,7 @@ function AirWaveZone:getPlayerUnitsNames()
   self.playerHumanUnitsNames = {}
 
   -- Static slot players from mist DB
+  local seenUnits = {}
   for _, unit in pairs(mist.DBs.humansByName) do
     local coalitionId = 0
     if unit.coalition then
@@ -768,6 +769,7 @@ function AirWaveZone:getPlayerUnitsNames()
     if self.playerCoalitions[coalitionId] then
       if unit.category then
         if unit.category == "plane" then
+          seenUnits[unit.unitName] = true
           table.insert(self.playerHumanUnitsNames, unit.unitName)
         end
       end
@@ -786,14 +788,8 @@ function AirWaveZone:getPlayerUnitsNames()
               if dcsUnit:getPlayerName() then
                 local dynamicUnitName = dcsUnit:getName()
                 -- Only add if not already present from mist DB
-                local alreadyAdded = false
-                for _, existingName in pairs(self.playerHumanUnitsNames) do
-                  if existingName == dynamicUnitName then
-                    alreadyAdded = true
-                    break
-                  end
-                end
-                if not alreadyAdded then
+                if not seenUnits[dynamicUnitName] then
+                  seenUnits[dynamicUnitName] = true
                   table.insert(self.playerHumanUnitsNames, dynamicUnitName)
                 end
               end

--- a/src/scripts/veaf/veafAirbases.lua
+++ b/src/scripts/veaf/veafAirbases.lua
@@ -122,6 +122,9 @@ function veafAirbases.getNearestAirbaseList(dcsUnit, iCount)
   end
 
   for _, veafAirbase in pairs(veafAirbases.Airbases) do
+    if not veafAirbase.DcsAirbase or not veafAirbase.DcsAirbase:isExist() then
+      -- skip stale/destroyed airbase references (e.g. sunk carriers)
+    else
     local vec3Airbase = veafAirbase.DcsAirbase:getPoint()
     local iDistance = mist.utils.get2DDist(vec3Unit, vec3Airbase)
     local bAdded = false
@@ -149,6 +152,7 @@ function veafAirbases.getNearestAirbaseList(dcsUnit, iCount)
     if bAdded then
       table.sort(nearestList, Sort)
     end
+    end -- end of isExist() guard
   end
 
   return nearestList

--- a/src/scripts/veaf/veafAirbases.lua
+++ b/src/scripts/veaf/veafAirbases.lua
@@ -125,33 +125,33 @@ function veafAirbases.getNearestAirbaseList(dcsUnit, iCount)
     if not veafAirbase.DcsAirbase or not veafAirbase.DcsAirbase:isExist() then
       -- skip stale/destroyed airbase references (e.g. sunk carriers)
     else
-    local vec3Airbase = veafAirbase.DcsAirbase:getPoint()
-    local iDistance = mist.utils.get2DDist(vec3Unit, vec3Airbase)
-    local bAdded = false
+      local vec3Airbase = veafAirbase.DcsAirbase:getPoint()
+      local iDistance = mist.utils.get2DDist(vec3Unit, vec3Airbase)
+      local bAdded = false
 
-    -- first fill all the nil positions
-    for i = 1, iCount, 1 do
-      if nearestList[i] == nil then
-        nearestList[i] = { veafAirbase, iDistance }
-        bAdded = true
-        break
-      end
-    end
-
-    if not bAdded then
-      -- then, replace the farthest one if the current one is closer
-      for i = iCount, 1, -1 do
-        if iDistance < nearestList[i][2] then
+      -- first fill all the nil positions
+      for i = 1, iCount, 1 do
+        if nearestList[i] == nil then
           nearestList[i] = { veafAirbase, iDistance }
           bAdded = true
           break
         end
       end
-    end
 
-    if bAdded then
-      table.sort(nearestList, Sort)
-    end
+      if not bAdded then
+        -- then, replace the farthest one if the current one is closer
+        for i = iCount, 1, -1 do
+          if iDistance < nearestList[i][2] then
+            nearestList[i] = { veafAirbase, iDistance }
+            bAdded = true
+            break
+          end
+        end
+      end
+
+      if bAdded then
+        table.sort(nearestList, Sort)
+      end
     end -- end of isExist() guard
   end
 

--- a/src/scripts/veaf/veafCasMission.lua
+++ b/src/scripts/veaf/veafCasMission.lua
@@ -1145,7 +1145,12 @@ function veafCasMission.reportTargetInformation(unitName)
   local averageGroupPosition = veaf.getAveragePosition(veafCasMission.casGroupName)
   local lat, lon = coord.LOtoLL(averageGroupPosition)
   local mgrsString = mist.tostringMGRS(coord.LLtoMGRS(lat, lon), 3)
-  local bullseye = mist.utils.makeVec3(mist.DBs.missionData.bullseye.blue, 0)
+  local bullseyeData = mist.DBs.missionData.bullseye.blue -- default to blue
+  local requestingUnit = Unit.getByName(unitName)
+  if requestingUnit and requestingUnit:getCoalition() == coalition.side.RED then
+    bullseyeData = mist.DBs.missionData.bullseye.red
+  end
+  local bullseye = mist.utils.makeVec3(bullseyeData, 0)
   local vec = { x = averageGroupPosition.x - bullseye.x, y = averageGroupPosition.y - bullseye.y, z = averageGroupPosition.z - bullseye.z }
   local dir = mist.utils.round(mist.utils.toDegree(mist.utils.getDir(vec, bullseye)), 0)
   local dist = mist.utils.get2DDist(averageGroupPosition, bullseye)

--- a/src/scripts/veaf/veafCombatZone.lua
+++ b/src/scripts/veaf/veafCombatZone.lua
@@ -809,7 +809,7 @@ function VeafCombatZone:initialize()
   return self
 end
 
-function VeafCombatZone:getInformation()
+function VeafCombatZone:getInformation(unitName)
   veaf.loggers.get(veafCombatZone.Id):trace(string.format("VeafCombatZone[%s]:getInformation()", veaf.p(self.missionEditorZoneName)))
   local message = "COMBAT ZONE " .. self:getFriendlyName() .. " \n\n"
   if self:getBriefing() then
@@ -941,7 +941,14 @@ function VeafCombatZone:getInformation()
       local zoneCenter = self:getCenter()
       local lat, lon = coord.LOtoLL(zoneCenter)
       local mgrsString = mist.tostringMGRS(coord.LLtoMGRS(lat, lon), 3)
-      local bullseye = mist.utils.makeVec3(mist.DBs.missionData.bullseye.blue, 0)
+      local bullseyeData = mist.DBs.missionData.bullseye.blue -- default to blue
+      if unitName then
+        local requestingUnit = Unit.getByName(unitName)
+        if requestingUnit and requestingUnit:getCoalition() == coalition.side.RED then
+          bullseyeData = mist.DBs.missionData.bullseye.red
+        end
+      end
+      local bullseye = mist.utils.makeVec3(bullseyeData, 0)
       local vec = { x = zoneCenter.x - bullseye.x, y = zoneCenter.y - bullseye.y, z = zoneCenter.z - bullseye.z }
       local dir = mist.utils.round(mist.utils.toDegree(mist.utils.getDir(vec, bullseye)), 0)
       local dist = mist.utils.get2DDist(zoneCenter, bullseye)
@@ -1942,7 +1949,7 @@ function veafCombatZone.GetInformationOnZone(parameters)
   local zoneName, unitName = veaf.safeUnpack(parameters)
   local zone = veafCombatZone.GetZone(zoneName)
   if zone then
-    local text = zone:getInformation()
+    local text = zone:getInformation(unitName)
     if unitName then
       veaf.outTextForGroup(unitName, text, 30)
     else

--- a/src/scripts/veaf/veafGrass.lua
+++ b/src/scripts/veaf/veafGrass.lua
@@ -1375,7 +1375,7 @@ function veafGrass.onBirth(event)
     return
   end
 
-  local isHumanUnit = mist.DBs.humansByName[unitName] ~= nil or event.id == world.event.S_EVENT_PLAYER_ENTER_UNIT
+  local isHumanUnit = mist.DBs.humansByName[unitName] ~= nil or (event.type and event.type.id == world.event.S_EVENT_PLAYER_ENTER_UNIT)
   if isHumanUnit then -- it's a human unit
     veaf.loggers.get(veafGrass.Id):debug("caught event BIRTH for human unit [%s]", veaf.p(unitName))
     local _unit = event.initiator

--- a/src/scripts/veaf/veafGrass.lua
+++ b/src/scripts/veaf/veafGrass.lua
@@ -1365,13 +1365,18 @@ function veafGrass.onBirth(event)
   local unitName = nil
   if event.initiator ~= nil then
     unitName = event.initiator.unitName
+    if not unitName and event.initiator.getName then
+      -- dynamic slot units are DCS objects without mist table properties
+      unitName = event.initiator:getName()
+    end
   end
   if not unitName then
     veaf.loggers.get(veafGrass.Id):warn("no unitname found in event %s", veaf.p(event))
     return
   end
 
-  if mist.DBs.humansByName[unitName] then -- it's a human unit
+  local isHumanUnit = mist.DBs.humansByName[unitName] ~= nil or event.id == world.event.S_EVENT_PLAYER_ENTER_UNIT
+  if isHumanUnit then -- it's a human unit
     veaf.loggers.get(veafGrass.Id):debug("caught event BIRTH for human unit [%s]", veaf.p(unitName))
     local _unit = event.initiator
     if _unit ~= nil then

--- a/src/scripts/veaf/veafNamedPoints.lua
+++ b/src/scripts/veaf/veafNamedPoints.lua
@@ -362,6 +362,9 @@ function veafNamedPoints.addAirbases()
 
   for _, veafAirbase in pairs(veafAirbases.Airbases) do
     if veafAirbase.Category == Airbase.Category.AIRDROME then
+      if not veafAirbase.DcsAirbase or not veafAirbase.DcsAirbase:isExist() then
+        -- skip stale/destroyed airbase references (e.g. sunk carriers)
+      else
       veaf.loggers.get(veafNamedPoints.Id):trace("processing airbase name=[%s]", veafAirbase.DisplayName)
       local vec3 = veafAirbase.DcsAirbase:getPoint()
       local runways = {}
@@ -375,6 +378,7 @@ function veafNamedPoints.addAirbases()
       local namedPoint = { x = vec3.x, y = 0, z = vec3.z, runways = runways } --{name="AIRBASE Batumi",  point={x=-356437,y=0,z=618211, atc=true, tower="V131, U260", tacan="16X BTM", runways={{name="13", hdg=125, ils="110.30"}, {name="31", hdg=305}}}},
       namedPoint.hidden = true
       veafNamedPoints.addPoint(string.format("AIRBASE %s", veafAirbase.DisplayName), namedPoint)
+      end -- end of isExist() guard
     end
   end
 

--- a/src/scripts/veaf/veafNamedPoints.lua
+++ b/src/scripts/veaf/veafNamedPoints.lua
@@ -365,19 +365,19 @@ function veafNamedPoints.addAirbases()
       if not veafAirbase.DcsAirbase or not veafAirbase.DcsAirbase:isExist() then
         -- skip stale/destroyed airbase references (e.g. sunk carriers)
       else
-      veaf.loggers.get(veafNamedPoints.Id):trace("processing airbase name=[%s]", veafAirbase.DisplayName)
-      local vec3 = veafAirbase.DcsAirbase:getPoint()
-      local runways = {}
-      for i, veafRunway in ipairs(veafAirbase.Runways) do
-        for __, veafRunwayEnd in ipairs(veafRunway) do
-          --veaf.loggers.get(veafNamedPoints.Id):trace(veaf.p(veafRunwayEnd))
-          table.insert(runways, { name = string.format("%02d", veafRunwayEnd.Number), hdg = veafRunwayEnd.Heading })
+        veaf.loggers.get(veafNamedPoints.Id):trace("processing airbase name=[%s]", veafAirbase.DisplayName)
+        local vec3 = veafAirbase.DcsAirbase:getPoint()
+        local runways = {}
+        for i, veafRunway in ipairs(veafAirbase.Runways) do
+          for __, veafRunwayEnd in ipairs(veafRunway) do
+            --veaf.loggers.get(veafNamedPoints.Id):trace(veaf.p(veafRunwayEnd))
+            table.insert(runways, { name = string.format("%02d", veafRunwayEnd.Number), hdg = veafRunwayEnd.Heading })
+          end
         end
-      end
 
-      local namedPoint = { x = vec3.x, y = 0, z = vec3.z, runways = runways } --{name="AIRBASE Batumi",  point={x=-356437,y=0,z=618211, atc=true, tower="V131, U260", tacan="16X BTM", runways={{name="13", hdg=125, ils="110.30"}, {name="31", hdg=305}}}},
-      namedPoint.hidden = true
-      veafNamedPoints.addPoint(string.format("AIRBASE %s", veafAirbase.DisplayName), namedPoint)
+        local namedPoint = { x = vec3.x, y = 0, z = vec3.z, runways = runways } --{name="AIRBASE Batumi",  point={x=-356437,y=0,z=618211, atc=true, tower="V131, U260", tacan="16X BTM", runways={{name="13", hdg=125, ils="110.30"}, {name="31", hdg=305}}}},
+        namedPoint.hidden = true
+        veafNamedPoints.addPoint(string.format("AIRBASE %s", veafAirbase.DisplayName), namedPoint)
       end -- end of isExist() guard
     end
   end

--- a/src/scripts/veaf/veafQraManager.lua
+++ b/src/scripts/veaf/veafQraManager.lua
@@ -585,21 +585,34 @@ function VeafQRA:humanBornEvent(unit)
   local coalitionId = 0
   if unit.unitCoalition then
     coalitionId = unit.unitCoalition
+  elseif unit.getCoalition then
+    -- dynamic slot: unit is a DCS object, use API
+    coalitionId = unit:getCoalition()
   end
   if self.enemyCoalitions[coalitionId] then
     veaf.loggers
       .get(veafQraManager.Id)
       :trace("VeafQRA[%s]:humanBornEvent() - unit being born is an enemy (coalition %s)", self.name, coalitionId)
-    if unit.unitCategory then
-      if (unit.unitCategory == Unit.Category.AIRPLANE) or (unit.unitCategory == Unit.Category.HELICOPTER and self.reactOnHelicopters) then
+    local unitCategory = unit.unitCategory
+    if unitCategory == nil and unit.getCategory then
+      -- dynamic slot: unit is a DCS object, use API
+      unitCategory = unit:getCategory()
+    end
+    if unitCategory then
+      if (unitCategory == Unit.Category.AIRPLANE) or (unitCategory == Unit.Category.HELICOPTER and self.reactOnHelicopters) then
+        local unitNameToCheck = unit.unitName
+        if unitNameToCheck == nil and unit.getName then
+          -- dynamic slot: unit is a DCS object, use API
+          unitNameToCheck = unit:getName()
+        end
         -- check if the unit is already in the list
-        for _, unitName in pairs(self._enemyHumanUnits) do
-          if unitName == unit.unitName then
+        for _, existingUnitName in pairs(self._enemyHumanUnits) do
+          if existingUnitName == unitNameToCheck then
             return
           end
         end
         veaf.loggers.get(veafQraManager.Id):trace("adding unit to enemy human units for QRA")
-        table.insert(self._enemyHumanUnits, unit.unitName)
+        table.insert(self._enemyHumanUnits, unitNameToCheck)
       end
     end
   end
@@ -1239,11 +1252,16 @@ end
 function veafQraManager.eventHandler(event)
   -- find the originator unit
   local unitName = event.initiator and event.initiator.unitName
+  if not unitName and event.initiator and event.initiator.getName then
+    -- dynamic slot units are DCS objects without mist table properties
+    unitName = event.initiator:getName()
+  end
   if not unitName then
     return
   end
 
-  if mist.DBs.humansByName[unitName] then -- it's a human unit
+  local isHumanUnit = mist.DBs.humansByName[unitName] ~= nil or event.id == world.event.S_EVENT_PLAYER_ENTER_UNIT
+  if isHumanUnit then -- it's a human unit
     local unit = event.initiator
     if unit ~= nil then
       -- handle the event on all QRAs

--- a/src/scripts/veaf/veafQraManager.lua
+++ b/src/scripts/veaf/veafQraManager.lua
@@ -1260,7 +1260,7 @@ function veafQraManager.eventHandler(event)
     return
   end
 
-  local isHumanUnit = mist.DBs.humansByName[unitName] ~= nil or event.id == world.event.S_EVENT_PLAYER_ENTER_UNIT
+  local isHumanUnit = mist.DBs.humansByName[unitName] ~= nil or (event.type and event.type.id == world.event.S_EVENT_PLAYER_ENTER_UNIT)
   if isHumanUnit then -- it's a human unit
     local unit = event.initiator
     if unit ~= nil then

--- a/src/scripts/veaf/veafRadio.lua
+++ b/src/scripts/veaf/veafRadio.lua
@@ -84,7 +84,7 @@ function veafRadio.onBirthEvent(event)
     return
   end
   veaf.loggers.get(veafRadio.Id):trace("unitName=%s", unitName)
-  local isHumanUnit = mist.DBs.humansByName[unitName] ~= nil or event.id == world.event.S_EVENT_PLAYER_ENTER_UNIT
+  local isHumanUnit = mist.DBs.humansByName[unitName] ~= nil or (event.type and event.type.id == world.event.S_EVENT_PLAYER_ENTER_UNIT)
   if isHumanUnit then -- it's a human unit
     veaf.loggers.get(veafRadio.Id):trace("veafRadio.humanUnits=%s", veafRadio.humanUnits)
     veaf.loggers.get(veafRadio.Id):trace("unitName %s is a human unit", unitName)
@@ -94,7 +94,10 @@ function veafRadio.onBirthEvent(event)
       local groupId = event and event.initiator and event.initiator.unitGroupId
       if not groupId and event and event.initiator and event.initiator.getGroup then
         -- dynamic slot: get group ID via DCS API
-        groupId = event.initiator:getGroup():getID()
+        local grp = event.initiator:getGroup()
+        if grp then
+          groupId = grp:getID()
+        end
       end
       local callsign = event and event.initiator and event.initiator.unitPilotName
       if not callsign then

--- a/src/scripts/veaf/veafRadio.lua
+++ b/src/scripts/veaf/veafRadio.lua
@@ -76,20 +76,33 @@ function veafRadio.onBirthEvent(event)
 
   -- find the originator unit
   local unitName = event and event.initiator and event.initiator.unitName
+  if not unitName and event and event.initiator and event.initiator.getName then
+    -- dynamic slot units are DCS objects without mist table properties
+    unitName = event.initiator:getName()
+  end
   if not unitName then
     return
   end
   veaf.loggers.get(veafRadio.Id):trace("unitName=%s", unitName)
-  if mist.DBs.humansByName[unitName] then -- it's a human unit
+  local isHumanUnit = mist.DBs.humansByName[unitName] ~= nil or event.id == world.event.S_EVENT_PLAYER_ENTER_UNIT
+  if isHumanUnit then -- it's a human unit
     veaf.loggers.get(veafRadio.Id):trace("veafRadio.humanUnits=%s", veafRadio.humanUnits)
     veaf.loggers.get(veafRadio.Id):trace("unitName %s is a human unit", unitName)
     if not veafRadio.humanUnits[unitName] then
       -- add the unit to the human units list and rebuild the radio menu
       veaf.loggers.get(veafRadio.Id):trace("Adding human unit %s", unitName)
       local groupId = event and event.initiator and event.initiator.unitGroupId
+      if not groupId and event and event.initiator and event.initiator.getGroup then
+        -- dynamic slot: get group ID via DCS API
+        groupId = event.initiator:getGroup():getID()
+      end
       local callsign = event and event.initiator and event.initiator.unitPilotName
       if not callsign then
         callsign = event and event.initiator and event.initiator.unitCallsign
+      end
+      if not callsign and event and event.initiator and event.initiator.getPlayerName then
+        -- dynamic slot: get player name via DCS API
+        callsign = event.initiator:getPlayerName()
       end
       local unitObject = { name = unitName, spawned = true, groupId = groupId, callsign = callsign }
       veafRadio.humanUnits[unitName] = {}

--- a/src/scripts/veaf/veafWeather.lua
+++ b/src/scripts/veaf/veafWeather.lua
@@ -1044,7 +1044,9 @@ veafWeatherAtis.ListInEffect = {}
 ---  CTORS
 function veafWeatherAtis:Create(veafAirbase, dateTimeZulu)
   if not veafAirbase.DcsAirbase or not veafAirbase.DcsAirbase:isExist() then
-    veaf.loggers.get(veafWeather.Id):debug("veafWeatherAtis:Create - airbase [%s] DCS object no longer exists, skipping ATIS", veafAirbase.Name)
+    veaf.loggers
+      .get(veafWeather.Id)
+      :debug("veafWeatherAtis:Create - airbase [%s] DCS object no longer exists, skipping ATIS", veafAirbase.Name)
     return nil
   end
   local iHoursSinceMidnight = dateTimeZulu.hour

--- a/src/scripts/veaf/veafWeather.lua
+++ b/src/scripts/veaf/veafWeather.lua
@@ -1043,6 +1043,10 @@ veafWeatherAtis.ListInEffect = {}
 ---------------------------------------------------------------------------------------------------
 ---  CTORS
 function veafWeatherAtis:Create(veafAirbase, dateTimeZulu)
+  if not veafAirbase.DcsAirbase or not veafAirbase.DcsAirbase:isExist() then
+    veaf.loggers.get(veafWeather.Id):debug("veafWeatherAtis:Create - airbase [%s] DCS object no longer exists, skipping ATIS", veafAirbase.Name)
+    return nil
+  end
   local iHoursSinceMidnight = dateTimeZulu.hour
   local sLetter = string.char(math.floor(iHoursSinceMidnight) + string.byte("A"))
 
@@ -1147,6 +1151,9 @@ function veafWeatherAtis.getAtis(veafAirbase)
 
   if atisInEffect == nil then
     atisInEffect = veafWeatherAtis:Create(veafAirbase, dateTimeZulu)
+    if not atisInEffect then
+      return nil
+    end
     veaf.loggers.get(veafWeather.Id):trace(
       string.format(
         "New ATIS in effect for airbase %s: %s %s",
@@ -1163,6 +1170,9 @@ end
 
 function veafWeatherAtis.getAtisString(veafAirbase)
   local atisInEffect = veafWeatherAtis.getAtis(veafAirbase)
+  if not atisInEffect then
+    return nil
+  end
   return atisInEffect.Message
 end
 
@@ -1788,7 +1798,9 @@ veaf.registerModule(veafWeather.Id, veafWeather.initialize, { enable = true }, 2
 veafAirbases.initialize()
 for _, veafAirbase in pairs(veafAirbases.Airbases) do
     veaf.loggers.get(veafWeather.Id):trace(veafWeatherAtis.getAtisString(veafAirbase))
-    veaf.loggers.get(veafWeather.Id):trace(veafWeatherData.getWeatherString(veafAirbase.DcsAirbase:getPoint()))
+    if veafAirbase.DcsAirbase and veafAirbase.DcsAirbase:isExist() then
+      veaf.loggers.get(veafWeather.Id):trace(veafWeatherData.getWeatherString(veafAirbase.DcsAirbase:getPoint()))
+    end
 end
 veaf.loggers.get(veafWeather.Id):trace(veaf.p(env.mission.weather.enable_fog))
 veaf.loggers.get(veafWeather.Id):trace(veaf.p(world.weather.getFogVisibilityDistance()))


### PR DESCRIPTION
## Summary

Implements all 6 tickets from Lot 7 (LUA high-priority fixes).

LUA-FIX-001 and LUA-FIX-006 were already resolved in previous commits (no code change needed).

---

## LUA-FIX-002 — Stale DCS object guard (`isExist()`) · closes #302

Prevents crashes when a carrier is sunk or an airbase is destroyed mid-mission. Added existence checks before any `DcsAirbase:getPoint()` call:

- **`veafAirbases.lua`** — `getNearestAirbaseList()`: skip airbases whose DCS object no longer exists
- **`veafNamedPoints.lua`** — `addAirbases()`: skip destroyed airbases when building named points
- **`veafWeather.lua`** — `veafWeatherAtis:Create()`: early return nil if airbase gone; `getAtis()` + `getAtisString()` guarded against nil return; commented-out trace block also fixed

---

## LUA-FIX-003 / LUA-FIX-004 — Dynamic slot players not detected · closes #293 #299

**Root cause**: `mist.DBs.humansByName` is populated at mission start from the mission file and never includes dynamic slot units spawned at runtime. Dynamic slots fire `S_EVENT_PLAYER_ENTER_UNIT` (always for humans) but are DCS Unit objects, not mist tables.

**Universal fix pattern**:
- `unitName` fallback: try `event.initiator.unitName` first, then `event.initiator:getName()` for DCS objects
- human check: `mist.DBs.humansByName[unitName] ~= nil or event.id == world.event.S_EVENT_PLAYER_ENTER_UNIT`

**Files changed**:
- **`veafRadio.lua`** — `onBirthEvent()`: unitName + groupId + callsign fallbacks via DCS API
- **`veafGrass.lua`** — `onBirth()`: unitName fallback + `S_EVENT_PLAYER_ENTER_UNIT` check
- **`veafQraManager.lua`** — `eventHandler()`: unitName fallback + `S_EVENT_PLAYER_ENTER_UNIT` check; `VeafQRA:humanBornEvent()`: handles DCS Unit objects by falling back to `:getCoalition()`, `:getCategory()`, `:getName()` when mist table properties are nil
- **`veafAirWaves.lua`** — `AirWaveZone:getPlayerUnitsNames()`: removed stale cache, rebuilds on each call; also scans `coalition.getGroups(AIRPLANE)` for live player-controlled units not in mist DB

---

## LUA-FIX-005 — Wrong bullseye (always Blue) · closes #304

Both CasMission and CombatZone were hardcoded to use `bullseye.blue` regardless of the requesting unit's coalition.

- **`veafCasMission.lua`** — `reportTargetInformation(unitName)`: detects coalition via `Unit.getByName(unitName):getCoalition()`, uses `bullseye.red` for red coalition
- **`veafCombatZone.lua`** — `VeafCombatZone:getInformation(unitName)`: added optional `unitName` parameter; uses it to select correct bullseye; `GetInformationOnZone` passes `unitName` through

---

## LUA-FIX-001 / LUA-FIX-006 — Already fixed (no code change)

- #287 (`math.atan` → `math.atan2`): already corrected in `WeatherMark.lua` line 419
- #295 / #296 (Currenthill Asset Pack units): already present in `dcsUnits.lua` (version 2025.11.17)

## Summary by Sourcery

Implement Lua Lot 7 runtime safety and dynamic slot handling fixes across airbase, weather, combat zone, CAS, radio, QRA, airwaves, and grass modules.

Bug Fixes:
- Guard airbase and weather logic against stale or destroyed DCS airbase objects when querying positions or building ATIS and named points.
- Ensure dynamic slot player aircraft are correctly recognized as human units in QRA, radio, airwaves, and grass event handlers and tracking logic.
- Correct CAS mission and combat zone bullseye selection to respect the requesting unit's coalition.

Documentation:
- Mark all Lot 7 Lua fix tickets as completed in the backlog, including updated unit list and prior fixes.