### PR TITLE
fix: migration guide corrections and weather output path/naming

### DIFF
--- a/doc/mission-maker/MIGRATION_GUIDE.fr.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.fr.md
@@ -31,6 +31,8 @@ Dans les deux cas, le résultat final est un **dossier de mission VEAF MCT v6** 
 
 3. Ayez votre dossier de mission v5 sous la main
 
+> **Conseil — configuration globale utilisateur :** Avant de commencer, créez `~/veafmct.yaml` (soit `C:\Users\VotreNom\veafmct.yaml` sous Windows) pour définir des préférences persistantes sur cette machine — notamment la langue (`lang: fr`) afin que tous les outils s'affichent en français. Voir [Configuration globale utilisateur](GUIDE.fr.md#configuration-globale-utilisateur) pour le détail et les commandes disponibles.
+
 ---
 
 ## Migration depuis VEAF MCT v5.xx
@@ -116,7 +118,7 @@ Certaines constructions v5 n'existent plus ou ont été renommées :
 #### 5. Vérifier avec un build de test
 
 ```powershell
-.\veaf-tools.exe build ma-mission .
+.\veaf-tools.exe build
 ```
 
 Ouvrez le `.miz` résultant dans DCS, chargez la mission et confirmez :

--- a/doc/mission-maker/MIGRATION_GUIDE.fr.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.fr.md
@@ -31,7 +31,7 @@ Dans les deux cas, le résultat final est un **dossier de mission VEAF MCT v6** 
 
 3. Ayez votre dossier de mission v5 sous la main
 
-> **Conseil — configuration globale utilisateur :** Avant de commencer, créez `~/veafmct.yaml` (soit `C:\Users\VotreNom\veafmct.yaml` sous Windows) pour définir des préférences persistantes sur cette machine — notamment la langue (`lang: fr`) afin que tous les outils s'affichent en français. Voir [Configuration globale utilisateur](GUIDE.fr.md#configuration-globale-utilisateur) pour le détail et les commandes disponibles.
+> **Conseil — configuration globale utilisateur :** Avant de commencer, créez `~/veafmct.yaml` (soit `C:\Users\VotreNom\veafmct.yaml` sous Windows) pour définir des préférences persistantes sur cette machine — notamment la langue (`lang: fr`) afin que tous les outils s'affichent en français. Voir [Configuration globale utilisateur](GUIDE.md#configuration-globale-utilisateur) pour le détail et les commandes disponibles.
 
 ---
 

--- a/doc/mission-maker/MIGRATION_GUIDE.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.md
@@ -32,6 +32,8 @@ In both cases the end result is a **VEAF MCT v6 mission folder** that you manage
 
 3. Have your v5 mission folder on hand
 
