### PR TITLE
fix(bundle): add veafCommands.lua to lua_scripts concat list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- `veaf_build/worker.py`: `veafCommands.lua` absent de la liste de concaténation → crash `attempt to index global 'veafCommands' (a nil value)` au chargement de mission (BUNDLE-001)
+
+---
+
 ## [6.3.0] — 2026-05-31
 
 ### Added

--- a/backlog.md
+++ b/backlog.md
@@ -52,9 +52,25 @@ x| Lot 23 — DOC-YAML | ~8h20 | ✅ |
 | Lot 25 — EXT-YAML | ~2h | ⬜ |
 | Lot FIX-SORT — LUADATA FIX | ~15 min | ✅ |
 | Lot 26 — IMC-FEEDBACK | ~2h40 | ✅ |
-| **Total** | **~160h00** | |
+| Lot FIX-BUNDLE — VEAFCOMMANDS MISSING | ~10 min | ✅ |
+| **Total** | **~160h10** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*
+
+---
+
+## Lot FIX-BUNDLE — VEAFCOMMANDS MISSING: veafCommands.lua absent du bundle
+
+**Goal**: Corriger le crash `attempt to index global 'veafCommands' (a nil value)` au chargement de mission — `veafCommands.lua` était absent de la liste de concaténation dans `veaf_build/worker.py`.
+
+**Context**: `veafGroundAI.lua`, `veafCasMission.lua` et d'autres modules appellent `veafCommands.registerCommandHandler()` dans leur `initialize()`. Or `veafCommands.lua` n'était pas inclus dans `lua_scripts` → absent du bundle `veaf-scripts.lua` → nil au runtime. Le guard IMC-010 dans `veaf.initialize()` ne pouvait pas non plus aider car il est lui-même dans le bundle.
+**Branch**: `fix/veafcommands-missing-bundle` → PR → `develop-v6`
+
+| # | Ticket | Fichiers touchés | Type | Effort | Status |
+|---|--------|-----------------|------|--------|--------|
+| BUNDLE-001 | Ajouter `"veafCommands.lua"` dans `lua_scripts` après `"veafMarkers.lua"` dans `veaf_build/worker.py` | `veaf_build/worker.py` | fix | 5 min | ✅ |
+
+**Raw total: 5 min → estimated (×1.15): ~6 min (~10 min)**
 
 ---
 

--- a/doc/mission-maker/MIGRATION_GUIDE.fr.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.fr.md
@@ -171,7 +171,7 @@ La commande `convert-mission` fait tout en une étape : extraction, injection de
 
 Cela :
 1. Extrait `vanilla.miz` dans `src/mission/`
-2. Copie le `src/scripts/missionConfig.lua` par défaut
+2. Crée `mission.yaml` et `src/scripts/mission-script.lua` par défaut
 3. Injecte le trigger chargeur VEAF MCT v6
 4. Reconstruit un nouveau `.miz` à côté du dossier
 
@@ -192,30 +192,27 @@ Puis copiez votre `.miz` sous `mission.miz` et exécutez :
 
 #### 5. Configurer les modules à activer
 
-Ouvrez `src/scripts/missionConfig.lua`. Par défaut, seuls les modules essentiels (marqueurs, spawn, radio) sont activés. Décommentez les modules que vous souhaitez :
+Éditez `mission.yaml` pour activer les modules souhaités. Par défaut, seuls les modules essentiels (marqueurs, spawn, radio) sont actifs :
 
-```lua
-veaf.config.MISSION_NAME = "Ma Mission Vanilla"
+```yaml
+name: Ma Mission Vanilla
 
