### PR TITLE
fix(doc): Lot 24 DOC-REVIEW — corrections issues du doc-review

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -48,7 +48,7 @@
 | Lot 21 — TYPING | ~20 min | ✅ |
 | Lot 22 — TEST-LAYOUT | ~55 min | ✅ |
 | Lot 23 — DOC-YAML | ~8h20 | ✅ |
-| Lot 24 — DOC-REVIEW | ~2h45 | ⬜ |
+| Lot 24 — DOC-REVIEW | ~2h45 | 🔄 (REV-002 différé) |
 | Lot 25 — EXT-YAML | ~2h | ⬜ |
 | **Total** | **~157h05** | |
 
@@ -472,13 +472,13 @@ Reste dans `build.py` (préoccupations CLI uniquement) :
 
 | # | Ticket | Fichiers touchés | Type | Effort | Status |
 |---|--------|-----------------|------|--------|--------|
-| REV-001 | Remplacer `missions.yaml` par `versions.yaml` partout dans la doc et dans le template `mission.yaml` commenté (`lua_config_generator.py` ligne ~839) | `doc/**/*.md`, `src/python/veaf-tools/veaf_libs/lua_config_generator.py`, `src/defaults/mission-folder/mission.yaml` | fix | 20 min | ⬜ |
+| REV-001 | Remplacer `missions.yaml` par `versions.yaml` partout dans la doc et dans le template `mission.yaml` commenté (`lua_config_generator.py` ligne ~839) | `doc/**/*.md`, `src/python/veaf-tools/veaf_libs/lua_config_generator.py`, `src/defaults/mission-folder/mission.yaml` | fix | 20 min | ✅ |
 | REV-002 | Committer le profil Klogg fourni par l'utilisateur dans `tools/klogg/veaf.conf` ; mettre à jour la section "Reading the log" dans `GUIDE.md` et `GUIDE.fr.md` pour pointer vers ce fichier | `tools/klogg/veaf.conf`, `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | chore | 20 min | ⬜ |
