### PR TITLE
refactor(lua): LUAR-002 — explicit FSM for AirWaveZone

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -107,7 +107,7 @@ Chaque ticket est indépendant mais risqué — à traiter un par un avec tests 
 | # | Ticket | File(s) | Type | Effort | Status |
 |---|--------|---------|------|--------|--------|
 | LUAR-001 | Scinder `veafSpawn.lua` (3200+ lignes) en 4 modules thématiques — `veafSpawn.lua` devient un proxy de backward compatibility | `veafSpawn*.lua` | feat | 240 min | ✅ |
-| LUAR-002 | Machine d'état explicite (FSM) pour `AirWaveZone` | `veafAirWaves.lua` | feat | 120 min | ⬜ |
+| LUAR-002 | Machine d'état explicite (FSM) pour `AirWaveZone` | `veafAirWaves.lua` | feat | 120 min | ✅ |
 | LUAR-003 | Scinder `VeafQRA` (1200+ lignes) en `VeafQRACore` + `VeafQRALogistics` | `veafQraManager.lua` | feat | 150 min | ⬜ |
 | LUAR-004 | `RadioMenuBuilder` — abstraction de la construction des menus dans veafRadio | `veafRadio.lua` | feat | 90 min | ✅ |
 

--- a/doc/mission-maker/scripts/veafAirWaves.fr.md
+++ b/doc/mission-maker/scripts/veafAirWaves.fr.md
@@ -1,6 +1,6 @@
 # veafAirWaves — Attaques aériennes par vagues
 
-**Module ID:** `AIRWAVES` | **Version:** 1.7.x | **Fichier:** `veafAirWaves.lua`
+**Module ID:** `AIRWAVES` | **Version:** 1.8.x | **Fichier:** `veafAirWaves.lua`
 
 ---
 
