### PR TITLE
fix(lua): add missing initialize() to 4 Lua modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- `veafCacheManager.lua`, `veafTime.lua`, `veafUnits.lua`, `veafSkynetIadsMonitor.lua`: added missing `initialize()` function — the generated `veaf-config.lua` calls `<module>.initialize()` on every listed module; absence caused a DCS runtime crash (`attempt to call field 'initialize' (a nil value)`)
+
 ### Added
 - `mission_builder_worker.py`: `complete_src_folder_with_defaults()` now warns when unexpected `.lua` files are found in `src/scripts/` (potential v5 residues that would be loaded as DCS mission scripts and may conflict with the bundled `veaf-scripts.lua`)
 - `prepare.py`: `.gitignore` template added to `src/defaults/mission-folder/` — copied on `veaf-tools prepare` when absent; never overwritten (even with `--force`) to preserve user customizations

--- a/backlog.md
+++ b/backlog.md
@@ -63,9 +63,42 @@
 | Lot FEAT-MODULE-UX — Catégories, modules obligatoires, dépendances | ~2h | [archived](backlog-archive.md) |
 | Lot FEAT-GITIGNORE — Template `.gitignore` VEAF MCT dans les defaults | ~25 min | [archived](backlog-archive.md) |
 | Lot FIX-OLDSCRIPTS — Détection fichiers .lua résiduels dans src/scripts/ | ~45 min | ✅ |
-| **Total** | **~167h20** | |
+| Lot FIX-MARKERS-INIT — Ajout de `veafMarkers.initialize()` manquante | ~5 min | ✅ |
+| Lot FIX-MISSING-INIT — `initialize()` manquante sur 4 modules Lua | ~20 min | ✅ |
+| **Total** | **~167h45** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*
+
+---
+
+## Lot FIX-MISSING-INIT — `initialize()` manquante sur 4 modules Lua
+
+**Goal**: Corriger les crashes DCS runtime `attempt to call field 'initialize' (a nil value)` sur les modules non encore couverts.
+
+**Context**: Le build Python (`lua_config_generator.py`) génère un appel `<module>.initialize()` pour tous les modules listés dans `_MODULE_INIT_ORDER`. Audit complet révèle 4 modules sans cette fonction : `veafCacheManager`, `veafTime`, `veafUnits`, `veafSkynetIadsMonitor`.
+
+**Branch**: `fix/missing-initialize-fns` → PR → `develop-v6`
+
+| # | Ticket | Files | Type | Effort | Status |
+|---|--------|-------|------|--------|--------|
+| MISSING-INIT-001 | Ajouter `initialize()` dans `veafCacheManager.lua` | `src/scripts/veaf/veafCacheManager.lua` | fix | 5 min | ✅ |
+| MISSING-INIT-002 | Ajouter `initialize()` dans `veafTime.lua` | `src/scripts/veaf/veafTime.lua` | fix | 5 min | ✅ |
+| MISSING-INIT-003 | Ajouter `initialize()` dans `veafUnits.lua` | `src/scripts/veaf/veafUnits.lua` | fix | 5 min | ✅ |
+| MISSING-INIT-004 | Ajouter `initialize()` dans `veafSkynetIadsMonitor.lua` | `src/scripts/veaf/veafSkynetIadsMonitor.lua` | fix | 5 min | ✅ |
+
+---
+
+## Lot FIX-MARKERS-INIT — Ajout de `veafMarkers.initialize()` manquante
+
+**Goal**: Corriger l'erreur DCS runtime `attempt to call field 'initialize' (a nil value)` sur `veafMarkers`.
+
+**Context**: La fonction `initialize()` était absente de `veafMarkers.lua` alors que `veaf-config.lua` l'appelle systématiquement. Le module était déjà auto-initialisé au chargement ; la fonction ajoutée se contente de logger.
+
+**Branch**: commit direct sans branche (fix minimal, testé par l'utilisateur)
+
+| # | Ticket | Files | Type | Effort | Status |
+|---|--------|-------|------|--------|--------|
+| MARKERS-INIT-001 | Ajouter `veafMarkers.initialize()` dans `src/scripts/veaf/veafMarkers.lua` | `src/scripts/veaf/veafMarkers.lua` | fix | 5 min | ✅ |
 
 ---
 

--- a/src/scripts/veaf/veafCacheManager.lua
+++ b/src/scripts/veaf/veafCacheManager.lua
@@ -125,4 +125,8 @@ function VeafCache:getCachedData(key)
   return nil
 end
 
+function veafCacheManager.initialize()
+  veaf.loggers.get(veafCacheManager.Id):info("Initializing module")
+end
+
 veaf.loggers.get(veafCacheManager.Id):info(veaf.loggers.get(veafCacheManager.Id):getVersionInfo(veafCacheManager.Version))

--- a/src/scripts/veaf/veafSkynetIadsMonitor.lua
+++ b/src/scripts/veaf/veafSkynetIadsMonitor.lua
@@ -650,4 +650,8 @@ end
 ---------------------------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------------------------
 
+function veafSkynetMonitor.initialize()
+  veaf.loggers.get(veafSkynetMonitor.Id):info("Initializing module")
+end
+
 veaf.loggers.get(veafSkynetMonitor.Id):info(veaf.loggers.get(veafSkynetMonitor.Id):getVersionInfo(veafSkynetMonitor.Version))

--- a/src/scripts/veaf/veafTime.lua
+++ b/src/scripts/veaf/veafTime.lua
@@ -723,4 +723,8 @@ elseif (sTheatre == "afghanistan") then
 end
 ]]
 
+function veafTime.initialize()
+  veaf.loggers.get(veafTime.Id):info("Initializing module")
+end
+
 veaf.loggers.get(veafTime.Id):info(veaf.loggers.get(veafTime.Id):getVersionInfo(veafTime.Version))

--- a/src/scripts/veaf/veafUnits.lua
+++ b/src/scripts/veaf/veafUnits.lua
@@ -2274,6 +2274,10 @@ veafUnits.GroupsDatabase = {
   },
 }
 
+function veafUnits.initialize()
+  veaf.loggers.get(veafUnits.Id):info("Initializing module")
+end
+
 veaf.loggers.get(veafUnits.Id):info(string.format("Loading version %s", veafUnits.Version))
 
 if veafUnits.OutputListsForDocumentation then


### PR DESCRIPTION
## Summary

- `veafCacheManager.lua`, `veafTime.lua`, `veafUnits.lua`, `veafSkynetIadsMonitor.lua`: added missing `initialize()` function
- The generated `veaf-config.lua` calls `<module>.initialize()` on every module listed in `_MODULE_INIT_ORDER` — absence caused a DCS runtime crash (`attempt to call field 'initialize' (a nil value)`)
- Full audit of all modules in `_MODULE_INIT_ORDER` performed; these 4 were the only ones missing (excluding `AIRWAVES` which is in `_NO_INIT_MODULES`)

## Test plan

- [x] `poetry run test-lua` — 32 suites, 0 failures
- [x] `stylua --check` — no formatting issues
- [ ] Build a mission and verify DCS loads without `initialize` crash on these modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add missing initialize() entry points to several Lua modules to prevent runtime crashes when modules are initialized by the generated configuration.

Bug Fixes:
- Add initialize() functions to veafCacheManager, veafTime, veafUnits, and veafSkynetIadsMonitor so generated veaf-config.lua can safely call module initialization without causing DCS runtime errors.

Documentation:
- Document the Lua module initialization fix and associated runtime crash in the Unreleased section of the changelog.

Chores:
- Update the backlog to track and mark as completed the work items related to adding missing initialize() functions to Lua modules.