-if veafRadio then
-    veafRadio.initialize(true)
-end
-if veafSpawn then
-    veafSpawn.initialize()
-end
-
--- Décommenter pour activer les missions CAS :
--- if veafCasMission then
---     veafCasMission.initialize()
--- end
-
--- Décommenter pour activer les opérations carrier :
--- if veafCarrierOperations then
---     veafCarrierOperations.initialize()
--- end
+lua_modules:
+  RADIO:
+    enable: true
+  SPAWN:
+    enable: true
+  # Décommenter pour activer les missions CAS :
+  # CASMISSION:
+  #   enable: true
+  # Décommenter pour activer les opérations carrier :
+  # CARRIER:
+  #   enable: true
 ```
 
-Consultez la [référence missionConfig.lua](#référence-missionconfiglua) ci-dessous et les guides de scripts individuels dans [scripts/](scripts/README.md) pour toutes les options.
+Pour du Lua personnalisé (appels de modules avancés, aliases, etc.), éditez `src/scripts/mission-script.lua`.
+
+Consultez la [référence YAML](../../MISSION_YAML_REFERENCE.md) et les guides de scripts individuels dans [scripts/](scripts/README.md) pour toutes les options.
 
 #### 6. Conserver votre contenu de mission existant
 
@@ -249,11 +246,12 @@ ma-mission/
 │   │   ├── options
 │   │   └── warehouses
 │   ├── scripts/
-│   │   ├── missionConfig.lua   ← votre config de modules (à commiter)
+│   │   ├── mission-script.lua  ← code Lua personnalisé (à commiter)
 │   │   └── veafDynamicConfig.lua   ← config de slots dynamiques (optionnel)
 │   ├── presets.yaml            ← config des préréglages radio (optionnel)
 │   ├── spawnables.yaml         ← groupes spawnable personnalisés (optionnel)
 │   └── waypoints.yaml          ← waypoints personnalisés (optionnel)
+├── mission.yaml                ← config des modules et du pipeline (à commiter)
 ├── published/                  ← installé par veaf-tools-updater (NE PAS commiter)
 │   ├── veaf-scripts.lua
 │   └── ...
@@ -273,30 +271,25 @@ __pycache__/
 
 ---
 
-## Référence missionConfig.lua
+## Référence mission-script.lua
 
-Le `missionConfig.lua` minimal fonctionnel :
+`mission-script.lua` est un fichier optionnel pour du code Lua personnalisé exécuté après l'initialisation de tous les modules VEAF. Utilisez-le pour la configuration avancée qui ne peut pas encore s'exprimer dans `mission.yaml` — aliases personnalisés, surcharges de paramètres de modules, assets, etc.
+
+Exemple minimal :
 
 ```lua
-veaf.config.MISSION_NAME = "Ma Mission"   -- affiché dans les logs
+-- Optionnel : surcharger un paramètre de module
+veafSpawn.SpawnKeyphrase = "_spawn"
 
--- Module radio (requis pour tous les menus F10)
-if veafRadio then
-    veafRadio.initialize(true)
-end
-
--- Module spawn (requis pour les commandes de marqueurs)
-if veafSpawn then
-    veafSpawn.initialize()
-end
-
--- Raccourcis (requis pour les alias)
-if veafShortcuts then
-    veafShortcuts.initialize()
-end
+-- Alias personnalisé
+veafShortcuts.AddAlias(
+  VeafAlias:new()
+    :setName("-monalias")
+    :setVeafCommand("_spawn group, name mon-template")
+)
 ```
 
-Pour chaque module supplémentaire, consultez le guide correspondant dans [scripts/](scripts/README.md).
+L'activation/désactivation des modules se configure dans `mission.yaml` → `lua_modules:` — pas dans ce fichier. Consultez la [référence YAML](../../MISSION_YAML_REFERENCE.md) pour la syntaxe complète de `mission.yaml`.
 
 ---
 

--- a/doc/mission-maker/MIGRATION_GUIDE.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.md
@@ -172,7 +172,7 @@ The `convert-mission` command does everything in one step: extract, inject VEAF 
 
 This:
 1. Extracts `vanilla.miz` into `src/mission/`
-2. Copies the default `src/scripts/missionConfig.lua`
+2. Creates default `mission.yaml` and `src/scripts/mission-script.lua`
 3. Injects the v6 VEAF loader trigger
 4. Rebuilds a new `.miz` next to the folder
 
@@ -193,30 +193,27 @@ Then copy your `.miz` as `mission.miz` and run:
 
 #### 5. Configure which modules to enable
 
-Open `src/scripts/missionConfig.lua`. By default, only the essential modules (markers, spawn, radio) are enabled. Uncomment the modules you want:
+Edit `mission.yaml` to enable the modules you want. By default, only the essential modules (markers, spawn, radio) are active:
 
-```lua
-veaf.config.MISSION_NAME = "My Vanilla Mission"
+```yaml
+name: My Vanilla Mission
 
-if veafRadio then
-    veafRadio.initialize(true)
-end
-if veafSpawn then
-    veafSpawn.initialize()
-end
-
--- Uncomment to enable CAS missions:
--- if veafCasMission then
---     veafCasMission.initialize()
--- end
-
--- Uncomment to enable carrier ops:
--- if veafCarrierOperations then
---     veafCarrierOperations.initialize()
--- end
+lua_modules:
+  RADIO:
+    enable: true
+  SPAWN:
+    enable: true
+  # Uncomment to enable CAS missions:
+  # CASMISSION:
+  #   enable: true
+  # Uncomment to enable carrier ops:
+  # CARRIER:
+  #   enable: true
 ```
 
