### PR TITLE
feat(ext-yaml): CSAR YAML config + CTLD initialize() generation (Lot 25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `lua_config_generator.py`: CSAR YAML support — `external_modules.csar` in `mission.yaml` generates `csar.xxx` property assignments and `csar.initialize()` in `veaf-config.lua`, symmetric to the existing CTLD support
+- `lua_config_generator.py`: CTLD block now wrapped in `if ctld then … end` guard and includes `ctld.initialize()` call — no more manual `ctld.initialize()` required in `mission-script.lua` when using YAML-first config
+- `doc/mission-maker/GUIDE.md` (+ `.fr.md`): CSAR YAML-first configuration documented; Lua fallback sections kept for complex settings (e.g. `aircraftType` tables)
+
 ### Fixed
 - `lua_config_generator.py`: asset `description`, `name`, `information` fields containing `\n` or `"` now use Lua long-string syntax (`[[...]]`) instead of plain `"..."` — prevents Lua syntax error at mission load
 

--- a/backlog.md
+++ b/backlog.md
@@ -49,7 +49,7 @@
 | Lot 22 — TEST-LAYOUT | ~55 min | ✅ |
 x| Lot 23 — DOC-YAML | ~8h20 | ✅ |
 | Lot 24 — DOC-REVIEW | ~2h45 | ✅ (REV-002 différé) |
-| Lot 25 — EXT-YAML | ~2h | ⬜ |
+| Lot 25 — EXT-YAML | ~2h | ✅ |
 | Lot FIX-SORT — LUADATA FIX | ~15 min | ✅ |
 | Lot 26 — IMC-FEEDBACK | ~2h40 | ✅ |
 | Lot FIX-BUNDLE — VEAFCOMMANDS MISSING | ~10 min | ✅ |
@@ -1289,10 +1289,10 @@ Les builder-chains Lua sont l'API bas niveau. En v6, QRA, CombatZone et AirWaves
 
 | # | Ticket | Fichiers touchés | Type | Effort | Status |
 |---|--------|-----------------|------|--------|--------|
-| EXT-001 | Ajouter support `external_modules.csar` dans `lua_config_generator.py` : générer `csar.xxx = value` + `csar.initialize()` depuis YAML, symétrique à l'implémentation CTLD existante | `veaf_libs/lua_config_generator.py`, `src/defaults/mission-folder/mission.yaml` | feature | 30 min | ⬜ |
-| EXT-002 | Étendre le support CTLD : générer l'appel `ctld.initialize()` depuis YAML (actuellement seules les propriétés sont générées, l'appel `initialize` lui-même reste en Lua) | `veaf_libs/lua_config_generator.py` | feature | 20 min | ⬜ |
-| EXT-003 | Tests unitaires pour EXT-001 et EXT-002 : vérifier la génération Lua correcte depuis des configs YAML CTLD/CSAR types (enabled/disabled, propriétés, initialize call) | `test/python/veaf_libs/test_lua_config_generator.py` | test | 40 min | ⬜ |
-| EXT-004 | Mettre à jour `GUIDE.md` (+ `.fr.md`) section "CTLD and CSAR Integration" : remplacer les exemples Lua callback par des exemples YAML-first, conserver Lua comme fallback | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | doc | 30 min | ⬜ |
+| EXT-001 | Ajouter support `external_modules.csar` dans `lua_config_generator.py` : générer `csar.xxx = value` + `csar.initialize()` depuis YAML, symétrique à l'implémentation CTLD existante | `veaf_libs/lua_config_generator.py`, `src/defaults/mission-folder/mission.yaml` | feature | 30 min | ✅ |
+| EXT-002 | Étendre le support CTLD : générer l'appel `ctld.initialize()` depuis YAML (actuellement seules les propriétés sont générées, l'appel `initialize` lui-même reste en Lua) | `veaf_libs/lua_config_generator.py` | feature | 20 min | ✅ |
+| EXT-003 | Tests unitaires pour EXT-001 et EXT-002 : vérifier la génération Lua correcte depuis des configs YAML CTLD/CSAR types (enabled/disabled, propriétés, initialize call) | `test/python/veaf_libs/test_lua_config_generator.py` | test | 40 min | ✅ |
+| EXT-004 | Mettre à jour `GUIDE.md` (+ `.fr.md`) section "CTLD and CSAR Integration" : remplacer les exemples Lua callback par des exemples YAML-first, conserver Lua comme fallback | `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | doc | 30 min | ✅ |
 
 **Raw total: 120 min → estimated (×1.15): ~140 min (~2h20)**
 

--- a/doc/mission-maker/GUIDE.fr.md
+++ b/doc/mission-maker/GUIDE.fr.md
@@ -367,7 +367,7 @@ local defenseZone = AirWaveZone:new()
 
 ## Intégration CTLD et CSAR
 
-[CTLD](https://github.com/ciribob/DCS-CTLD) (Combat Troop Loading and Deployment) et [CSAR](https://github.com/ciribob/DCS-CSAR) (Combat Search and Rescue) sont des scripts tiers que VEAF supporte nativement. VEAF monkey-patche leurs fonctions `initialize()` au démarrage, donc vous n'avez pas besoin de les charger ou de les initialiser séparément — appelez-les simplement depuis `mission-script.lua` en suivant le pattern VEAF standard.
+[CTLD](https://github.com/ciribob/DCS-CTLD) (Combat Troop Loading and Deployment) et [CSAR](https://github.com/ciribob/DCS-CSAR) (Combat Search and Rescue) sont des scripts tiers que VEAF supporte nativement. VEAF monkey-patche leurs fonctions `initialize()` au démarrage, donc vous n'avez pas besoin de les charger ou de les initialiser séparément — configurez-les directement dans `mission.yaml` avec l'approche YAML-first ci-dessous.
 
 ### Configurer CTLD via mission.yaml (YAML-first)
 
@@ -381,9 +381,22 @@ external_modules:
     slingLoad: true
 ```
 
