### PR TITLE
chore(docs): migrate deployment to veaf.github.io/documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
           git config --local --unset-all \
             "http.https://github.com/.extraheader" || true
           git remote add ext-docs \
-            "https://x-access-token:${DOCS_DEPLOY_TOKEN}@github.com/VEAF/VEAF-Mission-Creation-Tools-v6.git"
+            "https://x-access-token:${DOCS_DEPLOY_TOKEN}@github.com/VEAF/documentation.git"
           git fetch ext-docs gh-pages --depth=1 || true
 
       - name: Deploy docs (develop-v6 → alias "dev")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- `mkdocs.yml`, `docs.yml`: deploy documentation to `veaf.github.io/documentation/` (was `veaf.github.io/VEAF-Mission-Creation-Tools-v6/`)
 - Documentation: French is now the default language; English (`*.en.md`) is the secondary language — all 35 documentation page pairs renamed accordingly
 - `mkdocs.yml`: `fr` locale set as default, `en` as secondary
 - `doc/mission-maker/scripts/veafSkynetIadsHelper.md`: complete rewrite — corrected API names (`veafSkynet.*`), added point defence modes, group integration modes, dynamic spawn, command centers, network deactivation, and deferred network access pattern

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: VEAF Mission Creation Tools
 site_description: Tools and Lua scripts for dynamic DCS World missions
-site_url: https://veaf.github.io/VEAF-Mission-Creation-Tools-v6/
+site_url: https://veaf.github.io/documentation/
 repo_url: https://github.com/VEAF/VEAF-Mission-Creation-Tools
 repo_name: VEAF/VEAF-Mission-Creation-Tools
 docs_dir: doc


### PR DESCRIPTION
## Summary

- `mkdocs.yml`: `site_url` → `https://veaf.github.io/documentation/`
- `.github/workflows/docs.yml`: `ext-docs` remote → `VEAF/documentation.git`

## Action requise avant merge

Le repo `VEAF/documentation` contient actuellement la doc v5 (Jekyll) sur sa branche `gh-pages`. Avant que le workflow ne déploie dessus, il faut archiver ce contenu :

```bash
# Dans le repo VEAF/documentation :
git checkout gh-pages
git checkout -b archive/v5-jekyll
git push origin archive/v5-jekyll
```

Ensuite supprimer ou vider `gh-pages` — `mike` recréera la structure au premier déploiement.

Le secret `DOCS_DEPLOY_TOKEN` doit avoir accès en écriture à `VEAF/documentation` (vérifier les permissions du PAT si nécessaire).

## Test plan

- [ ] Archiver le contenu v5 de `gh-pages` dans `VEAF/documentation`
- [ ] Vérifier les permissions du `DOCS_DEPLOY_TOKEN` sur `VEAF/documentation`
- [ ] Merger cette PR → le workflow se déclenche sur `develop-v6` → vérifie que `veaf.github.io/documentation/dev/` est accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update documentation deployment to target the shared veaf.github.io/documentation site instead of the project-specific GitHub Pages URL.

Deployment:
- Retarget docs deployment workflow to push to the VEAF/documentation repository and veaf.github.io/documentation/ GitHub Pages site.

Documentation:
- Update MkDocs site_url to point to veaf.github.io/documentation/ and record the new deployment location in the changelog.