### PR TITLE
feat: build profiles — `--profile` option on `veaf-tools build` (FEAT-PROFILES)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `veaf_libs/build_profiles.py`: new `resolve_profile(yaml_data, profile_name)` function — deep-merges a named profile from the `profiles:` section of `mission.yaml` onto the base config; lists are replaced, not concatenated; `profiles:` key is stripped from the effective config
+- `mission_builder_worker.py`: `MissionBuilderWorker.__init__` now accepts `profile_name: str | None`; calls `resolve_profile` immediately after loading `mission.yaml`, before any other config resolution
+- `veaf_tools/commands/build.py`: new `--profile` / `-p` option on `veaf-tools build` to select a named build profile at build time
+- `src/defaults/mission-folder/mission.yaml`: new commented `profiles:` section with `TEST` and `SERVER` examples
+- `doc/MISSION_YAML_REFERENCE.md` (+ `.fr.md`): new `profiles:` section; entry added to the Build Pipeline index
+- `doc/mission-maker/GUIDE.md` (+ `.fr.md`): new "Build Profiles" section explaining `--profile` usage with an example
 - `lua_config_generator.py`: CSAR YAML support — `external_modules.csar` in `mission.yaml` generates `csar.xxx` property assignments and `csar.initialize()` in `veaf-config.lua`, symmetric to the existing CTLD support
 - `lua_config_generator.py`: CTLD block now wrapped in `if ctld then … end` guard and includes `ctld.initialize()` call — no more manual `ctld.initialize()` required in `mission-script.lua` when using YAML-first config
 - `doc/mission-maker/GUIDE.md` (+ `.fr.md`): CSAR YAML-first configuration documented; Lua fallback sections kept for complex settings (e.g. `aircraftType` tables)

--- a/backlog.md
+++ b/backlog.md
@@ -59,7 +59,7 @@
 | Lot FIX-README-COPY — ne plus copier presets.md dans src/ | ~10 min | ✅ |
 | Lot FIX-AIRCRAFT-ORPHAN — alerte fichier orphelin manquante pour aircraft-templates.yaml | ~15 min | ✅ |
 | Lot DOC-DEV-MODE — documenter dev_mode + scripts_path | ~30 min | ✅ |
-| Lot FEAT-PROFILES — profils de build dans mission.yaml | ~3h | ⬜ |
+| Lot FEAT-PROFILES — profils de build dans mission.yaml | ~3h | ✅ |
 | Lot FEAT-MODULE-UX — Catégories, modules obligatoires, dépendances | ~2h | ⬜ |
 | Lot FEAT-GITIGNORE — Template `.gitignore` VEAF MCT dans les defaults | ~25 min | ⬜ |
 | **Total** | **~167h20** | |

--- a/doc/MISSION_YAML_REFERENCE.fr.md
+++ b/doc/MISSION_YAML_REFERENCE.fr.md
@@ -309,6 +309,44 @@ build:
 
 ---
 
+### `profiles:`
+
+Profils de build nommés. Chaque profil est un ensemble de surcharges qui fusionnent en profondeur sur la `mission.yaml` de base lorsque vous passez `--profile <nom>` à `veaf-tools build`. Les clés absentes du profil conservent leur valeur de base. Les listes sont remplacées intégralement, pas concaténées. La clé `profiles:` elle-même n'est jamais transmise au générateur Lua ni au pipeline.
+
+| Champ | Type | Description |
+|-------|------|-------------|
+| `profiles.<nom>` | `dict` | N'importe quelle clé de premier niveau de `mission.yaml` (ex : `global_log_level`, `security`, `pipeline`) |
+
+**Règles de fusion**
+- Les dicts imbriqués sont fusionnés récursivement (seules les clés spécifiées sont surchargées).
+- Les valeurs scalaires et les listes sont remplacées en totalité.
+- `profiles:` est retiré de la config effective — il n'est jamais passé au générateur Lua ni au pipeline.
+
+```yaml
+profiles:
+  TEST:
+    global_log_level: debug
+    security:
+      disabled: true
+    pipeline:
+      weather: false
+  SERVER:
+    global_log_level: info
+    pipeline:
+      weather: true
+```
+
+Usage :
+
+```powershell
+veaf-tools.exe build --profile TEST
+veaf-tools.exe build --profile SERVER
+```
+
+> Si le profil nommé n'existe pas dans `mission.yaml`, un avertissement est émis et la config de base est utilisée sans modification.
+
+---
+
 ## Index par catégorie
 
 ### Essentiel — toute mission
