### PR TITLE
fix(assets): Lua long-string for asset fields containing newline or quote

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,12 @@ For each task or fix, rigorously apply these steps in order:
 4. Increment the PATCH version in `pyproject.toml`.
 5. Run the `poetry install` command to update the development environment.
 
+## PULL REQUEST PROCESS
+
+After pushing a branch and creating a PR:
+- **Do NOT request a Copilot review.** Sourcery reviews PRs automatically.
+- Request a Copilot review **only if** Sourcery posts a comment stating it cannot review the PR.
+
 ## PIPELINE COMMANDS
 
 - **Application Build**: `poetry run veaf-build build --version x.y.z`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- `lua_config_generator.py`: asset `description`, `name`, `information` fields containing `\n` or `"` now use Lua long-string syntax (`[[...]]`) instead of plain `"..."` — prevents Lua syntax error at mission load
+
 ---
 
 ## [6.3.2] — 2026-06-05

--- a/backlog.md
+++ b/backlog.md
@@ -53,7 +53,7 @@ x| Lot 23 — DOC-YAML | ~8h20 | ✅ |
 | Lot FIX-SORT — LUADATA FIX | ~15 min | ✅ |
 | Lot 26 — IMC-FEEDBACK | ~2h40 | ✅ |
 | Lot FIX-BUNDLE — VEAFCOMMANDS MISSING | ~10 min | ✅ |
-| Lot FIX-ASSETS-NEWLINE — ASSETS newline in Lua string | ~20 min | ⬜ |
+| Lot FIX-ASSETS-NEWLINE — ASSETS newline in Lua string | ~20 min | ✅ |
 | Lot FIX-WEATHER-ALIAS — missions.yaml + versions.yaml coexistence | ~25 min | ⬜ |
 | Lot FIX-MISSIONCONFIG-BAK — supprimer extension .bak inutile | ~20 min | ⬜ |
 | Lot FIX-README-COPY — ne plus copier presets.md dans src/ | ~10 min | ⬜ |
@@ -660,8 +660,8 @@ Scenario: mock `defaults_folder` with `src/versions.yaml`, mock `mission_folder/
 
 | # | Ticket | Files | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| ASSETS-001 | Add `_emit_lua_string(value: str) -> str` in `lua_config_generator.py`: returns `[[value]]` if value contains `\n` or `"`, otherwise `"value"`. Apply to `name`, `description`, `information` fields in the ASSETS block. | `veaf_libs/lua_config_generator.py` | fix | 10 min | ⬜ |
-| ASSETS-002 | Unit test: asset with multi-line `information` → generated Lua contains `[[...]]` and parses without error | `test/python/test_lua_config_generator.py` | chore | 10 min | ⬜ |
+| ASSETS-001 | Add `_emit_lua_string(value: str) -> str` in `lua_config_generator.py`: returns `[[value]]` if value contains `\n` or `"`, otherwise `"value"`. Apply to `name`, `description`, `information` fields in the ASSETS block. | `veaf_libs/lua_config_generator.py` | fix | 10 min | ✅ |
+| ASSETS-002 | Unit test: asset with multi-line `information` → generated Lua contains `[[...]]` and parses without error | `test/python/test_lua_config_generator.py` | chore | 10 min | ✅ |
 
 **Raw total: 20 min → estimated (×1.15): ~23 min (~25 min)**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.2"
+version = "6.3.3"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -108,20 +108,28 @@ def _to_lua_scalar(value: object) -> str:
 
 
 def _lua_long_string(text: str) -> str:
