### PR TITLE
Port PR #288 to develop-v6: replace weathermark._GetWind() and veaf.weatherReport()

### DIFF
--- a/src/scripts/veaf/veaf.lua
+++ b/src/scripts/veaf/veaf.lua
@@ -951,6 +951,9 @@ function veaf.invertHeading(heading)
 end
 
 function veaf.compute2dAzimuth(vec3)
+  if vec3 == nil or (vec3.x == 0 and vec3.z == 0) then
+    return 0
+  end
   local iAngleRadian = math.atan2(vec3.z, vec3.x) -- get azimuth angle in radians from the vector (x=north, z=east in DCS coordinates)
   local iAngleDegrees = math.deg(iAngleRadian)
   if iAngleDegrees < 0 then
@@ -960,6 +963,9 @@ function veaf.compute2dAzimuth(vec3)
 end
 
 function veaf.compute2dMagnitude(vec3)
+  if vec3 == nil then
+    return 0
+  end
   return math.sqrt(vec3.x ^ 2 + vec3.z ^ 2)
 end
 

--- a/src/scripts/veaf/veaf.lua
+++ b/src/scripts/veaf/veaf.lua
@@ -950,6 +950,19 @@ function veaf.invertHeading(heading)
   return result
 end
 
+function veaf.compute2dAzimuth(vec3)
+  local iAngleRadian = math.atan2(vec3.z, vec3.x) -- get azimuth angle in radians from the vector (x=north, z=east in DCS coordinates)
+  local iAngleDegrees = math.deg(iAngleRadian)
+  if iAngleDegrees < 0 then
+    iAngleDegrees = iAngleDegrees + 360
+  end
+  return iAngleDegrees
+end
+
+function veaf.compute2dMagnitude(vec3)
+  return math.sqrt(vec3.x ^ 2 + vec3.z ^ 2)
+end
+
 -- get a LL position based on a string
 -- can be UTM (U38TMP334456 or u37TMP4351)
 -- can be LL with either : or - as a separator, and either DMS, DM decimal, or D decimal (N42:23:45E044-12.5 or N42.3345E044-12.5)
@@ -2394,7 +2407,10 @@ end
 
 --- Weather Report. Report pressure QFE/QNH, temperature, wind at certain location.
 --- stolen from the weatherReport script and modified to fit our usage
+--- @deprecated use veafWeatherData.getWeatherString instead
 function veaf.weatherReport(vec3, alt, withLASTE)
+  return "veaf.weatherReport is deprecated, use veafWeatherData.getWeatherString instead"
+  --[[
   -- Get Temperature [K] and Pressure [Pa] at vec3.
   local T
   local Pqfe
@@ -2466,6 +2482,7 @@ function veaf.weatherReport(vec3, alt, withLASTE)
   end
 
   return text
+  ]]
 end
 
 local function _initializeCountriesAndCoalitions()