-See [missionConfig.lua reference](#missionconfiglua-reference) below and the individual script guides in [scripts/](scripts/README.md) for all options.
+For custom Lua (advanced module calls, custom aliases, etc.), edit `src/scripts/mission-script.lua`.
+
+See the [YAML reference](../../MISSION_YAML_REFERENCE.md) and the individual script guides in [scripts/](scripts/README.md) for all options.
 
 #### 6. Keep your existing mission content
 
@@ -250,11 +247,12 @@ my-mission/
 │   │   ├── options
 │   │   └── warehouses
 │   ├── scripts/
-│   │   ├── missionConfig.lua   ← your module config (commit this)
+│   │   ├── mission-script.lua  ← custom Lua code (commit this)
 │   │   └── veafDynamicConfig.lua   ← optional dynamic slots config
 │   ├── presets.yaml            ← radio presets config (optional)
 │   ├── spawnables.yaml         ← custom spawnable groups (optional)
 │   └── waypoints.yaml          ← custom waypoints (optional)
+├── mission.yaml                ← module config and pipeline settings (commit this)
 ├── published/                  ← installed by veaf-tools-updater (do NOT commit)
 │   ├── veaf-scripts.lua
 │   └── ...
@@ -274,30 +272,25 @@ __pycache__/
 
 ---
 
-## missionConfig.lua Reference
+## mission-script.lua Reference
 
-The minimal working `missionConfig.lua`:
+`mission-script.lua` is an optional file for custom Lua code that runs after all VEAF modules are initialized. Use it for advanced configuration that cannot yet be expressed in `mission.yaml` — custom shortcuts, per-module parameter overrides, custom assets, etc.
+
+A minimal example:
 
 ```lua
-veaf.config.MISSION_NAME = "My Mission"   -- shown in logs
+-- Optional: override a module parameter
+veafSpawn.SpawnKeyphrase = "_spawn"
 
--- Radio module (required for all F10 menus)
-if veafRadio then
-    veafRadio.initialize(true)
-end
-
--- Spawn module (required for marker commands)
-if veafSpawn then
-    veafSpawn.initialize()
-end
-
--- Shortcuts (required for aliases)
-if veafShortcuts then
-    veafShortcuts.initialize()
-end
+-- Custom alias
+veafShortcuts.AddAlias(
+  VeafAlias:new()
+    :setName("-myalias")
+    :setVeafCommand("_spawn group, name my-template")
+)
 ```
 
-For each additional module, see the corresponding guide in [scripts/](scripts/README.md).
+Module enable/disable is configured in `mission.yaml` → `lua_modules:` — not in this file. See the [YAML reference](../../MISSION_YAML_REFERENCE.md) for the full `mission.yaml` syntax.
 
 ---
 

--- a/doc/mission-maker/scripts/veafCarrierOperations.fr.md
+++ b/doc/mission-maker/scripts/veafCarrierOperations.fr.md
@@ -101,7 +101,7 @@ Le module connaît l'offset de pont incliné pour tous les porte-avions DCS stan
 ## Exemple de configuration
 
 ```lua
--- Dans missionconfig.lua
+-- Dans mission-script.lua
 veafCarrierOperations.initialize()
 
 -- Les porte-avions sont enregistrés via veafAssets :

--- a/doc/mission-maker/scripts/veafCarrierOperations.md
+++ b/doc/mission-maker/scripts/veafCarrierOperations.md
@@ -102,7 +102,7 @@ The module knows the angled-deck offset for all stock DCS carriers:
 ## Example Configuration
 
 ```lua
--- In missionconfig.lua
+-- In mission-script.lua
 veafCarrierOperations.initialize()
 
 -- Carriers are registered via veafAssets:

--- a/doc/mission-maker/scripts/veafCombatZone.md
+++ b/doc/mission-maker/scripts/veafCombatZone.md
@@ -120,7 +120,7 @@ This approach gives you full visual design in the editor while keeping the zone 
 1. **Create a trigger zone** — define the combat area. Name it, e.g. `ZONE-ALPHA`.
 2. **Place unit groups** inside the zone. Set them to any coalition — VEAF will handle their lifecycle.
 3. **Use unit name tags** (see below) to customise spawn behaviour per group.
-4. **Register the zone** in `missionConfig.lua`:
+4. **Register the zone** in `mission-script.lua`:
 
 ```lua
 VeafCombatZone:new()

--- a/doc/mission-maker/scripts/veafNamedPoints.fr.md
+++ b/doc/mission-maker/scripts/veafNamedPoints.fr.md
@@ -75,7 +75,7 @@ lua_modules:
 
 ---
 
-## Prédéfinir des points dans missionconfig.lua
+## Prédéfinir des points dans mission-script.lua
 
 Les points nommés peuvent être prédéfinis par programmation :
 

--- a/doc/mission-maker/scripts/veafNamedPoints.md
+++ b/doc/mission-maker/scripts/veafNamedPoints.md
@@ -76,7 +76,7 @@ lua_modules:
 
 ---
 
-## Pre-defining Points in missionconfig.lua
+## Pre-defining Points in mission-script.lua
 
 Named points can be pre-defined programmatically:
 

--- a/doc/mission-maker/scripts/veafQraManager.md
+++ b/doc/mission-maker/scripts/veafQraManager.md
@@ -240,7 +240,7 @@ Full states:
 
 1. **Create a trigger zone** — draw the airspace you want to protect. Name it something memorable, e.g. `ZONE-QRA-NORTH`.
 2. **Place the QRA group** — create the aircraft group that will scramble. Set it to **Late Activation** so it does not spawn at mission start (VEAF handles activation). Give the group a distinctive name, e.g. `MiG-29 QRA North`.
-3. **Wire it up in `missionConfig.lua`**:
+3. **Wire it up in `mission-script.lua`** (or via `mission.yaml` → `qra:` for the recommended YAML approach):
 
 ```lua
 VeafQRA:new()

--- a/doc/mission-maker/scripts/veafSecurity.fr.md
+++ b/doc/mission-maker/scripts/veafSecurity.fr.md
@@ -37,7 +37,7 @@ Le niveau de sécurité par défaut pour les commandes de spawn peut être défi
 Les mots de passe sont stockés sous forme de hachages SHA-1 pour la sécurité. Utiliser la fonction intégrée `sha1` :
 
 ```lua
--- Dans missionconfig.lua (après chargement de veafSecurity)
+-- Dans mission-script.lua (après chargement de veafSecurity)
 
 -- Effacer les mots de passe par défaut et définir les vôtres
 veafSecurity.password_L1 = {}

--- a/doc/mission-maker/scripts/veafSecurity.md
+++ b/doc/mission-maker/scripts/veafSecurity.md
@@ -38,7 +38,7 @@ The default security level for spawn commands can be set per-module.
 Passwords are stored as SHA-1 hashes for security. Use the built-in `sha1` function:
 
 ```lua
--- In missionconfig.lua (after veafSecurity is loaded)
+-- In mission-script.lua (after veafSecurity is loaded)
 
 -- Clear default passwords and set your own
 veafSecurity.password_L1 = {}

--- a/doc/mission-maker/scripts/veafShortcuts.fr.md
+++ b/doc/mission-maker/scripts/veafShortcuts.fr.md
@@ -74,7 +74,7 @@ Les créateurs de missions peuvent également ajouter des aliases personnalisés
 
 ## Aliases personnalisés
 
-Ajoutez des aliases spécifiques à votre mission dans `missionConfig.lua` :
+Ajoutez des aliases spécifiques à votre mission dans `mission-script.lua` :
 
 ```lua
 veafShortcuts.AddAlias(

--- a/doc/mission-maker/scripts/veafShortcuts.md
+++ b/doc/mission-maker/scripts/veafShortcuts.md
@@ -74,7 +74,7 @@ Mission makers can also add custom aliases in `mission-script.lua`:
 
 ## Custom Aliases
 
-Add mission-specific aliases in your `missionConfig.lua`:
+Add mission-specific aliases in your `mission-script.lua`:
 
 ```lua
 veafShortcuts.AddAlias(

--- a/doc/mission-maker/scripts/veafSkynetIadsHelper.fr.md
+++ b/doc/mission-maker/scripts/veafSkynetIadsHelper.fr.md
@@ -20,7 +20,7 @@ Intègre les groupes de missions VEAF avec le script tiers [Skynet IADS](https:/
 ## Activation
 
 ```lua
--- Charger Skynet en premier (dans vos triggers DO SCRIPT FILE ou missionconfig.lua)
+-- Charger Skynet en premier (dans vos triggers DO SCRIPT FILE ou mission-script.lua)
 -- Puis :
 veafSkynetIadsHelper.initialize()
 ```

--- a/doc/mission-maker/scripts/veafSkynetIadsHelper.md
+++ b/doc/mission-maker/scripts/veafSkynetIadsHelper.md
@@ -26,7 +26,7 @@ The VEAF module (`veafSkynet`) handles the construction of the Skynet network fo
 veafSkynet.initialize()
 ```
 
-Call this from `missionConfig.lua` after your other module initialisations. Skynet networks for both coalitions are built automatically.
+Call this from `mission-script.lua` after your other module initialisations. Skynet networks for both coalitions are built automatically.
 
 ### Optional parameters
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.0"
+version = "6.3.1"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/veaf_build/worker.py
+++ b/veaf_build/worker.py
@@ -145,6 +145,7 @@ class BuildAndReleaseWorker:
                     "veafCacheManager.lua",
                     "veafEventHandler.lua",
                     "veafMarkers.lua",
+                    "veafCommands.lua",
                     "veafInterpreter.lua",
                     "veafRadio.lua",
                     "veafRemote.lua",


### PR DESCRIPTION
## Problem

`veafCommands.lua` was missing from the `lua_scripts` concatenation list in `veaf_build/worker.py`. The resulting `veaf-scripts.lua` bundle never included `veafCommands`, causing a crash at mission load:

```
ERROR SCRIPTING (Main): Mission script error:
  [string "l10n/DEFAULT/veaf-scripts.lua"]:28283:
  attempt to index global 'veafCommands' (a nil value)
stack traceback:
  [string "l10n/DEFAULT/veaf-config.lua"]:19: in main chunk
```

`veafGroundAI`, `veafCasMission` and other modules call `veafCommands.registerCommandHandler()` during their `initialize()`. Since `veafCommands` was never loaded, the global was nil.

## Fix

Added `"veafCommands.lua"` after `"veafMarkers.lua"` in the `lua_scripts` list (dependency order: `veafCommands` depends on `veafMarkers`).

## Ticket

BUNDLE-001 (Lot FIX-BUNDLE — `backlog.md`)

## Summary by Sourcery

Fix bundling of VEAF Lua scripts and update mission maker docs to reflect the new YAML-based configuration flow and mission-script.lua usage.

Bug Fixes:
- Include veafCommands.lua in the veaf-scripts.lua concatenation list to prevent veafCommands being nil at mission load (BUNDLE-001).

Enhancements:
- Clarify the role of mission.yaml versus mission-script.lua and shift examples from missionConfig.lua to mission-script.lua across mission maker documentation.
- Document the new configuration layout and file structure for missions, including mission.yaml as the primary module configuration source.
- Update script-specific docs to reference mission-script.lua for custom Lua hooks and configuration instead of missionConfig.lua.

Build:
- Bump veaf-tools package version from 6.3.0 to 6.3.1.

Documentation:
- Revise French and English migration guides to describe YAML-based module configuration, default file generation, and the use of mission-script.lua for advanced Lua customization.
- Adjust multiple module documentation pages to reference mission-script.lua as the place for mission-specific Lua (aliases, security, carriers, combat zones, QRA, Skynet, named points, etc.).

Chores:
- Update backlog with Lot FIX-BUNDLE entry for veafCommands bundling fix and adjusted total effort.