### PR TITLE
feat(module-ux): categories, mandatory modules, dependency auto-resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `lua_config_generator.py`: `_MODULE_CATEGORIES` dict — groups modules into 4 tiers (Infrastructure, Core, Features, Combat) plus External; category comment headers (`-- ── Category ──`) are emitted in `veaf-config.lua` and (`# ── Category ──`) in the YAML template
+- `lua_config_generator.py`: `_MANDATORY_MODULES` frozenset — if a mandatory module (UNITS, TIME, CACHE, EVENTS, MARKERS, COMMANDS) has `enable: false`, a warning is logged and the flag is ignored (module still generated)
+- `lua_config_generator.py`: `_MODULE_DEPS` dict + `_resolve_deps()` — after building the effective module list, missing or disabled dependencies are auto-enabled in memory with a `logger.warning` per auto-added module; transitive chains are fully resolved; disk is never modified
+- `src/defaults/mission-folder/mission.yaml`: `lua_modules:` comment block reordered to match category grouping; Infrastructure modules annotated as mandatory
 - `veaf_libs/build_profiles.py`: new `resolve_profile(yaml_data, profile_name)` function — deep-merges a named profile from the `profiles:` section of `mission.yaml` onto the base config; lists are replaced, not concatenated; `profiles:` key is stripped from the effective config
 - `mission_builder_worker.py`: `MissionBuilderWorker.__init__` now accepts `profile_name: str | None`; calls `resolve_profile` immediately after loading `mission.yaml`, before any other config resolution
 - `veaf_tools/commands/build.py`: new `--profile` / `-p` option on `veaf-tools build` to select a named build profile at build time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.7"
+version = "6.3.8"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/defaults/mission-folder/mission.yaml
+++ b/src/defaults/mission-folder/mission.yaml
@@ -29,30 +29,22 @@
 # ── Per-module configuration ──────────────────────────────────────────────────
 # Enable, disable, or override the log level of individual VEAF Lua modules.
 # Modules not listed here are enabled with their default settings.
-# Module IDs: SECURITY, RADIO, SHORTCUTS, NAMEDPOINTS, SPAWN, CARRIER,
-#             CASMISSION, TRANSPORTMISSION, COMBATMISSION, COMBATZONE, QRA,
-#             GRASS, ASSETS, MOVE, SANCTUARY, WEATHER, REMOTE, INTERPRETER, …
 #
 # lua_modules:
+#   # ── Infrastructure (mandatory — cannot be disabled) ──────────────────────
+#   UNITS:    {}
+#   TIME:     {}
+#   CACHE:    {}
+#   EVENTS:   {}
+#   MARKERS:  {}
+#   COMMANDS: {}
+#   # ── Core ─────────────────────────────────────────────────────────────────
+#   SECURITY:    { enable: true }
 #   RADIO:
 #     enable: true
 #     init:
 #       help_menus: true
-#   SPAWN:
-#     logLevel: debug
-#   ASSETS:
-#     enable: true
-#     assets:
-#       - sort: 1
-#         name: "T1-Arco-1"
-#         description: "Arco-1 (KC-135)"
-#         information: "Tacan 64Y\nU290.50 (20)"
-#   NAMEDPOINTS:
-#     enable: true
-#     custom_points:
-#       # - name: "Battle Area Alpha"
-#       #   lat: "41.123456"
-#       #   lon: "44.987654"
+#   GROUNDAI:    { enable: true }
 #   SHORTCUTS:
 #     enable: true
 #     shortcuts:
@@ -60,6 +52,23 @@
 #         description: "Smoke command shortcut"
 #         command: "/_smoke"
 #         bypass_security: false
+#   NAMEDPOINTS:
+#     enable: true
+#     custom_points:
+#       # - name: "Battle Area Alpha"
+#       #   lat: "41.123456"
+#       #   lon: "44.987654"
+#   SPAWN:       { enable: true }
+#   # ── Features ─────────────────────────────────────────────────────────────
+#   ASSETS:
+#     enable: true
+#     assets:
+#       - sort: 1
+#         name: "T1-Arco-1"
+#         description: "Arco-1 (KC-135)"
+#         information: "Tacan 64Y\nU290.50 (20)"
+#   MOVE:        { enable: true }
+#   GRASS:       { enable: true }
 #   SANCTUARY:
 #     enable: true
 #     sanctuary_zones:
@@ -70,6 +79,15 @@
 #         coalition: BLUE
 #         delay_warning: 30
 #         delay_spawn: 60
+#   WEATHER:     { enable: true }
+#   REMOTE:      { enable: true }
+#   AIRBASES:    { enable: true }
+#   MISSILEGUARDIAN: { enable: true }
+#   INTERPRETER: { enable: true }
+#   # ── Combat ───────────────────────────────────────────────────────────────
+#   CASMISSION:       { enable: true }
+#   TRANSPORTMISSION: { enable: true }
+#   COMBATMISSION:    { enable: true }
 #   COMBATZONE:
 #     enable: true
 #     combat_zone_settings:
@@ -89,6 +107,7 @@
 #           - zone_name: "CZ-Alpha"
 #           - zone_name: "CZ-Bravo"
 #             dependencies: ["CZ-Alpha"]
+#   QRA:         { enable: true }
 #   AIRWAVES:
 #     enable: true
 #     airwave_zones:
@@ -101,6 +120,7 @@
 #         waves:
 #           - groups: "su27-2ship"
 #             delay: 0
+#   CARRIER: { enable: true }
 
 # ── External modules ─────────────────────────────────────────────────────────
 # external_modules:

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 
 from veaf_libs.i18n import t
+from veaf_libs.logger import logger
 from veaf_libs.lua_module_scanner import get_modules
 
 # ---------------------------------------------------------------------------
