### PR TITLE
fix: prevent versions.yaml copy when legacy missions.yaml exists (FIX-WEATHER-ALIAS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - `lua_config_generator.py`: asset `description`, `name`, `information` fields containing `\n` or `"` now use Lua long-string syntax (`[[...]]`) instead of plain `"..."` — prevents Lua syntax error at mission load
+- `mission_builder_worker.py`: `complete_src_folder_with_defaults()` no longer copies the default `versions.yaml` when a legacy `missions.yaml` already exists in `src/`; emits a warning prompting to rename it
+- `mission_builder_worker.py`: added `missions.yaml` to `_DEFAULT_FILE_MODULE_MAP` (pipeline `weather`) — covers future orphan-warning cases
 
 ---
 

--- a/backlog.md
+++ b/backlog.md
@@ -47,7 +47,7 @@
 | Lot 20 — DEEPENING | ~7h | ✅ |
 | Lot 21 — TYPING | ~20 min | ✅ |
 | Lot 22 — TEST-LAYOUT | ~55 min | ✅ |
-x| Lot 23 — DOC-YAML | ~8h20 | ✅ |
+| Lot 23 — DOC-YAML | ~8h20 | ✅ |
 | Lot 24 — DOC-REVIEW | ~2h45 | ✅ (REV-002 différé) |
 | Lot 25 — EXT-YAML | ~2h | ✅ |
 | Lot FIX-SORT — LUADATA FIX | ~15 min | ✅ |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.4"
+version = "6.3.5"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -247,6 +247,7 @@ class MissionBuilderWorker(BaseWorker):
             "presets.yaml": {"pipeline": "presets"},
             "presets.md": {"pipeline": "presets"},
             "versions.yaml": {"pipeline": "weather"},
+            "missions.yaml": {"pipeline": "weather"},
         }
         for f in defaults_folder.rglob("*"):
             if f.is_file():
@@ -280,6 +281,16 @@ class MissionBuilderWorker(BaseWorker):
                                     f"You can safely delete it."
                                 )
                             continue
+                # WEATHER-001: skip copying versions.yaml if legacy missions.yaml already exists
+                if f.name == "versions.yaml":
+                    legacy_weather = self.mission_folder / "src" / "missions.yaml"
+                    if legacy_weather.exists():
+                        logger.warning(
+                            "Legacy weather config 'src/missions.yaml' found. "
+                            "Skipping copy of default 'src/versions.yaml'. "
+                            "Consider renaming 'missions.yaml' \u2192 'versions.yaml'."
+                        )
+                        continue
                 relative_path = f.relative_to(defaults_folder).parent.as_posix()
                 relative_path = self.mission_folder / relative_path / f.name
                 if not relative_path.exists():

--- a/test/python/mission_builder/test_mission_builder_defaults.py
+++ b/test/python/mission_builder/test_mission_builder_defaults.py
@@ -154,6 +154,7 @@ class TestWeatherAliasCoexistence(unittest.TestCase):
     def test_versions_not_copied_when_missions_exists(self) -> None:
         """versions.yaml is NOT copied if src/missions.yaml already exists in mission folder."""
         tmpdir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmpdir)
         defaults_folder = tmpdir / "published" / "src" / "defaults" / "mission-folder"
         _seed_defaults(defaults_folder, "versions.yaml")
         (tmpdir / "src").mkdir(parents=True, exist_ok=True)
@@ -166,18 +167,17 @@ class TestWeatherAliasCoexistence(unittest.TestCase):
             any("missions.yaml" in w for w in warnings),
             f"Expected a warning mentioning missions.yaml; got: {warnings}",
         )
-        shutil.rmtree(tmpdir)
 
     def test_versions_copied_when_missions_absent(self) -> None:
         """versions.yaml IS copied normally when no legacy missions.yaml exists."""
         tmpdir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmpdir)
         defaults_folder = tmpdir / "published" / "src" / "defaults" / "mission-folder"
         _seed_defaults(defaults_folder, "versions.yaml")
 
         self._run_with_warnings(tmpdir, defaults_folder, {})
 
         self.assertTrue((tmpdir / "src" / "versions.yaml").exists(), "versions.yaml must be copied")
-        shutil.rmtree(tmpdir)
 
 
 if __name__ == "__main__":

--- a/test/python/mission_builder/test_mission_builder_defaults.py
+++ b/test/python/mission_builder/test_mission_builder_defaults.py
@@ -130,5 +130,55 @@ class TestCompleteDefaultsOrphanWarning(unittest.TestCase):
         self.assertTrue(orphan_warnings, "Expected at least one orphan warning")
 
 