+> **Tip — Global User Configuration:** Before starting, create `~/veafmct.yaml` (i.e. `C:\Users\YourName\veafmct.yaml` on Windows) to set persistent defaults for all your VEAF projects on this machine — for example your language preference (`lang: fr`). See [Global User Configuration](GUIDE.md#global-user-configuration) for the full reference and CLI commands.
+
 ---
 
 ## Migrating from VEAF MCT v5.xx
@@ -117,7 +119,7 @@ Some v5 constructs no longer exist or have been renamed:
 #### 5. Verify with a test build
 
 ```powershell
-.\veaf-tools.exe build my-mission .
+.\veaf-tools.exe build
 ```
 
 Open the resulting `.miz` in DCS, load the mission, and confirm:

--- a/src/python/veaf-tools/veaf_tools/commands/build.py
+++ b/src/python/veaf-tools/veaf_tools/commands/build.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from pathlib import Path
 
@@ -102,8 +103,14 @@ def build(
     # did not explicitly provide a different mission name on the CLI.
     _yaml_mission_name: str | None = (mission_yaml.get("mission") or {}).get("name") if mission_yaml else None
     if mission_name_or_file == DEFAULT_MISSION_FILE and _yaml_mission_name:
-        p_output_mission = p_mission_folder / f"{_yaml_mission_name}_{datetime.now().strftime('%Y%m%d')}.miz"
-        mission_base_name: str = _yaml_mission_name
+        _safe_name = re.sub(r'[\\/:*?"<>|\x00-\x1f]', "_", _yaml_mission_name).strip(" .")
+        if not _safe_name:
+            logger.warning(
+                f"mission.name {_yaml_mission_name!r} contains only invalid filename characters; using 'mission'"
+            )
+            _safe_name = "mission"
+        p_output_mission = p_mission_folder / f"{_safe_name}_{datetime.now().strftime('%Y%m%d')}.miz"
+        mission_base_name: str = _safe_name
     else:
         mission_base_name = p_output_mission.stem
 

--- a/src/python/veaf-tools/veaf_tools/commands/build.py
+++ b/src/python/veaf-tools/veaf_tools/commands/build.py
@@ -98,6 +98,15 @@ def build(
         pipeline_cfg = mission_yaml.get("pipeline") or {}
         build_cfg = mission_yaml.get("build") or {}
 
+    # Derive mission base name; update output path when mission.yaml defines a name and the user
+    # did not explicitly provide a different mission name on the CLI.
+    _yaml_mission_name: str | None = (mission_yaml.get("mission") or {}).get("name") if mission_yaml else None
+    if mission_name_or_file == DEFAULT_MISSION_FILE and _yaml_mission_name:
+        p_output_mission = p_mission_folder / f"{_yaml_mission_name}_{datetime.now().strftime('%Y%m%d')}.miz"
+        mission_base_name: str = _yaml_mission_name
+    else:
+        mission_base_name = p_output_mission.stem
+
     # Resolve dev_mode and scripts_path: CLI flags > mission.yaml > ~/veafmct.yaml > code defaults
     effective_dev_mode: bool = dev_mode if dev_mode is not None else bool(build_cfg.get("dev_mode", False))
     if effective_dev_mode:
@@ -239,7 +248,12 @@ def build(
     if weather_path:
         logger.info(f"Pipeline: injecting weather variants from {weather_path}")
         console.print(f"[bold blue]Pipeline: weather variants ({weather_path.name})[/bold blue]")
-        weather_worker = WeatherInjectorWorker(config_file=weather_path, mission_file=p_output_mission)
+        weather_worker = WeatherInjectorWorker(
+            config_file=weather_path,
+            mission_file=p_output_mission,
+            output_dir=p_mission_folder / "missions",
+            mission_base_name=mission_base_name,
+        )
         if created_files := weather_worker.work():
             console.print(f"[bold green]Pipeline: created {len(created_files)} weather variant(s)[/bold green]")
 

--- a/src/python/veaf-tools/weather_injector/test_weather_injector_worker.py
+++ b/src/python/veaf-tools/weather_injector/test_weather_injector_worker.py
@@ -626,5 +626,88 @@ class TestInjectWeather(unittest.TestCase):
             worker._inject_weather(version)  # should not raise
 
 
+# ---------------------------------------------------------------------------
+# mission_base_name — output path and sanitization
+# ---------------------------------------------------------------------------
+
+
+class TestMissionBaseNameOutput(unittest.TestCase):
+    def _patched_worker(
+        self,
+        tmp_path: Path,
+        mission_base_name: str | None,
+        version_name: str = "dawn",
+    ) -> tuple[WeatherInjectorWorker, VersionConfig]:
+        """Build a worker with read_miz/write_miz patched out."""
+        from unittest.mock import MagicMock, patch
+
+        config_data: dict[str, Any] = {"versions": [{"name": version_name}]}
+        config_file = tmp_path / "versions.yaml"
+        config_file.write_text(yaml.dump(config_data), encoding="utf-8")
+        mission_file = tmp_path / "test.miz"
+        mission_file.write_bytes(b"PK\x03\x04")
+        output_dir = tmp_path / "missions"
+
+        worker = WeatherInjectorWorker(
+            config_file=config_file,
+            mission_file=mission_file,
+            output_dir=output_dir,
+            mission_base_name=mission_base_name,
+        )
+
+        fake_mission = MagicMock()
+        fake_mission.mission_content = {"start_time": 0}
+        version = VersionConfig(name=version_name)
+
+        self._read_patcher = patch("weather_injector.weather_injector_worker.read_miz", return_value=fake_mission)
+        self._write_patcher = patch("weather_injector.weather_injector_worker.write_miz")
+        self._read_patcher.start()
+        self._write_patcher.start()
+        self.addCleanup(self._read_patcher.stop)
+        self.addCleanup(self._write_patcher.stop)
+
+        return worker, version
+
+    def test_output_prefixed_with_base_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            worker, version = self._patched_worker(Path(tmp), "VEAF-Demo")
+            result = worker._create_mission_version(version)
+        self.assertEqual(result.name, "VEAF-Demo_dawn.miz")
+
+    def test_output_without_base_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            worker, version = self._patched_worker(Path(tmp), None)
+            result = worker._create_mission_version(version)
+        self.assertEqual(result.name, "dawn.miz")
+
+    def test_base_name_stored_on_init(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            config_file = tmp_path / "v.yaml"
+            config_file.write_text(yaml.dump({"versions": []}), encoding="utf-8")
+            mission_file = tmp_path / "test.miz"
+            mission_file.write_bytes(b"PK")
+            worker = WeatherInjectorWorker(
+                config_file=config_file,
+                mission_file=mission_file,
+                mission_base_name="VEAF-Demo",
+            )
+        self.assertEqual(worker.mission_base_name, "VEAF-Demo")
+
+    def test_base_name_sanitized_on_init(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            config_file = tmp_path / "v.yaml"
+            config_file.write_text(yaml.dump({"versions": []}), encoding="utf-8")
+            mission_file = tmp_path / "test.miz"
+            mission_file.write_bytes(b"PK")
+            worker = WeatherInjectorWorker(
+                config_file=config_file,
+                mission_file=mission_file,
+                mission_base_name="My:Mission/Name*",
+            )
+        self.assertEqual(worker.mission_base_name, "My_Mission_Name_")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/python/veaf-tools/weather_injector/weather_injector_worker.py
+++ b/src/python/veaf-tools/weather_injector/weather_injector_worker.py
@@ -1,5 +1,6 @@
 """Main worker for creating mission versions with weather and time modifications."""
 
+import re
 from datetime import date as dt_date
 from datetime import timedelta
 from pathlib import Path
@@ -14,6 +15,8 @@ from veaf_libs.logger import logger
 from .models import MissionConfig, VersionConfig
 from .utils import SolarCalculator, TimeExpressionParser
 from .weather import DCSWeatherConverter
+
+_INVALID_FILENAME_CHARS = re.compile(r'[\\/:*?"<>|\x00-\x1f]')
 
 
 class WeatherInjectorWorker(BaseWorker):
@@ -51,7 +54,9 @@ class WeatherInjectorWorker(BaseWorker):
         self.mission_file = Path(mission_file)
         self.output_dir = Path(output_dir) if output_dir else self.config_file.parent
         self.output_dir.mkdir(parents=True, exist_ok=True)
-        self.mission_base_name: str | None = mission_base_name
+        self.mission_base_name: str | None = (
+            _INVALID_FILENAME_CHARS.sub("_", mission_base_name).strip(" .") if mission_base_name else None
+        )
 
         self.config: MissionConfig | None = None
         self.mission_data: DcsMission | None = None

--- a/src/python/veaf-tools/weather_injector/weather_injector_worker.py
+++ b/src/python/veaf-tools/weather_injector/weather_injector_worker.py
@@ -30,7 +30,13 @@ class WeatherInjectorWorker(BaseWorker):
        e. Write output mission file
     """
 
-    def __init__(self, config_file: Path, mission_file: Path, output_dir: Path | None = None, mission_base_name: str | None = None):
+    def __init__(
+        self,
+        config_file: Path,
+        mission_file: Path,
+        output_dir: Path | None = None,
+        mission_base_name: str | None = None,
+    ):
         """
         Initialize worker.
 

--- a/src/python/veaf-tools/weather_injector/weather_injector_worker.py
+++ b/src/python/veaf-tools/weather_injector/weather_injector_worker.py
@@ -30,7 +30,7 @@ class WeatherInjectorWorker(BaseWorker):
        e. Write output mission file
     """
 
-    def __init__(self, config_file: Path, mission_file: Path, output_dir: Path | None = None):
+    def __init__(self, config_file: Path, mission_file: Path, output_dir: Path | None = None, mission_base_name: str | None = None):
         """
         Initialize worker.
 
@@ -38,11 +38,14 @@ class WeatherInjectorWorker(BaseWorker):
             config_file: Path to YAML configuration file (versions.yaml)
             mission_file: Path to base mission .miz file
             output_dir: Output directory for mission files (defaults to config directory)
+            mission_base_name: Base name prefix for output files (e.g. "VEAF-Demo-Mission");
+                               if provided, output files are named ``{base}_{version}.miz``
         """
         self.config_file = Path(config_file)
         self.mission_file = Path(mission_file)
         self.output_dir = Path(output_dir) if output_dir else self.config_file.parent
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.mission_base_name: str | None = mission_base_name
 
         self.config: MissionConfig | None = None
         self.mission_data: DcsMission | None = None
@@ -151,7 +154,10 @@ class WeatherInjectorWorker(BaseWorker):
             self._inject_weather(version)
 
         # Write output
-        output_path = self.output_dir / f"{version.name}.miz"
+        if self.mission_base_name:
+            output_path = self.output_dir / f"{self.mission_base_name}_{version.name}.miz"
+        else:
+            output_path = self.output_dir / f"{version.name}.miz"
         logger.debug(f"Writing mission to: {output_path}")
         write_miz(mission=self.mission_data, miz_file_path=output_path)  # type: ignore[arg-type]
 


### PR DESCRIPTION
## Contexte

Corrections issues du suivi d'un utilisateur ayant effectué une migration v5 → v6.

## Corrections documentation (`MIGRATION_GUIDE.fr.md` + `MIGRATION_GUIDE.md`)

- **Commande du chapitre 5 corrigée** : la commande `.\veaf-tools.exe build ma-mission .` était fausse — `.\veaf-tools.exe build` suffit (la mission courante est détectée automatiquement).
- **Note config utilisateur ajoutée** dans la section "Avant de commencer" / "Before You Start" : pointe vers `GUIDE#configuration-globale-utilisateur` pour que le lecteur soit informé dès le début de l'existence de `~/veafmct.yaml` (notamment `lang: fr`).

## Corrections code

### `build.py` — nommage du `.miz` principal depuis `mission.yaml`

Quand l'utilisateur n'override pas le nom de la mission (i.e. lance `veaf-tools build` sans argument) et que `mission.yaml` définit `mission.name`, le `.miz` produit est maintenant nommé `{name}_{YYYYMMDD}.miz` (ex. `VEAF-Demo-Mission_20260524.miz`) au lieu de `mission.miz`.

### `build.py` + `weather_injector_worker.py` — sortie des variantes météo

| | Avant | Après |
|---|---|---|
| **Répertoire** | `src/` (parent de `missions.yaml`) | `missions/` (sous-dossier de la mission) |
| **Nommage** | `dawn.miz`, `dusk.miz` … | `VEAF-Demo-Mission_dawn.miz`, `VEAF-Demo-Mission_dusk.miz` … |

Le `WeatherInjectorWorker` reçoit maintenant `output_dir` et `mission_base_name` depuis `build.py`. Le paramètre `mission_base_name` est optionnel (défaut `None`) — comportement inchangé pour les appels existants sans ce paramètre.

## Summary by Sourcery

Adjust mission build outputs based on mission.yaml metadata and align documentation with the current CLI behavior.

Bug Fixes:
- Name the primary .miz output from veaf-tools build using mission.name from mission.yaml when no explicit mission name is given on the CLI, instead of always using mission.miz.
- Generate weather variant .miz files into a missions subdirectory and prefix them with the mission base name when available, while keeping existing behavior unchanged for callers that omit this parameter.
- Correct the example veaf-tools build command in both migration guides to reflect the default behavior without redundant arguments.

Documentation:
- Add guidance in both French and English migration guides about creating a global user configuration file (~/veafmct.yaml) to set persistent preferences such as language.