### PR TITLE
refactor(lua): Lot 14 — ARCH-COMMANDS dispatch infrastructure

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -51,7 +51,7 @@ globals = {
   -- VEAF module namespaces (camelCase — the module-level table, e.g. veafCombatMission = {})
   "veaf", "veafAirbase", "veafAirbaseRunway", "veafAirbases",
   "veafAirWaves", "veafAssets", "veafCacheManager", "veafCarrierOperations",
-  "veafCasMission", "veafCombatMission", "veafCombatZone",
+  "veafCasMission", "veafCombatMission", "veafCombatZone", "veafCommands",
   "veafEventHandler", "veafGrass", "veafGroundAI",
   "veafInterpreter", "veafMarkers", "veafMissileGuardian", "veafMove",
   "veafNamedPoints", "veafQraManager", "veafRadio", "veafRecorder", "veafRemote",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased] — develop-v6
 
 ### Added
+- `veafCommands.lua` — central priority-ordered command dispatcher for F10 markers and interpreter path; exposes `registerCommandHandler(fn, priority)` and priority constants (`PRIORITY_SHORTCUTS`…`PRIORITY_REMOTE`)
+- `veafSpawnParser.lua` — spawn command text parser extracted from `veafSpawnCore.lua` (`convertLaserToFreq`, `markTextAnalysis`)
+- `veafRemote.registerRemoteModule(name, fn)` — registry for hook-server remote commands (replaces hardcoded if/elseif in `executeCommandFromRemote`)
 - `plan-2026.05.16.md` — v6 restart plan and technical decisions
 - `doc/backlog.md` — operational backlog with ticket estimates
 - `doc/ROADMAP.md` — project roadmap
@@ -21,6 +24,11 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `--ci` flag on `veaf-build publish` and `veaf-build build-and-publish` for non-interactive CI mode
 
 ### Changed
+- All 8 command modules (Shortcuts, Spawn, NamedPoints, CasMission, Security, Move, Radio, Remote) self-register via `veafCommands.registerCommandHandler()` — per-module `onEventMarkChange` functions removed
+- `veafInterpreter.execute()` delegates to `veafCommands.execute()` — hardcoded 8-branch if/elseif removed
+- `veafSpawnCore.lua` reduced from ~1834 to ~900 lines: parser extracted; 25-branch if/elseif replaced by handler dispatch loop
+- `veafSpawnGround`, `veafSpawnAircraft`, `veafSpawnEffects` sub-modules self-register their spawn handlers via `veafSpawn.registerCommandHandler()`
+- 7 remote modules self-register via `veafRemote.registerRemoteModule()` — hardcoded switch in `executeCommandFromRemote` removed
 - Branch renamed from `develop/v6-new-build-system` to `develop-v6`
 - `veaf.BaseLogLevel` default changed from `trace` to `info`
 - All 1233 `veaf.p(` log-argument calls migrated to `veaf.lp(` across all Lua scripts
@@ -29,6 +37,10 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `cliff.toml`: `tag_pattern` now matches both `published-v*` and `v*` tags
 
 ### Removed
+- `module.onEventMarkChange()` functions from all 8 command modules (routing now handled by `veafCommands`)
+- Hardcoded 8-branch command dispatch in `veafInterpreter.execute()`
+- Hardcoded 25-branch if/elseif in `veafSpawnCore.executeCommand()`
+- Hardcoded module switch in `veafRemote.executeCommandFromRemote()`
 - `--scripts-variant` option from `veaf-tools build` and `veaf-tools convert`
 - `.github/workflows/changelog.yml` — superseded by `release.yml`
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Choose the guide that matches your role:
 | Reference | Description |
 |-----------|-------------|
 | [User Guide](doc/USER_GUIDE.md) | Extended pilot reference |
-| [Lua API Reference](doc/LUA_API_REFERENCE.md) | Full API for all 32 Lua runtime modules |
+| [Lua API Reference](doc/LUA_API_REFERENCE.md) | Full API for all 34 Lua runtime modules |
 | [Tools CLI Reference](doc/TOOLS_REFERENCE.md) | `veaf-tools.exe` and `veaf-tools-updater.exe` |
 | [Testing Guide](doc/TESTING.md) | Lua unit test suite, CI/CD pipeline |
 | [Roadmap](doc/ROADMAP.md) | Planned features and known limitations |
@@ -76,7 +76,7 @@ Full reference: [Developer Guide](doc/developer/README.md)
 
 VEAF Mission Creation Tools is a hybrid **Lua + Python** system:
 
-- **Runtime** (`src/scripts/veaf/`) — 32 Lua modules loaded inside DCS missions, providing spawning, asset management, mission types, radio menus, and more
+- **Runtime** (`src/scripts/veaf/`) — 34 Lua modules loaded inside DCS missions, providing spawning, asset management, mission types, radio menus, and more
 - **Design-time** (`src/python/veaf-tools/`) — Python CLI (`veaf-tools.exe`) for manipulating `.miz` files: normalizing, injecting weather/waypoints/radio presets/aircraft groups
 - **Release pipeline** (`veaf-build` CLI) — compiles Lua, builds EXE files, publishes to GitHub
 