@@ -89,6 +90,67 @@ _SKIP_SETCONFIG_KEYS: frozenset[str] = frozenset(
 #: Module IDs that do NOT have a global ``initialize()`` function.
 #: Their data (zones, etc.) is emitted directly without an ``initialize()`` call.
 _NO_INIT_MODULES: frozenset[str] = frozenset({"AIRWAVES"})
+
+#: Cosmetic category groupings for YAML template and generated Lua output.
+_MODULE_CATEGORIES: dict[str, list[str]] = {
+    "Infrastructure": ["UNITS", "TIME", "CACHE", "EVENTS", "MARKERS", "COMMANDS"],
+    "Core": ["SECURITY", "RADIO", "GROUNDAI", "SHORTCUTS", "NAMEDPOINTS", "SPAWN"],
+    "Features": [
+        "ASSETS",
+        "MOVE",
+        "GRASS",
+        "SANCTUARY",
+        "WEATHER",
+        "REMOTE",
+        "AIRBASES",
+        "MISSILEGUARDIAN",
+        "INTERPRETER",
+    ],
+    "Combat": [
+        "CASMISSION",
+        "TRANSPORTMISSION",
+        "COMBATMISSION",
+        "COMBATZONE",
+        "QRA",
+        "AIRWAVES",
+        "CARRIER",
+    ],
+    "External": ["SKYNET", "SKYNET_MONITOR"],
+}
+
+#: Flat module→category reverse lookup (built once at module load time).
+_MODULE_TO_CATEGORY: dict[str, str] = {
+    mod_id: cat for cat, ids in _MODULE_CATEGORIES.items() for mod_id in ids
+}
+
+#: Modules that are mandatory (infrastructure tier).
+#: Emitting ``enable: false`` for these produces a warning; the module is still generated.
+_MANDATORY_MODULES: frozenset[str] = frozenset({"UNITS", "TIME", "CACHE", "EVENTS", "MARKERS", "COMMANDS"})
+
+#: Dependency graph: module_id → list of module IDs it requires.
+_MODULE_DEPS: dict[str, list[str]] = {
+    # Core
+    "COMMANDS": ["MARKERS"],
+    "GROUNDAI": ["COMMANDS"],
+    "SHORTCUTS": ["RADIO", "COMMANDS"],
+    "NAMEDPOINTS": ["COMMANDS"],
+    "SPAWN": ["UNITS"],
+    # Features
+    "ASSETS": ["RADIO", "SPAWN"],
+    "MOVE": ["SPAWN", "COMMANDS"],
+    "GRASS": ["SPAWN"],
+    "INTERPRETER": ["RADIO", "COMMANDS"],
+    # Combat
+    "CASMISSION": ["SPAWN", "GROUNDAI"],
+    "TRANSPORTMISSION": ["SPAWN"],
+    "COMBATMISSION": ["SPAWN"],
+    "COMBATZONE": ["SPAWN"],
+    "QRA": ["SPAWN", "RADIO"],
+    "AIRWAVES": ["SPAWN"],
+    "CARRIER": ["RADIO"],
+    # External
+    "SKYNET_MONITOR": ["SKYNET"],
+}
 
 
 # ---------------------------------------------------------------------------
@@ -520,6 +582,40 @@ def _emit_combat_mission(cm: dict, var_name: str, indent: str = "    ") -> list[
     return lines
 
 
+def _resolve_deps(effective: dict) -> dict:
+    """Auto-enable missing or disabled dependencies; return updated dict.
+
+    For each enabled module that declares dependencies in ``_MODULE_DEPS``,
+    any dependency that is absent or explicitly disabled is auto-added with
+    ``enable: true`` and a ``logger.warning`` is emitted.  The loop repeats
+    until no more changes are needed (handles transitive dependency chains).
+    """
+    changed = True
+    while changed:
+        changed = False
+        for mod_id, deps in _MODULE_DEPS.items():
+            cfg = effective.get(mod_id, {})
+            if isinstance(cfg, dict) and cfg.get("enable") is False:
+                continue  # explicitly disabled — skip dep check
+            if mod_id not in effective:
+                continue  # not requested — skip
+            for dep in deps:
+                dep_cfg = effective.get(dep, {})
+                if isinstance(dep_cfg, dict) and dep_cfg.get("enable") is False:
+                    logger.warning(
+                        f"Module '{mod_id}' requires '{dep}' but '{dep}' is disabled — auto-enabling '{dep}'"
+                    )
+                    effective[dep] = {"enable": True}
+                    changed = True
+                elif dep not in effective:
+                    logger.warning(
+                        f"Module '{mod_id}' requires '{dep}' which is not configured — auto-enabling '{dep}'"
+                    )
+                    effective[dep] = {"enable": True}
+                    changed = True
+    return effective
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -607,19 +703,43 @@ def generate_config_lua(
     ctld_cfg: dict = external_modules.get("ctld") or {}
 
     if lua_modules:
+        # ── MODUX-002: warn on mandatory modules with enable: false ───────
+        effective_modules: dict = dict(lua_modules)
+        for mandatory_id in _MANDATORY_MODULES:
+            mcfg = effective_modules.get(mandatory_id, {})
+            if isinstance(mcfg, dict) and mcfg.get("enable") is False:
+                logger.warning(
+                    f"Module '{mandatory_id}' is mandatory and cannot be disabled — ignoring enable: false"
+                )
+                mcfg.pop("enable", None)
+                effective_modules[mandatory_id] = mcfg
+
+        # ── MODUX-003: auto-resolve missing/disabled dependencies ─────────
+        effective_modules = _resolve_deps(effective_modules)
+
         lines.append("-- ── Module configuration + initialization ────────────────────────────────────")
         lines.append("")
 
         # Determine full ordered list: known order + unknown modules + INTERPRETER
         known_order_set = set(_MODULE_INIT_ORDER)
         all_module_ids = {m["id"] for m in get_modules()}
-        extra_ids = [mid for mid in lua_modules if mid not in known_order_set and mid in all_module_ids]
+        extra_ids = [mid for mid in effective_modules if mid not in known_order_set and mid in all_module_ids]
         ordered_ids = [mid for mid in _MODULE_INIT_ORDER if mid != "INTERPRETER"] + extra_ids + ["INTERPRETER"]
 
+        # ── MODUX-001: track category to emit comment headers ─────────────
+        current_category: str | None = None
+
         for mod_id in ordered_ids:
-            mod_cfg: dict | None = lua_modules.get(mod_id)
+            mod_cfg: dict | None = effective_modules.get(mod_id)
             if mod_cfg is None:
                 continue
+
+            # Emit category header when entering a new category
+            cat = _MODULE_TO_CATEGORY.get(mod_id)
+            if cat and cat != current_category:
+                current_category = cat
+                lines.append(f"-- ── {cat} ──")
+                lines.append("")
 
             enabled = mod_cfg.get("enable", True)
             log_level: str | None = mod_cfg.get("logLevel")
@@ -759,15 +879,20 @@ def generate_mission_yaml_template(
     ordered_ids = _MODULE_INIT_ORDER
     all_module_map = {m["id"]: m for m in modules}
 
-    # Emit enabled modules first (uncommented), then disabled (commented)
-    enabled_found = [mid for mid in ordered_ids if mid in enabled_set and mid in all_module_map]
-    disabled_found = [mid for mid in ordered_ids if mid not in enabled_set and mid in all_module_map]
+    # Emit all modules grouped by category, enabled ones uncommented, others commented
+    all_ordered = [mid for mid in ordered_ids if mid in all_module_map]
     remaining = [mid for mid in all_module_map if mid not in set(ordered_ids)]
 
-    if enabled_found:
-        lines.append(f"  # {t('generated.mission_yaml.modules.active')}")
-        for mid in enabled_found:
-            yaml_key = f'"{mid}"' if not re.match(r"^[A-Za-z_]\w*$", mid) else mid
+    current_category: str | None = None
+    for mid in all_ordered + remaining:
+        cat = _MODULE_TO_CATEGORY.get(mid)
+        if cat and cat != current_category:
+            current_category = cat
+            mandatory_note = " (mandatory — cannot be disabled)" if cat == "Infrastructure" else ""
+            lines.append(f"  # ── {cat}{mandatory_note} ──")
+        is_enabled = mid in enabled_set
+        yaml_key = f'"{mid}"' if not re.match(r"^[A-Za-z_]\w*$", mid) else mid
+        if is_enabled:
             lines.append(f"  {yaml_key}:")
             lines.append("    enable: true")
             # Show init params example for known modules
@@ -787,11 +912,7 @@ def generate_mission_yaml_template(
                 lines.append('    #   - name: "Battle Area Alpha"')
                 lines.append('    #     lat: "41.123456"')
                 lines.append('    #     lon: "44.987654"')
-
-    if disabled_found or remaining:
-        lines.append(f"  # {t('generated.mission_yaml.modules.other')}")
-        for mid in disabled_found + remaining:
-            yaml_key = f'"{mid}"' if not re.match(r"^[A-Za-z_]\w*$", mid) else mid
+        else:
             lines.append(f"  # {yaml_key}:")
             lines.append("  #   enable: false")
 

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -119,9 +119,7 @@ _MODULE_CATEGORIES: dict[str, list[str]] = {
 }
 
 #: Flat module→category reverse lookup (built once at module load time).
-_MODULE_TO_CATEGORY: dict[str, str] = {
-    mod_id: cat for cat, ids in _MODULE_CATEGORIES.items() for mod_id in ids
-}
+_MODULE_TO_CATEGORY: dict[str, str] = {mod_id: cat for cat, ids in _MODULE_CATEGORIES.items() for mod_id in ids}
 
 #: Modules that are mandatory (infrastructure tier).
 #: Emitting ``enable: false`` for these produces a warning; the module is still generated.
@@ -605,7 +603,8 @@ def _resolve_deps(effective: dict) -> dict:
                     logger.warning(
                         f"Module '{mod_id}' requires '{dep}' but '{dep}' is disabled — auto-enabling '{dep}'"
                     )
-                    effective[dep] = {"enable": True}
+                    dep_cfg["enable"] = True
+                    effective[dep] = dep_cfg
                     changed = True
                 elif dep not in effective:
                     logger.warning(
@@ -708,9 +707,7 @@ def generate_config_lua(
         for mandatory_id in _MANDATORY_MODULES:
             mcfg = effective_modules.get(mandatory_id, {})
             if isinstance(mcfg, dict) and mcfg.get("enable") is False:
-                logger.warning(
-                    f"Module '{mandatory_id}' is mandatory and cannot be disabled — ignoring enable: false"
-                )
+                logger.warning(f"Module '{mandatory_id}' is mandatory and cannot be disabled — ignoring enable: false")
                 mcfg.pop("enable", None)
                 effective_modules[mandatory_id] = mcfg
 

--- a/test/python/veaf_libs/test_lua_config_generator.py
+++ b/test/python/veaf_libs/test_lua_config_generator.py
@@ -1,8 +1,14 @@
 """Tests for veaf_libs.lua_config_generator."""
 
 import re
+import logging
 
-from veaf_libs.lua_config_generator import _emit_lua_string, generate_config_lua
+from veaf_libs.lua_config_generator import (
+    _emit_lua_string,
+    _resolve_deps,
+    generate_config_lua,
+    generate_mission_yaml_template,
+)
 
 _LONG_STRING_RE = re.compile(r"^\[=*\[")
 
@@ -207,3 +213,119 @@ def test_ctld_and_csar_both_enabled():
     assert "if csar then" in lua
     assert "ctld.initialize()" in lua
     assert "csar.initialize()" in lua
+
+
+# ---------------------------------------------------------------------------
+# MODUX-001 — Category headers in generated Lua
+# ---------------------------------------------------------------------------
+
+
+def test_category_headers_present_in_lua():
+    """Category comment headers must appear in the Lua output."""
+    yaml_data: dict = {
+        "lua_modules": {
+            "UNITS": {},
+            "SPAWN": {},
+            "ASSETS": {"assets": []},
+        }
+    }
+    lua = generate_config_lua(yaml_data)
+    assert "-- ── Infrastructure ──" in lua
+    assert "-- ── Core ──" in lua
+    assert "-- ── Features ──" in lua
+
+
+def test_category_headers_present_in_yaml_template():
+    """Category comment headers must appear in the YAML template."""
+    template = generate_mission_yaml_template()
+    assert "# ── Infrastructure (mandatory — cannot be disabled) ──" in template
+    assert "# ── Core ──" in template
+    assert "# ── Features ──" in template
+    assert "# ── Combat ──" in template
+
+
+# ---------------------------------------------------------------------------
+# MODUX-002 — Mandatory module warning
+# ---------------------------------------------------------------------------
+
+
+def test_mandatory_module_disabled_emits_warning(caplog):
+    """Disabling a mandatory module must produce a logger.warning."""
+    yaml_data: dict = {
+        "lua_modules": {
+            "UNITS": {"enable": False},
+        }
+    }
+    with caplog.at_level(logging.WARNING, logger="veaf-tools"):
+        lua = generate_config_lua(yaml_data)
+    assert any("UNITS" in msg and "mandatory" in msg for msg in caplog.messages)
+    # Despite enable: false, the module should NOT emit setConfig(enable=false)
+    assert 'veaf.setConfig("UNITS", "enable", false)' not in lua
+
+
+def test_non_mandatory_disabled_no_warning(caplog):
+    """Disabling a non-mandatory module must NOT produce a mandatory warning."""
+    yaml_data: dict = {
+        "lua_modules": {
+            "ASSETS": {"enable": False},
+        }
+    }
+    with caplog.at_level(logging.WARNING, logger="veaf-tools"):
+        generate_config_lua(yaml_data)
+    assert not any("mandatory" in msg for msg in caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# MODUX-003 — Dependency auto-resolution
+# ---------------------------------------------------------------------------
+
+
+def test_dep_auto_resolution_missing_dep(caplog):
+    """SPAWN enabled without UNITS → UNITS auto-enabled + warning."""
+    effective = {"SPAWN": {}}
+    with caplog.at_level(logging.WARNING, logger="veaf-tools"):
+        result = _resolve_deps(effective)
+    assert "UNITS" in result
+    assert result["UNITS"].get("enable") is True
+    assert any("UNITS" in msg for msg in caplog.messages)
+
+
+def test_dep_auto_resolution_disabled_dep(caplog):
+    """SPAWN enabled and UNITS explicitly disabled → UNITS auto-enabled + warning."""
+    effective = {"SPAWN": {}, "UNITS": {"enable": False}}
+    with caplog.at_level(logging.WARNING, logger="veaf-tools"):
+        result = _resolve_deps(effective)
+    assert result["UNITS"].get("enable") is True
+    assert any("UNITS" in msg for msg in caplog.messages)
+
+
+def test_dep_no_warning_when_dep_present():
+    """No warning when dependency is already properly configured."""
+    effective = {"SPAWN": {}, "UNITS": {}}
+    # Should not raise and should return same dict with no auto-enable change
+    result = _resolve_deps(effective)
+    assert "UNITS" in result
+
+
+def test_transitive_dep_resolution(caplog):
+    """Transitive chain A→B→C: enabling A auto-enables B and C."""
+    # CASMISSION → SPAWN (→ UNITS) and GROUNDAI (→ COMMANDS → MARKERS)
+    effective = {"CASMISSION": {}}
+    with caplog.at_level(logging.WARNING, logger="veaf-tools"):
+        result = _resolve_deps(effective)
+    # Direct deps of CASMISSION
+    assert "SPAWN" in result
+    assert "GROUNDAI" in result
+    # Transitive: SPAWN → UNITS
+    assert "UNITS" in result
+    # Transitive: GROUNDAI → COMMANDS → MARKERS
+    assert "COMMANDS" in result
+    assert "MARKERS" in result
+
+
+def test_explicitly_disabled_module_skips_dep_check():
+    """If module itself is enable: false, its dependencies are not checked."""
+    effective = {"SPAWN": {"enable": False}}
+    result = _resolve_deps(effective)
+    # UNITS should NOT be auto-added since SPAWN is disabled
+    assert "UNITS" not in result

--- a/test/python/veaf_libs/test_lua_config_generator.py
+++ b/test/python/veaf_libs/test_lua_config_generator.py
@@ -291,11 +291,14 @@ def test_dep_auto_resolution_missing_dep(caplog):
 
 
 def test_dep_auto_resolution_disabled_dep(caplog):
-    """SPAWN enabled and UNITS explicitly disabled → UNITS auto-enabled + warning."""
-    effective = {"SPAWN": {}, "UNITS": {"enable": False}}
+    """SPAWN enabled and UNITS explicitly disabled → UNITS auto-enabled + warning.
+    Other config keys on the dep must be preserved."""
+    effective = {"SPAWN": {}, "UNITS": {"enable": False, "logLevel": "debug"}}
     with caplog.at_level(logging.WARNING, logger="veaf-tools"):
         result = _resolve_deps(effective)
     assert result["UNITS"].get("enable") is True
+    # Other config must be preserved (Sourcery fix)
+    assert result["UNITS"].get("logLevel") == "debug"
     assert any("UNITS" in msg for msg in caplog.messages)
 
 


### PR DESCRIPTION
## Lot FEAT-MODULE-UX — Categories, mandatory modules, dependency resolution

Improve the `lua_modules:` section of `veaf-config.lua` generation in three independent but cohesive ways.

### MODUX-001 — Category headers
- Added `_MODULE_CATEGORIES` dict (Infrastructure / Core / Features / Combat / External)
- Inserted `-- ── Category ──` comment headers in the generated `veaf-config.lua`
- Inserted `# ── Category ──` comment headers in the YAML template
- Infrastructure modules annotated as "mandatory — cannot be disabled"

### MODUX-002 — Mandatory module guard
- Added `_MANDATORY_MODULES` frozenset: `{UNITS, TIME, CACHE, EVENTS, MARKERS, COMMANDS}`
- If any of these have `enable: false`, a `logger.warning` is emitted and the flag is silently ignored — module is generated as if enabled

### MODUX-003 — Dependency auto-resolution
- Added `_MODULE_DEPS` dict covering all inter-module dependencies
- Added `_resolve_deps()` — recursive, stable-loop algorithm that auto-enables any missing or disabled dependency in memory, with a `logger.warning` per auto-added module
- Transitive chains are fully resolved (e.g. `CASMISSION → SPAWN → UNITS`, `CASMISSION → GROUNDAI → COMMANDS → MARKERS`)
- The `mission.yaml` on disk is **never** modified

### MODUX-004 — mission.yaml defaults updated
- `src/defaults/mission-folder/mission.yaml`: `lua_modules:` comment block reordered by category; Infrastructure modules annotated as mandatory

### MODUX-005 — Unit tests (25 tests total, all passing)
- Category headers present in generated Lua and YAML template
- Warning on mandatory module with `enable: false`
- Dependency auto-resolution for missing/disabled deps
- Transitive dep chain (A → B → C all resolved)
- Explicitly disabled modules skip dep check

## Summary by Sourcery

Improve Lua module configuration UX by introducing category groupings, enforcing mandatory infrastructure modules, and automatically resolving inter-module dependencies during config generation.

Enhancements:
- Group Lua modules into logical categories and emit corresponding category headers in generated Lua configs and mission YAML templates.
- Treat key infrastructure modules as mandatory, ignoring disable flags while emitting warnings when they are configured with enable: false.
- Automatically resolve and enable missing or disabled module dependencies in memory, including transitive chains, without modifying mission.yaml on disk.
- Update the default mission.yaml lua_modules block to follow the new category structure and annotate infrastructure modules as mandatory.

Build:
- Bump veaf-tools package version from 6.3.7 to 6.3.8.

Documentation:
- Document the new module categorization, mandatory-module behavior, and dependency auto-resolution in the changelog.

Tests:
- Add unit tests covering category headers in Lua and YAML, mandatory-module disabling warnings, dependency auto-resolution (including transitive chains), and skipping dependency checks for explicitly disabled modules.