### PR TITLE
chore(release): prepare release 6.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [6.3.3] — 2026-06-06
 
 ### Fixed
 - `veafCacheManager.lua`, `veafTime.lua`, `veafUnits.lua`, `veafSkynetIadsMonitor.lua`: added missing `initialize()` function — the generated `veaf-config.lua` calls `<module>.initialize()` on every listed module; absence caused a DCS runtime crash (`attempt to call field 'initialize' (a nil value)`)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,46 +1,96 @@
-# VEAF Mission Creation Tools — v6.3.0
+# VEAF Mission Creation Tools — Notes de version v6.3.3
 
-**Release Date:** 2026-05-31
+> Date de publication : 2026-06-06
 
-## Highlights
+## Vue d'ensemble
 
-- **Fix: crash lors de la conversion v5→v6** — `convert-v5` ne plante plus sur les missions dont les tables Lua contiennent des clés mixtes (entiers et chaînes)
-- **veaf-tools s'auto-pause après un double-clic** — la fenêtre ne se ferme plus avant que vous ayez pu lire la sortie
-- **Defaults intelligents** — `veaf-tools build` ne copie plus les fichiers de config inutilisés quand leur module est désactivé dans `mission.yaml`
-- **veaf.initialize() plus robuste** — message d'erreur clair si `veafCommands.lua` est absent (scripts VEAF trop anciens)
+La version 6.3.3 est une version de stabilisation et de correction de bugs. Aucun changement incompatible.
 
 ---
 
-## For Mission Makers
+## Corrections de bugs
 
-### Bug fix — crash de convert-v5 sur certaines missions
+### Corrections runtime Lua
 
-`veaf-tools convert-v5` pouvait planter avec `TypeError: '<' not supported between instances of 'int' and 'str'` lors de la conversion de missions dont le `missionConfig.lua` générait des tables Lua avec des clés à la fois entières et chaînes. Ce bug est corrigé.
+- **`initialize()` manquant sur plusieurs modules** — `veafCacheManager`, `veafTime`,
+  `veafUnits` et `veafSkynetIadsMonitor` ne disposaient pas de leur fonction
+  `initialize()`. Comme `veaf-config.lua` appelle `<module>.initialize()` sur
+  chaque module listé, leur absence provoquait un crash DCS au démarrage :
+  `attempt to call field 'initialize' (a nil value)`.
 
-### veaf-tools build — auto-pause après un double-clic
+### Corrections du pipeline de build
 
-Quand vous lancez `veaf-tools.exe` en double-cliquant dessus (et non depuis un terminal), l'outil **s'arrête automatiquement en fin d'exécution** pour vous laisser le temps de lire la sortie avant que la fenêtre se ferme. Le comportement s'adapte à la façon dont vous avez lancé l'outil :
+- **Erreur de syntaxe Lua sur les champs d'assets avec caractères spéciaux** —
+  les champs `description`, `name` et `information` contenant des sauts de ligne
+  (`\n`) ou des guillemets (`"`) utilisent désormais la syntaxe Lua longue
+  (`[[...]]`), évitant une erreur de syntaxe au chargement de la mission.
 
-- **Double-clic** : pause et attend un appui sur une touche
-- **Terminal / CI** : se termine immédiatement comme avant
+- **`versions.yaml` n'est plus écrasé quand `missions.yaml` existe** — le
+  builder ne copie plus le `versions.yaml` par défaut si un `missions.yaml`
+  legacy est déjà présent dans `src/` ; un avertissement est émis à la place.
 
-Les flags `--pause` et `--no-pause` restent prioritaires et surchargent cette détection automatique.
+- **Nom du fichier de backup `v5_converter` corrigé** — la sauvegarde de
+  migration utilise désormais `missionConfig.lua` (cohérent avec tous les autres
+  fichiers de backup dans `backup_v5/`).
 
-### Gestion intelligente des fichiers de config par défaut
+- **`presets.md` n'est plus créé silencieusement** — ce fichier a été retiré
+  des defaults ; il était copié dans les dossiers mission sans utilité.
 
-`veaf-tools build` ne copie plus les fichiers de template par défaut (ex. `aircraft-templates.yaml`, `waypoints.yaml`) dans votre dossier mission quand l'étape de pipeline ou le module Lua correspondant est **désactivé** dans `mission.yaml`. Si l'un de ces fichiers existe déjà mais que son module est désactivé, vous recevez maintenant un avertissement explicite.
-
-### convert-v5 — config annotée dans le rapport
-
-Le `missionConfig.lua` annoté (qui montre ce que chaque ligne a été migrée vers) est maintenant intégré **directement dans le rapport de conversion** (`convert-v5-report.md`) sous forme de bloc de code Lua, au lieu d'être écrit dans un fichier séparé dans `backup_v5/`. Le rapport est autonome et plus facile à consulter.
+- **Avertissement quand `aircraft-templates.yaml` existe mais que l'étape
+  pipeline est désactivée** — la commande build avertit désormais dans ce cas.
 
 ---
 
-## For Mission Script Developers
+## Améliorations
 
-### veaf.initialize() — nil-check pour veafCommands
+### Pipeline de build
 