+class TestWeatherAliasCoexistence(unittest.TestCase):
+    """WEATHER-001/002: versions.yaml copy skipped when legacy missions.yaml is present (FIX-WEATHER-ALIAS)."""
+
+    def _run_with_warnings(self, mission_folder: Path, defaults_folder: Path, mission_yaml: dict) -> list[str]:
+        from unittest.mock import patch
+
+        from veaf_libs.logger import logger
+
+        worker = _make_worker(mission_folder, defaults_folder, mission_yaml)
+        warnings: list[str] = []
+        orig_warning = logger.warning
+
+        def capture_warning(msg, *args, **kwargs):
+            warnings.append(str(msg))
+            return orig_warning(msg, *args, **kwargs)
+
+        with patch.object(logger, "warning", side_effect=capture_warning):
+            worker.complete_src_folder_with_defaults()
+
+        return warnings
+
+    def test_versions_not_copied_when_missions_exists(self) -> None:
+        """versions.yaml is NOT copied if src/missions.yaml already exists in mission folder."""
+        tmpdir = Path(tempfile.mkdtemp())
+        defaults_folder = tmpdir / "published" / "src" / "defaults" / "mission-folder"
+        _seed_defaults(defaults_folder, "versions.yaml")
+        (tmpdir / "src").mkdir(parents=True, exist_ok=True)
+        (tmpdir / "src" / "missions.yaml").write_text("# legacy weather config", encoding="utf-8")
+
+        warnings = self._run_with_warnings(tmpdir, defaults_folder, {})
+
+        self.assertFalse((tmpdir / "src" / "versions.yaml").exists(), "versions.yaml must not be created")
+        self.assertTrue(
+            any("missions.yaml" in w for w in warnings),
+            f"Expected a warning mentioning missions.yaml; got: {warnings}",
+        )
+        shutil.rmtree(tmpdir)
+
+    def test_versions_copied_when_missions_absent(self) -> None:
+        """versions.yaml IS copied normally when no legacy missions.yaml exists."""
+        tmpdir = Path(tempfile.mkdtemp())
+        defaults_folder = tmpdir / "published" / "src" / "defaults" / "mission-folder"
+        _seed_defaults(defaults_folder, "versions.yaml")
+
+        self._run_with_warnings(tmpdir, defaults_folder, {})
+
+        self.assertTrue((tmpdir / "src" / "versions.yaml").exists(), "versions.yaml must be copied")
+        shutil.rmtree(tmpdir)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## FIX-WEATHER-ALIAS — `missions.yaml` + `versions.yaml` coexistence

### Problem
After v5→v6 conversion, a mission folder could end up with **both** `src/missions.yaml` (legacy alias) and `src/versions.yaml` (default copy). `complete_src_folder_with_defaults()` only checked for the absence of `versions.yaml` → copied the default stub unconditionally, causing confusion when both files coexist.

### Changes

**WEATHER-001** — `mission_builder_worker.py`
Skip copying the default `versions.yaml` when `src/missions.yaml` already exists in the mission folder; emit a `logger.warning` prompting the user to rename it.

**WEATHER-002** — `mission_builder_worker.py`
Added `"missions.yaml": {"pipeline": "weather"}` to `_DEFAULT_FILE_MODULE_MAP` for future orphan-warning coverage.

**WEATHER-003** — `test/python/mission_builder/test_mission_builder_defaults.py`
Two new tests:
- `test_versions_not_copied_when_missions_exists` — asserts `versions.yaml` is NOT created + warning emitted
- `test_versions_copied_when_missions_absent` — asserts normal copy when no legacy file exists

### Quality gate
- `ruff check` + `mypy`: clean
- pytest: 844 passed, 1 skipped

## Summary by Sourcery

Prevent default weather versions file from being copied when a legacy missions file already exists and document the fix.

Bug Fixes:
- Skip copying src/versions.yaml when src/missions.yaml already exists and warn the user to rename the legacy file.

Enhancements:
- Map missions.yaml to the weather pipeline in the default file module map to ensure consistent orphan-warning handling.

Documentation:
- Document the weather alias coexistence fix and mapping change in the changelog.

Tests:
- Add tests covering coexistence of missions.yaml and versions.yaml to verify skip/warning behavior and normal copy when no legacy file is present.

Chores:
- Correct a formatting typo in backlog.md and bump the project version to 6.3.5 in pyproject.toml.