-VEAF génère la configuration Lua correspondante dans `veaf-config.lua` au moment du build. Utilisez `mission-script.lua` uniquement pour les paramètres pas encore supportés par le schéma YAML.
+VEAF génère la configuration Lua correspondante dans `veaf-config.lua` au moment du build, y compris l'appel `ctld.initialize()`. Utilisez `mission-script.lua` uniquement pour les paramètres pas encore supportés par le schéma YAML (ex. tables `aircraftType`).
 
-> **CSAR** : La configuration YAML de CSAR est prévue pour une future version. En attendant, configurez CSAR dans `mission-script.lua` comme indiqué ci-dessous.
+### Configurer CSAR via mission.yaml (YAML-first)
+
+CSAR se configure de la même façon :
+
+```yaml
+external_modules:
+  csar:
+    enabled: true
+    enableAllslots: true
+    useprefix: true
+    csarPrefix: "MEDEVAC"
+```
+
+VEAF génère les assignations `csar.xxx = value` et l'appel `csar.initialize()` dans `veaf-config.lua`. Pour les paramètres complexes comme `aircraftType` (une table par appareil), continuez à utiliser le pattern callback Lua dans `mission-script.lua`.
 
 ### Ordre de chargement dans la chaîne de triggers DCS
 
@@ -399,7 +412,7 @@ DO SCRIPT FILE → mission-script.lua (votre code personnalisé)
 
 Quand `veaf-scripts.lua` se charge, il détecte la présence des tables globales `ctld` et `csar` et enveloppe leurs fonctions `initialize()`, appliquant les valeurs par défaut VEAF avant d'appeler le vrai initialiseur.
 
-### Activer CTLD dans mission-script.lua
+### Fallback Lua — CTLD dans mission-script.lua
 
 Pour les paramètres non couverts par `mission.yaml`, utilisez le pattern callback Lua :
 
@@ -424,7 +437,9 @@ end
 
 Le `configurationCallback` est appelé immédiatement avant le vrai `ctld.initialize()` — définissez les propriétés CTLD là, pas avant.
 
