### PR TITLE
fix(lua): add missing initialize() to veafMarkers

### DIFF
--- a/src/scripts/veaf/veafMarkers.lua
+++ b/src/scripts/veaf/veafMarkers.lua
@@ -185,6 +185,10 @@ end
 -- initialisation
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
+function veafMarkers.initialize()
+  veaf.loggers.get(veafMarkers.Id):info("Initializing module")
+end
+
 --- Add event handler.
 world.addEventHandler(veafMarkers.eventHandler)
 


### PR DESCRIPTION
## Summary

- `veafMarkers.lua`: added missing `initialize()` function
- Same root cause as PR #361 — `veaf-config.lua` calls `<module>.initialize()` on every listed module; absence caused a DCS runtime crash (`attempt to call field 'initialize' (a nil value)`)
- This module was fixed separately as it was caught before the full audit that led to #361

## Test plan

- [x] `poetry run test-lua` — 32 suites, 0 failures
- [x] `stylua --check` — no formatting issues
- [ ] Build a mission and verify DCS loads without `initialize` crash on veafMarkers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent DCS runtime crashes by defining initialize() on the veafMarkers Lua module expected by veaf-config.