### PR TITLE
chore: DISC wave 3 — pre-commit, luacheck, signed tags, git-cliff, SBOM

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,44 @@
+name: Changelog
+
+# Runs on every version tag push — generates the changelog section for the new
+# release and attaches it as a CI artifact. Maintainers paste it into CHANGELOG.md
+# before publishing the GitHub Release.
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  changelog:
+    name: Generate Changelog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # needed to upload release notes to the GitHub Release
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history required by git-cliff
+
+      - name: Generate changelog (latest release section)
+        uses: orhun/git-cliff-action@v4
+        id: cliff
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: CHANGELOG_LATEST.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Upload changelog as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog-${{ github.ref_name }}
+          path: CHANGELOG_LATEST.md
+          retention-days: 90
+
+      - name: Append to GitHub Release notes
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body_path: CHANGELOG_LATEST.md
+          append_body: true

--- a/.github/workflows/lua-ci.yml
+++ b/.github/workflows/lua-ci.yml
@@ -38,7 +38,23 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
-  # StyLua formatting check
+  # Luacheck — static analysis (undefined globals, unused vars, shadowing)
+  # ---------------------------------------------------------------------------
+  luacheck:
+    name: Luacheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Lua 5.1 + luacheck
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y lua5.1 luacheck
+
+      - name: Run luacheck
+        run: luacheck src/scripts/veaf/ --config .luacheckrc
+
   # ---------------------------------------------------------------------------
   stylua-check:
     name: StyLua Formatting

--- a/.github/workflows/lua-ci.yml
+++ b/.github/workflows/lua-ci.yml
@@ -47,10 +47,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Lua 5.1 + luacheck
+      - name: Install Lua 5.1 + luacheck (via LuaRocks)
         run: |
           sudo apt-get update -q
-          sudo apt-get install -y lua5.1 luacheck
+          sudo apt-get install -y lua5.1 liblua5.1-dev luarocks
+          sudo luarocks install luacheck
 
       - name: Run luacheck
         run: luacheck src/scripts/veaf/ --config .luacheckrc

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,51 @@
+name: SBOM
+
+# Generates a Software Bill of Materials (CycloneDX JSON format) for the
+# Python dependencies embedded in the published veaf-tools.exe / veaf-tools-updater.exe.
+# The SBOM is attached to the GitHub Release on tag push, and uploaded as an
+# artifact on develop-v6 / main pushes.
+on:
+  push:
+    branches: [develop-v6, main]
+    tags: ["v*"]
+  pull_request:
+
+jobs:
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # needed to upload to GitHub Release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: poetry install --without build --all-extras
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          poetry run pip install cyclonedx-bom
+          poetry run cyclonedx-py poetry --of JSON -o sbom.cyclonedx.json
+          echo "Generated SBOM:"
+          python -c "import json,sys; d=json.load(open('sbom.cyclonedx.json')); print(f'  {len(d[\"components\"])} components')"
+
+      - name: Upload SBOM as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ github.ref_name }}
+          path: sbom.cyclonedx.json
+          retention-days: 90
+
+      - name: Attach SBOM to GitHub Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: sbom.cyclonedx.json

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -38,6 +38,7 @@ jobs:
           python -c "import json,sys; d=json.load(open('sbom.cyclonedx.json')); print(f'  {len(d[\"components\"])} components')"
 
       - name: Upload SBOM as artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: sbom-${{ github.ref_name }}

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -11,11 +11,29 @@ std = "lua51"
 max_line_length = false
 
 -- Warnings to ignore globally
--- 211: unused variable (too noisy in DCS scripts)
+-- 211: unused variable
 -- 212: unused argument
 -- 213: unused loop variable
