### PR TITLE
fix(oldscripts): warn on unexpected .lua files in src/scripts/ (OLDSCRIPTS-002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `mission_builder_worker.py`: `complete_src_folder_with_defaults()` now warns when unexpected `.lua` files are found in `src/scripts/` (potential v5 residues that would be loaded as DCS mission scripts and may conflict with the bundled `veaf-scripts.lua`)
 - `prepare.py`: `.gitignore` template added to `src/defaults/mission-folder/` — copied on `veaf-tools prepare` when absent; never overwritten (even with `--force`) to preserve user customizations
 - `lua_config_generator.py`: `_MODULE_CATEGORIES` dict — groups modules into 4 tiers (Infrastructure, Core, Features, Combat) plus External; category comment headers (`-- ── Category ──`) are emitted in `veaf-config.lua` and (`# ── Category ──`) in the YAML template
 - `lua_config_generator.py`: `_MANDATORY_MODULES` frozenset — if a mandatory module (UNITS, TIME, CACHE, EVENTS, MARKERS, COMMANDS) has `enable: false`, a warning is logged and the flag is ignored (module still generated)

--- a/backlog.md
+++ b/backlog.md
@@ -62,7 +62,7 @@
 | Lot FEAT-PROFILES — profils de build dans mission.yaml | ~3h | [archived](backlog-archive.md) |
 | Lot FEAT-MODULE-UX — Catégories, modules obligatoires, dépendances | ~2h | [archived](backlog-archive.md) |
 | Lot FEAT-GITIGNORE — Template `.gitignore` VEAF MCT dans les defaults | ~25 min | [archived](backlog-archive.md) |
-| Lot FIX-OLDSCRIPTS — Détection fichiers .lua résiduels dans src/scripts/ | ~45 min | ⬜ |
+| Lot FIX-OLDSCRIPTS — Détection fichiers .lua résiduels dans src/scripts/ | ~45 min | ✅ |
 | **Total** | **~167h20** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*
@@ -79,9 +79,9 @@
 
 | # | Ticket | Files | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| OLDSCRIPTS-000 | Investigation : reproduire le bug avec une vraie mission v5→v6 ; obtenir les logs DCS complets ; identifier le fichier responsable | — | chore | 15 min | ⬜ |
-| OLDSCRIPTS-001 | Fix : selon le résultat de l'investigation, corriger la cause racine identifiée | TBD | fix | TBD | ⬜ |
-| OLDSCRIPTS-002 | Ajouter un warning si des fichiers `.lua` inattendus sont présents dans `src/scripts/` (i.e. non listés explicitement dans `get_mission_script_files()`) | `mission_tools/mission_constants.py` ou `mission_builder_worker.py` | fix | 15 min | ⬜ |
+| OLDSCRIPTS-000 | Investigation : reproduire le bug avec une vraie mission v5→v6 ; obtenir les logs DCS complets ; identifier le fichier responsable | — | chore | 15 min | ✅ (résolu — voir contexte) |
+| OLDSCRIPTS-001 | Fix : selon le résultat de l'investigation, corriger la cause racine identifiée | TBD | fix | TBD | ✅ (résolu par FIX-BUNDLE) |
+| OLDSCRIPTS-002 | Ajouter un warning si des fichiers `.lua` inattendus sont présents dans `src/scripts/` (i.e. non listés explicitement dans `get_mission_script_files()`) | `mission_tools/mission_constants.py` ou `mission_builder_worker.py` | fix | 15 min | ✅ |
 
 **Raw total: ~45 min estimé (hors investigation)**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.9"
+version = "6.3.10"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -28,6 +28,16 @@ from veaf_libs.lua_module_scanner import get_modules
 from veaf_libs.paths import resolve_path
 from veaf_libs.progress import spinner_context
 
+# Lua files that are always expected in src/scripts/ of a VEAF v6 mission folder.
+# Any other .lua file found there is flagged as a potential v5 residue.
+_EXPECTED_SCRIPTS: frozenset[str] = frozenset(
+    {
+        "veaf-config.lua",
+        "mission-script.lua",
+        "veafDynamicConfig.lua",
+    }
+)
+
 
 class MissionBuilderWorker(BaseWorker):
     """
@@ -305,13 +315,6 @@ class MissionBuilderWorker(BaseWorker):
         # that folder, including potential v5 residues (e.g. veafSecurity.lua, veafCommands.lua).
         # Those would be loaded as individual DCS mission scripts and may conflict with the
         # bundled veaf-scripts.lua loaded by the VEAF triggers.
-        _EXPECTED_SCRIPTS: frozenset[str] = frozenset(
-            {
-                "veaf-config.lua",
-                "mission-script.lua",
-                "veafDynamicConfig.lua",
-            }
-        )
         scripts_dir = self.mission_folder / "src" / "scripts"
         if scripts_dir.is_dir():
             for lua_file in scripts_dir.glob("*.lua"):

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -300,6 +300,29 @@ class MissionBuilderWorker(BaseWorker):
                     logger.warning(f"Copied required file '{relative_path}' from default folder '{defaults_folder}'")
                     shutil.copy(f, relative_path)
 
+        # OLDSCRIPTS-002: warn about unexpected .lua files in src/scripts/
+        # The glob src/scripts/*.lua in get_mission_script_files() picks up ALL .lua files in
+        # that folder, including potential v5 residues (e.g. veafSecurity.lua, veafCommands.lua).
+        # Those would be loaded as individual DCS mission scripts and may conflict with the
+        # bundled veaf-scripts.lua loaded by the VEAF triggers.
+        _EXPECTED_SCRIPTS: frozenset[str] = frozenset(
+            {
+                "veaf-config.lua",
+                "mission-script.lua",
+                "veafDynamicConfig.lua",
+            }
+        )
+        scripts_dir = self.mission_folder / "src" / "scripts"
+        if scripts_dir.is_dir():
+            for lua_file in scripts_dir.glob("*.lua"):
+                if lua_file.name not in _EXPECTED_SCRIPTS:
+                    logger.warning(
+                        f"Unexpected Lua file 'src/scripts/{lua_file.name}' found in your mission folder. "
+                        f"This file will be loaded as a DCS mission script and may conflict with "
+                        f"the bundled veaf-scripts.lua. "
+                        f"If this is a leftover v5 VEAF script, delete it."
+                    )
+
     def create_mission(self) -> None:
         """Creates the initial mission file from the mission folder."""
 

--- a/test/python/mission_builder/test_mission_builder_defaults.py
+++ b/test/python/mission_builder/test_mission_builder_defaults.py
@@ -180,5 +180,69 @@ class TestWeatherAliasCoexistence(unittest.TestCase):
         self.assertTrue((tmpdir / "src" / "versions.yaml").exists(), "versions.yaml must be copied")
 
 
+class TestOldScriptsDetection(unittest.TestCase):
+    """OLDSCRIPTS-002: warn when unexpected .lua files are present in src/scripts/."""
+
+    def _run_with_warnings(self, mission_folder: Path) -> list[str]:
+        from unittest.mock import patch
+
+        from veaf_libs.logger import logger
+
+        # Minimal defaults folder (empty — we only care about the scripts/ check)
+        defaults_folder = mission_folder / "published" / "src" / "defaults" / "mission-folder"
+        defaults_folder.mkdir(parents=True, exist_ok=True)
+        worker = _make_worker(mission_folder, defaults_folder, {})
+
+        warnings: list[str] = []
+        orig_warning = logger.warning
+
+        def capture_warning(msg, *args, **kwargs):
+            warnings.append(str(msg))
+            return orig_warning(msg, *args, **kwargs)
+
+        with patch.object(logger, "warning", side_effect=capture_warning):
+            worker.complete_src_folder_with_defaults()
+
+        return warnings
+
+    def test_no_warning_for_expected_files(self) -> None:
+        """veaf-config.lua, mission-script.lua, veafDynamicConfig.lua must not trigger a warning."""
+        tmpdir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmpdir)
+        scripts_dir = tmpdir / "src" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        for name in ("veaf-config.lua", "mission-script.lua", "veafDynamicConfig.lua"):
+            (scripts_dir / name).write_text("-- ok", encoding="utf-8")
+
+        warnings = self._run_with_warnings(tmpdir)
+
+        unexpected = [w for w in warnings if "Unexpected Lua file" in w]
+        self.assertEqual(unexpected, [], f"Unexpected warnings: {unexpected}")
+
+    def test_warning_for_residual_v5_file(self) -> None:
+        """A leftover v5 file like veafSecurity.lua must trigger a warning."""
+        tmpdir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmpdir)
+        scripts_dir = tmpdir / "src" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "veafSecurity.lua").write_text("-- v5 residue", encoding="utf-8")
+
+        warnings = self._run_with_warnings(tmpdir)
+
+        unexpected = [w for w in warnings if "Unexpected Lua file" in w]
+        self.assertTrue(unexpected, "Expected a warning for veafSecurity.lua")
+        self.assertTrue(any("veafSecurity.lua" in w for w in unexpected))
+
+    def test_no_warning_when_scripts_dir_absent(self) -> None:
+        """No error or warning when src/scripts/ does not exist."""
+        tmpdir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmpdir)
+
+        warnings = self._run_with_warnings(tmpdir)
+
+        unexpected = [w for w in warnings if "Unexpected Lua file" in w]
+        self.assertEqual(unexpected, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/mission_builder/test_mission_builder_defaults.py
+++ b/test/python/mission_builder/test_mission_builder_defaults.py
@@ -197,7 +197,8 @@ class TestOldScriptsDetection(unittest.TestCase):
         orig_warning = logger.warning
 
         def capture_warning(msg, *args, **kwargs):
-            warnings.append(str(msg))
+            formatted = msg % args if args else str(msg)
+            warnings.append(formatted)
             return orig_warning(msg, *args, **kwargs)
 
         with patch.object(logger, "warning", side_effect=capture_warning):
@@ -232,6 +233,25 @@ class TestOldScriptsDetection(unittest.TestCase):
         unexpected = [w for w in warnings if "Unexpected Lua file" in w]
         self.assertTrue(unexpected, "Expected a warning for veafSecurity.lua")
         self.assertTrue(any("veafSecurity.lua" in w for w in unexpected))
+
+    def test_mixed_expected_and_unexpected_lua_files(self) -> None:
+        """Only unexpected files warn; expected files alongside them must not."""
+        tmpdir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmpdir)
+        scripts_dir = tmpdir / "src" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        for name in ("veaf-config.lua", "mission-script.lua", "veafDynamicConfig.lua"):
+            (scripts_dir / name).write_text("-- ok", encoding="utf-8")
+        (scripts_dir / "veafSecurity.lua").write_text("-- v5 residue", encoding="utf-8")
+
+        warnings = self._run_with_warnings(tmpdir)
+
+        unexpected = [w for w in warnings if "Unexpected Lua file" in w]
+        self.assertTrue(unexpected, "Expected a warning for veafSecurity.lua when mixed with valid files")
+        self.assertTrue(any("veafSecurity.lua" in w for w in unexpected))
+        self.assertFalse(any("veaf-config.lua" in w for w in unexpected))
+        self.assertFalse(any("mission-script.lua" in w for w in unexpected))
+        self.assertFalse(any("veafDynamicConfig.lua" in w for w in unexpected))
 
     def test_no_warning_when_scripts_dir_absent(self) -> None:
         """No error or warning when src/scripts/ does not exist."""


### PR DESCRIPTION
## FIX-OLDSCRIPTS — Détection fichiers .lua résiduels dans src/scripts/

### Context

The original `veafCommands nil` crash was resolved by FIX-BUNDLE. This lot addresses the secondary risk: leftover v5 individual VEAF `.lua` files in `src/scripts/` are picked up by the `src/scripts/*.lua` glob in `get_mission_script_files()` and loaded as DCS mission scripts, potentially conflicting with the bundled `veaf-scripts.lua`.

### What

- **`mission_builder_worker.py`**: at the end of `complete_src_folder_with_defaults()`, scan `src/scripts/*.lua` for unexpected files. Any file not in `{"veaf-config.lua", "mission-script.lua", "veafDynamicConfig.lua"}` triggers a `logger.warning` with an explicit message pointing to potential v5 residues.
- **`test_mission_builder_defaults.py`** (`TestOldScriptsDetection`): 3 new tests:
  - No warning for the 3 expected files
  - Warning emitted for `veafSecurity.lua` (v5 residue)
  - No error when `src/scripts/` is absent

### Tickets

| Ticket | Status |
|--------|--------|
| OLDSCRIPTS-000 | ✅ resolved — root cause was missing `veafCommands.lua` in bundle (FIX-BUNDLE) |
| OLDSCRIPTS-001 | ✅ resolved by FIX-BUNDLE |
| OLDSCRIPTS-002 | ✅ implemented here |

### Version

`6.3.9 → 6.3.10`

### Checklist

- [x] ruff ✅
- [x] mypy ✅
- [x] 881 passed, 1 skipped ✅
- [x] CHANGELOG updated
- [x] backlog.md updated (FIX-OLDSCRIPTS ✅)

## Summary by Sourcery

Warn about unexpected legacy Lua mission scripts in src/scripts and document the completion of the FIX-OLDSCRIPTS lot.

Bug Fixes:
- Log warnings when non-whitelisted .lua files are present in src/scripts/, highlighting potential legacy v5 VEAF scripts that could conflict with the bundled veaf-scripts.lua.

Enhancements:
- Add detection logic in mission_builder_worker to scan src/scripts for unexpected Lua files during src folder completion.

Build:
- Bump veaf-tools package version from 6.3.9 to 6.3.10.

Documentation:
- Update CHANGELOG with the new warning behavior for unexpected Lua files in src/scripts/.
- Mark FIX-OLDSCRIPTS tickets as completed in backlog.md.

Tests:
- Add unit tests to verify warnings are emitted for residual v5 Lua files, not emitted for expected Lua scripts, and that missing src/scripts does not produce warnings or errors.