@@ -90,6 +90,44 @@ AirWaveZone:new()
   end)
   :initialize()
 ```
+
+---
+
+## Cycle de vie de la zone (machine d'états)
+
+Chaque `AirWaveZone` progresse à travers un ensemble d'états nommés. Les connaître aide à lire les logs ou à écrire des callbacks.
+
+```
+STOP ──start()──► READY
+                    │  joueur(s) entrent dans la zone
+                    ▼
+         WAITING_FOR_MORE_HUMANS
+                    │  délai d'activation écoulé
+                    ▼
+              ┌── NEXTWAVE ──┐
+              │               │
+         dernière vague   autres vagues
+              │               │
+              ▼               ▼
+            OVER    WAITING_FOR_NEXTWAVE
+                            │  délai entre vagues écoulé
+                            ▼
+                          ACTIVE
+                            │  vague détruite
+                            └──► NEXTWAVE  (boucle jusqu'à OVER)
+```
+
+| État | Signification |
+|------|---------------|
+| `STOP` | Zone inactive — `stop()` a été appelé ou la zone n'a jamais démarré. |
+| `READY` | Zone démarrée, en attente de joueurs. |
+| `WAITING_FOR_MORE_HUMANS` | Au moins un joueur est dans la zone ; le minuteur d'activation tourne. |
+| `NEXTWAVE` | État de routage transitoire : décide immédiatement entre `OVER` et `WAITING_FOR_NEXTWAVE`. |
+| `WAITING_FOR_NEXTWAVE` | Prochain slot de vague disponible ; le délai entre vagues décompte. |
+| `ACTIVE` | La vague courante est spawnée et vivante. |
+| `OVER` | Toutes les vagues ont été détruites — la zone est terminée. |
+
+`NEXTWAVE` est un état transitoire que la zone traverse en un seul cycle de `check()` : elle n'y reste jamais. Les callbacks comme `setOnWaveDestroyed` se déclenchent à la sortie de `ACTIVE → NEXTWAVE`, et `setOnCompleted` à l'entrée de `NEXTWAVE → OVER`.
 
 ---
 

--- a/doc/mission-maker/scripts/veafAirWaves.md
+++ b/doc/mission-maker/scripts/veafAirWaves.md
@@ -1,7 +1,7 @@
 # veafAirWaves — Wave-Based Air Attacks
 
 
-**Module ID:** `AIRWAVES` | **Version:** 1.7.x | **File:** `veafAirWaves.lua`
+**Module ID:** `AIRWAVES` | **Version:** 1.8.x | **File:** `veafAirWaves.lua`
 
 ---
 
@@ -91,6 +91,44 @@ AirWaveZone:new()
   end)
   :initialize()
 ```
+
+---
+
+## Zone lifecycle (state machine)
+
+Each `AirWaveZone` progresses through a set of named states. Understanding them helps when reading logs or writing callbacks.
+
+```
+STOP ──start()──► READY
+                    │  player(s) enter zone
+                    ▼
+         WAITING_FOR_MORE_HUMANS
+                    │  activation delay elapsed
+                    ▼
+              ┌── NEXTWAVE ──┐
+              │               │
+         last wave        more waves
+              │               │
+              ▼               ▼
+            OVER    WAITING_FOR_NEXTWAVE
+                            │  inter-wave delay elapsed
+                            ▼
+                          ACTIVE
+                            │  wave destroyed
+                            └──► NEXTWAVE  (loops until OVER)
+```
+
+| State | Meaning |
+|-------|---------|
+| `STOP` | Zone inactive — `stop()` was called or the zone has never been started. |
+| `READY` | Zone started, watching for players to enter. |
+| `WAITING_FOR_MORE_HUMANS` | At least one player is in the zone; the activation timer is running. |
+| `NEXTWAVE` | Transient routing state: immediately decides between `OVER` and `WAITING_FOR_NEXTWAVE`. |
+| `WAITING_FOR_NEXTWAVE` | Wave slot available; the inter-wave delay is counting down. |
+| `ACTIVE` | Current wave is spawned and alive. |
+| `OVER` | All waves have been destroyed — the zone is finished. |
+
+`NEXTWAVE` is a transient state that the zone crosses in a single `check()` cycle: it never lingers there. Callbacks such as `setOnWaveDestroyed` fire on the `ACTIVE → NEXTWAVE` exit, and `setOnCompleted` fires on the `NEXTWAVE → OVER` entry.
 
 ---
 

--- a/src/scripts/veaf/veafAirWaves.lua
+++ b/src/scripts/veaf/veafAirWaves.lua
@@ -20,7 +20,7 @@ veafAirWaves = {}
 veafAirWaves.Id = "AIRWAVES"
 
 --- Version.
-veafAirWaves.Version = "1.7.8"
+veafAirWaves.Version = "1.8.0"
 
 -- trace level, specific to this module
 --veafAirWaves.LogLevel = "trace"
@@ -149,8 +149,17 @@ function AirWaveZone.init(object)
   object.timestampsOutOfZone = {}
 end
 
+veafAirWaves.STATUS_STOP = 0
+veafAirWaves.STATUS_READY = 1
+veafAirWaves.STATUS_WAITING_FOR_MORE_HUMANS = 1.5
+veafAirWaves.STATUS_ACTIVE = 2
+veafAirWaves.STATUS_WAITING_FOR_NEXTWAVE = 2.5
+veafAirWaves.STATUS_NEXTWAVE = 3
+veafAirWaves.STATUS_OVER = 4
+
 function veafAirWaves.statusToString(status)
   return veaf.enumToString(status, {
+    [veafAirWaves.STATUS_STOP] = "STATUS_STOP",
     [veafAirWaves.STATUS_READY] = "STATUS_READY",
     [veafAirWaves.STATUS_WAITING_FOR_MORE_HUMANS] = "STATUS_WAITING_FOR_MORE_HUMANS",
     [veafAirWaves.STATUS_ACTIVE] = "STATUS_ACTIVE",
@@ -159,12 +168,6 @@ function veafAirWaves.statusToString(status)
     [veafAirWaves.STATUS_OVER] = "STATUS_OVER",
   })
 end
-veafAirWaves.STATUS_READY = 1
-veafAirWaves.STATUS_WAITING_FOR_MORE_HUMANS = 1.5
-veafAirWaves.STATUS_ACTIVE = 2
-veafAirWaves.STATUS_WAITING_FOR_NEXTWAVE = 2.5
-veafAirWaves.STATUS_NEXTWAVE = 3
-veafAirWaves.STATUS_OVER = 4
 
 veafAirWaves.MINIMUM_LIFE_FOR_AI_IN_PERCENT = 0
 
@@ -886,135 +889,41 @@ function AirWaveZone:check()
         self:signalLost()
       end
       if self.resetWhenDying then
-        -- reset the zone
+        -- reset the zone; start() calls check() which handles rescheduling
         self:stop()
         self:start()
+        return
       end
     end
   end
 
-  if self.state == veafAirWaves.STATUS_READY then
-    if humansInZone and #humansInZone > 0 then
-      -- store the human units that we're going to monitor
-      self.unitsInZone = humansInZone
-      self.playerUnitsNames = humansInZoneNames
-      self:_setState(veafAirWaves.STATUS_WAITING_FOR_MORE_HUMANS)
-      if self.delayBeforeActivation and self.delayBeforeActivation > 0 then
-        self:signalWaitForHumans()
-      end
-      self.timeOfActivation = timer.getTime() + self.delayBeforeActivation
-      veaf.loggers.get(veafAirWaves.Id):debug("waiting %s seconds before activation", veaf.lp(self.delayBeforeActivation))
-      veaf.loggers.get(veafAirWaves.Id):trace("self.timeOfActivation=%s", veaf.lp(self.timeOfActivation))
-      veaf.loggers.get(veafAirWaves.Id):debug("restart the check immediately")
-      -- restart the check immediately (we don't want to wait for the next state to be processed)
-      self:check()
+  -- FSM: iterate transitions until the state stabilises in one check() tick
+  local transitioned = true
+  while transitioned do
+    transitioned = false
+    local fsmDef = AirWaveZone.FSM[self.state]
+    if not fsmDef then
+      break
     end
-  elseif self.state == veafAirWaves.STATUS_WAITING_FOR_MORE_HUMANS then
-    -- wait until the delay has passed
-    if self.timeOfActivation and timer.getTime() >= self.timeOfActivation then
-      -- zone is ready, check for players entering
-      local humansInZone, humanInZoneNames = getHumansInZone()
-      if humansInZone and #humansInZone > 0 then
-        -- store the human units that we're going to monitor
-        self.unitsInZone = humansInZone
-        self.playerUnitsNames = humanInZoneNames
-        -- reset wave index
-        self.currentWaveIndex = 0
-        self:_setState(veafAirWaves.STATUS_NEXTWAVE)
-        -- restart the check immediately (we don't want to wait for the next state to be processed)
-        self:check()
-      end
+    if fsmDef.tick then
+      fsmDef.tick(self)
     end
-  elseif self.state == veafAirWaves.STATUS_NEXTWAVE then
-    -- wave has been destroyed, or it's the first time a wave has to be deployed; check if there is a next one and deploy it
-    if self.currentWaveIndex < #self.waves then
-      if not self.delayBeforeNextWave then
-        self.delayBeforeNextWave = self.delayBetweenWaves
-      end
-      self:_setState(veafAirWaves.STATUS_WAITING_FOR_NEXTWAVE)
-      if self.delayBeforeNextWave and self.delayBeforeNextWave > 0 then
-        self:signalWaitToDeploy()
-      end
-      self.timeOfNextWave = timer.getTime() + self.delayBeforeNextWave
-      veaf.loggers.get(veafAirWaves.Id):debug("waiting %s seconds before spawning next wave(s)", veaf.lp(self.delayBeforeNextWave))
-      veaf.loggers.get(veafAirWaves.Id):trace("self.timeOfNextWave=%s", veaf.lp(self.timeOfNextWave))
-      -- restart the check immediately (we don't want to wait for the next state to be processed)
-      self:check()
-    else
-      self:signalWon()
-      self:_setState(veafAirWaves.STATUS_OVER)
-    end
-  elseif self.state == veafAirWaves.STATUS_WAITING_FOR_NEXTWAVE then
-    -- wait until the delay has passed
-    if self.timeOfNextWave and timer.getTime() >= self.timeOfNextWave then
-      -- deploy the next wave
-      local spawnedGroups, delayBeforeNextWave = self:deployWaves()
-      if spawnedGroups then
-        self.delayBeforeNextWave = delayBeforeNextWave or self.delayBetweenWaves
-        self:_setState(veafAirWaves.STATUS_ACTIVE)
-      end
-    end
-  elseif self.state == veafAirWaves.STATUS_ACTIVE then
-    -- zone is active
-
-    -- check if the current wave is still alive
-    local waveIsDead = self.isEnemyWaveDeadCallback(self, self.currentWaveIndex, self.spawnedGroupsNames)
-    if waveIsDead then
-      -- clean up any eventual remaining group of the wave
-      self:destroyCurrentWave()
-      -- signal that wave has been destroyed
-      self:signalDestroyed()
-      -- prepare next wave
-      self:_setState(veafAirWaves.STATUS_NEXTWAVE)
-      -- restart the check immediately (we don't want to wait for the next state to be processed)
-      self:check()
-    else
-      -- check if any IA wandered out of the zone for longer than it should have (maxSecondsOutsideOfZoneIA)
-      local triggerZone = veaf.getTriggerZone(self.triggerZoneName)
-      for _, groupName in pairs(self.spawnedGroupsNames) do
-        local group = Group.getByName(groupName)
-        if group then
-          local units = group:getUnits()
-          if units then
-            for _, unit in pairs(units) do
-              local unitName = unit:getName()
-              local outOfZone = false
-              if self.maxSecondsOutsideOfZoneIA then -- no need to check if feature is disabled
-                if triggerZone then
-                  outOfZone = not (veaf.isUnitInZone(unit, triggerZone))
-                else
-                  local pos = unit:getPosition().p
-                  if pos then -- you never know O.o
-                    local distanceFromCenter = ((pos.x - self.zoneCenter.x) ^ 2 + (pos.z - self.zoneCenter.z) ^ 2) ^ 0.5
-                    outOfZone = (distanceFromCenter > self.zoneRadius)
-                  end
-                end
-                if outOfZone then
-                  local timestampOutOfZone = timer.getTime()
-                  if self.timestampsOutOfZone[unitName] then
-                    timestampOutOfZone = self.timestampsOutOfZone[unitName]
-                  else
-                    self.timestampsOutOfZone[unitName] = timestampOutOfZone
-                  end
-                  local seconds = timer.getTime() - timestampOutOfZone
-                  local secondsOffend = seconds - self.maxSecondsOutsideOfZoneIA
-                  if secondsOffend > 0 then
-                    -- destroy the IA
-                    veaf.loggers.get(veafAirWaves.Id):debug("destroy out of zone AI unitName=%s", veaf.lp(unitName))
-                    unit:destroy()
-                  end
-                else
-                  self.timestampsOutOfZone[unitName] = nil
-                end
-              end
-            end
-          end
+    for targetState, guardFn in pairs(fsmDef.transitions) do
+      if guardFn(self, humansInZone, humansInZoneNames) then
+        if fsmDef.exit then
+          fsmDef.exit(self, humansInZone, humansInZoneNames)
         end
+        self:_setState(targetState)
+        local newFsmDef = AirWaveZone.FSM[targetState]
+        if newFsmDef and newFsmDef.enter then
+          newFsmDef.enter(self, humansInZone, humansInZoneNames)
+        end
+        transitioned = true
+        break
       end
     end
-  elseif self.state == veafAirWaves.STATUS_OVER then
-    -- zone has still to be reset to restart
   end
+
   if self.checkFunctionSchedule then
     -- deschedule if needed
     mist.removeFunction(self.checkFunctionSchedule)
@@ -1380,7 +1289,178 @@ function AirWaveZone:destroyCurrentWave()
 end
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
--- Utility methods
+-- FSM callbacks
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+-- READY → WAITING_FOR_MORE_HUMANS
+function AirWaveZone._canEnterWaitForMoreHumans(self, humansInZone)
+  return humansInZone ~= nil and #humansInZone > 0
+end
+
+-- enter WAITING_FOR_MORE_HUMANS: record who entered and start activation timer
+function AirWaveZone._onEnterWaitForMoreHumans(self, humansInZone, humansInZoneNames)
+  self.unitsInZone = humansInZone
+  self.playerUnitsNames = humansInZoneNames
+  if self.delayBeforeActivation and self.delayBeforeActivation > 0 then
+    self:signalWaitForHumans()
+  end
+  self.timeOfActivation = timer.getTime() + self.delayBeforeActivation
+  veaf.loggers.get(veafAirWaves.Id):debug("waiting %s seconds before activation", veaf.lp(self.delayBeforeActivation))
+  veaf.loggers.get(veafAirWaves.Id):trace("self.timeOfActivation=%s", veaf.lp(self.timeOfActivation))
+end
+
+-- WAITING_FOR_MORE_HUMANS → NEXTWAVE
+function AirWaveZone._canEnterNextWave(self, humansInZone)
+  return self.timeOfActivation ~= nil and timer.getTime() >= self.timeOfActivation and humansInZone ~= nil and #humansInZone > 0
+end
+
+-- exit WAITING_FOR_MORE_HUMANS: refresh tracked humans and reset wave counter
+function AirWaveZone._onExitWaitForMoreHumans(self, humansInZone, humansInZoneNames)
+  self.unitsInZone = humansInZone
+  self.playerUnitsNames = humansInZoneNames
+  self.currentWaveIndex = 0
+end
+
+-- NEXTWAVE → OVER (no more waves to deploy)
+function AirWaveZone._canEnterOver(self)
+  return self.currentWaveIndex >= #self.waves
+end
+
+-- NEXTWAVE → WAITING_FOR_NEXTWAVE (more waves remain)
+function AirWaveZone._canEnterWaitForNextWave(self)
+  return self.currentWaveIndex < #self.waves
+end
+
+-- enter WAITING_FOR_NEXTWAVE: set inter-wave timer and notify players
+function AirWaveZone._onEnterWaitForNextWave(self)
+  if not self.delayBeforeNextWave then
+    self.delayBeforeNextWave = self.delayBetweenWaves
+  end
+  self.timeOfNextWave = timer.getTime() + self.delayBeforeNextWave
+  if self.delayBeforeNextWave and self.delayBeforeNextWave > 0 then
+    self:signalWaitToDeploy()
+  end
+  veaf.loggers.get(veafAirWaves.Id):debug("waiting %s seconds before spawning next wave(s)", veaf.lp(self.delayBeforeNextWave))
+  veaf.loggers.get(veafAirWaves.Id):trace("self.timeOfNextWave=%s", veaf.lp(self.timeOfNextWave))
+end
+
+-- WAITING_FOR_NEXTWAVE → ACTIVE
+function AirWaveZone._canEnterActive(self)
+  return self.timeOfNextWave ~= nil and timer.getTime() >= self.timeOfNextWave
+end
+
+-- enter ACTIVE: deploy the next batch of enemy groups
+function AirWaveZone._onEnterActive(self)
+  local spawnedGroups, delayBeforeNextWave = self:deployWaves()
+  if spawnedGroups then
+    self.delayBeforeNextWave = delayBeforeNextWave or self.delayBetweenWaves
+  end
+end
+
+-- ACTIVE tick: destroy AI units that have left the zone for too long
+function AirWaveZone._tickActive(self)
+  if not self.maxSecondsOutsideOfZoneIA then
+    return
+  end
+  local triggerZone = veaf.getTriggerZone(self.triggerZoneName)
+  for _, groupName in pairs(self.spawnedGroupsNames) do
+    local group = Group.getByName(groupName)
+    if group then
+      local units = group:getUnits()
+      if units then
+        for _, unit in pairs(units) do
+          local unitName = unit:getName()
+          local outOfZone = false
+          if triggerZone then
+            outOfZone = not (veaf.isUnitInZone(unit, triggerZone))
+          else
+            local pos = unit:getPosition().p
+            if pos then
+              local distanceFromCenter = ((pos.x - self.zoneCenter.x) ^ 2 + (pos.z - self.zoneCenter.z) ^ 2) ^ 0.5
+              outOfZone = (distanceFromCenter > self.zoneRadius)
+            end
+          end
+          if outOfZone then
+            local timestampOutOfZone = timer.getTime()
+            if self.timestampsOutOfZone[unitName] then
+              timestampOutOfZone = self.timestampsOutOfZone[unitName]
+            else
+              self.timestampsOutOfZone[unitName] = timestampOutOfZone
+            end
+            local seconds = timer.getTime() - timestampOutOfZone
+            local secondsOffend = seconds - self.maxSecondsOutsideOfZoneIA
+            if secondsOffend > 0 then
+              veaf.loggers.get(veafAirWaves.Id):debug("destroy out of zone AI unitName=%s", veaf.lp(unitName))
+              unit:destroy()
+            end
+          else
+            self.timestampsOutOfZone[unitName] = nil
+          end
+        end
+      end
+    end
+  end
+end
+
+-- ACTIVE → NEXTWAVE
+function AirWaveZone._canExitActive(self)
+  return self.isEnemyWaveDeadCallback(self, self.currentWaveIndex, self.spawnedGroupsNames)
+end
+
+-- exit ACTIVE: clean up surviving enemies and announce wave completion
+function AirWaveZone._onExitActive(self)
+  self:destroyCurrentWave()
+  self:signalDestroyed()
+end
+
+-- enter OVER: announce victory
+function AirWaveZone._onEnterOver(self)
+  self:signalWon()
+end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- FSM definition
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+AirWaveZone.FSM = {
+  [veafAirWaves.STATUS_READY] = {
+    transitions = {
+      [veafAirWaves.STATUS_WAITING_FOR_MORE_HUMANS] = AirWaveZone._canEnterWaitForMoreHumans,
+    },
+  },
+  [veafAirWaves.STATUS_WAITING_FOR_MORE_HUMANS] = {
+    enter = AirWaveZone._onEnterWaitForMoreHumans,
+    exit = AirWaveZone._onExitWaitForMoreHumans,
+    transitions = {
+      [veafAirWaves.STATUS_NEXTWAVE] = AirWaveZone._canEnterNextWave,
+    },
+  },
+  [veafAirWaves.STATUS_NEXTWAVE] = {
+    transitions = {
+      [veafAirWaves.STATUS_OVER] = AirWaveZone._canEnterOver,
+      [veafAirWaves.STATUS_WAITING_FOR_NEXTWAVE] = AirWaveZone._canEnterWaitForNextWave,
+    },
+  },
+  [veafAirWaves.STATUS_WAITING_FOR_NEXTWAVE] = {
+    enter = AirWaveZone._onEnterWaitForNextWave,
+    transitions = {
+      [veafAirWaves.STATUS_ACTIVE] = AirWaveZone._canEnterActive,
+    },
+  },
+  [veafAirWaves.STATUS_ACTIVE] = {
+    enter = AirWaveZone._onEnterActive,
+    tick = AirWaveZone._tickActive,
+    exit = AirWaveZone._onExitActive,
+    transitions = {
+      [veafAirWaves.STATUS_NEXTWAVE] = AirWaveZone._canExitActive,
+    },
+  },
+  [veafAirWaves.STATUS_OVER] = {
+    enter = AirWaveZone._onEnterOver,
+    transitions = {},
+  },
+}
+
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 function veafAirWaves.add(aWaveZone, aName)

--- a/src/scripts/veaf/veafAirWaves.lua
+++ b/src/scripts/veaf/veafAirWaves.lua
@@ -1354,6 +1354,15 @@ function AirWaveZone._onEnterActive(self)
   local spawnedGroups, delayBeforeNextWave = self:deployWaves()
   if spawnedGroups then
     self.delayBeforeNextWave = delayBeforeNextWave or self.delayBetweenWaves
+  else
+    -- deploy failed (missing groups, spawn error): spawnedGroupsNames is already empty,
+    -- so _canExitActive returns true on the very next check() cycle and the zone moves
+    -- on to NEXTWAVE rather than getting stuck here.
+    veaf.loggers.get(veafAirWaves.Id):warning(
+      "AirWaveZone[%s]: deployWaves() returned no groups — wave %s will be skipped",
+      veaf.p(self.name),
+      veaf.p(self.currentWaveIndex)
+    )
   end
 end
 

--- a/test/lua/test_veafAirWaves.lua
+++ b/test/lua/test_veafAirWaves.lua
@@ -1,4 +1,4 @@
---- Tests for veafAirWaves.lua — statusToString, constants, AirWaveZone OOP.
+--- Tests for veafAirWaves.lua — statusToString, constants, AirWaveZone OOP, and FSM.
 local _base = debug.getinfo(1, "S").source:match("^@(.+)[\\/]") or "."
 luaunit = dofile(_base .. "/luaunit.lua")
 dofile(_base .. "/dcs_mocks.lua")
@@ -17,6 +17,10 @@ end
 
 function TestVeafAirWavesConstants:test_version()
   luaunit.assertIsString(veafAirWaves.Version)
+end
+
+function TestVeafAirWavesConstants:test_status_stop()
+  luaunit.assertEquals(veafAirWaves.STATUS_STOP, 0)
 end
 
 function TestVeafAirWavesConstants:test_status_ready()
@@ -59,6 +63,10 @@ end
 -- TestVeafAirWavesStatusToString
 -- ---------------------------------------------------------------------------
 TestVeafAirWavesStatusToString = {}
+
+function TestVeafAirWavesStatusToString:test_stop()
+  luaunit.assertEquals(veafAirWaves.statusToString(0), "STATUS_STOP")
+end
 
 function TestVeafAirWavesStatusToString:test_ready()
   luaunit.assertEquals(veafAirWaves.statusToString(1), "STATUS_READY")
@@ -164,4 +172,123 @@ function TestVeafAirWaveZoneOOP:test_name_field()
   luaunit.assertEquals(z:getName(), "myZone")
 end
 
+-- ---------------------------------------------------------------------------
+-- TestVeafAirWavesFSM
+-- ---------------------------------------------------------------------------
+TestVeafAirWavesFSM = {}
+
+function TestVeafAirWavesFSM:test_fsm_exists()
+  luaunit.assertIsTable(AirWaveZone.FSM)
+end
+
+function TestVeafAirWavesFSM:test_fsm_has_all_active_states()
+  luaunit.assertNotNil(AirWaveZone.FSM[veafAirWaves.STATUS_READY])
+  luaunit.assertNotNil(AirWaveZone.FSM[veafAirWaves.STATUS_WAITING_FOR_MORE_HUMANS])
+  luaunit.assertNotNil(AirWaveZone.FSM[veafAirWaves.STATUS_NEXTWAVE])
+  luaunit.assertNotNil(AirWaveZone.FSM[veafAirWaves.STATUS_WAITING_FOR_NEXTWAVE])
+  luaunit.assertNotNil(AirWaveZone.FSM[veafAirWaves.STATUS_ACTIVE])
+  luaunit.assertNotNil(AirWaveZone.FSM[veafAirWaves.STATUS_OVER])
+end
+
+function TestVeafAirWavesFSM:test_stop_state_has_no_fsm_entry()
+  -- STATUS_STOP is not in the FSM — a stopped zone does nothing in check()
+  luaunit.assertNil(AirWaveZone.FSM[veafAirWaves.STATUS_STOP])
+end
+
+function TestVeafAirWavesFSM:test_ready_transitions_to_waiting()
+  local readyDef = AirWaveZone.FSM[veafAirWaves.STATUS_READY]
+  luaunit.assertNotNil(readyDef.transitions[veafAirWaves.STATUS_WAITING_FOR_MORE_HUMANS])
+end
+
+-- guard: READY → WAITING_FOR_MORE_HUMANS
+function TestVeafAirWavesFSM:test_can_enter_wait_for_humans_with_humans()
+  local z = AirWaveZone:new()
+  local fake = {}
+  luaunit.assertTrue(AirWaveZone._canEnterWaitForMoreHumans(z, { fake }))
+end
+
+function TestVeafAirWavesFSM:test_cannot_enter_wait_for_humans_without_humans()
+  local z = AirWaveZone:new()
+  luaunit.assertFalse(AirWaveZone._canEnterWaitForMoreHumans(z, {}))
+end
+
+function TestVeafAirWavesFSM:test_cannot_enter_wait_for_humans_with_nil()
+  local z = AirWaveZone:new()
+  luaunit.assertFalse(AirWaveZone._canEnterWaitForMoreHumans(z, nil))
+end
+
+-- guard: NEXTWAVE → OVER vs WAITING_FOR_NEXTWAVE (mutually exclusive)
+function TestVeafAirWavesFSM:test_can_enter_over_when_all_waves_done()
+  local z = AirWaveZone:new()
+  z.waves = { {}, {} }
+  z.currentWaveIndex = 2
+  luaunit.assertTrue(AirWaveZone._canEnterOver(z))
+  luaunit.assertFalse(AirWaveZone._canEnterWaitForNextWave(z))
+end
+
+function TestVeafAirWavesFSM:test_can_enter_wait_for_next_wave_when_more_waves()
+  local z = AirWaveZone:new()
+  z.waves = { {}, {} }
+  z.currentWaveIndex = 1
+  luaunit.assertFalse(AirWaveZone._canEnterOver(z))
+  luaunit.assertTrue(AirWaveZone._canEnterWaitForNextWave(z))
+end
+
+-- guard: WAITING_FOR_NEXTWAVE → ACTIVE
+function TestVeafAirWavesFSM:test_can_enter_active_when_timer_expired()
+  local z = AirWaveZone:new()
+  z.timeOfNextWave = timer.getTime() - 1 -- in the past
+  luaunit.assertTrue(AirWaveZone._canEnterActive(z))
+end
+
+function TestVeafAirWavesFSM:test_cannot_enter_active_before_timer()
+  local z = AirWaveZone:new()
+  z.timeOfNextWave = timer.getTime() + 100 -- in the future
+  luaunit.assertFalse(AirWaveZone._canEnterActive(z))
+end
+
+function TestVeafAirWavesFSM:test_cannot_enter_active_without_timer()
+  local z = AirWaveZone:new()
+  z.timeOfNextWave = nil
+  luaunit.assertFalse(AirWaveZone._canEnterActive(z))
+end
+
+-- guard: ACTIVE → NEXTWAVE (wave dead)
+function TestVeafAirWavesFSM:test_can_exit_active_when_wave_dead()
+  local z = AirWaveZone:new()
+  z.spawnedGroupsNames = {} -- empty = no live enemies
+  z.currentWaveIndex = 1
+  luaunit.assertTrue(AirWaveZone._canExitActive(z))
+end
+
+-- enter WAITING_FOR_MORE_HUMANS stores humans and sets activation timer
+function TestVeafAirWavesFSM:test_on_enter_wait_stores_humans_and_sets_timer()
+  local z = AirWaveZone:new()
+  z:setDelayBeforeActivation(0)
+  local humans = { "p1" }
+  local names = { "p1" }
+  AirWaveZone._onEnterWaitForMoreHumans(z, humans, names)
+  luaunit.assertEquals(z.unitsInZone, humans)
+  luaunit.assertEquals(z.playerUnitsNames, names)
+  luaunit.assertNotNil(z.timeOfActivation)
+end
+
+-- exit WAITING_FOR_MORE_HUMANS resets wave counter
+function TestVeafAirWavesFSM:test_on_exit_wait_resets_wave_index()
+  local z = AirWaveZone:new()
+  z.currentWaveIndex = 5
+  AirWaveZone._onExitWaitForMoreHumans(z, {}, {})
+  luaunit.assertEquals(z.currentWaveIndex, 0)
+end
+
+-- enter WAITING_FOR_NEXTWAVE sets the wave timer
+function TestVeafAirWavesFSM:test_on_enter_wait_for_next_wave_sets_timer()
+  local z = AirWaveZone:new()
+  z.delayBetweenWaves = 10
+  z:setSilent(true)
+  AirWaveZone._onEnterWaitForNextWave(z)
+  luaunit.assertNotNil(z.timeOfNextWave)
+end
+
 os.exit(luaunit.LuaUnit.run())
+


### PR DESCRIPTION
## Summary

- Replace the large `if/elseif` chain in `AirWaveZone:check()` with a declarative `AirWaveZone.FSM` table keyed by numeric state constants
- Each FSM entry carries `enter`/`exit`/`tick` callbacks and a `transitions` map of guard functions; `check()` iterates until the state stabilises
- Add `STATUS_STOP = 0` as an explicit constant (was used by `stop()` but never declared — self.state was silently set to nil)
- Bump version `1.7.8` → `1.8.0`

## Test plan

- [ ] All 48 unit tests in `test/lua/test_veafAirWaves.lua` pass (48 successes, 0 failures)
- [ ] Full Lua test suite passes (all other suites unaffected)
- [ ] StyLua formatting clean (`--check` exit 0)
- [ ] `doc/backlog.md` LUAR-002 marked ✅

## Summary by Sourcery

Refactor AirWaveZone state handling to use an explicit finite state machine and formalize the stop state while updating metadata and tests accordingly.

New Features:
- Introduce an explicit AirWaveZone finite state machine definition with per-state enter/exit/tick callbacks and transition guards.

Enhancements:
- Add an explicit STATUS_STOP state constant and include it in status-to-string mapping for AirWaveZone.
- Update the AirWaveZone check loop to drive behavior via the FSM until state stabilizes in a single tick.
- Bump veafAirWaves module version from 1.7.8 to 1.8.0.

Documentation:
- Mark backlog item LUAR-002 (FSM for AirWaveZone) as completed in the backlog document.

Tests:
- Extend Lua tests to cover the new STATUS_STOP constant and its string representation.
- Add a dedicated FSM test suite validating AirWaveZone.FSM structure, guards, and callbacks.