-    """Wrap *text* in Lua long-string brackets ``[[...]]`` or ``[==[...]==]``."""
-    if "]]" not in text:
-        return f"[[{text}]]"
-    return f"[==[{text}]==]"
+    """Wrap *text* in a Lua long-string with a dynamically chosen bracket level.
+
+    Chooses the minimum number of ``=`` characters such that the closing
+    bracket sequence does not appear anywhere in *text*, making the result
+    valid for any input.
+    """
+    level = 0
+    while f"]{('=' * level)}]" in text:
+        level += 1
+    eq = "=" * level
+    return f"[{eq}[{text}]{eq}]"
 
 
 def _emit_lua_string(value: str) -> str:
     """Return a valid Lua string literal for *value*.
 
-    Uses ``[[...]]`` long-string when the value contains a newline or a double-quote
-    (both are illegal inside a plain ``"..."`` Lua string without escaping).
-    Otherwise returns the value wrapped in double quotes.
+    Uses a Lua long-string (``[[...]]`` or equivalent) when the value contains
+    a newline, a double-quote, or a backslash — characters that either cannot
+    appear unescaped inside a plain ``"..."`` Lua string or would be silently
+    transformed by Lua's escape processing.  Otherwise wraps in double quotes.
     """
-    if "\n" in value or '"' in value:
+    if "\n" in value or '"' in value or "\\" in value:
         return _lua_long_string(value)
     return f'"{value}"'
 

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -114,6 +114,18 @@ def _lua_long_string(text: str) -> str:
     return f"[==[{text}]==]"
 
 
