### PR TITLE
feat(devcontainer): reproducible dev environment — Python 3.13 + Lua 5.1 + StyLua (DISC-010)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,14 +11,22 @@ RUN apt-get update -q \
     && rm -rf /var/lib/apt/lists/*
 
 # StyLua 2.4.0 — exact version required by CI (.github/workflows/lua-ci.yml)
+# SHA256 sourced from the official GitHub release API (immutable release assets).
 RUN ARCH=$(dpkg --print-architecture) \
     && case "$ARCH" in \
-        amd64) ARCH_LABEL="x86_64" ;; \
-        arm64) ARCH_LABEL="aarch64" ;; \
+        amd64) \
+            ARCH_LABEL="x86_64" \
+            EXPECTED_SHA256="f9c84c210712061cb03ab8354a34a5d4f5fcf1f369d2ce916bea3ab9f7addac8" \
+            ;; \
+        arm64) \
+            ARCH_LABEL="aarch64" \
+            EXPECTED_SHA256="67bbd6ad4d864ab375babdd125ed926183968f5b6e55d7e0a6f9f425511a5408" \
+            ;; \
         *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
     esac \
     && curl -fsSL "https://github.com/JohnnyMorganz/StyLua/releases/download/v2.4.0/stylua-linux-${ARCH_LABEL}.zip" \
         -o /tmp/stylua.zip \
+    && echo "${EXPECTED_SHA256}  /tmp/stylua.zip" | sha256sum -c - \
     && unzip /tmp/stylua.zip -d /usr/local/bin \
     && rm /tmp/stylua.zip \
     && chmod +x /usr/local/bin/stylua
@@ -32,4 +40,5 @@ RUN useradd -m -s /bin/bash -u 1000 vscode \
     && chmod 0440 /etc/sudoers.d/vscode
 
 USER vscode
+# /workspace matches the workspaceFolder defined in devcontainer.json
 WORKDIR /workspace

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.13-slim-bookworm
+
+# System packages: Lua 5.1 (matches DCS runtime + CI), utilities
+RUN apt-get update -q \
+    && apt-get install -y --no-install-recommends \
+        lua5.1 \
+        curl \
+        unzip \
+        git \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# StyLua 2.4.0 — exact version required by CI (.github/workflows/lua-ci.yml)
+RUN ARCH=$(dpkg --print-architecture) \
+    && case "$ARCH" in \
+        amd64) ARCH_LABEL="x86_64" ;; \
+        arm64) ARCH_LABEL="aarch64" ;; \
+        *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/JohnnyMorganz/StyLua/releases/download/v2.4.0/stylua-linux-${ARCH_LABEL}.zip" \
+        -o /tmp/stylua.zip \
+    && unzip /tmp/stylua.zip -d /usr/local/bin \
+    && rm /tmp/stylua.zip \
+    && chmod +x /usr/local/bin/stylua
+
+# Poetry — same install method as CI (pip install poetry, no version pin)
+RUN pip install --no-cache-dir poetry
+
+# Create the standard VS Code non-root user
+RUN useradd -m -s /bin/bash -u 1000 vscode \
+    && echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/vscode \
+    && chmod 0440 /etc/sudoers.d/vscode
+
+USER vscode
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+{
+  "name": "VEAF Mission Creation Tools",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+
+  // Poetry creates the venv inside the project → VS Code auto-detects .venv/bin/python
+  "containerEnv": {
+    "POETRY_VIRTUALENVS_IN_PROJECT": "true"
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // Python
+        "ms-python.python",
+        "ms-python.pylance",
+        "charliermarsh.ruff",
+        // Lua
+        "sumneko.lua",
+        "JohnnyMorganz.stylua"
+      ],
+      "settings": {
+        // Pick up the venv created by `poetry install`
+        "python.defaultInterpreterPath": "/workspace/.venv/bin/python",
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true
+        },
+        "[lua]": {
+          "editor.defaultFormatter": "JohnnyMorganz.stylua",
+          "editor.formatOnSave": true
+        },
+        // Point StyLua extension to the binary installed in the container
+        "stylua.styluaPath": "/usr/local/bin/stylua"
+      }
+    }
+  },
+
+  // Install all Python dependencies after the container is created
+  // --without build: skip pyinstaller (only needed to produce the .exe)
+  // --all-extras: install lupa (needed by luadata / miz_tools tests)
+  "postCreateCommand": "poetry install --without build --all-extras",
+
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,11 @@
     "context": ".."
   },
 
+  // Force the workspace to be mounted at /workspace (instead of Codespaces default
+  // /workspaces/<repo>) so the WORKDIR, venv path and interpreter path all stay consistent.
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+
   // Poetry creates the venv inside the project → VS Code auto-detects .venv/bin/python
   "containerEnv": {
     "POETRY_VIRTUALENVS_IN_PROJECT": "true"
@@ -23,7 +28,7 @@
       ],
       "settings": {
         // Pick up the venv created by `poetry install`
-        "python.defaultInterpreterPath": "/workspace/.venv/bin/python",
+        "python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python",
         "[python]": {
           "editor.defaultFormatter": "charliermarsh.ruff",
           "editor.formatOnSave": true
@@ -38,9 +43,9 @@
     }
   },
 
-  // Install all Python dependencies after the container is created
+  // Install all Python dependencies after the container is created.
   // --without build: skip pyinstaller (only needed to produce the .exe)
-  // --all-extras: install lupa (needed by luadata / miz_tools tests)
+  // --all-extras: mirrors the CI invocation in python-quality.yml
   "postCreateCommand": "poetry install --without build --all-extras",
 
   "remoteUser": "vscode"

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -876,7 +876,7 @@ Cela débloque les tests unitaires des state machines (QRA, AirWaves).
 ## Lot 13 — DISCUSS: Standards industrie — à évaluer et décider
 
 **Goal**: Évaluer les standards industrie manquants et décider lesquels adopter. Chaque ticket est un point de discussion/décision avant implémentation éventuelle.
-**Branch**: décision d'abord, implémentation dans un lot futur
+**Branch**: `feature/disc-010-devcontainer` (PR #317 ouverte)
 **Statut**: 🟡 À discuter — pas d'implémentation avant validation
 
 | # | Ticket | Sujet | Type | Effort si adopté | Status |
@@ -890,7 +890,7 @@ Cela débloque les tests unitaires des state machines (QRA, AirWaves).
 | DISC-007 | Dependabot ou Renovate — auto-update des dépendances Python + GitHub Actions | chore | 20 min | [ ] |
 | DISC-008 | Release automation complète — GitHub Actions workflow sur tag push (build + publish, zéro intervention manuelle) | feat | 120 min | [ ] |
 | DISC-009 | `.editorconfig` — uniformité des settings IDE (indentation, EOL, trim trailing whitespace) | chore | 10 min | [ ] |
-| DISC-010 | DevContainer / Docker — environnement dev reproductible (Python 3.13 + Lua 5.1 + outils) | feat | 90 min | [ ] |
+| DISC-010 | DevContainer / Docker — environnement dev reproductible (Python 3.13 + Lua 5.1 + outils) | feat | 90 min | [x] |
 | DISC-011 | Signed commits / tag signing — intégrité supply chain | chore | 15 min | [ ] |
 | DISC-012 | Branch protection rules — require CI pass + review avant merge | chore | 10 min | [ ] |
 | DISC-013 | Changelog automation (`git-cliff` ou `release-please` + conventional commits) | feat | 60 min | [ ] |

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -877,7 +877,7 @@ Cela débloque les tests unitaires des state machines (QRA, AirWaves).
 
 **Goal**: Évaluer les standards industrie manquants et décider lesquels adopter. Chaque ticket est un point de discussion/décision avant implémentation éventuelle.
 **Branch**: `feature/disc-010-devcontainer` (PR #317 ouverte)
-**Statut**: 🟡 À discuter — pas d'implémentation avant validation
+**Statut**: 🟢 DISC-010 implémenté — autres tickets encore à discuter
 
 | # | Ticket | Sujet | Type | Effort si adopté | Status |
 |---|--------|-------|------|-----------------|--------|

--- a/doc/developer/GUIDE.md
+++ b/doc/developer/GUIDE.md
@@ -76,6 +76,28 @@ VEAF-Mission-Creation-Tools/
 
 ## Development Environment
 
+Two setup paths are available. The DevContainer is recommended for new contributors and ensures an environment identical to CI.
+
+### Option A — DevContainer (recommended)
+
+The repository ships a `.devcontainer/` configuration that provides a pre-configured, zero-install environment with Python 3.13, Lua 5.1, StyLua 2.4.0, Poetry, and all VS Code extensions already installed.
+
+**VS Code Dev Containers** (local Docker):
+
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) and the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
+2. Open the repository folder in VS Code
+3. Press `Ctrl+Shift+P` → *Dev Containers: Reopen in Container*
+4. Wait for the container to build and `poetry install` to complete — the environment is ready
+
+**GitHub Codespaces** (browser, no local install):
+
+1. On the repository page, click **Code** → **Codespaces** → **New codespace**
+2. The environment builds automatically — open a terminal and start working
+
+In both cases, `poetry install --without build --all-extras` runs automatically on first open.
+
+### Option B — Manual setup (Windows)
+
 ### Prerequisites
 
 - Python 3.9+ (3.13 recommended)

--- a/doc/developer/fr/GUIDE.md
+++ b/doc/developer/fr/GUIDE.md
@@ -74,6 +74,28 @@ VEAF-Mission-Creation-Tools/
 
 ## Environnement de développement
 
+Deux options de setup sont disponibles. Le DevContainer est recommandé pour les nouveaux contributeurs : il garantit un environnement identique à la CI.
+
+### Option A — DevContainer (recommandé)
+
+Le dépôt inclut une configuration `.devcontainer/` qui fournit un environnement pré-configuré, sans installation manuelle : Python 3.13, Lua 5.1, StyLua 2.4.0, Poetry et toutes les extensions VS Code sont déjà installés.
+
+**VS Code Dev Containers** (Docker local) :
+
+1. Installer [Docker Desktop](https://www.docker.com/products/docker-desktop/) et l'extension [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+2. Ouvrir le dossier du dépôt dans VS Code
+3. Appuyer sur `Ctrl+Shift+P` → *Dev Containers: Reopen in Container*
+4. Attendre la construction du conteneur et la fin de `poetry install` — l'environnement est prêt
+
+**GitHub Codespaces** (navigateur, sans installation locale) :
+
+1. Sur la page du dépôt, cliquer sur **Code** → **Codespaces** → **New codespace**
+2. L'environnement se construit automatiquement — ouvrir un terminal et commencer à travailler
+
+Dans les deux cas, `poetry install --without build --all-extras` s'exécute automatiquement à la première ouverture.
+
+### Option B — Setup manuel (Windows)
+
 ### Prérequis
 
 - Python 3.9+ (3.13 recommandé)

--- a/doc/developer/fr/GUIDE.md
+++ b/doc/developer/fr/GUIDE.md
@@ -78,7 +78,7 @@ Deux options de setup sont disponibles. Le DevContainer est recommandé pour les
 
 ### Option A — DevContainer (recommandé)
 
-Le dépôt inclut une configuration `.devcontainer/` qui fournit un environnement pré-configuré, sans installation manuelle : Python 3.13, Lua 5.1, StyLua 2.4.0, Poetry et toutes les extensions VS Code sont déjà installés.
+Le dépôt inclut une configuration `.devcontainer/` qui fournit un environnement pré-configuré, sans installation manuelle : Python 3.13, Lua 5.1, StyLua 2.4.0, Poetry et toutes les extensions VS Code sont déjà installées.
 
 **VS Code Dev Containers** (Docker local) :
 


### PR DESCRIPTION
## DISC-010 — DevContainer

Adds a `.devcontainer/` configuration for a fully reproducible development environment,
usable both in VS Code Dev Containers and GitHub Codespaces.

### What's included

| Tool | Version | Why |
|------|---------|-----|
| Python | 3.13 (slim-bookworm) | Matches `python-quality.yml` CI |
| Lua | 5.1 (`lua5.1` apt package) | Matches DCS runtime + `lua-ci.yml` |
| StyLua | 2.4.0 | Exact version pinned in `lua-ci.yml` |
| Poetry | latest (pip) | Same install method as CI |

### VS Code extensions pre-installed
- `ms-python.python` + `ms-python.pylance`
- `charliermarsh.ruff` (lint + format)
- `sumneko.lua` (Lua Language Server)
- `JohnnyMorganz.stylua` (Lua formatter)

### How it works
- `POETRY_VIRTUALENVS_IN_PROJECT=true` → `.venv` inside the workspace, auto-detected by VS Code
- `postCreateCommand` runs `poetry install --without build --all-extras` (mirrors CI)
- Format-on-save enabled for Python and Lua

### Also
- Developer guides (EN + FR) updated: new "Option A / Option B" structure in the
  *Development Environment* section

### Usage
\```
# VS Code: Ctrl+Shift+P → "Dev Containers: Reopen in Container"
# GitHub Codespaces: click "Code" → "Codespaces" → "New codespace"
\```

## Summary by Sourcery

Add a reproducible DevContainer-based development environment aligned with CI tooling and document its usage for contributors.

New Features:
- Introduce a VS Code / GitHub Codespaces DevContainer configuration providing Python 3.13, Lua 5.1, StyLua, Poetry, and recommended extensions.

Documentation:
- Document DevContainer-based setup as the recommended development environment option in both English and French developer guides, alongside existing manual setup instructions.
- Update the backlog to mark DISC-010 (DevContainer / Docker reproducible dev environment) as implemented and reference the corresponding feature branch and PR.