### PR TITLE
fix(converter): remove .bak extension from missionConfig backup

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -54,7 +54,7 @@
 | Lot 26 — IMC-FEEDBACK | ~2h40 | ✅ |
 | Lot FIX-BUNDLE — VEAFCOMMANDS MISSING | ~10 min | ✅ |
 | Lot FIX-ASSETS-NEWLINE — ASSETS newline in Lua string | ~20 min | ✅ |
-| Lot FIX-WEATHER-ALIAS — missions.yaml + versions.yaml coexistence | ~25 min | ⬜ |
+| Lot FIX-WEATHER-ALIAS — missions.yaml + versions.yaml coexistence | ~25 min | ✅ |
 | Lot FIX-MISSIONCONFIG-BAK — supprimer extension .bak inutile | ~20 min | ⬜ |
 | Lot FIX-README-COPY — ne plus copier presets.md dans src/ | ~10 min | ⬜ |
 | Lot FIX-AIRCRAFT-ORPHAN — alerte fichier orphelin manquante pour aircraft-templates.yaml | ~15 min | ⬜ |
@@ -608,9 +608,9 @@ Assert:
 
 | # | Ticket | Files | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| WEATHER-001 | `complete_src_folder_with_defaults()`: skip copying `versions.yaml` if `missions.yaml` already exists in `src/`; emit `logger.warning` with migration message | `mission_builder/mission_builder_worker.py` | fix | 10 min | ⬜ |
-| WEATHER-002 | Add `"missions.yaml": {"pipeline": "weather"}` to `_DEFAULT_FILE_MODULE_MAP` for orphan-warning coverage | `mission_builder/mission_builder_worker.py` | fix | 5 min | ⬜ |
-| WEATHER-003 | Unit test: mission folder with existing `src/missions.yaml` → `complete_src_folder_with_defaults()` does not create `src/versions.yaml` + warning is emitted | `test/python/test_mission_builder_worker.py` | chore | 10 min | ⬜ |
+| WEATHER-001 | `complete_src_folder_with_defaults()`: skip copying `versions.yaml` if `missions.yaml` already exists in `src/`; emit `logger.warning` with migration message | `mission_builder/mission_builder_worker.py` | fix | 10 min | ✅ |
+| WEATHER-002 | Add `"missions.yaml": {"pipeline": "weather"}` to `_DEFAULT_FILE_MODULE_MAP` for orphan-warning coverage | `mission_builder/mission_builder_worker.py` | fix | 5 min | ✅ |
+| WEATHER-003 | Unit test: mission folder with existing `src/missions.yaml` → `complete_src_folder_with_defaults()` does not create `src/versions.yaml` + warning is emitted | `test/python/test_mission_builder_worker.py` | chore | 10 min | ✅ |
 
 **Raw total: 25 min → estimated (×1.15): ~29 min (~30 min)**
 

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -673,7 +673,7 @@ class V5Converter:
         """Run ConfigMigrator on missionConfig.lua and write the result.
 
         File layout after migration:
-        - ``backup_v5/src/scripts/missionConfig.lua.bak``  — original unmodified copy
+        - ``backup_v5/src/scripts/missionConfig.lua``  — original unmodified copy
         - ``backup_v5/src/scripts/missionConfig.lua``       — annotated (-- [v6 ...] comments)
         - ``src/scripts/mission-script.lua``                — clean v6 file (callback stubs only)
         """
@@ -696,11 +696,11 @@ class V5Converter:
             backup_dir = mission_folder / "backup_v5" / rel.parent
             backup_dir.mkdir(parents=True, exist_ok=True)
 
-            bak_path = backup_dir / (src.stem + ".lua.bak")
+            bak_path = backup_dir / src.name
             if not bak_path.exists():
                 shutil.copy2(src, bak_path)
                 report.missionconfig_backup = bak_path
-                report.actions.append(t("convert_v5.action.missionconfig_bak", path=f"{rel.parent}/{src.stem}.lua.bak"))
+                report.actions.append(t("convert_v5.action.missionconfig_bak", path=f"{rel.parent}/{src.name}"))
 
             # Store the annotated content in the report (embedded in the Markdown).
             # We do NOT write it as a separate file in backup_v5/ to avoid confusion
@@ -719,7 +719,7 @@ class V5Converter:
                     "It was created automatically by 'veaf-tools convert-v5'.\n"
                     "\n"
                     "Contents:\n"
-                    "  src/scripts/missionConfig.lua.bak  — original unmodified file (for rollback)\n"
+                    "  src/scripts/missionConfig.lua  — original unmodified file (for rollback)\n"
                     "\n"
                     "The annotated version of missionConfig.lua (with [v6 ...] comments showing\n"
                     "what each line was migrated into) is embedded in the conversion report:\n"

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -673,9 +673,11 @@ class V5Converter:
         """Run ConfigMigrator on missionConfig.lua and write the result.
 
         File layout after migration:
-        - ``backup_v5/src/scripts/missionConfig.lua``  — original unmodified copy
-        - ``backup_v5/src/scripts/missionConfig.lua``       — annotated (-- [v6 ...] comments)
-        - ``src/scripts/mission-script.lua``                — clean v6 file (callback stubs only)
+        - ``backup_v5/src/scripts/missionConfig.lua``  — original unmodified copy (for rollback)
+        - ``src/scripts/mission-script.lua``            — clean v6 file (callback stubs only)
+
+        The annotated version (with ``-- [v6 ...]`` comments) is embedded in
+        ``convert-v5-report.md``, not written as a separate file in ``backup_v5/``.
         """
         src = report.missionconfig_path
         assert src is not None

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -91,7 +91,7 @@
   "report.section.actions": "Actions Taken",
   "report.section.review": "What Needs Manual Review",
   "report.section.annotated_config": "Annotated missionConfig.lua",