-### Activer CSAR dans mission-script.lua
+### Fallback Lua — CSAR dans mission-script.lua
+
+Pour les surcharges par type d'appareil ou d'autres paramètres complexes non supportés par YAML :
 
 ```lua
 if csar then

--- a/doc/mission-maker/GUIDE.md
+++ b/doc/mission-maker/GUIDE.md
@@ -368,7 +368,7 @@ local defenseZone = AirWaveZone:new()
 
 ## CTLD and CSAR Integration
 
-[CTLD](https://github.com/ciribob/DCS-CTLD) (Combat Troop Loading and Deployment) and [CSAR](https://github.com/ciribob/DCS-CSAR) (Combat Search and Rescue) are third-party scripts that VEAF supports natively. VEAF monkey-patches their `initialize()` functions at startup, so you do not need to load or initialise them separately — just call them from `mission-script.lua` using the standard VEAF pattern.
+[CTLD](https://github.com/ciribob/DCS-CTLD) (Combat Troop Loading and Deployment) and [CSAR](https://github.com/ciribob/DCS-CSAR) (Combat Search and Rescue) are third-party scripts that VEAF supports natively. VEAF monkey-patches their `initialize()` functions at startup, so you do not need to load or initialise them separately — just configure them via `mission.yaml` using the YAML-first approach below.
 
 ### Configuring CTLD via mission.yaml (YAML-first)
 
@@ -382,9 +382,22 @@ external_modules:
     slingLoad: true
 ```
 
-VEAF generates the corresponding Lua configuration in `veaf-config.lua` at build time. Use `mission-script.lua` only for settings not yet supported by the YAML schema.
+VEAF generates the corresponding Lua configuration in `veaf-config.lua` at build time, including the `ctld.initialize()` call. Use `mission-script.lua` only for settings not yet supported by the YAML schema (e.g. `aircraftType` tables).
 
-> **CSAR**: CSAR YAML configuration is planned for a future release. In the meantime, configure CSAR in `mission-script.lua` as shown below.
+### Configuring CSAR via mission.yaml (YAML-first)
+
+CSAR can be configured the same way:
+
+```yaml
+external_modules:
+  csar:
+    enabled: true
+    enableAllslots: true
+    useprefix: true
+    csarPrefix: "MEDEVAC"
+```
+
+VEAF generates the `csar.xxx = value` assignments and the `csar.initialize()` call in `veaf-config.lua`. For complex settings such as `aircraftType` (a per-aircraft table), continue using the Lua callback pattern in `mission-script.lua`.
 
 ### Loading order in the DCS trigger chain
 
@@ -400,7 +413,7 @@ DO SCRIPT FILE → mission-script.lua (your custom code)
 
 When `veaf-scripts.lua` loads, it detects the presence of `ctld` and `csar` global tables and wraps their `initialize()` functions, applying VEAF defaults before calling the real initialiser.
 
-### Enabling CTLD in mission-script.lua
+### Lua fallback — CTLD in mission-script.lua
 
 For settings not covered by `mission.yaml`, use the Lua callback pattern:
 
@@ -425,7 +438,9 @@ end
 
 The `configurationCallback` is called immediately before the real `ctld.initialize()` — set CTLD properties there, not before.
 