-Si votre mission utilise un `veaf-scripts.lua` antérieur à l'introduction de `veafCommands.lua`, `veaf.initialize()` affiche maintenant un message d'erreur clair au lieu d'échouer silencieusement. Mettez à jour votre `veaf-scripts.lua` pour corriger ce problème.
+- **Avertissement sur les fichiers `.lua` inattendus dans `src/scripts/`** — le
+  builder signale les fichiers `.lua` qui ressemblent à des résidus v5 ; ceux-ci
+  seraient chargés comme scripts de mission DCS et pourraient entrer en conflit
+  avec le `veaf-scripts.lua` fourni.
+
+- **Profils de build (`--profile`)** — nouvelle option `--profile` / `-p` sur
+  `veaf-tools build` permettant de sélectionner un profil nommé défini dans
+  `mission.yaml`. Les profils fusionnent en profondeur sur la config de base
+  (les listes sont remplacées, pas concaténées). Des exemples (`TEST`, `SERVER`)
+  sont inclus dans le template `mission.yaml` par défaut.
+
+- **`.gitignore` auto-généré** — `veaf-tools prepare` copie désormais un
+  template `.gitignore` dans le dossier mission s'il est absent ; il n'est
+  jamais écrasé (même avec `--force`) pour préserver les personnalisations.
+
+- **Configuration YAML-first pour CSAR** — `external_modules.csar` dans
+  `mission.yaml` génère désormais le bloc de configuration CSAR complet dans
+  `veaf-config.lua`, de façon symétrique au support CTLD existant.
+
+- **Bloc CTLD protégé et auto-initialisé** — le bloc CTLD dans `veaf-config.lua`
+  est maintenant encadré par `if ctld then … end` et inclut `ctld.initialize()`
+  automatiquement ; plus besoin d'appel manuel dans `mission-script.lua`.
+
+- **Modules obligatoires protégés** — les modules Infrastructure (UNITS, TIME,
+  CACHE, EVENTS, MARKERS, COMMANDS) sont désormais marqués obligatoires ; s'ils
+  sont désactivés dans `mission.yaml`, un avertissement est émis et le flag est
+  ignoré.
+
+- **Résolution automatique des dépendances** — les dépendances manquantes ou
+  désactivées sont auto-activées au moment du build avec un avertissement par
+  module ajouté ; les chaînes transitives sont entièrement résolues sans
+  modifier aucun fichier sur le disque.
+
+- **Catégories de modules dans `veaf-config.lua`** — les fichiers de config
+  générés incluent désormais des en-têtes de catégorie (Infrastructure, Core,
+  Features, Combat, External) pour une meilleure lisibilité.
+
+### Documentation
+
+- **Profils de build** documentés dans le Guide Mission Maker et
+  `MISSION_YAML_REFERENCE.md`.
+
+- **Mode développeur** (`dev_mode` / `scripts_path`) documenté dans le Guide
+  Développeur et `MISSION_YAML_REFERENCE.md`.
+
+- **Configuration YAML-first CSAR** documentée dans le Guide Mission Maker.
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,8 +36,8 @@ La version 6.3.3 est une version de stabilisation et de correction de bugs. Aucu
 - **`presets.md` n'est plus créé silencieusement** — ce fichier a été retiré
   des defaults ; il était copié dans les dossiers mission sans utilité.
 
-- **Avertissement quand `aircraft-templates.yaml` existe mais que l'étape
-  pipeline est désactivée** — la commande build avertit désormais dans ce cas.
+- **Avertissement quand `aircraft-templates.yaml` existe mais que l'étape de
+-  pipeline est désactivée** — la commande build avertit désormais dans ce cas.
 
 ---
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -40,7 +40,8 @@ This document describes the intended direction for the project. Items are ordere
 
 ### Release
 - ✅ **v6.2.0 release** — squash merge `develop-v6` → `master`, published 2026-05-30
-- 🔄 **v6.3.0 release** — bug fixes and UX improvements (Lot 26 + FIX-SORT): convert-v5 crash fix, auto-pause on double-click, smart defaults filtering, veaf.initialize() nil-check
+- ✅ **v6.3.0 release** — bug fixes and UX improvements (Lot 26 + FIX-SORT): convert-v5 crash fix, auto-pause on double-click, smart defaults filtering, veaf.initialize() nil-check
+- ✅ **v6.3.3 release** — stabilization and bug fixes: Lua initialize() crashes, build pipeline fixes, build profiles, CSAR YAML-first, auto dependency resolution
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.10"
+version = "6.3.3"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"


### PR DESCRIPTION
## Summary

- `RELEASE_NOTES.md` : notes de version v6.3.3 en français
- `CHANGELOG.md` : section `[Unreleased]` promue en `[6.3.3] — 2026-06-06`
- `pyproject.toml` : version bumped à `6.3.3`
- `doc/ROADMAP.md` : v6.3.0 et v6.3.3 marquées comme released

## After merge

```bash
git checkout develop-v6
git pull origin develop-v6
git tag published-v6.3.3
git push origin published-v6.3.3
```

> **Attention :** pousser le tag déclenche immédiatement le workflow CI de publication. Ne le faire qu'après merge et validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the 6.3.3 release metadata and documentation.

Build:
- Bump veaf-tools package version to 6.3.3 in pyproject.toml.
- Promote the unreleased changelog section to the 6.3.3 release entry with release date.

Documentation:
- Add detailed French release notes for version 6.3.3.
- Update roadmap to mark v6.3.0 and v6.3.3 as released with brief descriptions.