@@ -348,6 +386,7 @@ build:
 | [`build:`](#build) | Mode développeur et chemin des scripts |
 | `build.dev_mode` | Utiliser le bundle Lua local au lieu des scripts publiés |
 | `build.scripts_path` | Chemin vers un clone local de VEAF-Mission-Creation-Tools |
+| [`profiles:`](#profiles) | Profils de build nommés (surcharges deep-merge pour `--profile`) |
 
 ---
 

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -309,6 +309,44 @@ build:
 
 ---
 
+### `profiles:`
+
+Named build profiles. Each profile is a set of config overrides that deep-merge onto the base `mission.yaml` when you pass `--profile <name>` to `veaf-tools build`. Keys absent from the profile retain their base values. Lists are replaced, not concatenated. The `profiles:` key itself is never written to the built mission.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `profiles.<name>` | `dict` | Any top-level `mission.yaml` key (e.g. `global_log_level`, `security`, `pipeline`) |
+
+**Merge rules**
+- Nested dicts are merged recursively (only the keys you specify are overridden).
+- Scalar values and lists are replaced wholesale.
+- `profiles:` is stripped from the effective config — it is never passed to the Lua generator or the pipeline.
+
+```yaml
+profiles:
+  TEST:
+    global_log_level: debug
+    security:
+      disabled: true
+    pipeline:
+      weather: false
+  SERVER:
+    global_log_level: info
+    pipeline:
+      weather: true
+```
+
+Usage:
+
+```powershell
+veaf-tools.exe build --profile TEST
+veaf-tools.exe build --profile SERVER
+```
+
+> If the named profile does not exist in `mission.yaml`, a warning is emitted and the base config is used unchanged.
+
+---
+
 ## Index by category
 
 ### Core
@@ -369,6 +407,7 @@ build:
 | [`build:`](#build) | Developer mode and scripts path override |
 | `build.dev_mode` | Use local Lua bundle instead of published scripts |
 | `build.scripts_path` | Path to local VEAF-Mission-Creation-Tools clone |
+| [`profiles:`](#profiles) | Named build profiles (deep-merge overrides for `--profile`) |
 
 ---
 

--- a/doc/mission-maker/GUIDE.fr.md
+++ b/doc/mission-maker/GUIDE.fr.md
@@ -333,7 +333,7 @@ profiles:
 ```
 
 ```powershell
-# Build pour les tests (pas de météo, sécurité désactivée, logs verbose)
+# Build pour les tests (pas de météo, sécurité désactivée, journalisation détaillée)
 veaf-tools.exe build --profile TEST
 
 # Build pour le déploiement serveur

--- a/doc/mission-maker/GUIDE.fr.md
+++ b/doc/mission-maker/GUIDE.fr.md
@@ -307,6 +307,48 @@ veaf-tools.exe extract ma-mission.miz
 
 ---
 
+## Profils de build
+
+Les profils de build permettent de basculer entre différentes configurations nommées sans modifier `mission.yaml`. Définissez une section `profiles:` une seule fois, puis sélectionnez un profil au moment du build :
+
+```yaml
+# mission.yaml
+global_log_level: info
+security:
+  disabled: false
+pipeline:
+  weather: true
+
+profiles:
+  TEST:
+    global_log_level: debug
+    security:
+      disabled: true
+    pipeline:
+      weather: false   # pas de variantes météo pendant les builds de test
+  SERVER:
+    global_log_level: info
+    pipeline:
+      weather: true
+```
+
+```powershell
+# Build pour les tests (pas de météo, sécurité désactivée, logs verbose)
+veaf-tools.exe build --profile TEST
+
+# Build pour le déploiement serveur
+veaf-tools.exe build --profile SERVER
+
+# Build sans profil (config de base)
+veaf-tools.exe build
+```
+
+Les clés du profil **fusionnent en profondeur** sur la config de base : seules les clés que vous spécifiez sont surchargées, tout le reste reste tel que défini en haut de `mission.yaml`. Passer un nom de profil inconnu émet un avertissement et revient à la config de base.
+
+Voir [`profiles:` dans la référence YAML](../MISSION_YAML_REFERENCE.fr.md#profiles) pour la description complète.
+
+---
+
 ## Référence des scripts
 
 Tous les modules Lua VEAF sont disponibles une fois `veaf-scripts.lua` chargé. Voir [scripts/README.md](scripts/README.md) pour la liste complète avec les guides de configuration.

--- a/doc/mission-maker/GUIDE.md
+++ b/doc/mission-maker/GUIDE.md
@@ -308,6 +308,48 @@ veaf-tools.exe extract my-mission.miz
 
 ---
 
+## Build Profiles
+
+Build profiles let you switch between different named configurations without editing `mission.yaml`. Define a `profiles:` section once, then select a profile at build time:
+
+```yaml
+# mission.yaml
+global_log_level: info
+security:
+  disabled: false
+pipeline:
+  weather: true
+
+profiles:
+  TEST:
+    global_log_level: debug
+    security:
+      disabled: true
+    pipeline:
+      weather: false   # skip weather variants during test builds
+  SERVER:
+    global_log_level: info
+    pipeline:
+      weather: true
+```
+
+```powershell
+# Build for testing (no weather, security disabled, verbose logging)
+veaf-tools.exe build --profile TEST
+
+# Build for server deployment
+veaf-tools.exe build --profile SERVER
+
+# Build with no profile (base config)
+veaf-tools.exe build
+```
+
+Profile keys **deep-merge** onto the base config: only the keys you specify are overridden, everything else stays as defined at the top of `mission.yaml`. Passing an unknown profile name emits a warning and falls back to the base config.
+
+See [`profiles:` in the YAML Reference](../MISSION_YAML_REFERENCE.md#profiles) for the full field description.
+
+---
+
 ## Scripts Reference
 
 All VEAF Lua modules are available once `veaf-scripts.lua` is loaded. See [scripts/README.md](scripts/README.md) for the complete list with configuration guides.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.6"
+version = "6.3.7"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/defaults/mission-folder/mission.yaml
+++ b/src/defaults/mission-folder/mission.yaml
@@ -192,3 +192,19 @@
 #
 # veaf_tools:
 #   version: "6"         # accept any 6.x.x
+# ── Build profiles ────────────────────────────────────────────────────────────
+# Named overrides applied when building with: veaf-tools build --profile <name>
+# Keys in the profile deep-merge onto the base config above.
+# Lists are replaced, not concatenated.
+#
+# profiles:
+#   TEST:
+#     global_log_level: debug
+#     security:
+#       disabled: true
+#     pipeline:
+#       weather: false
+#   SERVER:
+#     global_log_level: info
+#     pipeline:
+#       weather: true

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -20,6 +20,7 @@ from mission_tools import (
 )
 from veaf_libs import user_config as _user_config
 from veaf_libs.base_worker import BaseWorker
+from veaf_libs.build_profiles import resolve_profile
 from veaf_libs.i18n import t
 from veaf_libs.logger import logger
 from veaf_libs.lua_config_generator import generate_config_lua
@@ -43,6 +44,7 @@ class MissionBuilderWorker(BaseWorker):
         log_modules_filter: str | None = None,
         migrate_from_v5: bool = True,
         no_veaf_triggers: bool = False,
+        profile_name: str | None = None,
     ):
         """
         Initialize the worker.  Config resolution priority: CLI override > mission.yaml > user config > code defaults.
@@ -59,13 +61,14 @@ class MissionBuilderWorker(BaseWorker):
         self.collected_mission_script_files: dict[str, bytes] | None = None
         self.collected_mission_data_files: dict[str, bytes] | None = None
 
-        # Read mission.yaml
+        # Read mission.yaml, then apply build profile (deep-merge)
         self.mission_yaml: dict = {}
         self.pipeline_cfg: dict = {}
         mission_yaml_path = mission_folder / "mission.yaml"
         if mission_yaml_path.exists():
             with mission_yaml_path.open("r", encoding="utf-8") as fh:
-                self.mission_yaml = yaml.safe_load(fh) or {}
+                raw_yaml: dict = yaml.safe_load(fh) or {}
+            self.mission_yaml = resolve_profile(raw_yaml, profile_name)
         build_cfg: dict = self.mission_yaml.get("build") or {}
         self.pipeline_cfg = self.mission_yaml.get("pipeline") or {}
 

--- a/src/python/veaf-tools/veaf_libs/build_profiles.py
+++ b/src/python/veaf-tools/veaf_libs/build_profiles.py
@@ -32,16 +32,19 @@ def resolve_profile(yaml_data: dict, profile_name: str | None) -> dict:
     returned as-is (minus ``profiles:``).  If the named profile is not found a
     warning is emitted and the base config is returned.
     """
-    profiles: dict = yaml_data.get("profiles") or {}
+    profiles_raw = yaml_data.get("profiles") or {}
+    if not isinstance(profiles_raw, dict):
+        logger.warning("Ignoring invalid 'profiles' section in mission.yaml (expected mapping)")
+        profiles: dict = {}
+    else:
+        profiles = profiles_raw
     base: dict = {k: v for k, v in yaml_data.items() if k != "profiles"}
 
     if profile_name is None:
         return base
 
     if profile_name not in profiles:
-        logger.warning(
-            f"Profile '{profile_name}' not found in mission.yaml — using base config"
-        )
+        logger.warning(f"Profile '{profile_name}' not found in mission.yaml — using base config")
         return base
 
     logger.info(f"Building with profile: {profile_name}")

--- a/src/python/veaf-tools/veaf_libs/build_profiles.py
+++ b/src/python/veaf-tools/veaf_libs/build_profiles.py
@@ -1,0 +1,48 @@
+"""
+Build-profile resolution for mission.yaml.
+
+Usage::
+
+    from veaf_libs.build_profiles import resolve_profile
+
+    effective_yaml = resolve_profile(raw_yaml, profile_name)
+"""
+
+from __future__ import annotations
+
+from veaf_libs.logger import logger
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Deep-merge *override* onto *base*.  Lists are replaced, not concatenated."""
+    result = dict(base)
+    for k, v in override.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = _deep_merge(result[k], v)
+        else:
+            result[k] = v
+    return result
+
+
+def resolve_profile(yaml_data: dict, profile_name: str | None) -> dict:
+    """Return the effective YAML config for *profile_name*.
+
+    The ``profiles:`` key is stripped from the returned dict so downstream
+    workers never see it.  If *profile_name* is ``None`` the base config is
+    returned as-is (minus ``profiles:``).  If the named profile is not found a
+    warning is emitted and the base config is returned.
+    """
+    profiles: dict = yaml_data.get("profiles") or {}
+    base: dict = {k: v for k, v in yaml_data.items() if k != "profiles"}
+
+    if profile_name is None:
+        return base
+
+    if profile_name not in profiles:
+        logger.warning(
+            f"Profile '{profile_name}' not found in mission.yaml — using base config"
+        )
+        return base
+
+    logger.info(f"Building with profile: {profile_name}")
+    return _deep_merge(base, profiles[profile_name])

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -275,6 +275,7 @@
   "cmd.build.opt.dynamic_mode": "If set, the mission will dynamically load the scripts from the provided location (via --scripts-path or in the local published and src/scripts folders).",
   "cmd.build.opt.dev_mode": "Resolve VEAF scripts from a local dev repo (build/veaf-scripts.lua) instead of published/. Requires --scripts-path pointing to the VEAF-Mission-Creation-Tools repo root. This setting is persisted in mission.yaml (build.dev_mode).",
   "cmd.build.opt.scripts_path": "Path to the VEAF and community scripts. Persisted in mission.yaml (build.scripts_path).",
+  "cmd.build.opt.profile": "Apply a named build profile from mission.yaml (e.g. TEST or SERVER). Profile keys deep-merge onto the base config.",
   "cmd.build.opt.migrate_from_v5": "If set, the builder will parse the mission for old v5 triggers and remove them.",
   "cmd.build.opt.log_modules_detail": "Comma-separated list of module IDs to keep at full log level. All other modules are silenced to 'error' level. Example: --log-modules 'SPAWN,RADIO'",
   "cmd.build.opt.mission_name_or_file": "Mission name; will build the mission with this name and the current date; can be set to a .miz file.",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -277,6 +277,7 @@
   "cmd.build.opt.dynamic_mode": "Si activé, la mission chargera les scripts dynamiquement depuis l'emplacement fourni (via --scripts-path ou les dossiers locaux published et src/scripts).",
   "cmd.build.opt.dev_mode": "Résout les scripts VEAF depuis un dépôt de développement local (build/veaf-scripts.lua) au lieu de published/. Nécessite --scripts-path pointant vers la racine du dépôt VEAF-Mission-Creation-Tools. Ce paramètre est persisté dans mission.yaml (build.dev_mode).",
   "cmd.build.opt.scripts_path": "Chemin vers les scripts VEAF et communautaires. Persisté dans mission.yaml (build.scripts_path).",
+  "cmd.build.opt.profile": "Applique un profil de build nommé depuis mission.yaml (ex : TEST ou SERVER). Les clés du profil fusionnent en profondeur sur la config de base.",
   "cmd.build.opt.migrate_from_v5": "Si activé, le builder analysera la mission pour supprimer les anciens triggers v5.",
   "cmd.build.opt.log_modules_detail": "Liste de modules séparés par des virgules à conserver au niveau de log complet. Tous les autres modules sont réduits au niveau 'error'. Exemple : --log-modules 'SPAWN,RADIO'",
   "cmd.build.opt.mission_name_or_file": "Nom de mission ; construira la mission avec ce nom et la date du jour ; peut être un fichier .miz.",

--- a/src/python/veaf-tools/veaf_tools/commands/build.py
+++ b/src/python/veaf-tools/veaf_tools/commands/build.py
@@ -44,6 +44,12 @@ def build(
         None,
         help=t("cmd.build.opt.scripts_path"),
     ),
+    profile: str | None = typer.Option(
+        None,
+        "--profile",
+        "-p",
+        help=t("cmd.build.opt.profile"),
+    ),
     migrate_from_v5: bool = typer.Option(True, help=t("cmd.build.opt.migrate_from_v5")),
     log_modules: str | None = typer.Option(
         None,
@@ -104,6 +110,7 @@ def build(
         output_mission=p_output_mission,
         migrate_from_v5=migrate_from_v5,
         no_veaf_triggers=no_veaf_triggers,
+        profile_name=profile,
     )
     worker.work()
 

--- a/test/python/test_build_profiles.py
+++ b/test/python/test_build_profiles.py
@@ -1,0 +1,128 @@
+"""Unit tests for veaf_libs.build_profiles — PROF-005."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from veaf_libs.build_profiles import _deep_merge, resolve_profile
+
+
+class TestDeepMerge(unittest.TestCase):
+    def test_no_overlap(self) -> None:
+        result = _deep_merge({"a": 1}, {"b": 2})
+        self.assertEqual(result, {"a": 1, "b": 2})
+
+    def test_scalar_override(self) -> None:
+        result = _deep_merge({"a": 1, "b": 2}, {"b": 99})
+        self.assertEqual(result, {"a": 1, "b": 99})
+
+    def test_nested_dict_merge(self) -> None:
+        base = {"security": {"disabled": False, "password_hashes": []}}
+        override = {"security": {"disabled": True}}
+        result = _deep_merge(base, override)
+        self.assertEqual(result["security"]["disabled"], True)
+        # key from base not in override must be kept
+        self.assertIn("password_hashes", result["security"])
+
+    def test_list_replaced_not_concatenated(self) -> None:
+        base = {"items": [1, 2, 3]}
+        override = {"items": [99]}
+        result = _deep_merge(base, override)
+        self.assertEqual(result["items"], [99])
+
+    def test_base_not_mutated(self) -> None:
+        base = {"a": {"x": 1}}
+        override = {"a": {"y": 2}}
+        _deep_merge(base, override)
+        self.assertNotIn("y", base["a"])
+
+    def test_transitive_nesting(self) -> None:
+        base = {"a": {"b": {"c": 1, "d": 2}}}
+        override = {"a": {"b": {"c": 99}}}
+        result = _deep_merge(base, override)
+        self.assertEqual(result["a"]["b"]["c"], 99)
+        self.assertEqual(result["a"]["b"]["d"], 2)
+
+
+class TestResolveProfile(unittest.TestCase):
+    _YAML: dict = {
+        "global_log_level": "info",
+        "security": {"disabled": False},
+        "pipeline": {"weather": True},
+        "profiles": {
+            "TEST": {
+                "global_log_level": "debug",
+                "security": {"disabled": True},
+                "pipeline": {"weather": False},
+            },
+            "SERVER": {
+                "pipeline": {"weather": True},
+            },
+            "EMPTY": {},
+        },
+    }
+
+    def test_no_profile_returns_base_without_profiles_key(self) -> None:
+        result = resolve_profile(self._YAML, None)
+        self.assertEqual(result["global_log_level"], "info")
+        self.assertNotIn("profiles", result)
+
+    def test_basic_merge(self) -> None:
+        result = resolve_profile(self._YAML, "TEST")
+        self.assertEqual(result["global_log_level"], "debug")
+        self.assertEqual(result["security"]["disabled"], True)
+        self.assertEqual(result["pipeline"]["weather"], False)
+        self.assertNotIn("profiles", result)
+
+    def test_partial_override_keeps_base_keys(self) -> None:
+        """SERVER only overrides pipeline.weather — security and log_level must come from base."""
+        result = resolve_profile(self._YAML, "SERVER")
+        self.assertEqual(result["global_log_level"], "info")
+        self.assertEqual(result["security"]["disabled"], False)
+        self.assertEqual(result["pipeline"]["weather"], True)
+
+    def test_empty_profile_returns_base(self) -> None:
+        result = resolve_profile(self._YAML, "EMPTY")
+        self.assertEqual(result["global_log_level"], "info")
+
+    def test_unknown_profile_warns_and_returns_base(self) -> None:
+        with patch("veaf_libs.build_profiles.logger") as mock_logger:
+            result = resolve_profile(self._YAML, "NONEXISTENT")
+            mock_logger.warning.assert_called_once()
+            warning_msg: str = mock_logger.warning.call_args[0][0]
+            self.assertIn("NONEXISTENT", warning_msg)
+        self.assertEqual(result["global_log_level"], "info")
+
+    def test_profile_disables_pipeline_step(self) -> None:
+        result = resolve_profile(self._YAML, "TEST")
+        self.assertFalse(result["pipeline"]["weather"])
+
+    def test_profiles_key_never_in_result(self) -> None:
+        for profile in (None, "TEST", "SERVER", "EMPTY"):
+            with self.subTest(profile=profile):
+                result = resolve_profile(self._YAML, profile)
+                self.assertNotIn("profiles", result)
+
+    def test_no_profiles_section_in_yaml(self) -> None:
+        yaml_data = {"global_log_level": "info"}
+        result = resolve_profile(yaml_data, None)
+        self.assertEqual(result, {"global_log_level": "info"})
+
+    def test_no_profiles_section_unknown_profile_warns(self) -> None:
+        yaml_data = {"global_log_level": "info"}
+        with patch("veaf_libs.build_profiles.logger") as mock_logger:
+            result = resolve_profile(yaml_data, "TEST")
+            mock_logger.warning.assert_called_once()
+        self.assertEqual(result["global_log_level"], "info")
+
+    def test_known_profile_logs_info(self) -> None:
+        with patch("veaf_libs.build_profiles.logger") as mock_logger:
+            resolve_profile(self._YAML, "TEST")
+            mock_logger.info.assert_called_once()
+            info_msg: str = mock_logger.info.call_args[0][0]
+            self.assertIn("TEST", info_msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/test_build_profiles.py
+++ b/test/python/test_build_profiles.py
@@ -116,6 +116,21 @@ class TestResolveProfile(unittest.TestCase):
             mock_logger.warning.assert_called_once()
         self.assertEqual(result["global_log_level"], "info")
 
+    def test_invalid_profiles_section_warns_and_ignores(self) -> None:
+        """profiles: set to a non-dict (e.g. list) must not raise TypeError."""
+        yaml_data = {"global_log_level": "info", "profiles": ["bad", "value"]}
+        with patch("veaf_libs.build_profiles.logger") as mock_logger:
+            result = resolve_profile(yaml_data, "TEST")
+            # At least one warning about the invalid profiles section
+            warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+            self.assertTrue(
+                any("invalid" in msg.lower() for msg in warning_calls),
+                f"Expected 'invalid' warning, got: {warning_calls}",
+            )
+        # Falls back to base config, profiles key stripped
+        self.assertEqual(result["global_log_level"], "info")
+        self.assertNotIn("profiles", result)
+
     def test_known_profile_logs_info(self) -> None:
         with patch("veaf_libs.build_profiles.logger") as mock_logger:
             resolve_profile(self._YAML, "TEST")


### PR DESCRIPTION
## Summary

Implements **Lot FEAT-PROFILES** from the backlog.

Allows defining named build profiles in `mission.yaml` that override configuration sections at build time. `veaf-tools build --profile TEST` applies deep-merge overrides on top of the base config — no more manual edits between builds.

---

## Changes

### New: `veaf_libs/build_profiles.py`
- `_deep_merge(base, override)` — recursive dict merge, lists replaced not concatenated
- `resolve_profile(yaml_data, profile_name)` — strips `profiles:` key, returns effective config; logs the active profile; warns on unknown profile name

### `mission_builder/mission_builder_worker.py`
- New `profile_name: str | None` parameter on `MissionBuilderWorker.__init__`
- Calls `resolve_profile` immediately after loading `mission.yaml`, before any other config resolution (pipeline, lua_modules, security, build, etc.)

### `veaf_tools/commands/build.py`
- New `--profile` / `-p` option on `veaf-tools build`

### Locales (EN + FR)
- New i18n key `cmd.build.opt.profile`

### `src/defaults/mission-folder/mission.yaml`
- New commented `profiles:` section with `TEST` and `SERVER` examples

### Documentation
- `doc/MISSION_YAML_REFERENCE.md` + `.fr.md`: new `profiles:` section with field table, merge rules, usage example; entry added to Build Pipeline index
- `doc/mission-maker/GUIDE.md` + `.fr.md`: new "Build Profiles" section

### Tests
- `test/python/test_build_profiles.py`: 16 unit tests — deep merge, basic profile, partial override, empty profile, unknown profile warning, no `profiles:` section, list replacement, `profiles:` never in result

---

## Example

```yaml
# mission.yaml
global_log_level: info
security:
  disabled: false
pipeline:
  weather: true

profiles:
  TEST:
    global_log_level: debug
    security:
      disabled: true
    pipeline:
      weather: false
  SERVER:
    global_log_level: info
    pipeline:
      weather: true
```

```powershell
veaf-tools.exe build --profile TEST
veaf-tools.exe build --profile SERVER
```

---

## Quality gate

- `ruff check src/python/` ✅
- `mypy src/python/veaf-tools/` ✅ (72 source files, no issues)
- `pytest --no-cov` ✅ 865 passed, 1 skipped
- `pyproject.toml` version bumped `6.3.6 → 6.3.7`
- `CHANGELOG.md` `[Unreleased]` updated

## Summary by Sourcery

Add support for named build profiles in mission.yaml that can be selected at build time via a new --profile option and are applied as deep-merge overrides to the base configuration.

New Features:
- Introduce build profile resolution utility that deep-merges a selected profile from mission.yaml onto the base configuration while stripping the profiles key.
- Expose a --profile / -p option on veaf-tools build and thread the selected profile into the mission builder so builds use the effective profiled config.
- Provide default mission.yaml examples demonstrating TEST and SERVER build profiles and how they alter logging, security, and pipeline settings.

Documentation:
- Document build profiles and the profiles: section in the mission maker guides (EN/FR) with examples of defining and using profiles at build time.
- Extend the mission.yaml reference (EN/FR) with a detailed profiles: section, merge rules, usage examples, and index entries.

Tests:
- Add unit tests for deep-merge behavior and profile resolution, including partial and empty profiles, missing profiles, absence of a profiles section, and logging behavior.

Chores:
- Bump veaf-tools package version from 6.3.6 to 6.3.7 and note the new build profile feature in the changelog.