+def _emit_lua_string(value: str) -> str:
+    """Return a valid Lua string literal for *value*.
+
+    Uses ``[[...]]`` long-string when the value contains a newline or a double-quote
+    (both are illegal inside a plain ``"..."`` Lua string without escaping).
+    Otherwise returns the value wrapped in double quotes.
+    """
+    if "\n" in value or '"' in value:
+        return _lua_long_string(value)
+    return f'"{value}"'
+
+
 def _yaml_comment(key: str) -> list[str]:
     """Convert a catalog entry to a list of YAML ``# ...`` comment lines.
 
@@ -171,10 +183,10 @@ def _emit_module_body(
             for asset in assets:
                 parts: list[str] = []
                 parts.append(f"sort = {_to_lua_scalar(asset.get('sort', 0))}")
-                parts.append(f'name = "{asset.get("name", "")}"')
-                parts.append(f'description = "{asset.get("description", "")}"')
+                parts.append(f"name = {_emit_lua_string(str(asset.get('name', '')))}")
+                parts.append(f"description = {_emit_lua_string(str(asset.get('description', '')))}")
                 info = str(asset.get("information", ""))
-                parts.append(f'information = "{info}"')
+                parts.append(f"information = {_emit_lua_string(info)}")
                 for opt_key in ("linked", "jtac", "freq", "mod"):
                     if opt_key in asset and asset[opt_key] is not None:
                         parts.append(f"{opt_key} = {_to_lua_scalar(asset[opt_key])}")

--- a/src/python/veaf-tools/veaf_tools/helpers.py
+++ b/src/python/veaf-tools/veaf_tools/helpers.py
@@ -99,10 +99,18 @@ def _build_process_tree_windows() -> "tuple[dict[int,int], dict[int,str]]":
     return pid_to_ppid, pid_to_name
 
 
-_TERMINAL_PROCESSES = frozenset({
-    "cmd.exe", "powershell.exe", "pwsh.exe", "wt.exe",
-    "windowsterminal.exe", "mintty.exe", "conemu64.exe", "conemu.exe",
-})
+_TERMINAL_PROCESSES = frozenset(
+    {
+        "cmd.exe",
+        "powershell.exe",
+        "pwsh.exe",
+        "wt.exe",
+        "windowsterminal.exe",
+        "mintty.exe",
+        "conemu64.exe",
+        "conemu.exe",
+    }
+)
 
 
 def _is_double_clicked() -> bool:

--- a/test/python/veaf_libs/test_config_generator.py
+++ b/test/python/veaf_libs/test_config_generator.py
@@ -152,7 +152,8 @@ class TestLuaLongString(unittest.TestCase):
 
     def test_contains_close_brackets(self) -> None:
         result = self._f("text with ]] inside")
-        self.assertEqual(result, "[==[text with ]] inside]==]")
+        # Dynamic level: ]] → level 1 → [=[...]=]
+        self.assertEqual(result, "[=[text with ]] inside]=]")
 
 
 class TestExportPath(unittest.TestCase):

--- a/test/python/veaf_libs/test_lua_config_generator.py
+++ b/test/python/veaf_libs/test_lua_config_generator.py
@@ -1,0 +1,93 @@
+"""Tests for veaf_libs.lua_config_generator."""
+
+from veaf_libs.lua_config_generator import _emit_lua_string, generate_config_lua
+
+
+# ---------------------------------------------------------------------------
+# _emit_lua_string
+# ---------------------------------------------------------------------------
+
+
+def test_emit_lua_string_plain():
+    assert _emit_lua_string("hello") == '"hello"'
+
+
+def test_emit_lua_string_empty():
+    assert _emit_lua_string("") == '""'
+
+
+def test_emit_lua_string_with_newline():
+    result = _emit_lua_string("line1\nline2")
+    assert result.startswith("[[")
+    assert result.endswith("]]")
+    assert "line1\nline2" in result
+    # Must NOT be a plain quoted string with an embedded newline
+    assert result != '"line1\nline2"'
+
+
+def test_emit_lua_string_with_double_quote():
+    result = _emit_lua_string('say "hello"')
+    assert result.startswith("[[")
+    assert "say" in result
+    # No raw double-quote at the outer wrapping level
+    assert not result.startswith('"')
+
+
+def test_emit_lua_string_multiline_no_closing_brackets():
+    value = "Tacan 64Y\nU290.50 (20)\nZone OUEST"
+    result = _emit_lua_string(value)
+    assert result == f"[[{value}]]"
+
+
+# ---------------------------------------------------------------------------
+# ASSETS block — newline in information produces valid Lua long-string
+# ---------------------------------------------------------------------------
+
+_MINIMAL_YAML: dict = {
+    "mission": {"name": "Test"},
+    "lua_modules": {
+        "ASSETS": {
+            "assets": [
+                {
+                    "sort": 1,
+                    "name": "T1-Arco-1",
+                    "description": "Arco-1 (KC-135)",
+                    "information": "Tacan 64Y\nU290.50 (20)\nZone OUEST",
+                    "linked": "T1-Arco-1 escort",
+                },
+            ]
+        }
+    },
+}
+
+
+def test_assets_multiline_information_uses_long_string():
+    lua = generate_config_lua(_MINIMAL_YAML)
+    # Long-string opener present
+    assert "[[" in lua
+    # Plain quoted newline must NOT appear
+    assert '"Tacan 64Y\n' not in lua
+    # Content present
+    assert "Tacan 64Y" in lua
+    assert "U290.50 (20)" in lua
+    assert "Zone OUEST" in lua
+
+
+def test_assets_plain_information_uses_quoted_string():
+    yaml_data: dict = {
+        "mission": {"name": "Test"},
+        "lua_modules": {
+            "ASSETS": {
+                "assets": [
+                    {
+                        "sort": 1,
+                        "name": "Base Alpha",
+                        "description": "Alpha base",
+                        "information": "No newlines here",
+                    },
+                ]
+            }
+        },
+    }
+    lua = generate_config_lua(yaml_data)
+    assert 'information = "No newlines here"' in lua

--- a/test/python/veaf_libs/test_lua_config_generator.py
+++ b/test/python/veaf_libs/test_lua_config_generator.py
@@ -1,6 +1,15 @@
 """Tests for veaf_libs.lua_config_generator."""
 
+import re
+
 from veaf_libs.lua_config_generator import _emit_lua_string, generate_config_lua
+
+_LONG_STRING_RE = re.compile(r"^\[=*\[")
+
+
+def _is_long_string(s: str) -> bool:
+    """True if *s* is a Lua long-string literal."""
+    return bool(_LONG_STRING_RE.match(s))
 
 
 # ---------------------------------------------------------------------------
@@ -18,25 +27,45 @@ def test_emit_lua_string_empty():
 
 def test_emit_lua_string_with_newline():
     result = _emit_lua_string("line1\nline2")
-    assert result.startswith("[[")
-    assert result.endswith("]]")
+    assert _is_long_string(result)
     assert "line1\nline2" in result
-    # Must NOT be a plain quoted string with an embedded newline
-    assert result != '"line1\nline2"'
+    # Must NOT be a plain quoted string
+    assert not result.startswith('"')
 
 
 def test_emit_lua_string_with_double_quote():
     result = _emit_lua_string('say "hello"')
-    assert result.startswith("[[")
-    assert "say" in result
-    # No raw double-quote at the outer wrapping level
+    assert _is_long_string(result)
+    assert 'say "hello"' in result
     assert not result.startswith('"')
+
+
+def test_emit_lua_string_with_backslash():
+    # Backslash would be misinterpreted by Lua escape processing in plain strings
+    result = _emit_lua_string(r"C:\Users\foo")
+    assert _is_long_string(result)
+    assert r"C:\Users\foo" in result
 
 
 def test_emit_lua_string_multiline_no_closing_brackets():
     value = "Tacan 64Y\nU290.50 (20)\nZone OUEST"
     result = _emit_lua_string(value)
+    # Value has no ]] — expect simplest [[...]] form
     assert result == f"[[{value}]]"
+
+
+def test_emit_lua_string_value_with_closing_brackets():
+    # Value forces long-string (has \n) AND contains ]] — dynamic level must pick a safe delimiter
+    value = "line1\nclose]]here"
+    result = _emit_lua_string(value)
+    assert _is_long_string(result)
+    assert value in result
+    # The closing bracket sequence of the chosen level must NOT appear inside the value
+    m = _LONG_STRING_RE.match(result)
+    assert m is not None
+    level = len(m.group(0)) - 2  # number of = chars
+    closing = "]" + "=" * level + "]"
+    assert closing not in value
 
 
 # ---------------------------------------------------------------------------
@@ -63,12 +92,11 @@ _MINIMAL_YAML: dict = {
 
 def test_assets_multiline_information_uses_long_string():
     lua = generate_config_lua(_MINIMAL_YAML)
-    # Long-string opener present
-    assert "[[" in lua
+    # The specific ASSETS information field must use a long-string
+    assert "information = [[Tacan 64Y" in lua
     # Plain quoted newline must NOT appear
     assert '"Tacan 64Y\n' not in lua
     # Content present
-    assert "Tacan 64Y" in lua
     assert "U290.50 (20)" in lua
     assert "Zone OUEST" in lua
 


### PR DESCRIPTION
## FIX-ASSETS-NEWLINE

### Problem
Asset `name`, `description`, or `information` fields containing `\n` or `"` in `mission.yaml` caused a **Lua syntax error at DCS mission load**. The generator was embedding raw newlines inside `"..."` Lua strings, which is invalid in Lua 5.1.

**Example** — broken output:
```lua
information = "Tacan 64Y
U290.50 (20)
Zone OUEST",
```

### Fix
Added `_emit_lua_string(value: str) -> str` in `lua_config_generator.py`:
- Returns `[[value]]` long-string when value contains `\n` or `"`
- Returns `"value"` otherwise

Applied to `name`, `description`, `information` fields in the ASSETS block.

**Correct output after fix:**
```lua
information = [[Tacan 64Y
U290.50 (20)
Zone OUEST]],
```

### Tests
7 new unit tests in `test/python/veaf_libs/test_lua_config_generator.py` covering:
- Plain string → quoted
- Multi-line → long-string
- String with double-quote → long-string
- Integration: full `generate_config_lua()` round-trip

### Checklist
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` — no issues
- [x] `pytest` — 833 passed, 1 skipped
- [x] CHANGELOG updated under `[Unreleased]`
- [x] Version bumped: `6.3.2` → `6.3.3`

## Summary by Sourcery

Fix Lua asset string generation to handle newlines and quotes safely, and add regression tests and metadata updates for the change.

Bug Fixes:
- Generate Lua asset `name`, `description`, and `information` fields using long-string syntax when needed to avoid Lua syntax errors on mission load.

Enhancements:
- Format the Windows terminal process name set for readability in `helpers.py`.

Build:
- Bump `veaf-tools` package version from 6.3.2 to 6.3.3.

Documentation:
- Mark the FIX-ASSETS-NEWLINE backlog items as completed in `backlog.md` and document the Lua asset string fix in the changelog.

Tests:
- Add unit tests for `_emit_lua_string` and for ASSETS block generation to verify correct use of Lua long-strings vs quoted strings.