-  "report.annotated_config.intro": "Below is your original `missionConfig.lua` with `-- [v6 ...]` comments showing what each line was migrated into. The unmodified original is in `backup_v5/src/scripts/missionConfig.lua.bak`. Delete the `backup_v5/` folder once you have verified the migration.",
+  "report.annotated_config.intro": "Below is your original `missionConfig.lua` with `-- [v6 ...]` comments showing what each line was migrated into. The unmodified original is in `backup_v5/src/scripts/missionConfig.lua`. Delete the `backup_v5/` folder once you have verified the migration.",
   "report.section.next_steps": "Next Steps",
   "report.section.docs": "Documentation",
   "report.section.missionconfig": "missionConfig.lua / mission-script.lua",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -91,7 +91,7 @@
   "report.section.actions": "Actions effectuées",
   "report.section.review": "Points à vérifier manuellement",
   "report.section.annotated_config": "missionConfig.lua annoté",
-  "report.annotated_config.intro": "Ci-dessous votre `missionConfig.lua` original avec des commentaires `-- [v6 ...]` indiquant ce qui a été migré. L'original non modifié se trouve dans `backup_v5/src/scripts/missionConfig.lua.bak`. Supprimez le dossier `backup_v5/` une fois la migration vérifiée.",
+  "report.annotated_config.intro": "Ci-dessous votre `missionConfig.lua` original avec des commentaires `-- [v6 ...]` indiquant ce qui a été migré. L'original non modifié se trouve dans `backup_v5/src/scripts/missionConfig.lua`. Supprimez le dossier `backup_v5/` une fois la migration vérifiée.",
   "report.section.next_steps": "Prochaines étapes",
   "report.section.docs": "Documentation",
   "report.section.missionconfig": "missionConfig.lua / mission-script.lua",

--- a/test/python/mission_builder/test_v5_converter.py
+++ b/test/python/mission_builder/test_v5_converter.py
@@ -441,5 +441,27 @@ class TestConversionReportAnnotatedContent(unittest.TestCase):
             self.assertIn(t("report.section.annotated_config"), md)
 
 
+# ---------------------------------------------------------------------------
+# BAK-004 — backup uses src.name (no .bak extension)
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateConfigBackupNoBak(unittest.TestCase):
+    """_migrate_config() backup must create missionConfig.lua, not missionConfig.lua.bak."""
+
+    def test_backup_creates_lua_not_bak(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            scripts_dir = folder / "src" / "scripts"
+            scripts_dir.mkdir(parents=True)
+            mc = scripts_dir / "missionConfig.lua"
+            mc.write_text("-- test\n", encoding="utf-8")
+            V5Converter().convert(folder, backup=True)
+            bak = folder / "backup_v5" / "src" / "scripts" / "missionConfig.lua"
+            bak_old = folder / "backup_v5" / "src" / "scripts" / "missionConfig.lua.bak"
+            self.assertTrue(bak.exists(), "backup_v5/.../missionConfig.lua should exist")
+            self.assertFalse(bak_old.exists(), "missionConfig.lua.bak must NOT exist")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## FIX-MISSIONCONFIG-BAK

During v5→v6 conversion, `missionConfig.lua` was backed up as `missionConfig.lua.bak` in `backup_v5/`. This was inconsistent — all other backed-up files keep their original name.

### Changes

- **BAK-001** — `v5_converter.py`: `bak_path = backup_dir / src.name` instead of `backup_dir / (src.stem + ".lua.bak")`
- **BAK-002** — `en.json` / `fr.json`: remove all `.bak` references from i18n strings and `report.annotated_config.intro`
- **BAK-003** — `v5_converter.py`: update the `README.txt` generated in `backup_v5/` (`missionConfig.lua.bak` → `missionConfig.lua`)
- **BAK-004** — `test_v5_converter.py`: new test asserting `backup_v5/.../missionConfig.lua` exists and `missionConfig.lua.bak` does **not**

### Quality gate
- ruff ✅ · mypy ✅ · pytest 844 passed ✅

## Summary by Sourcery

Align v5→v6 missionConfig backup naming and related messaging so backups no longer use a .bak extension.

Bug Fixes:
- Standardize missionConfig backup to keep the original filename instead of appending a .bak extension, including report messages and generated backup README contents.
- Update English and French i18n strings to remove outdated references to missionConfig.lua.bak.

Tests:
- Add a regression test ensuring the v5 converter creates backup_v5/.../missionConfig.lua and not missionConfig.lua.bak.

Chores:
- Update the internal backlog to mark the FIX-WEATHER-ALIAS and related WEATHER tasks as completed and track FIX-MISSIONCONFIG-BAK.