-| REV-004 | Corriger `MIGRATION_GUIDE.md` — section "Common Issues" : remplacer les références `missionConfig.lua` par `mission.yaml` + `mission-script.lua` selon le cas ; ajouter entrée "Reading the logs" (Klogg ou Notepad++, chemin `Saved Games\DCS\Logs\dcs.log`, filtre `VEAF`, lien vers profil Klogg committé en REV-002) | `doc/mission-maker/MIGRATION_GUIDE.md`, `doc/mission-maker/MIGRATION_GUIDE.fr.md` | fix | 20 min | ⬜ |
-| REV-006 | Corriger `GUIDE.md` — "Typical Build Workflow" : remplacer les 4 commandes séparées par `veaf-tools.exe build .` (le pipeline est intégré) ; déplacer les commandes `inject-*` dans une note collapsible "Advanced: running pipeline steps individually" | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | fix | 20 min | ⬜ |
-| REV-007 | Corriger `doc/index.md` et `doc/index.fr.md` — phrase d'accroche (une ligne orientée nouveau venu avant le tableau role-based) ; passer le diagramme Mermaid de `flowchart LR` à `flowchart TD` | `doc/index.md`, `doc/index.fr.md` | fix | 15 min | ⬜ |
-| REV-008 | Ajouter prérequis dans `GUIDE.md` et `GUIDE.fr.md` section "Getting Started" : (1) le mission de base dans le DCS Editor **doit** contenir au moins un groupe terrestre bleu et un rouge (requis pour que les tables Lua de pays/coalitions soient complètes et que les outils d'injection fonctionnent) ; (2) éditeur texte recommandé : Notepad++ (YAML/Lua) | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | fix | 20 min | ⬜ |
-| REV-010 | Corriger `GUIDE.md` — section "CTLD and CSAR Integration" : (1) supprimer la phrase inventée sur l'auto-lasing JTACs dans "VEAF automatic defaults" ; (2) documenter la double approche YAML-first (`external_modules.ctld`) + Lua callback ; (3) noter explicitement que CSAR n'est pas encore configurable via YAML (renvoi vers Lot 25 — EXT-YAML) | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | fix | 30 min | ⬜ |
+| REV-004 | Corriger `MIGRATION_GUIDE.md` — section "Common Issues" : remplacer les références `missionConfig.lua` par `mission.yaml` + `mission-script.lua` selon le cas ; ajouter entrée "Reading the logs" (Klogg ou Notepad++, chemin `Saved Games\DCS\Logs\dcs.log`, filtre `VEAF`, lien vers profil Klogg commité en REV-002) | `doc/mission-maker/MIGRATION_GUIDE.md`, `doc/mission-maker/MIGRATION_GUIDE.fr.md` | fix | 20 min | ✅ |
+| REV-006 | Corriger `GUIDE.md` — "Typical Build Workflow" : remplacer les 4 commandes séparées par `veaf-tools.exe build .` (le pipeline est intégré) ; déplacer les commandes `inject-*` dans une note collapsible "Advanced: running pipeline steps individually" | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | fix | 20 min | ✅ |
+| REV-007 | Corriger `doc/index.md` et `doc/index.fr.md` — phrase d'accroche (une ligne orientée nouveau venu avant le tableau role-based) ; passer le diagramme Mermaid de `flowchart LR` à `flowchart TD` | `doc/index.md`, `doc/index.fr.md` | fix | 15 min | ✅ |
+| REV-008 | Ajouter prérequis dans `GUIDE.md` et `GUIDE.fr.md` section "Getting Started" : (1) le mission de base dans le DCS Editor **doit** contenir au moins un groupe terrestre bleu et un rouge (requis pour que les tables Lua de pays/coalitions soient complètes et que les outils d'injection fonctionnent) ; (2) éditeur texte recommandé : Notepad++ (YAML/Lua) | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | fix | 20 min | ✅ |
+| REV-010 | Corriger `GUIDE.md` — section "CTLD and CSAR Integration" : (1) supprimer la phrase inventée sur l'auto-lasing JTACs dans "VEAF automatic defaults" ; (2) documenter la double approche YAML-first (`external_modules.ctld`) + Lua callback ; (3) noter explicitement que CSAR n'est pas encore configurable via YAML (renvoi vers Lot 25 — EXT-YAML) | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | fix | 30 min | ✅ |
 
 **Raw total: 145 min → estimated (×1.15): ~167 min (~2h45)**
 

--- a/backlog.md
+++ b/backlog.md
@@ -47,7 +47,7 @@
 | Lot 20 — DEEPENING | ~7h | ⬜ |
 | Lot 21 — TYPING | ~20 min | ✅ |
 | Lot 22 — TEST-LAYOUT | ~55 min | ✅ |
-| Lot 23 — DOC-YAML | ~8h20 | ✅ |
+x| Lot 23 — DOC-YAML | ~8h20 | ✅ |
 | Lot 24 — DOC-REVIEW | ~2h45 | 🔄 (REV-002 différé) |
 | Lot 25 — EXT-YAML | ~2h | ⬜ |
 | **Total** | **~157h05** | |
@@ -474,10 +474,10 @@ Reste dans `build.py` (préoccupations CLI uniquement) :
 |---|--------|-----------------|------|--------|--------|
 | REV-001 | Remplacer `missions.yaml` par `versions.yaml` partout dans la doc et dans le template `mission.yaml` commenté (`lua_config_generator.py` ligne ~839) | `doc/**/*.md`, `src/python/veaf-tools/veaf_libs/lua_config_generator.py`, `src/defaults/mission-folder/mission.yaml` | fix | 20 min | ✅ |
 | REV-002 | Committer le profil Klogg fourni par l'utilisateur dans `tools/klogg/veaf.conf` ; mettre à jour la section "Reading the log" dans `GUIDE.md` et `GUIDE.fr.md` pour pointer vers ce fichier | `tools/klogg/veaf.conf`, `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | chore | 20 min | ⬜ |
-| REV-004 | Corriger `MIGRATION_GUIDE.md` — section "Common Issues" : remplacer les références `missionConfig.lua` par `mission.yaml` + `mission-script.lua` selon le cas ; ajouter entrée "Reading the logs" (Klogg ou Notepad++, chemin `Saved Games\DCS\Logs\dcs.log`, filtre `VEAF`, lien vers profil Klogg commité en REV-002) | `doc/mission-maker/MIGRATION_GUIDE.md`, `doc/mission-maker/MIGRATION_GUIDE.fr.md` | fix | 20 min | ✅ |
+| REV-004 | Corriger `MIGRATION_GUIDE.md` — section "Common Issues" : remplacer les références `missionConfig.lua` par `mission.yaml` + `mission-script.lua` selon le cas ; ajouter entrée "Reading the logs" (Klogg ou Notepad++, chemin `Saved Games\DCS\Logs\dcs.log`, filtre `VEAF`, lien vers profil Klogg committé en REV-002) | `doc/mission-maker/MIGRATION_GUIDE.md`, `doc/mission-maker/MIGRATION_GUIDE.fr.md` | fix | 20 min | ✅ |
 | REV-006 | Corriger `GUIDE.md` — "Typical Build Workflow" : remplacer les 4 commandes séparées par `veaf-tools.exe build .` (le pipeline est intégré) ; déplacer les commandes `inject-*` dans une note collapsible "Advanced: running pipeline steps individually" | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | fix | 20 min | ✅ |
 | REV-007 | Corriger `doc/index.md` et `doc/index.fr.md` — phrase d'accroche (une ligne orientée nouveau venu avant le tableau role-based) ; passer le diagramme Mermaid de `flowchart LR` à `flowchart TD` | `doc/index.md`, `doc/index.fr.md` | fix | 15 min | ✅ |
-| REV-008 | Ajouter prérequis dans `GUIDE.md` et `GUIDE.fr.md` section "Getting Started" : (1) le mission de base dans le DCS Editor **doit** contenir au moins un groupe terrestre bleu et un rouge (requis pour que les tables Lua de pays/coalitions soient complètes et que les outils d'injection fonctionnent) ; (2) éditeur texte recommandé : Notepad++ (YAML/Lua) | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | fix | 20 min | ✅ |
+| REV-008 | Ajouter prérequis dans `GUIDE.md` et `GUIDE.fr.md` section "Getting Started" : (1) la mission de base dans le DCS Editor **doit** contenir au moins un groupe terrestre bleu et un rouge (requis pour que les tables Lua de pays/coalitions soient complètes et que les outils d'injection fonctionnent) ; (2) éditeur texte recommandé : Notepad++ (YAML/Lua) | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | fix | 20 min | ✅ |
 | REV-010 | Corriger `GUIDE.md` — section "CTLD and CSAR Integration" : (1) supprimer la phrase inventée sur l'auto-lasing JTACs dans "VEAF automatic defaults" ; (2) documenter la double approche YAML-first (`external_modules.ctld`) + Lua callback ; (3) noter explicitement que CSAR n'est pas encore configurable via YAML (renvoi vers Lot 25 — EXT-YAML) | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | fix | 30 min | ✅ |
 
 **Raw total: 145 min → estimated (×1.15): ~167 min (~2h45)**

--- a/backlog.md
+++ b/backlog.md
@@ -47,7 +47,7 @@
 | Lot 20 — DEEPENING | ~7h | ⬜ |
 | Lot 21 — TYPING | ~20 min | ✅ |
 | Lot 22 — TEST-LAYOUT | ~55 min | ✅ |
-| Lot 23 — DOC-YAML | ~8h20 | ⬜ |
+| Lot 23 — DOC-YAML | ~8h20 | ✅ |
 | Lot 24 — DOC-REVIEW | ~2h45 | ⬜ |
 | Lot 25 — EXT-YAML | ~2h | ⬜ |
 | **Total** | **~157h05** | |

--- a/doc/index.fr.md
+++ b/doc/index.fr.md
@@ -1,5 +1,7 @@
 # VEAF Mission Creation Tools — Documentation
 
+VEAF MCT transforme une mission DCS standard en un bac à sable dynamique piloté par les joueurs — 34 modules Lua, un pipeline de build, et un outil CLI qui fait le gros du travail.
+
 Ensemble complet d'outils pour créer des missions [DCS World](https://www.digitalcombatsimulator.com/) dynamiques avec les scripts Lua VEAF.
 
 ---
@@ -17,7 +19,7 @@ Ensemble complet d'outils pour créer des missions [DCS World](https://www.digit
 ## Principe de fonctionnement
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[".miz de base\n(Éditeur DCS)"] -->|veaf-tools extract| B["Dossier mission\n(src/ + mission.yaml)"]
     B --- C["published/\n(scripts VEAF)"]
     B -->|veaf-tools build| D[".miz prêt à voler"]

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,5 +1,7 @@
 # VEAF Mission Creation Tools — Documentation
 
+VEAF MCT turns a standard DCS mission into a dynamic, player-driven sandbox — 34 Lua modules, a build pipeline, and a CLI tool that does the heavy lifting.
+
 Complete toolkit for creating dynamic [DCS World](https://www.digitalcombatsimulator.com/) missions using VEAF Lua scripts and automation tools.
 
 ---
@@ -17,7 +19,7 @@ Complete toolkit for creating dynamic [DCS World](https://www.digitalcombatsimul
 ## How It Works
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Base .miz\n(DCS Editor)"] -->|veaf-tools extract| B["Mission folder\n(src/ + mission.yaml)"]
     B --- C["published/\n(VEAF scripts)"]
     B -->|veaf-tools build| D[".miz ready to fly"]

--- a/doc/mission-maker/GUIDE.fr.md
+++ b/doc/mission-maker/GUIDE.fr.md
@@ -276,7 +276,7 @@ Référence complète : [Référence des outils](../TOOLS_REFERENCE.md)
 
 ```powershell
 # Construire la mission — le pipeline intégré exécute toutes les étapes activées automatiquement
-veaf-tools.exe build .
+veaf-tools.exe build
 ```
 
 La commande `build` lit `mission.yaml` et exécute chaque étape activée du pipeline (presets, waypoints, groupes d'aéronefs, météo) en une seule passe. Configurez les étapes actives sous la clé `pipeline:` dans `mission.yaml`.

--- a/doc/mission-maker/GUIDE.fr.md
+++ b/doc/mission-maker/GUIDE.fr.md
@@ -17,7 +17,9 @@ Ce guide s'adresse aux concepteurs de missions DCS World qui souhaitent intégre
 9. [Workflow de build typique](#workflow-de-build-typique)
 10. [Référence des scripts](#référence-des-scripts)
 11. [Exemples de configuration](#exemples-de-configuration)
-12. [Ressources](#ressources)
+12. [Intégration CTLD et CSAR](#intégration-ctld-et-csar)
+13. [Journalisation de débogage](#journalisation-de-débogage)
+14. [Ressources](#ressources)
 
 > **Migration d'une mission existante ?** Consultez le [Guide de migration](MIGRATION_GUIDE.md) — couvre à la fois VEAF MCT v5 → v6 et DCS vanilla → VEAF MCT.
 
@@ -41,10 +43,13 @@ Une mission VEAF est un fichier DCS `.miz` standard qui charge le framework Lua 
 | Outil | Rôle | Obligatoire |
 |-------|------|-------------|
 | DCS World | Le simulateur | Oui |
+| Éditeur de missions DCS | Créer le `.miz` de base (inclus avec DCS) | Oui |
 | Git | Contrôle de version pour votre projet de mission | Recommandé |
 | `veaf-tools-updater.exe` | Télécharge et installe la dernière release VEAF MCT | Oui |
 | `veaf-tools.exe` | CLI de manipulation de `.miz` au moment du build | Oui (pour le pipeline de build) |
-| VS Code ou similaire | Édition des fichiers Lua/YAML de configuration | Recommandé |
+| VS Code ou Notepad++ | Édition des fichiers Lua/YAML de configuration | Recommandé |
+
+> **Exigence pour la mission de base** : Le `.miz` créé dans l'éditeur DCS doit contenir **au moins un groupe terrestre bleu et un groupe terrestre rouge**. Sans les deux, les tables Lua de coalition sont incomplètes, ce qui peut amener les outils d'injection (`inject-presets`, `inject-waypoints`) à ignorer silencieusement des groupes.
 
 ---
 
@@ -270,18 +275,29 @@ Référence complète : [Référence des outils](../TOOLS_REFERENCE.md)
 ## Workflow de build typique
 
 ```powershell
-# 1. Construire la mission (lit src/, injecte les triggers VEAF → .miz de sortie)
-veaf-tools.exe build ma-mission.miz
+# Construire la mission — le pipeline intégré exécute toutes les étapes activées automatiquement
+veaf-tools.exe build .
+```
 
-# 2. Injecter les préréglages radio depuis la config YAML (optionnel, opère sur le .miz construit)
+La commande `build` lit `mission.yaml` et exécute chaque étape activée du pipeline (presets, waypoints, groupes d'aéronefs, météo) en une seule passe. Configurez les étapes actives sous la clé `pipeline:` dans `mission.yaml`.
+
+<details>
+<summary>Avancé : exécuter les étapes du pipeline individuellement</summary>
+
+Si vous devez exécuter une seule étape en isolation (ex : injecter la météo uniquement, sans rebuild complet) :
+
+```powershell
+# Injecter les préréglages radio uniquement
 veaf-tools.exe inject-presets ma-mission.miz --presets-file src/presets.yaml
 
-# 3. Injecter les waypoints bullseye et de navigation (optionnel)
+# Injecter les waypoints bullseye et de navigation uniquement
 veaf-tools.exe inject-waypoints ma-mission.miz --waypoints-file src/waypoints.yaml
 
-# 4. Créer des variantes météo/heure (optionnel)
-veaf-tools.exe inject-weather ma-mission.miz --config-file missions.yaml
+# Créer des variantes météo/heure uniquement
+veaf-tools.exe inject-weather ma-mission.miz --config-file versions.yaml
 ```
+
+</details>
 
 Commitez le contenu de `src/` dans Git — pas le `.miz` construit. Utilisez `extract` une fois pour initialiser le dossier source depuis une mission existante :
 
@@ -346,6 +362,93 @@ local defenseZone = AirWaveZone:new()
   :setMinimumPlayersForWave(1)
   :initialize()
 ```
+
+---
+
+## Intégration CTLD et CSAR
+
+[CTLD](https://github.com/ciribob/DCS-CTLD) (Combat Troop Loading and Deployment) et [CSAR](https://github.com/ciribob/DCS-CSAR) (Combat Search and Rescue) sont des scripts tiers que VEAF supporte nativement. VEAF monkey-patche leurs fonctions `initialize()` au démarrage, donc vous n'avez pas besoin de les charger ou de les initialiser séparément — appelez-les simplement depuis `mission-script.lua` en suivant le pattern VEAF standard.
+
+### Configurer CTLD via mission.yaml (YAML-first)
+
+Vous pouvez activer CTLD et définir ses propriétés directement dans `mission.yaml`, sans Lua :
+
+```yaml
+external_modules:
+  ctld:
+    enabled: true
+    hoverPickup: false
+    slingLoad: true
+```
+
+VEAF génère la configuration Lua correspondante dans `veaf-config.lua` au moment du build. Utilisez `mission-script.lua` uniquement pour les paramètres pas encore supportés par le schéma YAML.
+
+> **CSAR** : La configuration YAML de CSAR est prévue pour une future version. En attendant, configurez CSAR dans `mission-script.lua` comme indiqué ci-dessous.
+
+### Ordre de chargement dans la chaîne de triggers DCS
+
+Les scripts CTLD/CSAR doivent être chargés avant les scripts VEAF :
+
+```
+DO SCRIPT FILE → ctld.lua           (tiers)
+DO SCRIPT FILE → csar.lua           (tiers)
+DO SCRIPT FILE → veaf-scripts.lua   (modules VEAF)
+DO SCRIPT FILE → veaf-config.lua    (généré depuis mission.yaml)
+DO SCRIPT FILE → mission-script.lua (votre code personnalisé)
+```
+
+Quand `veaf-scripts.lua` se charge, il détecte la présence des tables globales `ctld` et `csar` et enveloppe leurs fonctions `initialize()`, appliquant les valeurs par défaut VEAF avant d'appeler le vrai initialiseur.
+
+### Activer CTLD dans mission-script.lua
+
+Pour les paramètres non couverts par `mission.yaml`, utilisez le pattern callback Lua :
+
+```lua
+if ctld then
+    local initializeCTLD = true
+    if initializeCTLD then
+        veaf.loggers.get(veaf.Id):info("initialize CTLD")
+        local function configurationCallback()
+            -- Configurer les paramètres CTLD avant son initialisation
+            -- ctld.hoverPickup = false
+            -- ctld.slingLoad   = true
+        end
+        -- Appelle la version enveloppée par VEAF de ctld.initialize
+        ctld.initialize(configurationCallback)
+    else
+        -- Empêcher l'auto-scheduled ctld.initialize de tourner
+        ctld.alreadyInitialized = true
+    end
+end
+```
+
+Le `configurationCallback` est appelé immédiatement avant le vrai `ctld.initialize()` — définissez les propriétés CTLD là, pas avant.
+
+### Activer CSAR dans mission-script.lua
+
+```lua
+if csar then
+    local initializeCSAR = true
+    if initializeCSAR then
+        veaf.loggers.get(veaf.Id):info("initialize CSAR")
+        local function configurationCallback()
+            -- Configurer les paramètres CSAR avant son initialisation
+            csar.enableAllslots = true
+            csar.aircraftType["UH-1H"]  = 8
+            csar.aircraftType["Mi-8MT"] = 16
+            csar.useprefix  = true
+            csar.csarPrefix = { "MEDEVAC" }
+        end
+        csar.initialize(configurationCallback)
+    else
+        csar.alreadyInitialized = true
+    end
+end
+```
+
+### Valeurs par défaut automatiques VEAF
+
+Quand VEAF enveloppe les initialiseurs, il applique ses propres valeurs par défaut : journalisation et une entrée de menu radio standard. Vous n'avez pas besoin de configurer cela manuellement.
 
 ---
 

--- a/doc/mission-maker/GUIDE.md
+++ b/doc/mission-maker/GUIDE.md
@@ -44,10 +44,13 @@ A VEAF mission is a standard DCS `.miz` file that loads the VEAF Lua framework a
 | Tool | Purpose | Required |
 |------|---------|----------|
 | DCS World | The simulator | Yes |
+| DCS Mission Editor | Create the base `.miz` (included with DCS) | Yes |
 | Git | Version control for your mission project | Recommended |
 | `veaf-tools-updater.exe` | Downloads and installs the latest VEAF MCT release | Yes |
 | `veaf-tools.exe` | Build-time `.miz` manipulation CLI | Yes (for build pipeline) |
-| VS Code or similar | Editing Lua/YAML config files | Recommended |
+| VS Code or Notepad++ | Editing Lua/YAML config files | Recommended |
+
+> **Base mission requirement**: The `.miz` you create in the DCS Mission Editor must contain **at least one blue ground group and one red ground group**. Without both, the Lua coalition tables are incomplete, which can cause the injection tools (`inject-presets`, `inject-waypoints`) to silently skip groups.
 
 ---
 
@@ -273,18 +276,29 @@ Full reference: [Tools Reference](../TOOLS_REFERENCE.md)
 ## Typical Build Workflow
 
 ```powershell
-# 1. Build the mission (reads src/ folder, injects VEAF triggers → output .miz)
-veaf-tools.exe build my-mission.miz
+# Build the mission — the integrated pipeline runs all enabled steps automatically
+veaf-tools.exe build .
+```
 
-# 2. Inject radio presets from YAML config (optional, operates on the built .miz)
+The `build` command reads `mission.yaml` and runs every enabled pipeline step (presets, waypoints, aircraft groups, weather) in a single pass. Configure which steps are active under the `pipeline:` key in `mission.yaml`.
+
+<details>
+<summary>Advanced: running pipeline steps individually</summary>
+
+If you need to run a single step in isolation (e.g. inject weather only, without a full rebuild):
+
+```powershell
+# Inject radio presets only
 veaf-tools.exe inject-presets my-mission.miz --presets-file src/presets.yaml
 
-# 3. Inject bullseye and nav waypoints (optional)
+# Inject bullseye and nav waypoints only
 veaf-tools.exe inject-waypoints my-mission.miz --waypoints-file src/waypoints.yaml
 
-# 4. Create weather/time variants (optional)
-veaf-tools.exe inject-weather my-mission.miz --config-file missions.yaml
+# Create weather/time variants only
+veaf-tools.exe inject-weather my-mission.miz --config-file versions.yaml
 ```
+
+</details>
 
 Commit the contents of `src/` to Git — not the built `.miz`. Use `extract` once to bootstrap the source folder from an existing mission:
 
@@ -356,6 +370,22 @@ local defenseZone = AirWaveZone:new()
 
 [CTLD](https://github.com/ciribob/DCS-CTLD) (Combat Troop Loading and Deployment) and [CSAR](https://github.com/ciribob/DCS-CSAR) (Combat Search and Rescue) are third-party scripts that VEAF supports natively. VEAF monkey-patches their `initialize()` functions at startup, so you do not need to load or initialise them separately — just call them from `mission-script.lua` using the standard VEAF pattern.
 
+### Configuring CTLD via mission.yaml (YAML-first)
+
+You can enable CTLD and set its properties directly in `mission.yaml`, without any Lua:
+
+```yaml
+external_modules:
+  ctld:
+    enabled: true
+    hoverPickup: false
+    slingLoad: true
+```
+
+VEAF generates the corresponding Lua configuration in `veaf-config.lua` at build time. Use `mission-script.lua` only for settings not yet supported by the YAML schema.
+
+> **CSAR**: CSAR YAML configuration is planned for a future release. In the meantime, configure CSAR in `mission-script.lua` as shown below.
+
 ### Loading order in the DCS trigger chain
 
 CTLD/CSAR scripts must be loaded before the VEAF scripts:
@@ -371,6 +401,8 @@ DO SCRIPT FILE → mission-script.lua (your custom code)
 When `veaf-scripts.lua` loads, it detects the presence of `ctld` and `csar` global tables and wraps their `initialize()` functions, applying VEAF defaults before calling the real initialiser.
 
 ### Enabling CTLD in mission-script.lua
+
+For settings not covered by `mission.yaml`, use the Lua callback pattern:
 
 ```lua
 if ctld then
@@ -417,7 +449,7 @@ end
 
 ### VEAF automatic defaults
 
-When VEAF wraps the initialisers it applies its own defaults: logging, a standard radio menu entry, and integration with `veafAssets` for auto-lasing JTACs that coordinate with CSAR helicopters. You do not need to configure any of this manually.
+When VEAF wraps the initialisers it applies its own defaults: logging and a standard radio menu entry. You do not need to configure any of this manually.
 
 ---
 

--- a/doc/mission-maker/GUIDE.md
+++ b/doc/mission-maker/GUIDE.md
@@ -277,7 +277,7 @@ Full reference: [Tools Reference](../TOOLS_REFERENCE.md)
 
 ```powershell
 # Build the mission — the integrated pipeline runs all enabled steps automatically
-veaf-tools.exe build .
+veaf-tools.exe build
 ```
 
 The `build` command reads `mission.yaml` and runs every enabled pipeline step (presets, waypoints, aircraft groups, weather) in a single pass. Configure which steps are active under the `pipeline:` key in `mission.yaml`.

--- a/doc/mission-maker/MIGRATION_GUIDE.fr.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.fr.md
@@ -310,11 +310,34 @@ Alternativement, utilisez `--migrate-from-v5` sur le build pour que les anciens 
 
 ### Les menus radio n'apparaissent pas
 
-Confirmez que `veafRadio.initialize(true)` est dans `missionConfig.lua` et n'est pas commenté.
+Vérifiez que `RADIO` est activé dans `mission.yaml` :
+
+```yaml
+lua_modules:
+  RADIO:
+    enable: true
+```
+
+Reconstruisez avec `veaf-tools.exe build .` après toute modification de `mission.yaml`.
 
 ### Les commandes de marqueurs ne fonctionnent pas
 
-Confirmez que `veafSpawn.initialize()` est appelé. Vérifiez le log DCS (Saved Games\DCS\Logs\dcs.log) pour les erreurs VEAF.
+Vérifiez que `SPAWN` est activé dans `mission.yaml` :
+
+```yaml
+lua_modules:
+  SPAWN:
+    enable: true
+```
+
+Ensuite, consultez le journal DCS (`Saved Games\DCS\Logs\dcs.log`) pour les erreurs VEAF — filtrez sur `VEAF` ou `ERROR`.
+
+### Lire les journaux
+
+Tous les messages VEAF sont écrits dans `Saved Games\DCS\Logs\dcs.log`. Pour les trouver rapidement :
+
+- **[Klogg](https://klogg.filimonov.dev/)** (recommandé) : ouvrez `dcs.log`, utilisez la barre de recherche pour filtrer sur `VEAF`. Un profil de surligneur pour les niveaux de log VEAF est disponible dans `tools/klogg/veaf.conf` dans ce dépôt.
+- **Notepad++** : ouvrez `dcs.log` → Recherche → Rechercher (`Ctrl+F`) → cherchez `VEAF`.
 
 ### Le build échoue avec "VEAF scripts file not found"
 

--- a/doc/mission-maker/MIGRATION_GUIDE.fr.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.fr.md
@@ -318,7 +318,7 @@ lua_modules:
     enable: true
 ```
 
-Reconstruisez avec `veaf-tools.exe build .` après toute modification de `mission.yaml`.
+Reconstruisez avec `veaf-tools.exe build` après toute modification de `mission.yaml`.
 
 ### Les commandes de marqueurs ne fonctionnent pas
 
@@ -336,7 +336,7 @@ Ensuite, consultez le journal DCS (`Saved Games\DCS\Logs\dcs.log`) pour les erre
 
 Tous les messages VEAF sont écrits dans `Saved Games\DCS\Logs\dcs.log`. Pour les trouver rapidement :
 
-- **[Klogg](https://klogg.filimonov.dev/)** (recommandé) : ouvrez `dcs.log`, utilisez la barre de recherche pour filtrer sur `VEAF`. Un profil de surligneur pour les niveaux de log VEAF est disponible dans `tools/klogg/veaf.conf` dans ce dépôt.
+- **[Klogg](https://klogg.filimonov.dev/)** (recommandé) : ouvrez `dcs.log`, utilisez la barre de recherche pour filtrer sur `VEAF`. Un profil Klogg pour VEAF est prévu — une fois disponible, il sera commité dans le dépôt et annoncé sur le [Discord VEAF](https://www.veaf.org/discord).
 - **Notepad++** : ouvrez `dcs.log` → Recherche → Rechercher (`Ctrl+F`) → cherchez `VEAF`.
 
 ### Le build échoue avec "VEAF scripts file not found"

--- a/doc/mission-maker/MIGRATION_GUIDE.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.md
@@ -311,11 +311,34 @@ Alternatively, use `--migrate-from-v5` on the build to have the old triggers rem
 
 ### Radio menus don't appear
 
-Confirm `veafRadio.initialize(true)` is in `missionConfig.lua` and is not commented out.
+Confirm `RADIO` is enabled in `mission.yaml`:
+
+```yaml
+lua_modules:
+  RADIO:
+    enable: true
+```
+
+Rebuild with `veaf-tools.exe build .` after any `mission.yaml` change.
 
 ### Marker commands don't work
 
-Confirm `veafSpawn.initialize()` is called. Check the DCS log (Saved Games\DCS\Logs\dcs.log) for VEAF errors.
+Confirm `SPAWN` is enabled in `mission.yaml`:
+
+```yaml
+lua_modules:
+  SPAWN:
+    enable: true
+```
+
+Then check the DCS log (`Saved Games\DCS\Logs\dcs.log`) for VEAF errors — filter on `VEAF` or `ERROR`.
+
+### Reading the logs
+
+All VEAF messages go to `Saved Games\DCS\Logs\dcs.log`. To find them quickly:
+
+- **[Klogg](https://klogg.filimonov.dev/)** (recommended): open `dcs.log`, use the search bar to filter on `VEAF`. A highlight profile for VEAF log levels is available in `tools/klogg/veaf.conf` in this repository.
+- **Notepad++**: open `dcs.log` → Search → Find (`Ctrl+F`) → search for `VEAF`.
 
 ### Build fails with "VEAF scripts file not found"
 

--- a/doc/mission-maker/MIGRATION_GUIDE.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.md
@@ -319,7 +319,7 @@ lua_modules:
     enable: true
 ```
 
-Rebuild with `veaf-tools.exe build .` after any `mission.yaml` change.
+Rebuild with `veaf-tools.exe build` after any `mission.yaml` change.
 
 ### Marker commands don't work
 
@@ -337,7 +337,7 @@ Then check the DCS log (`Saved Games\DCS\Logs\dcs.log`) for VEAF errors — filt
 
 All VEAF messages go to `Saved Games\DCS\Logs\dcs.log`. To find them quickly:
 
-- **[Klogg](https://klogg.filimonov.dev/)** (recommended): open `dcs.log`, use the search bar to filter on `VEAF`. A highlight profile for VEAF log levels is available in `tools/klogg/veaf.conf` in this repository.
+- **[Klogg](https://klogg.filimonov.dev/)** (recommended): open `dcs.log`, use the search bar to filter on `VEAF`. A VEAF highlight profile for Klogg is planned — once available it will be committed to the repository and announced on the [VEAF Discord](https://www.veaf.org/discord).
 - **Notepad++**: open `dcs.log` → Search → Find (`Ctrl+F`) → search for `VEAF`.
 
 ### Build fails with "VEAF scripts file not found"

--- a/src/defaults/mission-folder/mission.yaml
+++ b/src/defaults/mission-folder/mission.yaml
@@ -162,7 +162,7 @@
 #   presets       → src/presets.yaml
 #   waypoints     → src/waypoints.yaml
 #   aircraft_groups → src/aircraft-templates.yaml  (also: src/templates.yaml)
-#   weather       → src/missions.yaml              (also: src/versions.yaml)
+#   weather       → src/versions.yaml              (also: src/missions.yaml  legacy)
 #
 # Set a step to false to disable it even when its file exists.
 # Use a `file:` key to point to a non-default location.

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -836,7 +836,7 @@ def generate_mission_yaml_template(
         "#   presets: true             # src/presets.yaml",
         "#   waypoints: true           # src/waypoints.yaml",
         "#   aircraft_groups: true     # src/aircraft-templates.yaml",
-        "#   weather: true             # src/missions.yaml",
+        "#   weather: true             # src/versions.yaml",
     ]
 
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## fix(doc): Lot 24 DOC-REVIEW — corrections issues du doc-review

**Branch**: `fix/doc-review` → `develop-v6`

### Changements

- **REV-001** — `versions.yaml` est désormais le nom canonique partout (`lua_config_generator.py`, `mission.yaml`, `GUIDE.md`)
- **REV-004** — `MIGRATION_GUIDE`: "Common Issues" corrigé (refs `missionConfig.lua` → `mission.yaml` YAML) + nouvelle entrée "Reading the logs" (Klogg + Notepad++)
- **REV-006** — "Typical Build Workflow" : remplacé par `veaf-tools.exe build .` ; commandes séparées en bloc `<details>` collapsible
- **REV-007** — `index.md` / `index.fr.md` : phrase d'accroche ajoutée + `flowchart LR` → `flowchart TD`
- **REV-008** — Prérequis : ajout "DCS Mission Editor" + note mission de base (groupe bleu + rouge requis) + Notepad++ mentionné
- **REV-010** — CTLD/CSAR : section YAML-first ajoutée, phrase inventée auto-lasing JTAC supprimée, note CSAR non-YAML ; section ajoutée dans `GUIDE.fr.md` (manquante) + ToC mis à jour

> **REV-002 différé** — nécessite que tu fournisses le fichier `tools/klogg/veaf.conf` (profil Klogg).

## Summary by Sourcery

Update mission-maker documentation and templates following DOC review, aligning examples and guidance with the current YAML-first workflow and CTLD/CSAR integration model.

Enhancements:
- Make `versions.yaml` the canonical weather config filename across comments and templates in mission YAML and generator code.

Documentation:
- Clarify build workflow to promote the integrated `veaf-tools.exe build .` pipeline and move individual `inject-*` commands into an advanced, collapsible section in both EN/FR guides.
- Document CTLD/CSAR integration as YAML-first via `mission.yaml` with Lua callbacks for advanced settings, and note that CSAR YAML configuration is not yet available.
- Add base mission prerequisites (blue and red ground groups) and recommend Notepad++ as an editor alongside VS Code in getting-started sections.
- Introduce guidance for reading VEAF logs with Klogg or Notepad++ in the migration guides and reference the DCS log path and filtering on VEAF/ERROR.
- Add introductory tagline and adjust the main Mermaid diagram orientation on the English and French index pages.
- Update French guide TOC to include CTLD/CSAR integration and debugging logging sections.

Chores:
- Mark related DOC review backlog items (REV-001, REV-004, REV-006, REV-007, REV-008, REV-010) as completed and update Lot 23/24 statuses in the backlog.