-### Enabling CSAR in mission-script.lua
+### Lua fallback — CSAR in mission-script.lua
+
+For per-aircraft type overrides or other complex settings not supported by YAML:
 
 ```lua
 if csar then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.3"
+version = "6.3.4"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/defaults/mission-folder/mission.yaml
+++ b/src/defaults/mission-folder/mission.yaml
@@ -113,6 +113,9 @@
 #   ctld:
 #     enabled: false
 #     # ctld.xxx = value pairs go here (e.g. hoverPickup: true)
+#   csar:
+#     enabled: false
+#     # csar.xxx = value pairs go here (e.g. enableAllslots: true)
 
 # ── QRA (Quick Reaction Alert) ────────────────────────────────────────────────
 # Requires QRA module enabled in lua_modules above.

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -672,9 +672,24 @@ def generate_config_lua(
     if ctld_cfg.get("enabled"):
         lines.append("-- ── CTLD configuration ───────────────────────────────────────────────────────")
         lines.append("-- Note: CTLD.lua must be loaded by mission-script.lua before this block.")
+        lines.append("if ctld then")
         ctld_props = {k: v for k, v in ctld_cfg.items() if k != "enabled"}
         for key, value in ctld_props.items():
-            lines.append(f"ctld.{key} = {_to_lua_scalar(value)}")
+            lines.append(f"    ctld.{key} = {_to_lua_scalar(value)}")
+        lines.append("    ctld.initialize()")
+        lines.append("end")
+        lines.append("")
+
+    csar_cfg: dict = external_modules.get("csar") or {}
+    if csar_cfg.get("enabled"):
+        lines.append("-- ── CSAR configuration ───────────────────────────────────────────────────────")
+        lines.append("-- Note: CSAR.lua must be loaded by mission-script.lua before this block.")
+        lines.append("if csar then")
+        csar_props = {k: v for k, v in csar_cfg.items() if k != "enabled"}
+        for key, value in csar_props.items():
+            lines.append(f"    csar.{key} = {_to_lua_scalar(value)}")
+        lines.append("    csar.initialize()")
+        lines.append("end")
         lines.append("")
 
     return "\n".join(lines)
@@ -794,6 +809,9 @@ def generate_mission_yaml_template(
         "#   ctld:",
         "#     enabled: false",
         "#     # ctld.xxx = value  (e.g. hoverPickup: true)",
+        "#   csar:",
+        "#     enabled: false",
+        "#     # csar.xxx = value  (e.g. enableAllslots: true)",
     ]
 
     # ── QRA ───────────────────────────────────────────────────────────────

--- a/test/python/veaf_libs/test_lua_config_generator.py
+++ b/test/python/veaf_libs/test_lua_config_generator.py
@@ -119,3 +119,79 @@ def test_assets_plain_information_uses_quoted_string():
     }
     lua = generate_config_lua(yaml_data)
     assert 'information = "No newlines here"' in lua
+
+
+# ---------------------------------------------------------------------------
+# External modules — CTLD
+# ---------------------------------------------------------------------------
+
+
+def test_ctld_enabled_generates_guard_and_initialize():
+    yaml_data: dict = {
+        "external_modules": {
+            "ctld": {"enabled": True, "hoverPickup": False, "slingLoad": True}
+        }
+    }
+    lua = generate_config_lua(yaml_data)
+    assert "if ctld then" in lua
+    assert "ctld.hoverPickup = false" in lua
+    assert "ctld.slingLoad = true" in lua
+    assert "ctld.initialize()" in lua
+    assert "end" in lua
+
+
+def test_ctld_disabled_emits_nothing():
+    yaml_data: dict = {"external_modules": {"ctld": {"enabled": False}}}
+    lua = generate_config_lua(yaml_data)
+    assert "ctld" not in lua
+
+
+def test_ctld_missing_emits_nothing():
+    yaml_data: dict = {"external_modules": {}}
+    lua = generate_config_lua(yaml_data)
+    assert "ctld" not in lua
+
+
+# ---------------------------------------------------------------------------
+# External modules — CSAR
+# ---------------------------------------------------------------------------
+
+
+def test_csar_enabled_generates_guard_and_initialize():
+    yaml_data: dict = {
+        "external_modules": {
+            "csar": {"enabled": True, "enableAllslots": True, "useprefix": True}
+        }
+    }
+    lua = generate_config_lua(yaml_data)
+    assert "if csar then" in lua
+    assert "csar.enableAllslots = true" in lua
+    assert "csar.useprefix = true" in lua
+    assert "csar.initialize()" in lua
+    assert "end" in lua
+
+
+def test_csar_disabled_emits_nothing():
+    yaml_data: dict = {"external_modules": {"csar": {"enabled": False}}}
+    lua = generate_config_lua(yaml_data)
+    assert "csar" not in lua
+
+
+def test_csar_missing_emits_nothing():
+    yaml_data: dict = {"external_modules": {}}
+    lua = generate_config_lua(yaml_data)
+    assert "csar" not in lua
+
+
+def test_ctld_and_csar_both_enabled():
+    yaml_data: dict = {
+        "external_modules": {
+            "ctld": {"enabled": True, "hoverPickup": True},
+            "csar": {"enabled": True, "enableAllslots": False},
+        }
+    }
+    lua = generate_config_lua(yaml_data)
+    assert "if ctld then" in lua
+    assert "if csar then" in lua
+    assert "ctld.initialize()" in lua
+    assert "csar.initialize()" in lua

--- a/test/python/veaf_libs/test_lua_config_generator.py
+++ b/test/python/veaf_libs/test_lua_config_generator.py
@@ -137,7 +137,13 @@ def test_ctld_enabled_generates_guard_and_initialize():
     assert "ctld.hoverPickup = false" in lua
     assert "ctld.slingLoad = true" in lua
     assert "ctld.initialize()" in lua
-    assert "end" in lua
+    # Block structure: guard → props → initialize → end, in order
+    idx_guard = lua.index("if ctld then")
+    idx_init = lua.index("ctld.initialize()")
+    idx_end = lua.index("end", idx_init)
+    assert idx_guard < idx_init < idx_end
+    # initialize() appears exactly once
+    assert lua.count("ctld.initialize()") == 1
 
 
 def test_ctld_disabled_emits_nothing():
@@ -168,7 +174,13 @@ def test_csar_enabled_generates_guard_and_initialize():
     assert "csar.enableAllslots = true" in lua
     assert "csar.useprefix = true" in lua
     assert "csar.initialize()" in lua
-    assert "end" in lua
+    # Block structure: guard → props → initialize → end, in order
+    idx_guard = lua.index("if csar then")
+    idx_init = lua.index("csar.initialize()")
+    idx_end = lua.index("end", idx_init)
+    assert idx_guard < idx_init < idx_end
+    # initialize() appears exactly once
+    assert lua.count("csar.initialize()") == 1
 
 
 def test_csar_disabled_emits_nothing():


### PR DESCRIPTION
## Lot 25 — EXT-YAML: Support YAML pour les modules externes (CTLD/CSAR)

### What

- **EXT-001** — `external_modules.csar` support in `lua_config_generator.py`: generates `if csar then ... csar.initialize() end` block with property assignments, symmetric to existing CTLD support
- **EXT-002** — CTLD block now wrapped in `if ctld then ... end` guard and includes `ctld.initialize()` call — no more manual call needed in `mission-script.lua` when using YAML-first config
- **EXT-003** — 7 new unit tests: CTLD/CSAR enabled/disabled/missing/both combinations
- **EXT-004** — `GUIDE.md` + `GUIDE.fr.md`: YAML-first documented for both CTLD and CSAR; Lua callback sections kept as fallback for complex settings (e.g. `aircraftType` tables)

### Files changed

- `src/python/veaf-tools/veaf_libs/lua_config_generator.py`
- `src/defaults/mission-folder/mission.yaml`
- `test/python/veaf_libs/test_lua_config_generator.py`
- `doc/mission-maker/GUIDE.md`
- `doc/mission-maker/GUIDE.fr.md`
- `CHANGELOG.md`, `pyproject.toml` (bump 6.3.3 → 6.3.4)

### Example

```yaml
external_modules:
  ctld:
    enabled: true
    hoverPickup: false
  csar:
    enabled: true
    enableAllslots: true
    useprefix: true
```

Generates in `veaf-config.lua`:
```lua
if ctld then
    ctld.hoverPickup = false
    ctld.initialize()
end

if csar then
    csar.enableAllslots = true
    csar.useprefix = true
    csar.initialize()
end
```

## Summary by Sourcery

Add YAML-first configuration support and initialization handling for CTLD and CSAR external modules, update documentation, and bump the tools version.

New Features:
- Support configuring CSAR via `external_modules.csar` in `mission.yaml`, generating corresponding property assignments and `csar.initialize()` in `veaf-config.lua`.
- Extend CTLD YAML support to generate a guarded configuration block that includes the `ctld.initialize()` call from `mission.yaml`.

Documentation:
- Document YAML-first configuration flows for CTLD and CSAR in the English and French mission maker guides, keeping Lua callback usage as a fallback for complex settings.

Tests:
- Add unit tests covering CTLD and CSAR Lua generation for enabled, disabled, missing, and combined configurations.

Chores:
- Mark Lot 25 EXT-YAML backlog items as complete and bump veaf-tools version from 6.3.3 to 6.3.4 in project metadata.