--- a/src/scripts/veaf/veafCarrierOperations.lua
+++ b/src/scripts/veaf/veafCarrierOperations.lua
@@ -751,7 +751,15 @@ function veafCarrierOperations.getAtcForCarrierOperations(groupName, skipNavigat
     end
   end
 
-  result = result .. "\n" .. veaf.weatherReport(startPosition)
+  -- determine the correct unit system based on carrier type
+  local weatherUnitSystem = veafWeatherUnitSystem.Systems.FaaNavy -- default for US carriers
+  if carrierUnit then
+    local carrierType = carrierUnit:getDesc()["typeName"]
+    if carrierType == "KUZNECOW" or carrierType == "CV_1143_5" then
+      weatherUnitSystem = veafWeatherUnitSystem.Systems.MetricEastern -- for Russian carriers
+    end
+  end
+  result = result .. "\nWEATHER:\n" .. veafWeatherData.getWeatherString(startPosition, nil, weatherUnitSystem, 20) -- typical carrier deck height
 
   return result
 end

--- a/src/scripts/veaf/veafCasMission.lua
+++ b/src/scripts/veaf/veafCasMission.lua
@@ -1148,7 +1148,7 @@ function veafCasMission.reportTargetInformation(unitName)
   message = message .. "FROM BULLSEYE    : " .. fromBullseye .. ".\n"
   message = message .. "\n"
 
-  message = message .. veaf.weatherReport(averageGroupPosition, nil, true)
+  message = message .. "\n\nWEATHER:\n" .. veafWeatherData.getWeatherString(averageGroupPosition, unitName)
 
   -- send message only for the unit
   veaf.outTextForGroup(unitName, message, 30)

--- a/src/scripts/veaf/veafCombatZone.lua
+++ b/src/scripts/veaf/veafCombatZone.lua
@@ -964,7 +964,7 @@ function VeafCombatZone:getInformation(unitName)
       message = message .. "\n"
 
       -- get altitude, qfe and wind information
-      message = message .. veaf.weatherReport(zoneCenter, nil, true)
+      message = message .. "\n\nWEATHER:\n" .. veafWeatherData.getWeatherString(zoneCenter, nil, veafWeatherUnitSystem.Systems.Full)
     end
   else
     message = message .. "zone is not yet active."

--- a/src/scripts/veaf/veafWeather.lua
+++ b/src/scripts/veaf/veafWeather.lua
@@ -176,7 +176,7 @@ end
 
 local function _weatherSliceAtAltitude(vec3, iAltitudeMeters)
   local nTemperatureKelvin, nPressurePa = atmosphere.getTemperatureAndPressure({ x = vec3.x, y = iAltitudeMeters, z = vec3.z })
-  local iWindDir, iWindSpeedMps = weathermark._GetWind(vec3, iAltitudeMeters)
+  local iWindDir, iWindSpeedMps = veafWeather.getWind(vec3, iAltitudeMeters)
 
   return {
     AltitudeMeters = iAltitudeMeters,
@@ -395,7 +395,7 @@ function veafWeatherData:create(vec3, iAbsTime, iAltitudeMeters)
   local sunTimesZulu = veafTime.getSunTimesZulu(vec3)
   local sunTimesLocal = veafTime.getSunTimesLocal(vec3)
 
-  local iWindDirSurface, iWindSpeedSurfaceMps = weathermark._GetWind(vec3, iAltitudeMeters + 10) -- Measure the wind velocity at the standard height of 10 metres above the surface. This is the internationally accepted meteorological definition of ‘surface wind’ designed to eliminate distortion attributable to very local terrain effects
+  local iWindDirSurface, iWindSpeedSurfaceMps = veafWeather.getWind(vec3, iAltitudeMeters + 10) -- Measure the wind velocity at the standard height of 10 metres above the surface. This is the internationally accepted meteorological definition of ‘surface wind’ designed to eliminate distortion attributable to very local terrain effects
 
   -- the static env.mission.weather.visibility.distance is not used anymore, and the DCS engine apparently sets a default at 100000, as seen in this log line:
   -- WEATHER (Main): set fog: visibility:100000  thickness:0.0
@@ -835,7 +835,7 @@ function veafWeatherData:toStringLaste()
     local iAltitudeFeet = math.floor((mist.utils.metersToFeet(self.AltitudeMeter) + iDesiredHeightFeet + 500) / 1000) * 1000
     local iAltitudeMeters = mist.utils.feetToMeters(iAltitudeFeet)
     local iTemperatureKelvin, _ = atmosphere.getTemperatureAndPressure({ x = self.Vec3.x, y = iAltitudeMeters, z = self.Vec3.z })
-    local iWindDirection, iWindSpeedMps = weathermark._GetWind(self.Vec3, iAltitudeMeters)
+    local iWindDirection, iWindSpeedMps = veafWeather.getWind(self.Vec3, iAltitudeMeters)
     local iWindDirectionMagnetic = veafWeatherData:getNormalizedWindDirection(iWindDirection, true)
 
     local sLaste = string.format(
@@ -1197,6 +1197,40 @@ function veafWeatherAtis.getAtisStringFromVeafPoint(sPointName, iAbsTime)
     :trace("Airbase found from veaf point named %s: %s", veaf.lp(sPointName), veaf.lp(veaf.ifnn(dcsAirbase, "getName")))
 
   return veafWeatherAtis.getAtisString(veafAirbase)
+end
+
+function veafWeather.getWind(vec3, iAltitudeMeters, bTurbulence)
+  bTurbulence = bTurbulence or false
+
+  local vec3AtAltitude = { x = vec3.x, y = iAltitudeMeters, z = vec3.z }
+
+  local vec3Wind
+  if bTurbulence then
+    vec3Wind = atmosphere.getWindWithTurbulence(vec3AtAltitude)
+  else
+    vec3Wind = atmosphere.getWind(vec3AtAltitude)
+  end
+
+  local iDirection = veaf.compute2dAzimuth(vec3Wind)
+
+  -- convert direction from "to" to "from"
+  if iDirection > 180 then
+    iDirection = iDirection - 180
+  else
+    iDirection = iDirection + 180
+  end
+
+  local iSpeed = veaf.compute2dMagnitude(vec3Wind)
+
+  veaf.loggers.get(veafWeather.Id):trace(
+    "Wind vec3 alt [ %d ]: [ z(east)=%f, x(north)=%f ] -- direction [ %f ], strength [ %f ]",
+    iAltitudeMeters,
+    vec3Wind.z,
+    vec3Wind.x,
+    iDirection,
+    iSpeed
+  )
+  return iDirection, iSpeed
 end
 
 function veafWeather.messageWeatherAtClosestPoint(unitName, forUnit)

--- a/src/scripts/veaf/veafWeather.lua
+++ b/src/scripts/veaf/veafWeather.lua
@@ -497,7 +497,7 @@ end
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Static methods
-function veafWeatherData.getWeatherString(vec3, dcsElementName, unitSystem)
+function veafWeatherData.getWeatherString(vec3, dcsElementName, unitSystem, iSurfaceAltitudeMeters)
   local bWithLaste = false
 
   local sTypeName = veaf.getDcsTypeName(dcsElementName)
@@ -510,7 +510,7 @@ function veafWeatherData.getWeatherString(vec3, dcsElementName, unitSystem)
     bWithLaste = true
   end
 
-  local weatherData = veafWeatherData:create(vec3)
+  local weatherData = veafWeatherData:create(vec3, nil, iSurfaceAltitudeMeters)
   return weatherData:toString(unitSystem, bWithLaste)
 end
 
@@ -1200,6 +1200,9 @@ function veafWeatherAtis.getAtisStringFromVeafPoint(sPointName, iAbsTime)
 end
 
 function veafWeather.getWind(vec3, iAltitudeMeters, bTurbulence)
+  if vec3 == nil then
+    return 0, 0
+  end
   bTurbulence = bTurbulence or false
 
   local vec3AtAltitude = { x = vec3.x, y = iAltitudeMeters, z = vec3.z }
@@ -1220,10 +1223,19 @@ function veafWeather.getWind(vec3, iAltitudeMeters, bTurbulence)
     iDirection = iDirection + 180
   end
 
+  -- round to integer degrees and wrap to [1, 360]
+  iDirection = math.floor(iDirection + 0.5)
+  if iDirection > 360 then
+    iDirection = iDirection - 360
+  end
+  if iDirection <= 0 then
+    iDirection = iDirection + 360
+  end
+
   local iSpeed = veaf.compute2dMagnitude(vec3Wind)
 
   veaf.loggers.get(veafWeather.Id):trace(
-    "Wind vec3 alt [ %d ]: [ z(east)=%f, x(north)=%f ] -- direction [ %f ], strength [ %f ]",
+    "Wind vec3 alt [ %d ]: [ z(east)=%f, x(north)=%f ] -- direction [ %d ], strength [ %f ]",
     iAltitudeMeters,
     vec3Wind.z,
     vec3Wind.x,

--- a/test/lua/test_veafWeather.lua
+++ b/test/lua/test_veafWeather.lua
@@ -413,6 +413,92 @@ function TestVeafWeatherCarrierCase:test_day_no_clouds_case1()
 end
 
 -- ============================================================================
+-- TestVeafWeatherGetWind
+-- ============================================================================
+TestVeafWeatherGetWind = {}
+
+function TestVeafWeatherGetWind:setUp()
+  dcs_mocks.reset()
+end
+
+-- Helper: override atmosphere.getWind to return a fixed vector
+local function setWind(x, z)
+  atmosphere.getWind = function(_) return { x = x, y = 0, z = z } end
+  atmosphere.getWindWithTurbulence = function(_) return { x = x, y = 0, z = z } end
+end
+
+-- No wind → direction 0 (calm), speed 0
+function TestVeafWeatherGetWind:test_calm_wind()
+  setWind(0, 0)
+  local dir, spd = veafWeather.getWind({ x = 0, y = 0, z = 0 }, 0)
+  luaunit.assertEquals(spd, 0)
+  -- direction is undefined for calm wind; just check it's an integer in [1,360]
+  luaunit.assertTrue(dir >= 1 and dir <= 360)
+end
+
+-- Wind blowing toward north (x=1, z=0) → "from" direction should be south = 180
+function TestVeafWeatherGetWind:test_wind_toward_north_from_south()
+  setWind(1, 0)
+  local dir, _ = veafWeather.getWind({ x = 0, y = 0, z = 0 }, 0)
+  luaunit.assertEquals(dir, 180)
+end
+
+-- Wind blowing toward east (x=0, z=1) → "from" direction should be west = 270
+function TestVeafWeatherGetWind:test_wind_toward_east_from_west()
+  setWind(0, 1)
+  local dir, _ = veafWeather.getWind({ x = 0, y = 0, z = 0 }, 0)
+  luaunit.assertEquals(dir, 270)
+end
+
+-- Wind blowing toward south (x=-1, z=0) → "from" direction should be north = 360
+function TestVeafWeatherGetWind:test_wind_toward_south_from_north()
+  setWind(-1, 0)
+  local dir, _ = veafWeather.getWind({ x = 0, y = 0, z = 0 }, 0)
+  luaunit.assertEquals(dir, 360)
+end
+
+-- Wind blowing toward west (x=0, z=-1) → "from" direction should be east = 90
+function TestVeafWeatherGetWind:test_wind_toward_west_from_east()
+  setWind(0, -1)
+  local dir, _ = veafWeather.getWind({ x = 0, y = 0, z = 0 }, 0)
+  luaunit.assertEquals(dir, 90)
+end
+
+-- Result direction must be integer in [1, 360]
+function TestVeafWeatherGetWind:test_direction_is_integer_in_range()
+  setWind(1, 1)
+  local dir, _ = veafWeather.getWind({ x = 0, y = 0, z = 0 }, 0)
+  luaunit.assertEquals(dir, math.floor(dir)) -- integer
+  luaunit.assertTrue(dir >= 1 and dir <= 360)
+end
+
+-- Speed matches the 2D magnitude of the wind vector
+function TestVeafWeatherGetWind:test_speed_matches_magnitude()
+  setWind(3, 4)
+  local _, spd = veafWeather.getWind({ x = 0, y = 0, z = 0 }, 0)
+  luaunit.assertAlmostEquals(spd, 5.0, 1e-6) -- sqrt(9+16)
+end
+
+-- bTurbulence flag routes to getWindWithTurbulence
+function TestVeafWeatherGetWind:test_turbulence_flag()
+  local called = false
+  atmosphere.getWindWithTurbulence = function(_)
+    called = true
+    return { x = 1, y = 0, z = 0 }
+  end
+  atmosphere.getWind = function(_) return { x = 0, y = 0, z = 0 } end
+  veafWeather.getWind({ x = 0, y = 0, z = 0 }, 0, true)
+  luaunit.assertTrue(called)
+end
+
+-- nil vec3 guard → returns 0, 0 without error
+function TestVeafWeatherGetWind:test_nil_vec3_returns_zero()
+  local dir, spd = veafWeather.getWind(nil, 0)
+  luaunit.assertEquals(dir, 0)
+  luaunit.assertEquals(spd, 0)
+end
+
+-- ============================================================================
 -- Run
 -- ============================================================================
 os.exit(luaunit.LuaUnit.run())


### PR DESCRIPTION
## Description

Manual port of PR #288 (`fix-weather-wind-direction`) to `develop-v6`.

The files had diverged too much for an automatic cherry-pick, so changes were applied manually.

## Changes

### `veaf.lua`
- Add `veaf.compute2dAzimuth()` and `veaf.compute2dMagnitude()` (needed by `veafWeather.getWind`)
- Deprecate `veaf.weatherReport()`: body replaced by a deprecation notice, old code kept as a comment

### `veafWeather.lua`
- Add `veafWeather.getWind(vec3, iAltitudeMeters, bTurbulence)` — internal replacement for `weathermark._GetWind()`
- Replace all 3 occurrences of `weathermark._GetWind()` with `veafWeather.getWind()`

### `veafCasMission.lua`
- Replace `veaf.weatherReport(averageGroupPosition, nil, true)` with `veafWeatherData.getWeatherString(averageGroupPosition, unitName)`

### `veafCombatZone.lua`
- Replace `veaf.weatherReport(zoneCenter, nil, true)` with `veafWeatherData.getWeatherString(zoneCenter, nil, veafWeatherUnitSystem.Systems.Full)`

### `veafCarrierOperations.lua`
- Replace `veaf.weatherReport(startPosition)` with `veafWeatherData.getWeatherString()` using a carrier-type-appropriate unit system (FaaNavy for US carriers, MetricEastern for Russian carriers)

## Testing

- StyLua check: ✅
- Lua unit tests (32 suites, 1057 tests): ✅ all passed

## Summary by Sourcery

Port wind computation and weather reporting changes to use a new internal wind getter and the standardized veafWeatherData weather string API.

New Features:
- Introduce veafWeather.getWind as the internal API for querying wind direction and speed, with optional turbulence handling.
- Add generic 2D azimuth and magnitude helpers in veaf.lua for vector-based computations.

Enhancements:
- Switch existing weather-related code paths to use veafWeather.getWind instead of weathermark._GetWind.
- Update carrier operations, CAS mission, and combat zone messaging to use veafWeatherData.getWeatherString with appropriate unit systems and formatting.
- Deprecate veaf.weatherReport in favor of veafWeatherData.getWeatherString while preserving the old implementation as commented reference.