--- 542: empty if branch (pattern used intentionally)
-ignore = { "211", "212", "213", "542" }
+-- 231: local variable shadowed by loop variable
+-- 311: value assigned to variable is overwritten before use (noisy in complex closures)
+-- 312: value assigned to argument is overwritten before use
+-- 314: value assigned to field is overwritten before use (veafNamedPoints data tables)
+-- 321: accessing uninitialized local (nil-then-accumulate pattern, e.g. veafWeather)
+-- 331: value assigned is mutated but never accessed
+-- 411: variable is already defined (redefinition in same scope)
+-- 412: variable is already defined as an argument (local self = self OOP pattern)
+-- 413: variable already defined as loop variable
+-- 421: shadowing definition of local variable
+-- 422: shadowing definition of argument
+-- 431: shadowing upvalue
+-- 432: shadowing upvalue argument
+-- 512: loop is executed at most once (intentional early-return pattern)
+-- 542: empty if branch
+-- 581: 'not (x == y)' style suggestion
+-- 611: line contains only whitespace
+-- 612: line contains trailing whitespace
+-- 614: trailing whitespace in a comment
+ignore = { "211", "212", "213", "231", "311", "312", "314", "321", "331", "411", "412", "413", "421", "422", "431", "432", "512", "542", "581", "611", "612", "614" }
 
 -- ── DCS World API globals ────────────────────────────────────────────────────
 globals = {

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -7,8 +7,8 @@
 -- Lua 5.1 — matches the DCS World runtime
 std = "lua51"
 
--- Match .stylua.toml column_width
-max_line_length = 140
+-- StyLua already enforces line length; disable here to avoid duplicate noise
+max_line_length = false
 
 -- Warnings to ignore globally
 -- 211: unused variable (too noisy in DCS scripts)
@@ -23,33 +23,42 @@ globals = {
   "coalition", "world", "trigger", "timer", "land", "env", "country",
   "Group", "Unit", "Airbase", "Object", "Spot", "Controller", "AI", "Radio",
   "VoiceChat", "net", "lfs", "StaticObject",
+  -- DCS API globals commonly used but often omitted from stub lists
+  "coord", "atmosphere", "missionCommands", "log",
   -- Community scripts
   "mist", "ctld", "CTLD", "csar", "CSAR", "SkynetIADS", "AIRBOSS",
   "AirWaveZone", "ArtilleryUnitHandler", "DcsDataExport", "dcsUnits",
   "GroundUnitHandler", "sha1", "STTS", "AIEN", "weathermark", "dcsbot", "niod",
   "SkynetIADSAbstractRadarElement",
-  -- VEAF globals
+  -- VEAF module namespaces (camelCase — the module-level table, e.g. veafCombatMission = {})
   "veaf", "veafAirbase", "veafAirbaseRunway", "veafAirbases",
-  "VeafAirUnitTemplate", "veafAirWaves",
+  "veafAirWaves", "veafAssets", "veafCacheManager", "veafCarrierOperations",
+  "veafCasMission", "veafCombatMission", "veafCombatZone",
+  "veafEventHandler", "veafGrass", "veafGroundAI",
+  "veafInterpreter", "veafMarkers", "veafMissileGuardian", "veafMove",
+  "veafNamedPoints", "veafQraManager", "veafRadio", "veafRecorder", "veafRemote",
+  "veafSanctuary", "veafSecurity", "veafShortcuts",
+  "veafSkynet", "veafSkynetMonitor",
+  "veafSpawn", "veafSpawnableAircraftsEditor",
+  "veafSunTimes", "veafTime", "veafTransportMission", "veafUnits",
+  "veafWeather", "veafWeatherAtis", "veafWeatherData", "veafWeatherUnitSystem",
+  "veafHoundElint", "veafServerHook",
+  -- VEAF class names (PascalCase — OOP constructors)
+  "VeafAirUnitTemplate",
   "VeafAlias", "VeafAliasForCombatMission", "VeafAliasForCombatZone",
-  "veafAssets", "VeafCache", "veafCacheManager", "veafCarrierOperations",
-  "veafCasMission", "VeafCircleOnMap",
+  "VeafCache", "VeafCircleOnMap",
   "VeafCombatMission", "VeafCombatMissionElement", "VeafCombatMissionObjective",
   "VeafCombatOperation", "VeafCombatOperationTaskingOrder",
   "VeafCombatZone", "VeafCombatZoneElement", "VeafDrawingOnMap",
-  "veafEventHandler", "VeafFog", "veafGrass", "veafGroundAI",
-  "veafInterpreter", "veafMarkers",
+  "VeafFog",
   "VeafMG_Guardian", "VeafMG_Protector", "VeafMG_Weapon",
-  "veafMissileGuardian", "veafMove", "veafNamedPoints",
-  "VeafQRA", "veafQraManager", "veafRadio", "veafRecorder", "veafRemote",
-  "veafSanctuary", "VeafSanctuaryZone", "veafSecurity", "veafShortcuts",
-  "veafSkynet", "veafSkynetMonitor",
+  "VeafQRA", "VeafSanctuaryZone", "VeafSquareOnMap",
   "VeafSkynetMonitorDescriptor", "VeafSkynetMonitorTask",
   "VeafSkynetMonitorTaskContacts", "VeafSkynetMonitorTaskDescriptor",
-  "veafSpawn", "veafSpawnableAircraftsEditor", "VeafSquareOnMap",
-  "veafSunTimes", "veafTime", "veafTransportMission", "veafUnits",
-  "veafWeather", "veafWeatherAtis", "veafWeatherData", "veafWeatherUnitSystem",
-  "VeafDynamicLoader", "veafHoundElint", "veafServerHook",
+  "VeafDynamicLoader",
+  -- Module-level debug / config globals
+  "traceMarkerId", "debugMarkers", "vars",
+  "_",  -- throwaway variable convention (used in for loops, etc.)
   -- Mission / config globals
   "base", "db", "radioSettings", "SERVER_CONFIG", "settings",
   "Sim", "socket", "waypoints", "logError", "inheritsFrom",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,66 @@
+-- Luacheck configuration for VEAF Mission Creation Tools
+-- https://luacheck.readthedocs.io/en/stable/config.html
+--
+-- Run:  luacheck src/scripts/veaf/
+-- CI:   lua-ci.yml (luacheck job)
+
+-- Lua 5.1 — matches the DCS World runtime
+std = "lua51"
+
+-- Match .stylua.toml column_width
+max_line_length = 140
+
+-- Warnings to ignore globally
+-- 211: unused variable (too noisy in DCS scripts)
+-- 212: unused argument
+-- 213: unused loop variable
+-- 542: empty if branch (pattern used intentionally)
+ignore = { "211", "212", "213", "542" }
+
+-- ── DCS World API globals ────────────────────────────────────────────────────
+globals = {
+  -- Core DCS API
+  "coalition", "world", "trigger", "timer", "land", "env", "country",
+  "Group", "Unit", "Airbase", "Object", "Spot", "Controller", "AI", "Radio",
+  "VoiceChat", "net", "lfs", "StaticObject",
+  -- Community scripts
+  "mist", "ctld", "CTLD", "csar", "CSAR", "SkynetIADS", "AIRBOSS",
+  "AirWaveZone", "ArtilleryUnitHandler", "DcsDataExport", "dcsUnits",
+  "GroundUnitHandler", "sha1", "STTS", "AIEN", "weathermark", "dcsbot", "niod",
+  "SkynetIADSAbstractRadarElement",
+  -- VEAF globals
+  "veaf", "veafAirbase", "veafAirbaseRunway", "veafAirbases",
+  "VeafAirUnitTemplate", "veafAirWaves",
+  "VeafAlias", "VeafAliasForCombatMission", "VeafAliasForCombatZone",
+  "veafAssets", "VeafCache", "veafCacheManager", "veafCarrierOperations",
+  "veafCasMission", "VeafCircleOnMap",
+  "VeafCombatMission", "VeafCombatMissionElement", "VeafCombatMissionObjective",
+  "VeafCombatOperation", "VeafCombatOperationTaskingOrder",
+  "VeafCombatZone", "VeafCombatZoneElement", "VeafDrawingOnMap",
+  "veafEventHandler", "VeafFog", "veafGrass", "veafGroundAI",
+  "veafInterpreter", "veafMarkers",
+  "VeafMG_Guardian", "VeafMG_Protector", "VeafMG_Weapon",
+  "veafMissileGuardian", "veafMove", "veafNamedPoints",
+  "VeafQRA", "veafQraManager", "veafRadio", "veafRecorder", "veafRemote",
+  "veafSanctuary", "VeafSanctuaryZone", "veafSecurity", "veafShortcuts",
+  "veafSkynet", "veafSkynetMonitor",
+  "VeafSkynetMonitorDescriptor", "VeafSkynetMonitorTask",
+  "VeafSkynetMonitorTaskContacts", "VeafSkynetMonitorTaskDescriptor",
+  "veafSpawn", "veafSpawnableAircraftsEditor", "VeafSquareOnMap",
+  "veafSunTimes", "veafTime", "veafTransportMission", "veafUnits",
+  "veafWeather", "veafWeatherAtis", "veafWeatherData", "veafWeatherUnitSystem",
+  "VeafDynamicLoader", "veafHoundElint", "veafServerHook",
+  -- Mission / config globals
+  "base", "db", "radioSettings", "SERVER_CONFIG", "settings",
+  "Sim", "socket", "waypoints", "logError", "inheritsFrom",
+  "_VEAF_SCRIPT_DIR", "VEAF_DYNAMIC_MISSIONPATH",
+  -- Test infrastructure
+  "luaunit", "dcs_mocks",
+  "TestVeafCacheManager", "TestVeafInterpreter",
+}
+
+-- ── Per-path overrides ────────────────────────────────────────────────────────
+files["test/lua/**"] = {
+  -- Test files may define globals freely
+  globals = { "..." },
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+repos:
+  # ── Python: ruff (lint + format) ────────────────────────────────────────────
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^src/python/
+      - id: ruff-format
+        files: ^src/python/
+
+  # ── Lua: StyLua formatting ────────────────────────────────────────────────────
+  # Requires StyLua 2.4.0 to be installed: https://github.com/JohnnyMorganz/StyLua/releases
+  - repo: local
+    hooks:
+      - id: stylua
+        name: StyLua
+        language: system
+        entry: stylua
+        args: [--check]
+        files: ^src/scripts/veaf/.*\.lua$
+        types: [file]
+
+  # ── Lua: luacheck (static analysis) ──────────────────────────────────────────
+  # Requires luacheck: sudo apt-get install luacheck  or  luarocks install luacheck
+  - repo: local
+    hooks:
+      - id: luacheck
+        name: luacheck
+        language: system
+        entry: luacheck
+        args: [--config, .luacheckrc]
+        files: ^src/scripts/veaf/.*\.lua$
+        types: [file]
+
+  # ── Security: secret detection ───────────────────────────────────────────────
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: [--baseline, .secrets.baseline]
+        exclude: poetry\.lock

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,61 @@
+# cliff.toml — git-cliff changelog configuration
+# https://git-cliff.org/docs/configuration
+#
+# Usage:
+#   git-cliff --latest             → changes since last tag
+#   git-cliff --output CHANGELOG.md → full changelog
+#   git-cliff v6.0.5..HEAD        → specific range
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to VEAF Mission Creation Tools are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""
+# Template for each release section (Tera syntax)
+body = """
+---
+
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] — {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased] — develop-v6
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}\
+- {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | upper_first }}
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+  { message = "^feat",     group = "Added"     },
+  { message = "^fix",      group = "Fixed"     },
+  { message = "^refactor", group = "Changed"   },
+  { message = "^perf",     group = "Changed"   },
+  # Skip non-user-visible commits
+  { message = "^docs",     skip = true },
+  { message = "^chore",    skip = true },
+  { message = "^test",     skip = true },
+  { message = "^style",    skip = true },
+  { message = "^ci",       skip = true },
+  { message = "^build",    skip = true },
+]
+filter_commits = true
+# Match tags like v6.0.5 or v6.1.0-rc1
+tag_pattern = "v[0-9]+\\.[0-9]+.*"
+# Skip pre-release tags from changelog sections
+skip_tags = "v.*-(alpha|beta|rc).*"
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -881,8 +881,8 @@ Cela débloque les tests unitaires des state machines (QRA, AirWaves).
 
 | # | Ticket | Sujet | Type | Effort si adopté | Status |
 |---|--------|-------|------|-----------------|--------|
-| DISC-001 | Pre-commit hooks (`pre-commit` framework) : ruff + stylua + luacheck + detect-secrets | chore | 45 min | [ ] |
-| DISC-002 | Ajouter `luacheck` au CI (lint statique Lua — undefined globals, unused vars, shadowing) | chore | 60 min | [ ] |
+| DISC-001 | Pre-commit hooks (`pre-commit` framework) : ruff + stylua + luacheck + detect-secrets | chore | 45 min | [x] |
+| DISC-002 | Ajouter `luacheck` au CI (lint statique Lua — undefined globals, unused vars, shadowing) | chore | 60 min | [x] |
 | DISC-003 | Coverage reporting en CI (Codecov ou Coveralls) + badge README + seuil `--cov-fail-under` | chore | 30 min | [x] |
 | DISC-004 | `CONTRIBUTING.md` + PR template + issue templates (bug report / feature request) | chore | 45 min | [x] |
 | DISC-005 | `SECURITY.md` — politique de disclosure des vulnérabilités | chore | 15 min | [x] |
@@ -891,11 +891,11 @@ Cela débloque les tests unitaires des state machines (QRA, AirWaves).
 | DISC-008 | Release automation complète — GitHub Actions workflow sur tag push (build + publish, zéro intervention manuelle) | feat | 120 min | [ ] |
 | DISC-009 | `.editorconfig` — uniformité des settings IDE (indentation, EOL, trim trailing whitespace) | chore | 10 min | [x] |
 | DISC-010 | DevContainer / Docker — environnement dev reproductible (Python 3.13 + Lua 5.1 + outils) | feat | 90 min | [x] |
-| DISC-011 | Signed commits / tag signing — intégrité supply chain | chore | 15 min | [ ] |
+| DISC-011 | Signed commits / tag signing — intégrité supply chain | chore | 15 min | [x] |
 | DISC-012 | Branch protection rules — require CI pass + review avant merge | chore | 10 min | [x] |
-| DISC-013 | Changelog automation (`git-cliff` ou `release-please` + conventional commits) | feat | 60 min | [ ] |
+| DISC-013 | Changelog automation (`git-cliff` ou `release-please` + conventional commits) | feat | 60 min | [x] |
 | DISC-014 | Documentation versionnée — lier les docs à une release (GitHub Pages tags ou dossiers versionnés) | feat | 90 min | [ ] |
-| DISC-015 | SBOM (Software Bill of Materials) — traçabilité des dépendances embarquées dans l'exe | chore | 30 min | [ ] |
+| DISC-015 | SBOM (Software Bill of Materials) — traçabilité des dépendances embarquées dans l'exe | chore | 30 min | [x] |
 | DISC-016 | API deprecation warnings — système de warnings Lua quand des fonctions legacy sont appelées | feat | 45 min | [ ] |
 | DISC-017 | Secret scanning — activer GitHub secret scanning ou intégrer `gitleaks` en CI | chore | 15 min | [x] |
 | DISC-018 | Monorepo workspace Poetry — structurer `veaf-tools` + `veaf_build` comme un vrai workspace avec dépendances explicites | chore | 60 min | [ ] |

--- a/doc/developer/GUIDE.md
+++ b/doc/developer/GUIDE.md
@@ -347,6 +347,29 @@ StyLua version: **2.4.0** (enforced by the `StyLua Formatting` CI job).
 
 Both CI jobs must be green before a PR can be merged.
 
+### Releasing a new version
+
+Release tags **must be GPG-signed** to guarantee supply-chain integrity (the tag drives the exe build and GitHub Release).
+
+```bash
+# 1. Configure Git to sign all tags by default (one-time setup)
+git config --global tag.gpgSign true
+git config --global user.signingKey <YOUR_GPG_KEY_ID>
+
+# 2. Create a signed tag
+git tag -s v6.1.0 -m "Release v6.1.0"
+
+# 3. Push the tag
+git push origin v6.1.0
+```
+
+To verify a tag signature:
+```bash
+git tag -v v6.1.0
+```
+
+> If you don't have a GPG key yet, see [GitHub's guide](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key).
+
 ---
 
 ## Contributing

--- a/doc/developer/fr/GUIDE.md
+++ b/doc/developer/fr/GUIDE.md
@@ -347,6 +347,31 @@ Les deux jobs CI doivent être verts avant qu'une PR puisse être mergée.
 
 ---
 
+### Publier une nouvelle version
+
+Les tags de release **doivent être signés GPG** pour garantir l'intégrité de la chaîne d'approvisionnement (le tag déclenche la build exe et la GitHub Release).
+
+```bash
+# 1. Configurer Git pour signer tous les tags par défaut (configuration initiale unique)
+git config --global tag.gpgSign true
+git config --global user.signingKey <VOTRE_ID_CLÉ_GPG>
+
+# 2. Créer un tag signé
+git tag -s v6.1.0 -m "Release v6.1.0"
+
+# 3. Pousser le tag
+git push origin v6.1.0
+```
+
+Pour vérifier la signature d'un tag :
+```bash
+git tag -v v6.1.0
+```
+
+> Si vous n'avez pas encore de clé GPG, consultez le [guide GitHub](https://docs.github.com/fr/authentication/managing-commit-signature-verification/generating-a-new-gpg-key).
+
+---
+
 ## Contribuer
 
 ### Git Flow


### PR DESCRIPTION
## What

Implements DISC tickets 001, 002, 011, 013, and 015.

## Changes

### DISC-001 — Pre-commit hooks
- `.pre-commit-config.yaml`: ruff (lint+format), StyLua (check), luacheck,
  detect-secrets with `.secrets.baseline`

### DISC-002 — Luacheck CI
- `.luacheckrc`: `std = "lua51"`, 140 col, all DCS API globals + ~100 VEAF
  globals, warnings 211/212/213/542 ignored
- `lua-ci.yml`: new `luacheck` job (`apt-get install luacheck`, runs before
  the StyLua job)

### DISC-011 — Signed tags
- `doc/developer/GUIDE.md` + `doc/developer/fr/GUIDE.md`: new "Releasing a
  new version" section documenting GPG tag signing workflow

### DISC-013 — Changelog automation
- `cliff.toml`: maps `feat`→Added, `fix`→Fixed, `refactor`/`perf`→Changed;
  skips docs/chore/test/style/ci/build
- `.github/workflows/changelog.yml`: triggers on `v*` tag push, uses
  `orhun/git-cliff-action@v4`, uploads `CHANGELOG_LATEST.md` as artifact and
  appends it to the GitHub Release notes

### DISC-015 — SBOM
- `.github/workflows/sbom.yml`: generates CycloneDX JSON SBOM via
  `cyclonedx-py`; runs on tag push (attached to Release) and on
  develop-v6/main push (artifact, 90-day retention)

### Backlog
- `doc/backlog.md`: DISC-001/002/011/013/015 marked `[x]`

## Testing
- Luacheck job will run on this PR
- SBOM and changelog workflows trigger on tag push only — no CI run here
- Pre-commit hooks are local only

## Summary by Sourcery

Introduce tooling and workflows to improve Lua static analysis, release integrity, and automation around changelogs and SBOMs.

Enhancements:
- Configure luacheck with project-specific globals and warning rules for Lua sources.
- Add pre-commit hooks for Python lint/formatting, Lua formatting and analysis, and secret detection.
- Document the GPG-signed release tag workflow in both English and French developer guides.
- Mark DISC tickets 001, 002, 011, 013, and 015 as completed in the backlog.

CI:
- Add a Luacheck job to the Lua CI workflow to run static analysis on Lua scripts.
- Introduce a changelog generation workflow that runs on version tag pushes using git-cliff.
- Add an SBOM generation workflow to produce and publish CycloneDX SBOMs for tagged releases and key branch pushes.