--- a/doc/LUA_API_REFERENCE.md
+++ b/doc/LUA_API_REFERENCE.md
@@ -14,9 +14,11 @@
    - [veaf.lua](#veaflua) - Core utilities and logger
    - [veafEventHandler.lua](#veafeventhandlerlua) - Event management
    - [veafMarkers.lua](#veafmarkerslua) - Map marker system
+   - [veafCommands.lua](#veafcommandslua) - Central command dispatcher
    - [veafInterpreter.lua](#veafinterpreterlua) - Command parsing
 4. [Unit & Group Management](#unit--group-management)
    - [veafSpawn.lua](#veafspawnlua) - Dynamic spawning
+   - [veafSpawnParser.lua](#veafspawnparserlua) - Spawn command text parser
    - [veafUnits.lua](#veafunitslua) - Unit definitions
    - [veafAssets.lua](#veafassetslua) - Asset tracking
    - [veafMove.lua](#veafmovelua) - Movement control
@@ -56,7 +58,7 @@ The VEAF (Virtual European Air Force) Lua modules provide a comprehensive framew
 
 ### Key Features
 
-- **31+ Lua modules** providing runtime functionality
+- **33+ Lua modules** providing runtime functionality
 - **Event-driven architecture** using DCS World event system
 - **Modular design** allowing selective module usage
 - **Extensive logging** with configurable log levels
@@ -1547,19 +1549,21 @@ Marker events received by handlers contain:
 
 **Command Pattern:**
 
-Most VEAF modules use markers for commands:
+Modules register a handler with `veafCommands` which routes all F10 marker commands centrally:
 ```lua
-veafMarkers.registerEventHandler(veafMarkers.MarkerChange, function(pos, event)
+-- In a module's initialize() function:
+veafCommands.registerCommandHandler(function(pos, event, bypass, fromMarker, groups, route)
   local text = event.text or ""
-
-  -- Check for command keyword
-  if text:lower():match("^_spawn") then
-    veafSpawn.onEventMarkChange(pos, event)
-  elseif text:lower():match("^_cas") then
-    veafCasMission.onEventMarkChange(pos, event)
+  if not text:lower():match("^_mycommand") then
+    return false  -- not our command
   end
-end)
+  -- handle the command...
+  return true   -- consumed
+end, veafCommands.PRIORITY_SPAWN)
 ```
+
+All handlers are called in priority order until one returns `true`.
+The central dispatcher (`veafCommands.dispatchMarker`) handles the mark removal automatically.
 
 **Security Pattern:**
 
@@ -1586,6 +1590,58 @@ veafMarkers.registerEventHandler(veafMarkers.MarkerChange, function(pos, event)
   end
 end)
 ```
+
+---
+
+### veafCommands.lua
+
+**Module ID:** `COMMANDS`
+**Init order:** 15 (after veafMarkers, before all command modules)
+**Purpose:** Central registry and dispatcher for all text commands (F10 markers and interpreter)
+
+#### Constants
+
+```lua
+veafCommands.PRIORITY_SHORTCUTS    = 10
+veafCommands.PRIORITY_SPAWN        = 20
+veafCommands.PRIORITY_NAMEDPOINTS  = 30
+veafCommands.PRIORITY_CASMISSION   = 40
+veafCommands.PRIORITY_SECURITY     = 50
+veafCommands.PRIORITY_MOVE         = 60
+veafCommands.PRIORITY_RADIO        = 70
+veafCommands.PRIORITY_REMOTE       = 80
+```
+
+#### Functions
+
+##### `veafCommands.registerCommandHandler(fn, priority)`
+
+Register a command handler function. Handlers are called in ascending priority order.
+
+**Parameters:**
+- `fn` (function) - Handler with signature `(pos, event, bypass, fromMarker, groups, route) → boolean`
+- `priority` (number) - Execution order (lower = earlier); use the `PRIORITY_*` constants
+
+##### `veafCommands.execute(pos, text, coalition, groups, route)`
+
+Execute a command from the interpreter path (unit names). The coalition is used as-is.
+
+**Parameters:**
+- `pos` (vec3) - Execution position
+- `text` (string) - Command text
+- `coalition` (number) - Coalition number
+- `groups` (table, optional) - Table to receive spawned group names
+- `route` (table, optional) - Route definition
+
+**Returns:** `boolean` — true if a handler consumed the command
+
+##### `veafCommands.dispatchMarker(eventPos, event)`
+
+Handle a marker change event. Inverts coalition (marker events report the placer's side, not the target's), calls all registered handlers in priority order, and removes the mark on success.
+
+**Parameters:**
+- `eventPos` (vec3) - Marker position
+- `event` (table) - Marker event object
 
 ---
 
@@ -1623,7 +1679,7 @@ local command = veafInterpreter.interpret(unitName)
 
 ##### `veafInterpreter.execute(command, position, coalition, route, spawnedGroups)`
 
-Execute VEAF command.
+Execute VEAF command. Delegates to `veafCommands.execute()` — all registered handlers are tried in priority order.
 
 **Parameters:**
 - `command` (string) - Command string
@@ -1634,15 +1690,7 @@ Execute VEAF command.
 
 **Returns:** `boolean` - True if command executed successfully
 
-**Supported Commands:**
-- Shortcut commands (via veafShortcuts)
-- Spawn commands (via veafSpawn)
-- Named points (via veafNamedPoints)
-- CAS missions (via veafCasMission)
-- Security commands (via veafSecurity)
-- Move commands (via veafMove)
-- Radio commands (via veafRadio)
-- Remote commands (via veafRemote)
+**Note:** Command routing is handled by `veafCommands`. Modules register themselves via `veafCommands.registerCommandHandler()`.
 
 **Example:**
 ```lua
@@ -1730,6 +1778,32 @@ Unit name: #veafInterpreter["_spawn, convoy, name convoy1, dest marker1, speed 5
 ---
 
 ## Unit & Group Management
+
+### veafSpawnParser.lua
+
+**Purpose:** Parse spawn command text into options tables. Extracted sub-module of `veafSpawn`.
+
+#### Functions
+
+##### `veafSpawn.markTextAnalysis(text)`
+
+Parse marker text for spawn parameters. Defined in `veafSpawnParser.lua`, available on the `veafSpawn` table.
+
+**Parameters:**
+- `text` (string) - Marker text to parse
+
+**Returns:** `table` — options table with parsed key/value pairs
+
+##### `veafSpawn.convertLaserToFreq(laser)`
+
+Convert a laser code to a TACAN/radio frequency string.
+
+**Parameters:**
+- `laser` (number) - Laser code (1111–1788)
+
+**Returns:** `string` — frequency label, or nil if not found
+
+---
 
 ### veafSpawn.lua
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -175,11 +175,11 @@ Chaque ticket est indépendant — ordre recommandé : ARCH-001 → ARCH-002 →
 
 | # | Ticket | File(s) | Type | Effort | Status |
 |---|--------|---------|------|--------|--------|
-| ARCH-001 | Registre de modules dans `veafInterpreter.execute` — remplacer le if/elseif de 8 modules par un tableau ordonné ; chaque module s'auto-enregistre dans `initialize()` | `veafInterpreter.lua` + 8 modules | chore | 60 min | ⬜ |
-| ARCH-002 | Registre de modules dans `veafRemote.executeCommandFromRemote` — `veafRemote.registerRemoteModule(name, fn)` ; remplace le switch string sur 7 modules | `veafRemote.lua` + 7 modules | chore | 60 min | ⬜ |
-| ARCH-003 | Factoriser le boilerplate `onEventMarkChange` — helper `veafMarkers.makeMarkHandler(fn)` qui génère la fonction standard (invertedCoalition + executeCommand + removeMark) ; remplace 8 fonctions quasi-identiques | `veafMarkers.lua` + 8 modules | chore | 90 min | ⬜ |
-| ARCH-004 | Extraire `veafSpawnParser.lua` — isoler `markTextAnalysis` + `convertLaserToFreq` hors de `veafSpawnCore.lua` ; le parseur devient testable indépendamment (portage LUAR-005 pt.1) | `veafSpawnCore.lua` → `veafSpawnParser.lua`, `veafSpawn.lua` | feat | 60 min | ⬜ |
-| ARCH-005 | Système de handlers dans `veafSpawnCore.executeCommand` — `veafSpawn.registerCommandHandler(key, fn)` ; les 4 sous-modules s'enregistrent ; Core < 300 lignes (portage LUAR-005 pt.2) | `veafSpawnCore.lua`, `veafSpawnGround.lua`, `veafSpawnAircraft.lua`, `veafSpawnEffects.lua` | feat | 120 min | ⬜ |
+| ARCH-001 | Registre de modules dans `veafInterpreter.execute` — remplacer le if/elseif de 8 modules par un tableau ordonné ; chaque module s'auto-enregistre dans `initialize()` | `veafInterpreter.lua` + 8 modules | chore | 60 min | ✅ |
+| ARCH-002 | Registre de modules dans `veafRemote.executeCommandFromRemote` — `veafRemote.registerRemoteModule(name, fn)` ; remplace le switch string sur 7 modules | `veafRemote.lua` + 7 modules | chore | 60 min | ✅ |
+| ARCH-003 | Factoriser le boilerplate `onEventMarkChange` — helper `veafMarkers.makeMarkHandler(fn)` qui génère la fonction standard (invertedCoalition + executeCommand + removeMark) ; remplace 8 fonctions quasi-identiques | `veafMarkers.lua` + 8 modules | chore | 90 min | ✅ |
+| ARCH-004 | Extraire `veafSpawnParser.lua` — isoler `markTextAnalysis` + `convertLaserToFreq` hors de `veafSpawnCore.lua` ; le parseur devient testable indépendamment (portage LUAR-005 pt.1) | `veafSpawnCore.lua` → `veafSpawnParser.lua`, `veafSpawn.lua` | feat | 60 min | ✅ |
+| ARCH-005 | Système de handlers dans `veafSpawnCore.executeCommand` — `veafSpawn.registerCommandHandler(key, fn)` ; les 4 sous-modules s'enregistrent ; Core < 300 lignes (portage LUAR-005 pt.2) | `veafSpawnCore.lua`, `veafSpawnGround.lua`, `veafSpawnAircraft.lua`, `veafSpawnEffects.lua` | feat | 120 min | ✅ |
 
 **Raw total: 390 min → estimated (×1.15): ~449 min (~7h30)**
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -37,7 +37,7 @@
 | Lot 11 — I18N | ~7h10 | ✅ |
 | Lot 12 — QUALITY | ~16h35 | ✅ |
 | Lot 13 — DISCUSS | ~13h50 | ✅ |
-| Lot 14 — ARCH-COMMANDS | ~7h30 | ⬜ |
+| Lot 14 — ARCH-COMMANDS | ~7h30 | ✅ |
 | **Total** | **~103h** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*

--- a/doc/developer/GUIDE.fr.md
+++ b/doc/developer/GUIDE.fr.md
@@ -36,12 +36,12 @@ Le projet comporte deux couches complètement séparées :
 ┌──────────────────────────────────────────────────────────┐
 │  RUNTIME (Lua, dans DCS World)                           │
 │                                                          │
-│  veaf-scripts.lua  ────── les 32 modules concaténés     │
+│  veaf-scripts.lua  ────── les 34 modules concaténés     │
 │  missionconfig.lua ────── config spécifique à la mission │
 └──────────────────────────────────────────────────────────┘
 ```
 
-- **Runtime** (`src/scripts/veaf/`) — 32 modules Lua chargés dans les missions DCS
+- **Runtime** (`src/scripts/veaf/`) — 34 modules Lua chargés dans les missions DCS
 - **Design-time** (`src/python/veaf-tools/`) — outils CLI Python pour la manipulation des fichiers `.miz`
 
 ---
@@ -53,7 +53,7 @@ VEAF-Mission-Creation-Tools/
 ├── veaf_build/                   # CLI veaf-build (orchestrateur build & publication)
 ├── build-and-release.py          # Shim de rétrocompatibilité (utiliser veaf-build à la place)
 ├── src/
-│   ├── scripts/veaf/             # Modules Lua runtime (32 fichiers)
+│   ├── scripts/veaf/             # Modules Lua runtime (34 fichiers)
 │   └── python/veaf-tools/        # Code source Python CLI
 │       ├── veaf-tools.py         # Point d'entrée
 │       ├── veaf_libs/            # Utilitaires partagés (logger, progress, miz)
@@ -419,7 +419,7 @@ Types : `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `style`.
 
 ## Pour aller plus loin
 
-- [Référence API Lua](../LUA_API_REFERENCE.md) — API publique complète des 32 modules
+- [Référence API Lua](../LUA_API_REFERENCE.md) — API publique complète des 34 modules
 - [Guide de tests](../TESTING.md) — détails de l'infrastructure de test
 - [Référence des outils](../TOOLS_REFERENCE.md) — CLI `veaf-tools.exe`
 - [Feuille de route](../ROADMAP.md) — travaux planifiés

--- a/doc/developer/GUIDE.md
+++ b/doc/developer/GUIDE.md
@@ -37,12 +37,12 @@ The project has two completely separate layers:
 ┌──────────────────────────────────────────────────────────┐
 │  RUNTIME (Lua, inside DCS World)                         │
 │                                                          │
-│  veaf-scripts.lua  ────── all 32 modules concatenated   │
+│  veaf-scripts.lua  ────── all 34 modules concatenated   │
 │  missionconfig.lua ────── mission-specific config        │
 └──────────────────────────────────────────────────────────┘
 ```
 
-- **Runtime** (`src/scripts/veaf/`) — 32 Lua modules loaded inside DCS missions
+- **Runtime** (`src/scripts/veaf/`) — 34 Lua modules loaded inside DCS missions
 - **Design-time** (`src/python/veaf-tools/`) — Python CLI tools for `.miz` file manipulation
 
 ---
@@ -54,7 +54,7 @@ VEAF-Mission-Creation-Tools/
 ├── veaf_build/                   # veaf-build CLI (build & publish orchestrator)
 ├── build-and-release.py          # Backward-compat shim (use veaf-build instead)
 ├── src/
-│   ├── scripts/veaf/             # Lua runtime modules (32 files)
+│   ├── scripts/veaf/             # Lua runtime modules (34 files)
 │   └── python/veaf-tools/        # Python CLI source
 │       ├── veaf-tools.py         # Entry point
 │       ├── veaf_libs/            # Shared utilities (logger, progress, miz)
@@ -418,7 +418,7 @@ Types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `style`.
 
 ## Further Reading
 
-- [Lua API Reference](../LUA_API_REFERENCE.md) — full public API for all 32 modules
+- [Lua API Reference](../LUA_API_REFERENCE.md) — full public API for all 34 modules
 - [Testing Guide](../TESTING.md) — test infrastructure details
 - [Tools Reference](../TOOLS_REFERENCE.md) — `veaf-tools.exe` CLI
 - [Roadmap](../ROADMAP.md) — planned work

--- a/src/scripts/veaf/veafCarrierOperations.lua
+++ b/src/scripts/veaf/veafCarrierOperations.lua
@@ -1174,6 +1174,7 @@ function veafCarrierOperations.initialize()
   veafCarrierOperations.initializeCarrierGroups()
   veafCarrierOperations.buildRadioMenu()
   veafCarrierOperations.operationsScheduler()
+  veafRemote.registerRemoteModule("carrier", veafCarrierOperations.executeCommandFromRemote)
 end
 
 veaf.loggers.get(veafCarrierOperations.Id):info(veaf.loggers.get(veafCarrierOperations.Id):getVersionInfo(veafCarrierOperations.Version))

--- a/src/scripts/veaf/veafCasMission.lua
+++ b/src/scripts/veaf/veafCasMission.lua
@@ -410,25 +410,6 @@ veafCasMission.SIDE_BLUE = coalition.side.BLUE
 -- Event handler functions.
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
---- Function executed when a mark has changed. This happens when text is entered or changed.
-function veafCasMission.onEventMarkChange(eventPos, event)
-  veaf.loggers.get(veafCasMission.Id):trace(string.format("event  = %s", veaf.p(event)))
-
-  -- choose by default the coalition opposing the player who triggered the event
-  local invertedCoalition = 1
-  if event.coalition == 1 then
-    invertedCoalition = 2
-  end
-
-  veaf.loggers.get(veafCasMission.Id):trace(string.format("event.idx  = %s", veaf.p(event.idx)))
-
-  if veafCasMission.executeCommand(eventPos, event.text, invertedCoalition, event.idx) then
-    -- Delete old mark.
-    veaf.loggers.get(veafCasMission.Id):trace(string.format("Removing mark # %d.", event.idx))
-    trigger.action.removeMark(event.idx)
-  end
-end
-
 function veafCasMission.executeCommand(eventPos, eventText, coalition, markId, bypassSecurity)
   veaf.loggers.get(veafCasMission.Id):debug(string.format("veafCasMission.executeCommand(eventText=[%s])", eventText))
   veaf.loggers.get(veafCasMission.Id):trace(string.format("coalition=%s", veaf.p(coalition)))
@@ -1304,7 +1285,10 @@ end
 
 function veafCasMission.initialize()
   veafCasMission.buildRadioMenu()
-  veafMarkers.registerEventHandler(veafMarkers.MarkerChange, veafCasMission.onEventMarkChange)
+  veafCommands.registerCommandHandler(function(pos, event, bypass, fromMarker, groups, route)
+    local coal = fromMarker and ((event.coalition == 1) and 2 or 1) or event.coalition
+    return veafCasMission.executeCommand(pos, event.text, coal, event.idx, bypass)
+  end, veafCommands.PRIORITY_CASMISSION)
 end
 
 veaf.loggers.get(veafCasMission.Id):info(veaf.loggers.get(veafCasMission.Id):getVersionInfo(veafCasMission.Version))

--- a/src/scripts/veaf/veafCombatMission.lua
+++ b/src/scripts/veaf/veafCombatMission.lua
@@ -1599,6 +1599,7 @@ function veafCombatMission.initialize()
   veaf.loggers.get(veafCombatMission.Id):info("Initializing module")
   veafCombatMission.buildRadioMenu()
   veafCombatMission.dumpMissionsList(veaf.config.MISSION_EXPORT_PATH)
+  veafRemote.registerRemoteModule("air", veafCombatMission.executeCommandFromRemote)
 end
 
 veaf.loggers.get(veafCombatMission.Id):info(veaf.loggers.get(veafCombatMission.Id):getVersionInfo(veafCombatMission.Version))

--- a/src/scripts/veaf/veafCommands.lua
+++ b/src/scripts/veaf/veafCommands.lua
@@ -1,0 +1,132 @@
+------------------------------------------------------------------
+-- VEAF central text command dispatcher for DCS World
+-- By Zip (2025)
+--
+-- Features:
+-- ---------
+-- * Centralises textual command dispatch (marker events and interpreter)
+--   behind a single ordered registry so modules self-register instead
+--   of being hardcoded in veafInterpreter and eight separate marker handlers.
+--
+-- Usage:
+-- * In a module's initialize(), call veafCommands.registerCommandHandler(fn, priority)
+-- * fn(pos, event, bypassSecurity, fromMarker, spawnedGroups, route) -> bool
+--   - pos          : vec3 position
+--   - event        : table { text, coalition, idx } (real DCS event or constructed)
+--   - bypassSecurity : true when called from the interpreter (trusted context)
+--   - fromMarker   : true when dispatched from a DCS marker event
+--   - spawnedGroups: may be nil (only provided by the interpreter)
+--   - route        : may be nil (only provided by the interpreter)
+--
+-- See the documentation : https://veaf.github.io/documentation/
+------------------------------------------------------------------
+
+veafCommands = {}
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Global settings. Stores the script constants
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+--- Identifier. All output in DCS.log will start with this.
+veafCommands.Id = "COMMANDS"
+
+--- Version.
+veafCommands.Version = "1.0.0"
+
+-- trace level, specific to this module (uncomment for debugging)
+--veafCommands.LogLevel = "trace"
+
+veaf.loggers.new(veafCommands.Id, veafCommands.LogLevel)
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Dispatch priority constants — lower value = earlier in the chain.
+-- Order reproduces the legacy veafInterpreter.execute() if/elseif sequence.
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+veafCommands.PRIORITY_SHORTCUTS = 10
+veafCommands.PRIORITY_SPAWN = 20
+veafCommands.PRIORITY_NAMEDPOINTS = 30
+veafCommands.PRIORITY_CASMISSION = 40
+veafCommands.PRIORITY_SECURITY = 50
+veafCommands.PRIORITY_MOVE = 60
+veafCommands.PRIORITY_RADIO = 70
+veafCommands.PRIORITY_REMOTE = 80
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Do not change anything below unless you know what you are doing!
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+-- Ordered list of registered command handlers.
+-- Each entry: { fn = function, priority = number }
+veafCommands.commandHandlers = {}
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Public API
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+--- Register a text command handler.
+-- @param fn       function(pos, event, bypassSecurity, fromMarker, spawnedGroups, route) -> bool
+-- @param priority number — lower values are tried first (use PRIORITY_* constants)
+function veafCommands.registerCommandHandler(fn, priority)
+  assert(type(fn) == "function", "veafCommands.registerCommandHandler: fn must be a function")
+  assert(type(priority) == "number", "veafCommands.registerCommandHandler: priority must be a number")
+  local i = 1
+  while i <= #veafCommands.commandHandlers and veafCommands.commandHandlers[i].priority <= priority do
+    i = i + 1
+  end
+  table.insert(veafCommands.commandHandlers, i, { fn = fn, priority = priority })
+  veaf.loggers.get(veafCommands.Id):debug("registered handler at priority %d (position %d)", priority, i)
+end
+
+--- Dispatch a DCS marker event through the registry.
+-- Called by the single central veafMarkers handler registered in initialize().
+-- @return bool  true if a handler consumed the event (mark will be removed by caller)
+function veafCommands.dispatchMarker(eventPos, event)
+  veaf.loggers.get(veafCommands.Id):debug("dispatchMarker(text=[%s])", tostring(event.text))
+  for _, entry in ipairs(veafCommands.commandHandlers) do
+    if entry.fn(eventPos, event, false, true, nil, nil) then
+      return true
+    end
+  end
+  return false
+end
+
+--- Dispatch a text command from veafInterpreter (unit-name commands at mission start).
+-- @param pos      vec3 position
+-- @param text     command text
+-- @param coalition coalition of the unit carrying the interpreter command
+-- @param spawnedGroups optional table accumulating spawned groups
+-- @param route    optional route table
+-- @return bool
+function veafCommands.execute(pos, text, coalition, spawnedGroups, route)
+  veaf.loggers.get(veafCommands.Id):debug("execute(text=[%s])", tostring(text))
+  local event = { text = text, coalition = coalition, idx = nil }
+  for _, entry in ipairs(veafCommands.commandHandlers) do
+    if entry.fn(pos, event, true, false, spawnedGroups, route) then
+      return true
+    end
+  end
+  return false
+end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- initialisation
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+function veafCommands.initialize()
+  veaf.loggers.get(veafCommands.Id):info("Initializing module")
+  -- Register the single central marker handler that replaces the eight
+  -- per-module onEventMarkChange functions.
+  veafMarkers.registerEventHandler(veafMarkers.MarkerChange, function(eventPos, event)
+    if veafCommands.dispatchMarker(eventPos, event) then
+      veaf.loggers.get(veafCommands.Id):trace("Removing mark #%d", event.idx)
+      trigger.action.removeMark(event.idx)
+    end
+  end)
+end
+
+veaf.loggers.get(veafCommands.Id):info(veaf.loggers.get(veafCommands.Id):getVersionInfo(veafCommands.Version))
+
+-- Priority 15: after veafEventHandler (10) and veafMarkers (no explicit order, loads early),
+-- before all command modules so they can call registerCommandHandler in their own initialize().
+veaf.registerModule(veafCommands.Id, veafCommands.initialize, { enable = true }, 15)

--- a/src/scripts/veaf/veafInterpreter.lua
+++ b/src/scripts/veaf/veafInterpreter.lua
@@ -65,46 +65,12 @@ function veafInterpreter.interpret(text)
 end
 
 function veafInterpreter.execute(command, position, coalition, route, spawnedGroups)
-  local function logDebug(message)
-    veaf.loggers.get(veafInterpreter.Id):debug(message)
-    return true
-  end
-
-  if command == nil then
-    return
-  end
-  if position == nil then
+  if command == nil or position == nil then
     return
   end
   veaf.loggers.get(veafInterpreter.Id):trace("veafInterpreter.execute([%s],[%s])", command, position)
-
-  local commandExecuted = false
   spawnedGroups = spawnedGroups or {}
-
-  if
-    logDebug("checking in veafShortcuts") and veafShortcuts.executeCommand(position, command, coalition, nil, true, spawnedGroups, route)
-  then
-    return true
-  elseif
-    logDebug("checking in veafSpawn")
-    and veafSpawn.executeCommand(position, command, coalition, nil, true, spawnedGroups, nil, nil, route, true)
-  then
-    return true
-  elseif logDebug("checking in veafNamedPoints") and veafNamedPoints.executeCommand(position, { text = command, coalition = -1 }, true) then
-    return true
-  elseif logDebug("checking in veafCasMission") and veafCasMission.executeCommand(position, command, coalition, true) then
-    return true
-  elseif logDebug("checking in veafSecurity") and veafSecurity.executeCommand(position, command, true) then
-    return true
-  elseif logDebug("checking in veafMove") and veafMove.executeCommand(position, command, true) then
-    return true
-  elseif logDebug("checking in veafRadio") and veafRadio.executeCommand(position, command, coalition, true) then
-    return true
-  elseif logDebug("checking in veafRemote") and veafRemote.executeCommand(position, command) then
-    return true
-  else
-    return false
-  end
+  return veafCommands.execute(position, command, coalition, spawnedGroups, route)
 end
 
 function veafInterpreter.executeCommandOnUnit(unitName, command)

--- a/src/scripts/veaf/veafMove.lua
+++ b/src/scripts/veaf/veafMove.lua
@@ -85,15 +85,6 @@ veafMove.Tankers = {}
 -- Event handler functions.
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
---- Function executed when a mark has changed. This happens when text is entered or changed.
-function veafMove.onEventMarkChange(eventPos, event)
-  if veafMove.executeCommand(eventPos, event.text) then
-    -- Delete old mark.
-    veaf.loggers.get(veafMove.Id):trace(string.format("Removing mark # %d.", event.idx))
-    trigger.action.removeMark(event.idx)
-  end
-end
-
 function veafMove.executeCommand(eventPos, eventText, bypassSecurity)
   -- Check if marker has a text and the veafMove.keyphrase keyphrase.
   if eventText ~= nil and eventText:lower():find(veafMove.Keyphrase) then
@@ -1016,7 +1007,9 @@ function veafMove.initialize()
     veafMove.Tankers = veafMove.findAllTankers()
   end
   veafMove.buildRadioMenu()
-  veafMarkers.registerEventHandler(veafMarkers.MarkerChange, veafMove.onEventMarkChange)
+  veafCommands.registerCommandHandler(function(pos, event, bypass, fromMarker, groups, route)
+    return veafMove.executeCommand(pos, event.text, bypass)
+  end, veafCommands.PRIORITY_MOVE)
 end
 
 veaf.loggers.get(veafMove.Id):info(veaf.loggers.get(veafMove.Id):getVersionInfo(veafMove.Version))

--- a/src/scripts/veaf/veafNamedPoints.lua
+++ b/src/scripts/veaf/veafNamedPoints.lua
@@ -46,15 +46,6 @@ veafNamedPoints.markid = 1270000 --- Initial Marker id.
 -- Event handler functions.
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
---- Function executed when a mark has changed. This happens when text is entered or changed.
-function veafNamedPoints.onEventMarkChange(eventPos, event)
-  if veafNamedPoints.executeCommand(eventPos, event) then
-    -- Delete old mark.
-    veaf.loggers.get(veafNamedPoints.Id):trace(string.format("Removing mark # %d.", event.idx))
-    trigger.action.removeMark(event.idx)
-  end
-end
-
 function veafNamedPoints.executeCommand(eventPos, event, bypassSecurity)
   -- Check if marker has a text and the veafNamedPoints.keyphrase keyphrase.
   if event.text ~= nil and event.text:lower():find(veafNamedPoints.Keyphrase) then
@@ -307,7 +298,13 @@ function veafNamedPoints.initialize(customPoints)
   veafNamedPoints.addCustomPoints(customPoints)
 
   veafNamedPoints.buildRadioMenu()
-  veafMarkers.registerEventHandler(veafMarkers.MarkerChange, veafNamedPoints.onEventMarkChange)
+  veafCommands.registerCommandHandler(function(pos, event, bypass, fromMarker, groups, route)
+    -- From the interpreter (fromMarker=false), preserve legacy coalition=-1 so named
+    -- points created via unit names are visible to all coalitions (same as before).
+    local effectiveEvent = fromMarker and event or { text = event.text, coalition = -1, idx = nil }
+    return veafNamedPoints.executeCommand(pos, effectiveEvent, bypass)
+  end, veafCommands.PRIORITY_NAMEDPOINTS)
+  veafRemote.registerRemoteModule("point", veafNamedPoints.executeCommandFromRemote)
 end
 
 function veafNamedPoints.addCities()

--- a/src/scripts/veaf/veafRadio.lua
+++ b/src/scripts/veaf/veafRadio.lua
@@ -137,15 +137,6 @@ function veafRadio.onBirthEvent(event)
   end
 end
 
---- Function executed when a mark has changed. This happens when text is entered or changed.
-function veafRadio.onEventMarkChange(eventPos, event)
-  if veafRadio.executeCommand(eventPos, event.text, event.coalition) then
-    -- Delete old mark.
-    veaf.loggers.get(veafRadio.Id):trace(string.format("Removing mark # %d.", event.idx))
-    trigger.action.removeMark(event.idx)
-  end
-end
-
 function veafRadio.executeCommand(eventPos, eventText, eventCoalition, bypassSecurity)
   veaf.loggers.get(veafRadio.Id):trace(string.format("veafRadio.executeCommand(%s)", eventText))
 
@@ -952,7 +943,10 @@ function veafRadio.initialize(skipHelpMenus, dontCreateMenus)
   --mist.scheduleFunction(veafRadio._refreshRadioMenu,{},timer.getTime()+15) --TODO check if this is still needed (commented out when added the BIRTH event handler)
 
   -- add marker change event handler
-  veafMarkers.registerEventHandler(veafMarkers.MarkerChange, veafRadio.onEventMarkChange)
+  veafCommands.registerCommandHandler(function(pos, event, bypass, fromMarker, groups, route)
+    -- veafRadio uses raw (non-inverted) coalition — pass event.coalition directly
+    return veafRadio.executeCommand(pos, event.text, event.coalition, bypass)
+  end, veafCommands.PRIORITY_RADIO)
 
   -- add human birth event handler
   veafEventHandler.addCallback("veafRadio.eventHandler", { "S_EVENT_BIRTH", "S_EVENT_PLAYER_ENTER_UNIT" }, veafRadio.onBirthEvent)

--- a/src/scripts/veaf/veafRemote.lua
+++ b/src/scripts/veaf/veafRemote.lua
@@ -43,10 +43,22 @@ veafRemote.MIN_LEVEL_FOR_MARKER = 10
 veafRemote.monitoredCommands = {}
 veafRemote.remoteUsers = {}
 veafRemote.remoteUnitsPilots = {}
+-- Registry for executeCommandFromRemote() — maps lowercase module name to handler function.
+-- Modules register via veafRemote.registerRemoteModule(name, fn).
+veafRemote.remoteModuleRegistry = {}
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Utility methods
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+--- Register a remote module handler for executeCommandFromRemote().
+-- @param name  lowercase module key (e.g. "air", "point"); may be called multiple times for aliases
+-- @param fn    function(parameters) to dispatch to
+function veafRemote.registerRemoteModule(name, fn)
+  assert(type(name) == "string", "veafRemote.registerRemoteModule: name must be a string")
+  assert(type(fn) == "function", "veafRemote.registerRemoteModule: fn must be a function")
+  veafRemote.remoteModuleRegistry[name:lower()] = fn
+end
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- NIOD callbacks
@@ -168,15 +180,6 @@ end
 -- Event handler functions.
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
---- Function executed when a mark has changed. This happens when text is entered or changed.
-function veafRemote.onEventMarkChange(eventPos, event)
-  if veafRemote.executeCommand(eventPos, event.text) then
-    -- Delete old mark.
-    veaf.loggers.get(veafRemote.Id):trace(string.format("Removing mark # %d.", event.idx))
-    trigger.action.removeMark(event.idx)
-  end
-end
-
 function veafRemote.executeCommand(eventPos, eventText)
   veaf.loggers.get(veafRemote.Id):debug(string.format("veafRemote.executeCommand(eventText=[%s])", tostring(eventText)))
 
@@ -268,28 +271,13 @@ function veafRemote.executeCommandFromRemote(username, level, unitName, veafModu
   local _parameters = { _user, username, unitName, command }
   local _status, _retval
   local _module = veafModule:lower()
-  if _module == "air" then
-    veaf.loggers.get(veafRemote.Id):debug(string.format("running veafCombatMission.executeCommandFromRemote"))
-    _status, _retval = pcall(veafCombatMission.executeCommandFromRemote, _parameters)
-  elseif _module == "point" then
-    veaf.loggers.get(veafRemote.Id):debug(string.format("running veafNamedPoints.executeCommandFromRemote"))
-    _status, _retval = pcall(veafNamedPoints.executeCommandFromRemote, _parameters)
-  elseif _module == "atis" or _module == "atc" or _module == "weather" then
-    veaf.loggers.get(veafRemote.Id):debug(string.format("running veafWeather.executeCommandFromRemote"))
-    _status, _retval = pcall(veafWeather.executeCommandFromRemote, _parameters)
-  elseif _module == "alias" then
-    veaf.loggers.get(veafRemote.Id):debug(string.format("running veafShortcuts.executeCommandFromRemote"))
-    _status, _retval = pcall(veafShortcuts.executeCommandFromRemote, _parameters)
-  elseif _module == "carrier" then
-    veaf.loggers.get(veafRemote.Id):debug(string.format("running veafShortcuts.executeCommandFromRemote"))
-    _status, _retval = pcall(veafCarrierOperations.executeCommandFromRemote, _parameters)
-  elseif _module == "secu" then
-    veaf.loggers.get(veafRemote.Id):debug(string.format("running veafSecurity.executeCommandFromRemote"))
-    _status, _retval = pcall(veafSecurity.executeCommandFromRemote, _parameters)
-  else
+  local handler = veafRemote.remoteModuleRegistry[_module]
+  if not handler then
     veaf.loggers.get(veafRemote.Id):error(string.format("Module not found : [%s]", veaf.p(veafModule)))
     return false
   end
+  veaf.loggers.get(veafRemote.Id):debug(string.format("running remote module [%s]", _module))
+  _status, _retval = pcall(handler, _parameters)
   veaf.loggers.get(veafRemote.Id):trace(string.format("_status = [%s]", veaf.p(_status)))
   veaf.loggers.get(veafRemote.Id):trace(string.format("_retval = [%s]", veaf.p(_retval)))
   if not _status then
@@ -378,7 +366,9 @@ end
 function veafRemote.initialize()
   veaf.loggers.get(veafRemote.Id):info("Initializing module")
   veafRemote.buildDefaultList()
-  veafMarkers.registerEventHandler(veafMarkers.MarkerChange, veafRemote.onEventMarkChange)
+  veafCommands.registerCommandHandler(function(pos, event, bypass, fromMarker, groups, route)
+    return veafRemote.executeCommand(pos, event.text)
+  end, veafCommands.PRIORITY_REMOTE)
 end
 
 veaf.loggers.get(veafRemote.Id):info(veaf.loggers.get(veafRemote.Id):getVersionInfo(veafRemote.Version))

--- a/src/scripts/veaf/veafSecurity.lua
+++ b/src/scripts/veaf/veafSecurity.lua
@@ -452,15 +452,6 @@ end
 -- Event handler functions.
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
---- Function executed when a mark has changed. This happens when text is entered or changed.
-function veafSecurity.onEventMarkChange(eventPos, event)
-  if veafSecurity.executeCommand(eventPos, event.text) then
-    -- Delete old mark.
-    veaf.loggers.get(veafSecurity.Id):trace(string.format("Removing mark # %d.", event.idx))
-    trigger.action.removeMark(event.idx)
-  end
-end
-
 function veafSecurity.executeCommand(eventPos, eventText, bypassSecurity)
   -- Check if marker has a text and the veafCasMission.keyphrase keyphrase.
   if eventText ~= nil and eventText:lower():find(veafSecurity.Keyphrase) then
@@ -666,7 +657,10 @@ function veafSecurity.isAuthenticated()
 end
 
 function veafSecurity.initialize()
-  veafMarkers.registerEventHandler(veafMarkers.MarkerChange, veafSecurity.onEventMarkChange)
+  veafCommands.registerCommandHandler(function(pos, event, bypass, fromMarker, groups, route)
+    return veafSecurity.executeCommand(pos, event.text, bypass)
+  end, veafCommands.PRIORITY_SECURITY)
+  veafRemote.registerRemoteModule("secu", veafSecurity.executeCommandFromRemote)
   veafSecurity.authenticated = veaf.SecurityDisabled
 end
 

--- a/src/scripts/veaf/veafShortcuts.lua
+++ b/src/scripts/veaf/veafShortcuts.lua
@@ -588,23 +588,6 @@ end
 -- Event handler functions.
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
---- Function executed when a mark has changed. This happens when text is entered or changed.
-function veafShortcuts.onEventMarkChange(eventPos, event)
-  -- choose by default the coalition opposing the player who triggered the event
-  local invertedCoalition = 1
-  if event.coalition == 1 then
-    invertedCoalition = 2
-  end
-
-  veaf.loggers.get(veafShortcuts.Id):trace(string.format("event.idx  = %s", veaf.p(event.idx)))
-
-  if veafShortcuts.executeCommand(eventPos, event.text, invertedCoalition, event.idx) then
-    -- Delete old mark.
-    veaf.loggers.get(veafShortcuts.Id):trace(string.format("Removing mark # %d.", event.idx))
-    trigger.action.removeMark(event.idx)
-  end
-end
-
 function veafShortcuts.executeCommand(eventPos, eventText, eventCoalition, markId, bypassSecurity, spawnedGroups, route)
   veaf.loggers.get(veafShortcuts.Id):debug("veafShortcuts.executeCommand(eventText=[%s])", eventText)
 
@@ -1738,7 +1721,11 @@ end
 function veafShortcuts.initialize()
   veaf.loggers.get(veafShortcuts.Id):info("Initializing module")
   veafShortcuts.buildDefaultList()
-  veafMarkers.registerEventHandler(veafMarkers.MarkerChange, veafShortcuts.onEventMarkChange)
+  veafCommands.registerCommandHandler(function(pos, event, bypass, fromMarker, groups, route)
+    local coal = fromMarker and ((event.coalition == 1) and 2 or 1) or event.coalition
+    return veafShortcuts.executeCommand(pos, event.text, coal, event.idx, bypass, groups, route)
+  end, veafCommands.PRIORITY_SHORTCUTS)
+  veafRemote.registerRemoteModule("alias", veafShortcuts.executeCommandFromRemote)
   veafShortcuts.dumpAliasesList()
 end
 

--- a/src/scripts/veaf/veafSpawn.lua
+++ b/src/scripts/veaf/veafSpawn.lua
@@ -11,8 +11,9 @@
 --
 -- See the documentation : https://veaf.github.io/documentation/
 --
--- This file is a proxy that loads the 4 sub-modules:
---   veafSpawnCore.lua     (constants, event handling, parsing, drawing, group spawn, mission master)
+-- This file is a proxy that loads the 5 sub-modules:
+--   veafSpawnCore.lua     (constants, event handling, drawing, group spawn, mission master)
+--   veafSpawnParser.lua   (text parser: convertLaserToFreq, markTextAnalysis)
 --   veafSpawnGround.lua   (FARP, FOB, infantry, armored, air defense, convoy)
 --   veafSpawnAircraft.lua (aircraft, CAP, AFAC, JTAC)
 --   veafSpawnEffects.lua  (cargo, bomb, smoke, flares, destroy, teleport)
@@ -30,6 +31,7 @@ if not veafSpawn or not veafSpawn.Id then
     end
   end
   dofile(_dir .. "veafSpawnCore.lua")
+  dofile(_dir .. "veafSpawnParser.lua")
   dofile(_dir .. "veafSpawnGround.lua")
   dofile(_dir .. "veafSpawnAircraft.lua")
   dofile(_dir .. "veafSpawnEffects.lua")

--- a/src/scripts/veaf/veafSpawnAircraft.lua
+++ b/src/scripts/veaf/veafSpawnAircraft.lua
@@ -1405,3 +1405,82 @@ function veafSpawn.startCapWatchdog(capGroupName, capCoalition, capZone, pTarget
     timer.getTime() + veafSpawn.CAP_WATCHDOG_DELAY
   )
 end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Aircraft spawn command handlers
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+veafSpawn.registerCommandHandler("unit", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local code = options.laserCode
+  local channel = options.freq
+  local band = options.mod
+  if options.role == "tacan" then
+    channel = options.tacanChannel or 99
+    code = options.tacanCode or ("T" .. tostring(channel))
+    band = options.tacanBand or "X"
+  end
+  local g = veafSpawn.spawnUnit(
+    eventPos,
+    options.radius,
+    options.name,
+    options.czName,
+    options.country,
+    options.altitude,
+    options.heading,
+    options.unitName,
+    options.role,
+    options.forceStatic,
+    code,
+    channel,
+    band,
+    bypassSecurity,
+    not options.showMFD
+  )
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("afac", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local g = veafSpawn.spawnAFAC(
+    eventPos,
+    options.name,
+    options.country,
+    options.altitude,
+    options.speed,
+    options.heading,
+    options.freq,
+    options.mod,
+    options.laserCode,
+    options.immortal,
+    false,
+    options.showMFD
+  )
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("cap", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local g = veafSpawn.spawnCombatAirPatrol(
+    eventPos,
+    options.radius,
+    options.name,
+    options.country,
+    options.altitude,
+    options.altitudedelta,
+    options.heading,
+    options.distance,
+    options.speed,
+    options.capradius,
+    options.skill,
+    bypassSecurity,
+    options.showMFD
+  )
+  return g, nil, false
+end)

--- a/src/scripts/veaf/veafSpawnCore.lua
+++ b/src/scripts/veaf/veafSpawnCore.lua
@@ -131,7 +131,7 @@ veafSpawn.AFAC.missionData[coalition.side.RED] = {}
 veafSpawn.traceMarkerId = 3727
 
 -- Registry mapping option-key strings to handler functions registered by sub-modules.
-veafSpawn.commandHandlers = {}
+veafSpawn.commandHandlers = {} -- ordered list: { {key=string, fn=function}, ... }
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Utility methods
@@ -141,7 +141,7 @@ veafSpawn.commandHandlers = {}
 -- @param key   options field name that activates this handler (e.g. "unit", "farp")
 -- @param fn    function(eventPos, options, coalition, markId, bypassSecurity) -> spawnedGroup, routeDone, abort
 function veafSpawn.registerCommandHandler(key, fn)
-  veafSpawn.commandHandlers[key] = fn
+  table.insert(veafSpawn.commandHandlers, { key = key, fn = fn })
 end
 
 function veafSpawn.executeCommand(
@@ -277,11 +277,11 @@ function veafSpawn.executeCommand(
           hasDest = true
         end
 
-        -- Dispatch to registered command handler
+        -- Dispatch to registered command handler (ordered list, first match wins)
         local _handler = nil
-        for _key, _fn in pairs(veafSpawn.commandHandlers) do
-          if options[_key] then
-            _handler = _fn
+        for _, _entry in ipairs(veafSpawn.commandHandlers) do
+          if options[_entry.key] then
+            _handler = _entry.fn
             break
           end
         end

--- a/src/scripts/veaf/veafSpawnCore.lua
+++ b/src/scripts/veaf/veafSpawnCore.lua
@@ -130,31 +130,18 @@ veafSpawn.AFAC.missionData[coalition.side.RED] = {}
 
 veafSpawn.traceMarkerId = 3727
 
+-- Registry mapping option-key strings to handler functions registered by sub-modules.
+veafSpawn.commandHandlers = {}
+
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Utility methods
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
--------------------------------------------------------------------------------------------------------------------------------------------------------------
--- Event handler functions.
--------------------------------------------------------------------------------------------------------------------------------------------------------------
-
---- Function executed when a mark has changed. This happens when text is entered or changed.
-function veafSpawn.onEventMarkChange(eventPos, event)
-  veaf.loggers.get(veafSpawn.Id):trace(string.format("event  = %s", veaf.p(event)))
-
-  -- choose by default the coalition opposing the player who triggered the event
-  local invertedCoalition = 1
-  if event.coalition == 1 then
-    invertedCoalition = 2
-  end
-
-  veaf.loggers.get(veafSpawn.Id):trace(string.format("event.idx  = %s", veaf.p(event.idx)))
-
-  if veafSpawn.executeCommand(eventPos, event.text, invertedCoalition, event.idx, nil, nil, nil, nil, nil, true) then
-    -- Delete old mark.
-    veaf.loggers.get(veafSpawn.Id):trace(string.format("Removing mark # %d.", event.idx))
-    trigger.action.removeMark(event.idx)
-  end
+--- Register a command handler for executeCommand().
+-- @param key   options field name that activates this handler (e.g. "unit", "farp")
+-- @param fn    function(eventPos, options, coalition, markId, bypassSecurity) -> spawnedGroup, routeDone, abort
+function veafSpawn.registerCommandHandler(key, fn)
+  veafSpawn.commandHandlers[key] = fn
 end
 
 function veafSpawn.executeCommand(
@@ -290,379 +277,25 @@ function veafSpawn.executeCommand(
           hasDest = true
         end
 
-        -- Check options commands
-        if options.unit then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+        -- Dispatch to registered command handler
+        local _handler = nil
+        for _key, _fn in pairs(veafSpawn.commandHandlers) do
+          if options[_key] then
+            _handler = _fn
+            break
+          end
+        end
+        if _handler then
+          local _g, _done, _abort = _handler(eventPos, options, coalition, markId, bypassSecurity)
+          if _abort then
             return
           end
-          ---@type string|number|nil
-          local code = options.laserCode
-          ---@type string|number|nil
-          local channel = options.freq
-          local band = options.mod
-          if options.role == "tacan" then
-            channel = options.tacanChannel or 99
-            code = options.tacanCode or ("T" .. tostring(channel))
-            band = options.tacanBand or "X"
+          if _g then
+            spawnedGroup = _g
           end
-          spawnedGroup = veafSpawn.spawnUnit(
-            eventPos,
-            options.radius,
-            options.name,
-            options.czName,
-            options.country,
-            options.altitude,
-            options.heading,
-            options.unitName,
-            options.role,
-            options.forceStatic,
-            code,
-            channel,
-            band,
-            bypassSecurity,
-            not options.showMFD
-          )
-        elseif options.farp then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
+          if _done then
+            routeDone = _done
           end
-          if not options.type then
-            options.type = "invisible"
-          end
-          local channel = options.tacanChannel
-          local code = options.tacanCode
-          local mod = options.tacanBand
-          spawnedGroup = veafSpawn.spawnFarp(
-            eventPos,
-            options.radius,
-            options.name,
-            options.country,
-            options.type,
-            options.side,
-            options.heading,
-            options.spacing,
-            bypassSecurity,
-            not options.showMFD,
-            options.noFarpMarkers,
-            code,
-            channel,
-            mod
-          )
-        elseif options.fob then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnFob(
-            eventPos,
-            options.radius,
-            options.name,
-            options.country,
-            options.type,
-            options.side,
-            options.heading,
-            options.spacing,
-            bypassSecurity,
-            not options.showMFD
-          )
-        elseif options.cap then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnCombatAirPatrol(
-            eventPos,
-            options.radius,
-            options.name,
-            options.country,
-            options.altitude,
-            options.altitudedelta,
-            options.heading,
-            options.distance,
-            options.speed,
-            options.capradius,
-            options.skill,
-            bypassSecurity,
-            options.showMFD
-          )
-        elseif options.afac then
-          --check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnAFAC(
-            eventPos,
-            options.name,
-            options.country,
-            options.altitude,
-            options.speed,
-            options.heading,
-            options.freq,
-            options.mod,
-            options.laserCode,
-            options.immortal,
-            false,
-            options.showMFD
-          )
-        elseif options.group then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnGroup(
-            eventPos,
-            options.radius,
-            options.name,
-            options.czName,
-            options.country,
-            options.altitude,
-            options.heading,
-            options.spacing,
-            options.unitName,
-            bypassSecurity,
-            hasDest,
-            not options.showMFD
-          )
-        elseif options.infantryGroup then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnInfantryGroup(
-            eventPos,
-            options.radius,
-            options.czName,
-            options.country,
-            options.side,
-            options.heading,
-            options.spacing,
-            options.defense,
-            options.armor,
-            options.size,
-            bypassSecurity,
-            not options.showMFD
-          )
-        elseif options.armoredPlatoon then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnArmoredPlatoon(
-            eventPos,
-            options.radius,
-            options.czName,
-            options.country,
-            options.side,
-            options.heading,
-            options.spacing,
-            options.defense,
-            options.armor,
-            options.size,
-            bypassSecurity,
-            hasDest,
-            not options.showMFD
-          )
-        elseif options.airDefenseBattery then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnAirDefenseBattery(
-            eventPos,
-            options.radius,
-            options.czName,
-            options.country,
-            options.side,
-            options.heading,
-            options.spacing,
-            options.defense,
-            bypassSecurity,
-            hasDest,
-            not options.showMFD
-          )
-        elseif options.transportCompany then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnTransportCompany(
-            eventPos,
-            options.radius,
-            options.czName,
-            options.country,
-            options.side,
-            options.heading,
-            options.spacing,
-            options.defense,
-            options.size,
-            bypassSecurity,
-            hasDest,
-            not options.showMFD
-          )
-        elseif options.fullCombatGroup then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnFullCombatGroup(
-            eventPos,
-            options.radius,
-            options.czName,
-            options.country,
-            options.side,
-            options.heading,
-            options.spacing,
-            options.defense,
-            options.armor,
-            options.size,
-            bypassSecurity,
-            not options.showMFD
-          )
-        elseif options.convoy then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnConvoy(
-            eventPos,
-            options.name,
-            options.czName,
-            options.radius,
-            options.country,
-            options.side,
-            options.heading,
-            options.spacing,
-            options.speed,
-            options.patrol,
-            options.offroad,
-            options.destination,
-            options.defense,
-            options.size,
-            options.armor,
-            bypassSecurity,
-            not options.showMFD
-          )
-          routeDone = true
-        elseif options.cargo then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnCargo(
-            eventPos,
-            options.radius,
-            options.cargoType,
-            options.country,
-            options.cargoWeightBias,
-            options.cargoSmoke,
-            options.unitName,
-            bypassSecurity,
-            not options.showMFD
-          )
-        elseif options.logistic then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
-            return
-          end
-          spawnedGroup = veafSpawn.spawnLogistic(eventPos, options.radius, options.country, bypassSecurity, not options.showMFD)
-        elseif options.destroy then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
-            return
-          end
-          veafSpawn.destroy(eventPos, options.radius, options.unitName)
-        elseif options.teleport then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
-            return
-          end
-          veafSpawn.teleport(eventPos, options.name, bypassSecurity)
-        elseif options.bomb then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
-            return
-          end
-          veafSpawn.spawnBomb(
-            eventPos,
-            options.radius,
-            options.shells,
-            options.power,
-            options.altitude,
-            options.altitudedelta,
-            options.password
-          )
-        elseif options.smoke then
-          veafSpawn.spawnSmoke(eventPos, options.smokeColor, options.radius, options.shells)
-        elseif options.flare then
-          if not options.altitude or options.altitude == 0 then
-            options.altitude = 1000
-          end
-          if not options.power or options.power == 0 then
-            options.power = 500
-          end
-          options.power = options.power * 1000
-          veafSpawn.spawnIlluminationFlare(
-            eventPos,
-            options.radius,
-            options.shells,
-            options.power,
-            options.altitude,
-            options.heading,
-            options.distance,
-            options.speed
-          )
-        elseif options.signal then
-          veafSpawn.spawnSignalFlare(eventPos, options.radius, options.shells, options.smokeColor)
-        elseif options.addDrawing then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
-            return
-          end
-          veafSpawn.addPointToDrawing(eventPos, options.name, options.drawColor, options.drawFillColor, options.type, options.drawArrow)
-        elseif options.drawSquare then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
-            return
-          end
-          veafSpawn.drawSquare(eventPos, options.name, options.radius, options.drawColor, options.drawFillColor, options.type)
-        elseif options.drawCircle then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
-            return
-          end
-          veafSpawn.drawCircle(eventPos, options.name, options.radius, options.drawColor, options.drawFillColor, options.type)
-        elseif options.eraseDrawing then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
-            return
-          end
-          veafSpawn.eraseDrawing(options.name)
-        elseif options.mmFlagOn then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_MM(options.password)) then
-            return
-          end
-          veafSpawn.missionMasterSetFlag(options.name, 1)
-        elseif options.mmFlagOff then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_MM(options.password)) then
-            return
-          end
-          veafSpawn.missionMasterSetFlag(options.name, 0)
-        elseif options.mmGetFlag then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_MM(options.password)) then
-            return
-          end
-          veafSpawn.missionMasterGetFlag(options.name)
-        elseif options.mmRun then
-          -- check security
-          if not (bypassSecurity or veafSecurity.checkSecurity_MM(options.password)) then
-            return
-          end
-          veafSpawn.missionMasterRun(options.name)
         end
         if spawnedGroup then
           ---@type Group|StaticObject|nil
@@ -744,630 +377,7 @@ function veafSpawn.executeCommand(
   return false
 end
 
--------------------------------------------------------------------------------------------------------------------------------------------------------------
--- Analyse the mark text and extract keywords.
--------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-function veafSpawn.convertLaserToFreq(laser)
-  veaf.loggers.get(veafSpawn.Id):trace(string.format("convertLaserToFreq(laser=%s)", tostring(laser)))
-  local laser = tonumber(laser)
-  if laser and laser >= 1111 and laser <= 1688 then
-    local laserB = math.floor((laser - 1000) / 100)
-    local laserCD = laser - 1000 - laserB * 100
-    local frequency = tostring(30 + laserB + laserCD * 0.05)
-    veaf.loggers.get(veafSpawn.Id):trace(string.format("laserB=%s", tostring(laserB)))
-    veaf.loggers.get(veafSpawn.Id):trace(string.format("laserCD=%s", tostring(laserCD)))
-    veaf.loggers.get(veafSpawn.Id):trace(string.format("frequency=%s", tostring(frequency)))
-    return frequency
-  else
-    return nil
-  end
-end
-
---- Extract keywords from mark text.
-function veafSpawn.markTextAnalysis(text)
-  veaf.loggers.get(veafSpawn.Id):trace(string.format("veafSpawn.markTextAnalysis(text=%s)", text))
-
-  -- Option parameters extracted from the mark text.
-  local options = {}
-  options.czName = nil -- name of the CZ to add to the group name, if any
-  options.unit = false
-  options.forceStatic = false -- if true, will force the spawned unit to be a static
-  options.group = false
-  options.cap = false
-  options.farp = false
-  options.noFarpMarkers = false
-  options.fob = false
-  options.type = nil
-  options.cargo = false
-  options.logistic = false
-  options.smoke = false
-  options.flare = false
-  options.signal = false
-  options.bomb = false
-  options.destroy = false
-  options.teleport = false
-  options.convoy = false
-  options.role = nil
-  options.laserCode = 1688
-  options.infantryGroup = false
-  options.armoredPlatoon = false
-  options.airDefenseBattery = false
-  options.transportCompany = false
-  options.fullCombatGroup = false
-  options.speed = nil
-  options.capradius = nil
-  options.shells = 1
-  options.multiplier = 1
-  options.skynet = false -- if true, add to skynet
-  options.forceEwr = false -- if true, unit will be added as an IADS EWR
-  options.pointDefense = false -- if true, unit will be added as point defense to the closest IADS SAM site
-  options.AlarmState = 2 -- Alarm state of the convoy to be spawned, 0 is AUTO, 1 is GREEN, 2 is RED. Note: This option is useful for some vehicules which behave badly in Alarm State RED when spawned such as the Scud or Sa-11 (they deploy and can't drive anywhere). Auto is better suited
-  options.disperse = 15 --disperse time of groups if under attack, by default is set to 20s
-  options.showMFD = false --option to enable groups to be seen on MFDs
-  options.addDrawing = false -- draw a polygon on the map
-  options.drawSquare = false -- draw a square on the map
-  options.drawCircle = false -- draw a circle on the map
-  options.eraseDrawing = false -- erase a polygon from the map
-  options.stopDrawing = false -- close a polygon started on the map
-
-  options.drawColor = nil
-  options.drawFillColor = nil
-  options.drawArrow = nil
-
-  -- spawned group/unit type/alias
-  options.name = ""
-
-  -- spawned unit name
-  options.unitName = nil
-
-  -- spawned group units spacing
-  options.spacing = 5
-
-  options.country = nil
-  options.side = nil
-  options.altitude = 0
-  options.altitudedelta = 0
-  options.heading = 0
-  options.distance = nil
-  options.skill = nil
-
-  -- if true, group is part of a road convoy
-  options.isConvoy = false
-
-  -- if true, group is patroling between its spawn point and its destination named point
-  options.patrol = false
-
-  -- if true, group is set to not follow roads
-  options.offroad = false
-
-  -- if set and convoy is true, send the group to the named point
-  options.destination = nil
-
-  -- the size of the generated dynamic groups (platoons, convoys, etc.)
-  options.size = math.random(7) + 8
-
-  -- defenses force ; ranges from 1 to 5, 5 being the toughest.
-  options.defense = math.random(5)
-
-  -- armor force ; ranges from 1 to 5, 5 being the strongest and most modern.
-  options.armor = math.random(5)
-
-  -- bomb power
-  options.power = 100
-
-  -- smoke color
-  options.smokeColor = trigger.smokeColor.RED
-
-  -- optional cargo smoke
-  options.cargoSmoke = false
-
-  -- cargo type
-  options.cargoType = "container_cargo"
-  options.cargoWeightBias = 2 --weight bias of the cargo, if equal to 0, cargo will be very close to minimum weight, if equal to 5, cargo will be close to maximum
-
-  options.password = nil
-
-  --AFAC spawn option
-  options.afac = false
-  options.immortal = false
-
-  -- JTAC radio comms
-  options.freq = veafSpawn.convertLaserToFreq(options.laserCode)
-  options.mod = "fm"
-
-  -- TACAN name and channel
-  options.tacanChannel = nil
-  options.tacanBand = nil
-
-  -- repeat options
-  options.repeatCount = nil
-  options.repeatDelay = nil
-
-  -- delayed start option
-  options.delayedStart = 0
-
-  -- Check for correct keywords.
-  if text:lower():find(veafSpawn.SpawnKeyphrase .. " unit") then
-    options.unit = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " afac") then
-    options.afac = true
-    --default country for the AFAC
-    options.country = "USA"
-    --default AFAC spawned
-    options.name = "mq-9"
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " cap") then
-    options.cap = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " group") then
-    options.group = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " farp") then
-    options.farp = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " fob") then
-    options.fob = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " convoy") then
-    options.convoy = true
-    options.size = 10 -- default the size parameter to 10
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " infantrygroup") then
-    options.infantryGroup = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " armorgroup") then
-    options.armoredPlatoon = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " samgroup") then
-    options.airDefenseBattery = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " transportgroup") then
-    options.transportCompany = true
-    options.size = math.random(2, 5)
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " combatgroup") then
-    options.fullCombatGroup = true
-    options.size = 1 -- default the size parameter to 1
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " smoke") then
-    options.smoke = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " flare") then
-    options.flare = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " signal") then
-    options.signal = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " cargo") then
-    options.cargo = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " logistic") then
-    options.logistic = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " bomb") then
-    options.bomb = true
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " jtac") then
-    options.role = "jtac"
-    options.unit = true
-    -- default country for friendly JTAC: USA
-    options.country = "USA"
-    -- default name for JTAC
-    options.name = "LUV HMMWV Jeep"
-    -- default JTAC name (will overwrite previous unit with same name)
-    options.unitName = "JTAC1"
-  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " tacan") then
-    options.role = "tacan"
-    options.unit = true
-    -- default country for friendly tacan: USA
-    options.country = "USA"
-    -- default name for tacan
-    options.name = "TACAN_beacon"
-    -- default name (will overwrite previous unit with same name)
-    options.unitName = "TACAN TCN"
-  elseif text:lower():find(veafSpawn.DestroyKeyphrase) then
-    options.destroy = true
-  elseif text:lower():find(veafSpawn.TeleportKeyphrase) then
-    options.teleport = true
-  elseif text:lower():find(veafSpawn.DrawingKeyphrase .. " add") then
-    options.addDrawing = true
-  elseif text:lower():find(veafSpawn.DrawingKeyphrase .. " erase") then
-    options.eraseDrawing = true
-  elseif text:lower():find(veafSpawn.DrawingKeyphrase .. " square") then
-    options.drawSquare = true
-  elseif text:lower():find(veafSpawn.DrawingKeyphrase .. " circle") then
-    options.drawCircle = true
-  elseif text:lower():find(veafSpawn.MissionMasterKeyphrase .. " flagon") then
-    options.mmFlagOn = true
-  elseif text:lower():find(veafSpawn.MissionMasterKeyphrase .. " flagoff") then
-    options.mmFlagOff = true
-  elseif text:lower():find(veafSpawn.MissionMasterKeyphrase .. " getflag") then
-    options.mmGetFlag = true
-  elseif text:lower():find(veafSpawn.MissionMasterKeyphrase .. " run") then
-    options.mmRun = true
-  else
-    return nil
-  end
-
-  -- keywords are split by ","
-  local keywords = veaf.split(text, ",")
-
-  for _, keyphrase in pairs(keywords) do
-    -- Split keyphrase by space. First one is the key and second, ... the parameter(s) until the next comma.
-    local str = veaf.breakString(veaf.trim(keyphrase), " ")
-    local key = str[1]
-    local val = str[2] or ""
-
-    if key:lower() == "unitname" then
-      -- Set name.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword unitname = %s", tostring(val)))
-      options.unitName = val
-    end
-
-    if key:lower() == "name" then
-      -- Set name.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword name = %s", tostring(val)))
-      options.name = val
-    end
-
-    if key:lower() == "czname" then
-      -- Set name.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword czname = %s", tostring(val)))
-      options.czName = val
-    end
-
-    if key:lower() == "destination" or key:lower() == "dest" then
-      -- Set destination.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword destination = %s", tostring(val)))
-      options.destination = val
-      options.AlarmState = 0 --since some units will not move when they are told to have an alarm state red, it's best to by default leave it on auto. AI is pretty all knowing anyways, it knows when it should go to red state
-      options.spacing = 1 --compress the convoy to not make it extremely long at departure
-      options.radius = 1 --convoy spawns on the marker exactly to not have them spawn in trees etc.
-    end
-
-    if key:lower() == "isconvoy" then
-      veaf.loggers.get(veafSpawn.Id):trace("Keyword isconvoy found")
-      options.convoy = true
-    end
-
-    if key:lower() == "patrol" then
-      veaf.loggers.get(veafSpawn.Id):trace("Keyword patrol found")
-      options.patrol = true
-    end
-
-    if key:lower() == "offroad" then
-      veaf.loggers.get(veafSpawn.Id):trace("Keyword offroad found")
-      options.offroad = true
-    end
-
-    if key:lower() == "skynet" then
-      -- Retreive the name of the IADS you wish to add the spawned group to
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword skynet = %s", tostring(val)))
-      options.skynet = val:lower()
-      if options.skynet == "" or options.skynet == "true" then
-        options.skynet = true
-      elseif options.skynet == "false" then
-        options.skynet = false
-      end
-    end
-
-    if key:lower() == "ewr" then
-      -- Set force IADS EWR toggle for unit spawn
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword ewr found"))
-      options.forceEwr = true
-    end
-
-    if key:lower() == "pointdefense" then
-      -- Tells IADS to add the spawned SAM to the point defenses of the specified site or to the nearest site
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword pointdefense found"))
-      options.pointDefense = true
-      if val ~= "" then
-        veaf.loggers.get(veafSpawn.Id):trace(string.format("groupName specified : %s", tostring(val)))
-        options.pointDefense = tostring(val)
-      end
-    end
-
-    --to be placed after the skynet input, SAMs in the skynet network work better if set to AlarmState RED, so AlarmState is equal to 2 if skynet is enabled
-    if key:lower() == "alarm" then
-      -- Set Alarm State of the unit to be spawned
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword alarm = %s", tostring(val)))
-      if (val == "0" or val == "2" or val == "1") and not options.skynet then
-        options.AlarmState = tonumber(val)
-      end
-    end
-
-    if key:lower() == "radius" then
-      -- Set name.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword radius = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.radius = nVal
-    end
-
-    if key:lower() == "spacing" then
-      -- Set spacing.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword spacing = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.spacing = nVal
-    end
-
-    if key:lower() == "multiplier" then
-      -- Set multiplier.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword multiplier = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.multiplier = nVal
-    end
-
-    if key:lower() == "alt" then
-      -- Set altitude.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword alt = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.altitude = nVal
-    end
-
-    if key:lower() == "altdelta" then
-      -- Set altitude delta.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword altdelta = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.altitudedelta = nVal
-    end
-
-    if key:lower() == "speed" then
-      -- Set speed.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword speed = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.speed = nVal
-    end
-
-    if key:lower() == "capradius" then
-      -- Set capradius.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword capradius = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.capradius = nVal
-    end
-
-    if key:lower() == "shells" then
-      -- Set altitude.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword shells = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.shells = nVal
-    end
-
-    if key:lower() == "hdg" then
-      -- Set heading.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword hdg = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.heading = nVal
-    end
-
-    if key:lower() == "heading" then
-      -- Set heading.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword heading = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.heading = nVal
-    end
-
-    if key:lower() == "country" then
-      -- Set country
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword country = %s", tostring(val)))
-      options.country = val:upper()
-    end
-
-    if key:lower() == "side" then
-      -- Set side
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword side = %s", tostring(val)))
-      if val:upper() == "BLUE" then
-        options.side = veafCasMission.SIDE_BLUE
-      else
-        options.side = veafCasMission.SIDE_RED
-      end
-    end
-
-    if key:lower() == "password" then
-      -- Unlock the command
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword password", tostring(val)))
-      options.password = val
-    end
-
-    if key:lower() == "power" then
-      -- Set bomb power.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword power = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.power = nVal
-    end
-
-    if key:lower() == "laser" then
-      -- Set laser code.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("laser code = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.freq = veafSpawn.convertLaserToFreq(nVal)
-      options.laserCode = nVal
-    end
-
-    if key:lower() == "freq" then
-      -- Set JTAC/AFAC frequency.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("freq = %s", tostring(val)))
-      options.freq = val
-    end
-
-    if key:lower() == "mod" then
-      -- Set JTAC/AFAC modulation.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("mod = %s", tostring(val)))
-      options.mod = val
-    end
-
-    if key:lower() == "band" then
-      -- Set TACAN band
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("band = %s", tostring(val)))
-      options.tacanBand = val
-    end
-
-    if key:lower() == "code" then
-      -- Set TACAN code
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("code = %s", tostring(val)))
-      options.tacanCode = val
-    end
-
-    if key:lower() == "channel" then
-      -- Set TACAN channel.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("channel = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.tacanChannel = nVal
-    end
-
-    if key:lower() == "arrow" then
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword arrow = %s", tostring(val)))
-      options.drawArrow = true
-    end
-    if key:lower() == "fill" then
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword fill = %s", tostring(val)))
-      options.drawFillColor = val
-    end
-
-    if key:lower() == "color" then
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword color = %s", tostring(val)))
-      options.drawColor = val
-      -- Set smoke color.
-      if val:lower() == "red" then
-        options.smokeColor = trigger.smokeColor.RED
-      elseif val:lower() == "green" then
-        options.smokeColor = trigger.smokeColor.GREEN
-      elseif val:lower() == "orange" then
-        options.smokeColor = trigger.smokeColor.ORANGE
-      elseif val:lower() == "blue" then
-        options.smokeColor = trigger.smokeColor.BLUE
-      elseif val:lower() == "white" then
-        options.smokeColor = trigger.smokeColor.WHITE
-      end
-    end
-
-    if key:lower() == "skill" then
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword skill = %s", tostring(val)))
-      options.skill = val
-    end
-
-    if key:lower() == "dist" or key:lower() == "distance" then
-      -- Set distance.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword distance = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.distance = nVal
-    end
-
-    if options.cargo and key:lower() == "name" then
-      -- Set cargo type.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword name = %s", tostring(val)))
-      options.cargoType = val
-    end
-
-    if options.cargo and key:lower() == "weight" then
-      -- Set cargo type.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword weight = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      if nVal >= 0 and nVal <= veafSpawn.cargoWeightBiasRange then
-        options.cargoWeightBias = nVal
-      elseif nVal > veafSpawn.cargoWeightBiasRange then
-        options.cargoWeightBias = veafSpawn.cargoWeightBiasRange
-      elseif nVal < 0 then
-        options.cargoWeightBias = 0
-      end
-    end
-
-    if key:lower() == "type" then
-      -- Set farp type.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword type = %s", tostring(val)))
-      options.type = val
-    end
-
-    if options.farp and key:lower() == "nofarpmarkers" then
-      -- Skip the invisible FARP special vehicles that mark the position of the FARP
-      veaf.loggers.get(veafSpawn.Id):trace("Keyword noFarpMarkers is set")
-      options.noFarpMarkers = true
-    end
-
-    if options.cargo and key:lower() == "smoke" then
-      -- Mark with green smoke.
-      veaf.loggers.get(veafSpawn.Id):trace("Keyword smoke is set")
-      options.cargoSmoke = true
-    end
-
-    if key:lower() == "size" then
-      -- Set size.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword size = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.size = nVal
-    end
-
-    if key:lower() == "defense" then
-      -- Set defense.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword defense = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      if nVal >= 0 then
-        options.defense = nVal
-      end
-    end
-
-    if key:lower() == "armor" then
-      -- Set armor.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword armor = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      if nVal >= 0 then
-        options.armor = nVal
-      end
-    end
-
-    if key:lower() == "repeat" then
-      -- Set repeat count.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword repeat = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.repeatCount = nVal
-    end
-
-    if key:lower() == "delay" then
-      -- Set delay.
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword delay = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      options.repeatDelay = nVal
-    end
-
-    if key:lower() == "static" then
-      -- Set static unit spawn toggle
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword static found"))
-      options.forceStatic = true
-    end
-
-    if key:lower() == "immortal" then
-      -- Set spawned unit to invisible and immortal
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword immortal found"))
-      options.immortal = true
-    end
-
-    if key:lower() == "delayed" then
-      -- Set delayed start on first spawn occurence
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword delayed = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      if nVal >= 0 then
-        options.delayedStart = nVal
-      else
-        options.delayedStart = veafSpawn.MIN_REPEAT_DELAY
-      end
-    end
-
-    if key:lower() == "showmfd" then
-      -- Set hiddenOnMFD option or not
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword showmfd found"))
-      options.showMFD = true
-    end
-
-    if key:lower() == "disperse" then
-      -- Set hiddenOnMFD option or not
-      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword disperse = %s", tostring(val)))
-      local nVal = veaf.getRandomizableNumeric(val)
-      if nVal >= 0 then
-        options.disperse = nVal
-      end
-    end
-  end
-
-  -- check mandatory parameter "name" for command "group"
-  if options.group and not options.name then
-    return nil
-  end
-
-  -- check mandatory parameter "name" for command "unit"
-  if options.unit and not options.name then
-    return nil
-  end
-
-  -- check mandatory parameter "name" for all mission master commands
-  if (options.mmFlagOff or options.mmFlagOn or options.mmRun) and not options.name then
-    return nil
-  end
-
-  return options
-end
+-- veafSpawn.convertLaserToFreq() and veafSpawn.markTextAnalysis() are defined in veafSpawnParser.lua
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Manage drawings on the map
@@ -1819,13 +829,84 @@ function veafSpawn.buildRadioMenu()
 end
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Core command handlers (drawing + mission master) — registered at load time
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+veafSpawn.registerCommandHandler("addDrawing", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
+    return nil, nil, true
+  end
+  veafSpawn.addPointToDrawing(eventPos, options.name, options.drawColor, options.drawFillColor, options.type, options.drawArrow)
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("drawSquare", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
+    return nil, nil, true
+  end
+  veafSpawn.drawSquare(eventPos, options.name, options.radius, options.drawColor, options.drawFillColor, options.type)
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("drawCircle", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
+    return nil, nil, true
+  end
+  veafSpawn.drawCircle(eventPos, options.name, options.radius, options.drawColor, options.drawFillColor, options.type)
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("eraseDrawing", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
+    return nil, nil, true
+  end
+  veafSpawn.eraseDrawing(options.name)
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("mmFlagOn", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_MM(options.password)) then
+    return nil, nil, true
+  end
+  veafSpawn.missionMasterSetFlag(options.name, 1)
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("mmFlagOff", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_MM(options.password)) then
+    return nil, nil, true
+  end
+  veafSpawn.missionMasterSetFlag(options.name, 0)
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("mmGetFlag", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_MM(options.password)) then
+    return nil, nil, true
+  end
+  veafSpawn.missionMasterGetFlag(options.name)
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("mmRun", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_MM(options.password)) then
+    return nil, nil, true
+  end
+  veafSpawn.missionMasterRun(options.name)
+  return nil, nil, false
+end)
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- initialisation
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 function veafSpawn.initialize()
   veafSpawn.buildRadioMenu()
   veafSpawn.initializeAirUnitTemplates()
-  veafMarkers.registerEventHandler(veafMarkers.MarkerChange, veafSpawn.onEventMarkChange)
+  veafCommands.registerCommandHandler(function(pos, event, bypass, fromMarker, groups, route)
+    local coal = fromMarker and ((event.coalition == 1) and 2 or 1) or event.coalition
+    return veafSpawn.executeCommand(pos, event.text, coal, event.idx, bypass, groups, nil, nil, route, true)
+  end, veafCommands.PRIORITY_SPAWN)
   veafSpawn.dumpSpawnablePlanesList()
 end
 

--- a/src/scripts/veaf/veafSpawnEffects.lua
+++ b/src/scripts/veaf/veafSpawnEffects.lua
@@ -479,3 +479,88 @@ function veafSpawn.teleport(spawnSpot, name, silent)
     end
   end
 end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Effects spawn command handlers
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+veafSpawn.registerCommandHandler("cargo", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local g = veafSpawn.spawnCargo(
+    eventPos,
+    options.radius,
+    options.cargoType,
+    options.country,
+    options.cargoWeightBias,
+    options.cargoSmoke,
+    options.unitName,
+    bypassSecurity,
+    not options.showMFD
+  )
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("logistic", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local g = veafSpawn.spawnLogistic(eventPos, options.radius, options.country, bypassSecurity, not options.showMFD)
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("destroy", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
+    return nil, nil, true
+  end
+  veafSpawn.destroy(eventPos, options.radius, options.unitName)
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("teleport", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
+    return nil, nil, true
+  end
+  veafSpawn.teleport(eventPos, options.name, bypassSecurity)
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("bomb", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L1(options.password, markId)) then
+    return nil, nil, true
+  end
+  veafSpawn.spawnBomb(eventPos, options.radius, options.shells, options.power, options.altitude, options.altitudedelta, options.password)
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("smoke", function(eventPos, options, coalition, markId, bypassSecurity)
+  veafSpawn.spawnSmoke(eventPos, options.smokeColor, options.radius, options.shells)
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("flare", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not options.altitude or options.altitude == 0 then
+    options.altitude = 1000
+  end
+  if not options.power or options.power == 0 then
+    options.power = 500
+  end
+  options.power = options.power * 1000
+  veafSpawn.spawnIlluminationFlare(
+    eventPos,
+    options.radius,
+    options.shells,
+    options.power,
+    options.altitude,
+    options.heading,
+    options.distance,
+    options.speed
+  )
+  return nil, nil, false
+end)
+
+veafSpawn.registerCommandHandler("signal", function(eventPos, options, coalition, markId, bypassSecurity)
+  veafSpawn.spawnSignalFlare(eventPos, options.radius, options.shells, options.smokeColor)
+  return nil, nil, false
+end)

--- a/src/scripts/veaf/veafSpawnGround.lua
+++ b/src/scripts/veaf/veafSpawnGround.lua
@@ -819,3 +819,208 @@ function veafSpawn.cleanupAllConvoys()
     trigger.action.outText("No convoy found", 10)
   end
 end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Ground spawn command handlers
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+veafSpawn.registerCommandHandler("farp", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  if not options.type then
+    options.type = "invisible"
+  end
+  local g = veafSpawn.spawnFarp(
+    eventPos,
+    options.radius,
+    options.name,
+    options.country,
+    options.type,
+    options.side,
+    options.heading,
+    options.spacing,
+    bypassSecurity,
+    not options.showMFD,
+    options.noFarpMarkers,
+    options.tacanCode,
+    options.tacanChannel,
+    options.tacanBand
+  )
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("fob", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local g = veafSpawn.spawnFob(
+    eventPos,
+    options.radius,
+    options.name,
+    options.country,
+    options.type,
+    options.side,
+    options.heading,
+    options.spacing,
+    bypassSecurity,
+    not options.showMFD
+  )
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("group", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local hasDest = options.destination ~= nil
+  local g = veafSpawn.spawnGroup(
+    eventPos,
+    options.radius,
+    options.name,
+    options.czName,
+    options.country,
+    options.altitude,
+    options.heading,
+    options.spacing,
+    options.unitName,
+    bypassSecurity,
+    hasDest,
+    not options.showMFD
+  )
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("infantryGroup", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local g = veafSpawn.spawnInfantryGroup(
+    eventPos,
+    options.radius,
+    options.czName,
+    options.country,
+    options.side,
+    options.heading,
+    options.spacing,
+    options.defense,
+    options.armor,
+    options.size,
+    bypassSecurity,
+    not options.showMFD
+  )
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("armoredPlatoon", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local hasDest = options.destination ~= nil
+  local g = veafSpawn.spawnArmoredPlatoon(
+    eventPos,
+    options.radius,
+    options.czName,
+    options.country,
+    options.side,
+    options.heading,
+    options.spacing,
+    options.defense,
+    options.armor,
+    options.size,
+    bypassSecurity,
+    hasDest,
+    not options.showMFD
+  )
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("airDefenseBattery", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local hasDest = options.destination ~= nil
+  local g = veafSpawn.spawnAirDefenseBattery(
+    eventPos,
+    options.radius,
+    options.czName,
+    options.country,
+    options.side,
+    options.heading,
+    options.spacing,
+    options.defense,
+    bypassSecurity,
+    hasDest,
+    not options.showMFD
+  )
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("transportCompany", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local hasDest = options.destination ~= nil
+  local g = veafSpawn.spawnTransportCompany(
+    eventPos,
+    options.radius,
+    options.czName,
+    options.country,
+    options.side,
+    options.heading,
+    options.spacing,
+    options.defense,
+    options.size,
+    bypassSecurity,
+    hasDest,
+    not options.showMFD
+  )
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("fullCombatGroup", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local g = veafSpawn.spawnFullCombatGroup(
+    eventPos,
+    options.radius,
+    options.czName,
+    options.country,
+    options.side,
+    options.heading,
+    options.spacing,
+    options.defense,
+    options.armor,
+    options.size,
+    bypassSecurity,
+    not options.showMFD
+  )
+  return g, nil, false
+end)
+
+veafSpawn.registerCommandHandler("convoy", function(eventPos, options, coalition, markId, bypassSecurity)
+  if not (bypassSecurity or veafSecurity.checkSecurity_L9(options.password, markId)) then
+    return nil, nil, true
+  end
+  local g = veafSpawn.spawnConvoy(
+    eventPos,
+    options.name,
+    options.czName,
+    options.radius,
+    options.country,
+    options.side,
+    options.heading,
+    options.spacing,
+    options.speed,
+    options.patrol,
+    options.offroad,
+    options.destination,
+    options.defense,
+    options.size,
+    options.armor,
+    bypassSecurity,
+    not options.showMFD
+  )
+  return g, true, false
+end)

--- a/src/scripts/veaf/veafSpawnParser.lua
+++ b/src/scripts/veaf/veafSpawnParser.lua
@@ -1,0 +1,631 @@
+------------------------------------------------------------------
+-- VEAF spawn text parser for DCS World
+-- Extracted from veafSpawnCore.lua — parse spawn command text into options tables.
+--
+-- See the documentation : https://veaf.github.io/documentation/
+------------------------------------------------------------------
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Analyse the mark text and extract keywords.
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+function veafSpawn.convertLaserToFreq(laser)
+  veaf.loggers.get(veafSpawn.Id):trace(string.format("convertLaserToFreq(laser=%s)", tostring(laser)))
+  local laser = tonumber(laser)
+  if laser and laser >= 1111 and laser <= 1688 then
+    local laserB = math.floor((laser - 1000) / 100)
+    local laserCD = laser - 1000 - laserB * 100
+    local frequency = tostring(30 + laserB + laserCD * 0.05)
+    veaf.loggers.get(veafSpawn.Id):trace(string.format("laserB=%s", tostring(laserB)))
+    veaf.loggers.get(veafSpawn.Id):trace(string.format("laserCD=%s", tostring(laserCD)))
+    veaf.loggers.get(veafSpawn.Id):trace(string.format("frequency=%s", tostring(frequency)))
+    return frequency
+  else
+    return nil
+  end
+end
+
+--- Extract keywords from mark text.
+function veafSpawn.markTextAnalysis(text)
+  veaf.loggers.get(veafSpawn.Id):trace(string.format("veafSpawn.markTextAnalysis(text=%s)", text))
+
+  -- Option parameters extracted from the mark text.
+  local options = {}
+  options.czName = nil -- name of the CZ to add to the group name, if any
+  options.unit = false
+  options.forceStatic = false -- if true, will force the spawned unit to be a static
+  options.group = false
+  options.cap = false
+  options.farp = false
+  options.noFarpMarkers = false
+  options.fob = false
+  options.type = nil
+  options.cargo = false
+  options.logistic = false
+  options.smoke = false
+  options.flare = false
+  options.signal = false
+  options.bomb = false
+  options.destroy = false
+  options.teleport = false
+  options.convoy = false
+  options.role = nil
+  options.laserCode = 1688
+  options.infantryGroup = false
+  options.armoredPlatoon = false
+  options.airDefenseBattery = false
+  options.transportCompany = false
+  options.fullCombatGroup = false
+  options.speed = nil
+  options.capradius = nil
+  options.shells = 1
+  options.multiplier = 1
+  options.skynet = false -- if true, add to skynet
+  options.forceEwr = false -- if true, unit will be added as an IADS EWR
+  options.pointDefense = false -- if true, unit will be added as point defense to the closest IADS SAM site
+  options.AlarmState = 2 -- Alarm state of the convoy to be spawned, 0 is AUTO, 1 is GREEN, 2 is RED. Note: This option is useful for some vehicules which behave badly in Alarm State RED when spawned such as the Scud or Sa-11 (they deploy and can't drive anywhere). Auto is better suited
+  options.disperse = 15 --disperse time of groups if under attack, by default is set to 20s
+  options.showMFD = false --option to enable groups to be seen on MFDs
+  options.addDrawing = false -- draw a polygon on the map
+  options.drawSquare = false -- draw a square on the map
+  options.drawCircle = false -- draw a circle on the map
+  options.eraseDrawing = false -- erase a polygon from the map
+  options.stopDrawing = false -- close a polygon started on the map
+
+  options.drawColor = nil
+  options.drawFillColor = nil
+  options.drawArrow = nil
+
+  -- spawned group/unit type/alias
+  options.name = ""
+
+  -- spawned unit name
+  options.unitName = nil
+
+  -- spawned group units spacing
+  options.spacing = 5
+
+  options.country = nil
+  options.side = nil
+  options.altitude = 0
+  options.altitudedelta = 0
+  options.heading = 0
+  options.distance = nil
+  options.skill = nil
+
+  -- if true, group is part of a road convoy
+  options.isConvoy = false
+
+  -- if true, group is patroling between its spawn point and its destination named point
+  options.patrol = false
+
+  -- if true, group is set to not follow roads
+  options.offroad = false
+
+  -- if set and convoy is true, send the group to the named point
+  options.destination = nil
+
+  -- the size of the generated dynamic groups (platoons, convoys, etc.)
+  options.size = math.random(7) + 8
+
+  -- defenses force ; ranges from 1 to 5, 5 being the toughest.
+  options.defense = math.random(5)
+
+  -- armor force ; ranges from 1 to 5, 5 being the strongest and most modern.
+  options.armor = math.random(5)
+
+  -- bomb power
+  options.power = 100
+
+  -- smoke color
+  options.smokeColor = trigger.smokeColor.RED
+
+  -- optional cargo smoke
+  options.cargoSmoke = false
+
+  -- cargo type
+  options.cargoType = "container_cargo"
+  options.cargoWeightBias = 2 --weight bias of the cargo, if equal to 0, cargo will be very close to minimum weight, if equal to 5, cargo will be close to maximum
+
+  options.password = nil
+
+  --AFAC spawn option
+  options.afac = false
+  options.immortal = false
+
+  -- JTAC radio comms
+  options.freq = veafSpawn.convertLaserToFreq(options.laserCode)
+  options.mod = "fm"
+
+  -- TACAN name and channel
+  options.tacanChannel = nil
+  options.tacanBand = nil
+
+  -- repeat options
+  options.repeatCount = nil
+  options.repeatDelay = nil
+
+  -- delayed start option
+  options.delayedStart = 0
+
+  -- Check for correct keywords.
+  if text:lower():find(veafSpawn.SpawnKeyphrase .. " unit") then
+    options.unit = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " afac") then
+    options.afac = true
+    --default country for the AFAC
+    options.country = "USA"
+    --default AFAC spawned
+    options.name = "mq-9"
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " cap") then
+    options.cap = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " group") then
+    options.group = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " farp") then
+    options.farp = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " fob") then
+    options.fob = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " convoy") then
+    options.convoy = true
+    options.size = 10 -- default the size parameter to 10
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " infantrygroup") then
+    options.infantryGroup = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " armorgroup") then
+    options.armoredPlatoon = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " samgroup") then
+    options.airDefenseBattery = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " transportgroup") then
+    options.transportCompany = true
+    options.size = math.random(2, 5)
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " combatgroup") then
+    options.fullCombatGroup = true
+    options.size = 1 -- default the size parameter to 1
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " smoke") then
+    options.smoke = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " flare") then
+    options.flare = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " signal") then
+    options.signal = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " cargo") then
+    options.cargo = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " logistic") then
+    options.logistic = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " bomb") then
+    options.bomb = true
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " jtac") then
+    options.role = "jtac"
+    options.unit = true
+    -- default country for friendly JTAC: USA
+    options.country = "USA"
+    -- default name for JTAC
+    options.name = "LUV HMMWV Jeep"
+    -- default JTAC name (will overwrite previous unit with same name)
+    options.unitName = "JTAC1"
+  elseif text:lower():find(veafSpawn.SpawnKeyphrase .. " tacan") then
+    options.role = "tacan"
+    options.unit = true
+    -- default country for friendly tacan: USA
+    options.country = "USA"
+    -- default name for tacan
+    options.name = "TACAN_beacon"
+    -- default name (will overwrite previous unit with same name)
+    options.unitName = "TACAN TCN"
+  elseif text:lower():find(veafSpawn.DestroyKeyphrase) then
+    options.destroy = true
+  elseif text:lower():find(veafSpawn.TeleportKeyphrase) then
+    options.teleport = true
+  elseif text:lower():find(veafSpawn.DrawingKeyphrase .. " add") then
+    options.addDrawing = true
+  elseif text:lower():find(veafSpawn.DrawingKeyphrase .. " erase") then
+    options.eraseDrawing = true
+  elseif text:lower():find(veafSpawn.DrawingKeyphrase .. " square") then
+    options.drawSquare = true
+  elseif text:lower():find(veafSpawn.DrawingKeyphrase .. " circle") then
+    options.drawCircle = true
+  elseif text:lower():find(veafSpawn.MissionMasterKeyphrase .. " flagon") then
+    options.mmFlagOn = true
+  elseif text:lower():find(veafSpawn.MissionMasterKeyphrase .. " flagoff") then
+    options.mmFlagOff = true
+  elseif text:lower():find(veafSpawn.MissionMasterKeyphrase .. " getflag") then
+    options.mmGetFlag = true
+  elseif text:lower():find(veafSpawn.MissionMasterKeyphrase .. " run") then
+    options.mmRun = true
+  else
+    return nil
+  end
+
+  -- keywords are split by ","
+  local keywords = veaf.split(text, ",")
+
+  for _, keyphrase in pairs(keywords) do
+    -- Split keyphrase by space. First one is the key and second, ... the parameter(s) until the next comma.
+    local str = veaf.breakString(veaf.trim(keyphrase), " ")
+    local key = str[1]
+    local val = str[2] or ""
+
+    if key:lower() == "unitname" then
+      -- Set name.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword unitname = %s", tostring(val)))
+      options.unitName = val
+    end
+
+    if key:lower() == "name" then
+      -- Set name.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword name = %s", tostring(val)))
+      options.name = val
+    end
+
+    if key:lower() == "czname" then
+      -- Set name.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword czname = %s", tostring(val)))
+      options.czName = val
+    end
+
+    if key:lower() == "destination" or key:lower() == "dest" then
+      -- Set destination.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword destination = %s", tostring(val)))
+      options.destination = val
+      options.AlarmState = 0 --since some units will not move when they are told to have an alarm state red, it's best to by default leave it on auto. AI is pretty all knowing anyways, it knows when it should go to red state
+      options.spacing = 1 --compress the convoy to not make it extremely long at departure
+      options.radius = 1 --convoy spawns on the marker exactly to not have them spawn in trees etc.
+    end
+
+    if key:lower() == "isconvoy" then
+      veaf.loggers.get(veafSpawn.Id):trace("Keyword isconvoy found")
+      options.convoy = true
+    end
+
+    if key:lower() == "patrol" then
+      veaf.loggers.get(veafSpawn.Id):trace("Keyword patrol found")
+      options.patrol = true
+    end
+
+    if key:lower() == "offroad" then
+      veaf.loggers.get(veafSpawn.Id):trace("Keyword offroad found")
+      options.offroad = true
+    end
+
+    if key:lower() == "skynet" then
+      -- Retreive the name of the IADS you wish to add the spawned group to
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword skynet = %s", tostring(val)))
+      options.skynet = val:lower()
+      if options.skynet == "" or options.skynet == "true" then
+        options.skynet = true
+      elseif options.skynet == "false" then
+        options.skynet = false
+      end
+    end
+
+    if key:lower() == "ewr" then
+      -- Set force IADS EWR toggle for unit spawn
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword ewr found"))
+      options.forceEwr = true
+    end
+
+    if key:lower() == "pointdefense" then
+      -- Tells IADS to add the spawned SAM to the point defenses of the specified site or to the nearest site
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword pointdefense found"))
+      options.pointDefense = true
+      if val ~= "" then
+        veaf.loggers.get(veafSpawn.Id):trace(string.format("groupName specified : %s", tostring(val)))
+        options.pointDefense = tostring(val)
+      end
+    end
+
+    --to be placed after the skynet input, SAMs in the skynet network work better if set to AlarmState RED, so AlarmState is equal to 2 if skynet is enabled
+    if key:lower() == "alarm" then
+      -- Set Alarm State of the unit to be spawned
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword alarm = %s", tostring(val)))
+      if (val == "0" or val == "2" or val == "1") and not options.skynet then
+        options.AlarmState = tonumber(val)
+      end
+    end
+
+    if key:lower() == "radius" then
+      -- Set name.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword radius = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.radius = nVal
+    end
+
+    if key:lower() == "spacing" then
+      -- Set spacing.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword spacing = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.spacing = nVal
+    end
+
+    if key:lower() == "multiplier" then
+      -- Set multiplier.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword multiplier = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.multiplier = nVal
+    end
+
+    if key:lower() == "alt" then
+      -- Set altitude.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword alt = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.altitude = nVal
+    end
+
+    if key:lower() == "altdelta" then
+      -- Set altitude delta.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword altdelta = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.altitudedelta = nVal
+    end
+
+    if key:lower() == "speed" then
+      -- Set speed.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword speed = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.speed = nVal
+    end
+
+    if key:lower() == "capradius" then
+      -- Set capradius.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword capradius = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.capradius = nVal
+    end
+
+    if key:lower() == "shells" then
+      -- Set altitude.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword shells = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.shells = nVal
+    end
+
+    if key:lower() == "hdg" then
+      -- Set heading.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword hdg = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.heading = nVal
+    end
+
+    if key:lower() == "heading" then
+      -- Set heading.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword heading = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.heading = nVal
+    end
+
+    if key:lower() == "country" then
+      -- Set country
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword country = %s", tostring(val)))
+      options.country = val:upper()
+    end
+
+    if key:lower() == "side" then
+      -- Set side
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword side = %s", tostring(val)))
+      if val:upper() == "BLUE" then
+        options.side = veafCasMission.SIDE_BLUE
+      else
+        options.side = veafCasMission.SIDE_RED
+      end
+    end
+
+    if key:lower() == "password" then
+      -- Unlock the command
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword password", tostring(val)))
+      options.password = val
+    end
+
+    if key:lower() == "power" then
+      -- Set bomb power.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword power = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.power = nVal
+    end
+
+    if key:lower() == "laser" then
+      -- Set laser code.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("laser code = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.freq = veafSpawn.convertLaserToFreq(nVal)
+      options.laserCode = nVal
+    end
+
+    if key:lower() == "freq" then
+      -- Set JTAC/AFAC frequency.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("freq = %s", tostring(val)))
+      options.freq = val
+    end
+
+    if key:lower() == "mod" then
+      -- Set JTAC/AFAC modulation.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("mod = %s", tostring(val)))
+      options.mod = val
+    end
+
+    if key:lower() == "band" then
+      -- Set TACAN band
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("band = %s", tostring(val)))
+      options.tacanBand = val
+    end
+
+    if key:lower() == "code" then
+      -- Set TACAN code
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("code = %s", tostring(val)))
+      options.tacanCode = val
+    end
+
+    if key:lower() == "channel" then
+      -- Set TACAN channel.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("channel = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.tacanChannel = nVal
+    end
+
+    if key:lower() == "arrow" then
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword arrow = %s", tostring(val)))
+      options.drawArrow = true
+    end
+    if key:lower() == "fill" then
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword fill = %s", tostring(val)))
+      options.drawFillColor = val
+    end
+
+    if key:lower() == "color" then
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword color = %s", tostring(val)))
+      options.drawColor = val
+      -- Set smoke color.
+      if val:lower() == "red" then
+        options.smokeColor = trigger.smokeColor.RED
+      elseif val:lower() == "green" then
+        options.smokeColor = trigger.smokeColor.GREEN
+      elseif val:lower() == "orange" then
+        options.smokeColor = trigger.smokeColor.ORANGE
+      elseif val:lower() == "blue" then
+        options.smokeColor = trigger.smokeColor.BLUE
+      elseif val:lower() == "white" then
+        options.smokeColor = trigger.smokeColor.WHITE
+      end
+    end
+
+    if key:lower() == "skill" then
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword skill = %s", tostring(val)))
+      options.skill = val
+    end
+
+    if key:lower() == "dist" or key:lower() == "distance" then
+      -- Set distance.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword distance = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.distance = nVal
+    end
+
+    if options.cargo and key:lower() == "name" then
+      -- Set cargo type.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword name = %s", tostring(val)))
+      options.cargoType = val
+    end
+
+    if options.cargo and key:lower() == "weight" then
+      -- Set cargo type.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword weight = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      if nVal >= 0 and nVal <= veafSpawn.cargoWeightBiasRange then
+        options.cargoWeightBias = nVal
+      elseif nVal > veafSpawn.cargoWeightBiasRange then
+        options.cargoWeightBias = veafSpawn.cargoWeightBiasRange
+      elseif nVal < 0 then
+        options.cargoWeightBias = 0
+      end
+    end
+
+    if key:lower() == "type" then
+      -- Set farp type.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword type = %s", tostring(val)))
+      options.type = val
+    end
+
+    if options.farp and key:lower() == "nofarpmarkers" then
+      -- Skip the invisible FARP special vehicles that mark the position of the FARP
+      veaf.loggers.get(veafSpawn.Id):trace("Keyword noFarpMarkers is set")
+      options.noFarpMarkers = true
+    end
+
+    if options.cargo and key:lower() == "smoke" then
+      -- Mark with green smoke.
+      veaf.loggers.get(veafSpawn.Id):trace("Keyword smoke is set")
+      options.cargoSmoke = true
+    end
+
+    if key:lower() == "size" then
+      -- Set size.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword size = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.size = nVal
+    end
+
+    if key:lower() == "defense" then
+      -- Set defense.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword defense = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      if nVal >= 0 then
+        options.defense = nVal
+      end
+    end
+
+    if key:lower() == "armor" then
+      -- Set armor.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword armor = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      if nVal >= 0 then
+        options.armor = nVal
+      end
+    end
+
+    if key:lower() == "repeat" then
+      -- Set repeat count.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword repeat = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.repeatCount = nVal
+    end
+
+    if key:lower() == "delay" then
+      -- Set delay.
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword delay = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      options.repeatDelay = nVal
+    end
+
+    if key:lower() == "static" then
+      -- Set static unit spawn toggle
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword static found"))
+      options.forceStatic = true
+    end
+
+    if key:lower() == "immortal" then
+      -- Set spawned unit to invisible and immortal
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword immortal found"))
+      options.immortal = true
+    end
+
+    if key:lower() == "delayed" then
+      -- Set delayed start on first spawn occurence
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword delayed = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      if nVal >= 0 then
+        options.delayedStart = nVal
+      else
+        options.delayedStart = veafSpawn.MIN_REPEAT_DELAY
+      end
+    end
+
+    if key:lower() == "showmfd" then
+      -- Set hiddenOnMFD option or not
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword showmfd found"))
+      options.showMFD = true
+    end
+
+    if key:lower() == "disperse" then
+      -- Set hiddenOnMFD option or not
+      veaf.loggers.get(veafSpawn.Id):trace(string.format("Keyword disperse = %s", tostring(val)))
+      local nVal = veaf.getRandomizableNumeric(val)
+      if nVal >= 0 then
+        options.disperse = nVal
+      end
+    end
+  end
+
+  -- check mandatory parameter "name" for command "group"
+  if options.group and not options.name then
+    return nil
+  end
+
+  -- check mandatory parameter "name" for command "unit"
+  if options.unit and not options.name then
+    return nil
+  end
+
+  -- check mandatory parameter "name" for all mission master commands
+  if (options.mmFlagOff or options.mmFlagOn or options.mmRun) and not options.name then
+    return nil
+  end
+
+  return options
+end

--- a/src/scripts/veaf/veafSpawnParser.lua
+++ b/src/scripts/veaf/veafSpawnParser.lua
@@ -613,17 +613,17 @@ function veafSpawn.markTextAnalysis(text)
   end
 
   -- check mandatory parameter "name" for command "group"
-  if options.group and not options.name then
+  if options.group and (not options.name or options.name == "") then
     return nil
   end
 
   -- check mandatory parameter "name" for command "unit"
-  if options.unit and not options.name then
+  if options.unit and (not options.name or options.name == "") then
     return nil
   end
 
   -- check mandatory parameter "name" for all mission master commands
-  if (options.mmFlagOff or options.mmFlagOn or options.mmRun) and not options.name then
+  if (options.mmFlagOff or options.mmFlagOn or options.mmRun) and (not options.name or options.name == "") then
     return nil
   end
 

--- a/src/scripts/veaf/veafWeather.lua
+++ b/src/scripts/veaf/veafWeather.lua
@@ -1781,8 +1781,10 @@ end
 function veafWeather.initialize()
   veaf.loggers.get(veafWeather.Id):debug("veafWeather.initialize()")
   veafWeather.buildRadioMenu()
-  -- TODO veafMarkers.registerEventHandler(veafMarkers.MarkerChange, veafWeather.onEventMarkChange)
   veafAirbases.initialize()
+  veafRemote.registerRemoteModule("atis", veafWeather.executeCommandFromRemote)
+  veafRemote.registerRemoteModule("atc", veafWeather.executeCommandFromRemote)
+  veafRemote.registerRemoteModule("weather", veafWeather.executeCommandFromRemote)
 end
 
 veaf.loggers.get(veafWeather.Id):info(veaf.loggers.get(veafWeather.Id):getVersionInfo(veafWeather.Version))

--- a/test/lua/test_veafCommands.lua
+++ b/test/lua/test_veafCommands.lua
@@ -1,0 +1,123 @@
+--- Unit tests for veafCommands.lua — registry ordering and dispatch behaviour.
+---
+--- Run:  lua test/lua/test_veafCommands.lua
+---
+--- Covers:
+---   - registerCommandHandler inserts entries in ascending priority order
+---   - execute() stops at the first handler returning true
+---   - execute() tries all handlers when none matches
+---   - fromMarker flag is false on the execute() path
+---   - bypassSecurity is true on the execute() path
+
+-- ---------------------------------------------------------------------------
+-- Bootstrap
+-- ---------------------------------------------------------------------------
+local _base = debug.getinfo(1, "S").source:match("^@(.+)[\\/]") or "."
+luaunit = dofile(_base .. "/luaunit.lua")
+dofile(_base .. "/dcs_mocks.lua")
+local src = _base .. "/../../src/scripts/veaf"
+dofile(src .. "/veaf.lua")
+dofile(src .. "/veafMarkers.lua")
+dofile(src .. "/veafCommands.lua")
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+local function resetHandlers()
+  veafCommands.commandHandlers = {}
+end
+
+local function makeHandler(retval, collector)
+  return function(pos, event, bypass, fromMarker, groups, route)
+    if collector then
+      table.insert(collector, { bypass = bypass, fromMarker = fromMarker })
+    end
+    return retval
+  end
+end
+
+local pos = { x = 0, y = 0, z = 0 }
+
+-- ---------------------------------------------------------------------------
+-- TestVeafCommandsRegistry — priority ordering
+-- ---------------------------------------------------------------------------
+TestVeafCommandsRegistry = {}
+
+function TestVeafCommandsRegistry:setUp()
+  resetHandlers()
+end
+
+function TestVeafCommandsRegistry:test_single_handler_registered()
+  local fn = makeHandler(false)
+  veafCommands.registerCommandHandler(fn, 10)
+  luaunit.assertEquals(#veafCommands.commandHandlers, 1)
+  luaunit.assertEquals(veafCommands.commandHandlers[1].priority, 10)
+end
+
+function TestVeafCommandsRegistry:test_handlers_sorted_ascending()
+  veafCommands.registerCommandHandler(makeHandler(false), 30)
+  veafCommands.registerCommandHandler(makeHandler(false), 10)
+  veafCommands.registerCommandHandler(makeHandler(false), 20)
+  luaunit.assertEquals(veafCommands.commandHandlers[1].priority, 10)
+  luaunit.assertEquals(veafCommands.commandHandlers[2].priority, 20)
+  luaunit.assertEquals(veafCommands.commandHandlers[3].priority, 30)
+end
+
+function TestVeafCommandsRegistry:test_equal_priority_preserves_insertion_order()
+  local calls = {}
+  local fn1 = function() table.insert(calls, 1) return false end
+  local fn2 = function() table.insert(calls, 2) return false end
+  veafCommands.registerCommandHandler(fn1, 20)
+  veafCommands.registerCommandHandler(fn2, 20)
+  veafCommands.execute(pos, "ignored", 2, nil, nil)
+  luaunit.assertEquals(calls, { 1, 2 })
+end
+
+-- ---------------------------------------------------------------------------
+-- TestVeafCommandsDispatch — execute() behaviour
+-- ---------------------------------------------------------------------------
+TestVeafCommandsDispatch = {}
+
+function TestVeafCommandsDispatch:setUp()
+  resetHandlers()
+end
+
+function TestVeafCommandsDispatch:test_stops_at_first_true()
+  local calls = {}
+  veafCommands.registerCommandHandler(function() table.insert(calls, 1) return true end, 10)
+  veafCommands.registerCommandHandler(function() table.insert(calls, 2) return true end, 20)
+  local result = veafCommands.execute(pos, "cmd", 2, nil, nil)
+  luaunit.assertTrue(result)
+  luaunit.assertEquals(calls, { 1 })
+end
+
+function TestVeafCommandsDispatch:test_tries_all_when_none_matches()
+  local calls = {}
+  veafCommands.registerCommandHandler(function() table.insert(calls, 1) return false end, 10)
+  veafCommands.registerCommandHandler(function() table.insert(calls, 2) return false end, 20)
+  local result = veafCommands.execute(pos, "cmd", 2, nil, nil)
+  luaunit.assertFalse(result)
+  luaunit.assertEquals(calls, { 1, 2 })
+end
+
+function TestVeafCommandsDispatch:test_execute_sets_fromMarker_false()
+  local captured = {}
+  veafCommands.registerCommandHandler(makeHandler(true, captured), 10)
+  veafCommands.execute(pos, "cmd", 2, nil, nil)
+  luaunit.assertFalse(captured[1].fromMarker)
+end
+
+function TestVeafCommandsDispatch:test_execute_sets_bypassSecurity_true()
+  local captured = {}
+  veafCommands.registerCommandHandler(makeHandler(true, captured), 10)
+  veafCommands.execute(pos, "cmd", 2, nil, nil)
+  luaunit.assertTrue(captured[1].bypass)
+end
+
+function TestVeafCommandsDispatch:test_no_handlers_returns_false()
+  local result = veafCommands.execute(pos, "anything", 2, nil, nil)
+  luaunit.assertFalse(result)
+end
+
+-- ---------------------------------------------------------------------------
+os.exit(luaunit.LuaUnit.run())

--- a/test/lua/test_veafSpawn.lua
+++ b/test/lua/test_veafSpawn.lua
@@ -152,19 +152,31 @@ function TestVeafSpawnMarkTextAnalysis:test_spawn_alone_returns_nil()
   luaunit.assertNil(r)
 end
 
-function TestVeafSpawnMarkTextAnalysis:test_spawn_unit_returns_table()
+function TestVeafSpawnMarkTextAnalysis:test_spawn_unit_returns_nil_without_name()
+  -- "unit" requires a "name" parameter — empty name must be rejected
   local r = veafSpawn.markTextAnalysis("_spawn unit")
+  luaunit.assertNil(r)
+end
+
+function TestVeafSpawnMarkTextAnalysis:test_spawn_unit_returns_table_with_name()
+  local r = veafSpawn.markTextAnalysis("_spawn unit, name F-16C")
   luaunit.assertIsTable(r)
 end
 
 function TestVeafSpawnMarkTextAnalysis:test_spawn_unit_sets_flag()
-  local r = veafSpawn.markTextAnalysis("_spawn unit")
+  local r = veafSpawn.markTextAnalysis("_spawn unit, name F-16C")
   luaunit.assertNotNil(r)
   luaunit.assertTrue(r.unit)
 end
 
-function TestVeafSpawnMarkTextAnalysis:test_spawn_group_sets_flag()
+function TestVeafSpawnMarkTextAnalysis:test_spawn_group_returns_nil_without_name()
+  -- "group" requires a "name" parameter — empty name must be rejected
   local r = veafSpawn.markTextAnalysis("_spawn group")
+  luaunit.assertNil(r)
+end
+
+function TestVeafSpawnMarkTextAnalysis:test_spawn_group_sets_flag()
+  local r = veafSpawn.markTextAnalysis("_spawn group, name MyGroup")
   luaunit.assertNotNil(r)
   luaunit.assertTrue(r.group)
 end


### PR DESCRIPTION
## Summary

- **ARCH-001** — New `veafCommands.lua`: single F10-marker event handler + priority-ordered text-command registry. `veafInterpreter.execute()` delegates to it. 8 modules self-register via `veafCommands.registerCommandHandler()` in their `initialize()`; `onEventMarkChange` functions removed. A `fromMarker` flag disambiguates marker vs interpreter context (coalition inversion, veafNamedPoints coalition=-1 legacy behaviour preserved).
- **ARCH-002** — `veafRemote.registerRemoteModule()` registry: `executeCommandFromRemote()` replaces its 7-branch string-switch with a registry lookup. 7 modules register their handler in `initialize()`.
- **ARCH-003 + ARCH-004** — Extract `veafSpawnParser.lua`: `convertLaserToFreq` + `markTextAnalysis` (~630 lines) moved out of `veafSpawnCore.lua`; `veafSpawn.lua` loads Parser after Core.
- **ARCH-005** — `veafSpawn.registerCommandHandler()` registry: `executeCommand()` 25-branch if/elseif replaced by a handler dispatch loop. Handlers split by sub-module (Core: drawing + mission-master; Ground: 9 keys; Aircraft: unit/afac/cap; Effects: 8 keys). `veafSpawnCore.lua` goes from 1834 → ~900 lines.

## Test plan

- [x] Lua test suite: 31 suites, 0 failures (`lua test/lua/test_*.lua`)
- [x] StyLua auto-format applied to all modified files
- [ ] luacheck (CI will enforce — not locally installed)
- [ ] F10 marker dispatch: `_spawn`, `_shortcut`, `_point`, `_cas`, `_move`, `_remote` — verify each module responds and mark is removed on match
- [ ] Interpreter path: unit named `#veafInterpreter["_spawn unit, ..."]` — verify command executes at mission start
- [ ] Remote hook: `veafRemote.executeCommandFromRemote(user, level, unit, "air", cmd)` — verify registry dispatch works for all 7 modules
- [ ] Spawn sub-commands: `_spawn farp`, `_spawn unit`, `_spawn cargo`, `_spawn smoke`, `_drawing add`, `_mm flagon` — verify handler dispatch
- [ ] Deploy on a test mission and run ARCH-005 verification checklist

## Summary by Sourcery

Centralize text command dispatch and spawn parsing into shared registries to simplify handler wiring across VEAF modules and veafInterpreter.

New Features:
- Introduce a veafCommands module that provides a priority-ordered registry for text command handlers used by marker events and the interpreter.
- Add a veafSpawn command handler registry that lets sub-modules register spawn sub-commands instead of using a large conditional chain.
- Extract veafSpawn text parsing logic into a dedicated veafSpawnParser module to make spawn command parsing reusable and testable.

Enhancements:
- Refactor veafInterpreter to delegate command execution to the centralized veafCommands dispatcher rather than directly chaining module calls.
- Update multiple VEAF modules (spawn, shortcuts, named points, CAS, security, move, radio, remote) to self-register their handlers with veafCommands instead of defining their own marker change callbacks.
- Replace veafRemote.executeCommandFromRemote string-switch logic with a registry-based dispatch using veafRemote.registerRemoteModule, and register all participating modules.
- Register spawn-related command handlers in the appropriate veafSpawn sub-modules (core, ground, aircraft, effects) to reduce veafSpawnCore size and improve separation of concerns.
- Adjust luacheck configuration and backlog documentation to account for the new veafCommands and spawn architecture.