### PR TITLE
docs(developer): expand setup guide and fix Lua test command

### DIFF
--- a/doc/developer/GUIDE.en.md
+++ b/doc/developer/GUIDE.en.md
@@ -116,7 +116,7 @@ python --version   # Python 3.11 or higher expected
 Poetry manages Python virtual environments and project dependencies. The recommended installation method is via `pipx`, which isolates Poetry in its own environment:
 
 ```powershell
-pip install pipx
+python -m pip install pipx
 pipx ensurepath        # adds ~/.local/bin to PATH — restart the terminal afterwards
 pipx install poetry
 ```

--- a/doc/developer/GUIDE.en.md
+++ b/doc/developer/GUIDE.en.md
@@ -95,28 +95,116 @@ In both cases, `poetry install --without build --all-extras` runs automatically 
 
 ### Option B — Manual setup (Windows)
 
-### Prerequisites
+#### 1. Python 3.11+
 
-- Python 3.9+ (3.13 recommended)
-- Git
-- GitHub CLI (`gh`) — for publishing releases
-- Lua 5.1 — for running unit tests locally
-- StyLua 2.4.0 — for Lua formatting (installed at `~/.local/bin/stylua.exe`)
-
-### Setup
+Download the installer from [python.org](https://www.python.org/downloads/) (**3.13** recommended) or via winget:
 
 ```powershell
-# Clone
-git clone https://github.com/VEAF/VEAF-Mission-Creation-Tools.git
-cd VEAF-Mission-Creation-Tools
-
-# Install dependencies (Poetry manages its own virtual environment)
-poetry install              # quality gate + veaf-tools
-poetry install --with build # add PyInstaller (needed to compile .exe)
+winget install --id Python.Python.3.13
 ```
 
-> Use `poetry run <cmd>` to execute any Python command inside Poetry's environment,
-> or `poetry shell` to open an interactive session.
+> **Important:** during the graphical installer, check **"Add Python to PATH"**. Without it, `python` and `pip` will not be found in the terminal.
+
+Verify:
+
+```powershell
+python --version   # Python 3.11 or higher expected
+```
+
+#### 2. Poetry
+
+Poetry manages Python virtual environments and project dependencies. The recommended installation method is via `pipx`, which isolates Poetry in its own environment:
+
+```powershell
+pip install pipx
+pipx ensurepath        # adds ~/.local/bin to PATH — restart the terminal afterwards
+pipx install poetry
+```
+
+Verify:
+
+```powershell
+poetry --version
+```
+
+> `poetry install` automatically creates an isolated virtualenv inside the project. All project commands are then run with the `poetry run <command>` prefix.
+
+#### 3. Git
+
+```powershell
+winget install --id Git.Git
+```
+
+Or download from [git-scm.com](https://git-scm.com/download/win).
+
+#### 4. Lua 5.1 (for unit tests)
+
+Lua 5.1 is required to run tests locally. Version **5.1** is mandatory — versions 5.2+ are not compatible with DCS World code.
+
+Via [Scoop](https://scoop.sh/) (recommended Windows package manager):
+
+```powershell
+# Install Scoop if not already present
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+
+# Install Lua 5.1
+scoop install lua51
+```
+
+Alternatively, download a binary from [LuaBinaries](https://luabinaries.sourceforge.net/) (`lua-5.1.x_Win64_bin.zip`), extract it, and add the folder to the system PATH.
+
+Verify:
+
+```powershell
+lua -v   # Lua 5.1.x expected
+```
+
+#### 5. StyLua 2.4.0 (Lua code quality)
+
+StyLua formats Lua code. **Version 2.4.0 is enforced by CI** — any other version will fail the formatting job.
+
+Download `stylua-windows-x86_64.zip` from the [v2.4.0 release page](https://github.com/JohnnyMorganz/StyLua/releases/tag/v2.4.0), then install:
+
+```powershell
+# Create target folder
+New-Item -ItemType Directory -Force "$HOME\.local\bin"
+
+# Extract and place the executable (adjust path to where the zip was extracted)
+Copy-Item "path\to\stylua.exe" "$HOME\.local\bin\stylua.exe"
+
+# Verify
+~/.local/bin/stylua.exe --version   # stylua 2.4.0 expected
+```
+
+#### 6. GitHub CLI — optional, only needed to publish releases
+
+```powershell
+winget install --id GitHub.cli
+gh auth login
+```
+
+#### Clone and initialise the project
+
+Once all prerequisites are installed:
+
+```powershell
+git clone https://github.com/VEAF/VEAF-Mission-Creation-Tools.git
+cd VEAF-Mission-Creation-Tools
+git checkout develop-v6
+
+# Install all Python dependencies
+poetry install
+
+# Verify everything works
+poetry run test-lua   # Lua tests (requires Lua 5.1)
+poetry run pytest     # Python tests
+```
+
+> To compile the Windows executables (`veaf-tools.exe`, etc.), add the `build` group:
+> ```powershell
+> poetry install --with build
+> ```
 
 ### Python Dependencies
 

--- a/doc/developer/GUIDE.md
+++ b/doc/developer/GUIDE.md
@@ -115,7 +115,7 @@ python --version   # Python 3.11 ou supérieur attendu
 Poetry gère les environnements virtuels Python et les dépendances du projet. La méthode recommandée est via `pipx`, qui isole Poetry dans son propre environnement :
 
 ```powershell
-pip install pipx
+python -m pip install pipx
 pipx ensurepath        # ajoute ~/.local/bin au PATH — redémarrer le terminal ensuite
 pipx install poetry
 ```

--- a/doc/developer/GUIDE.md
+++ b/doc/developer/GUIDE.md
@@ -94,28 +94,116 @@ Dans les deux cas, `poetry install --without build --all-extras` s'exécute auto
 
 ### Option B — Setup manuel (Windows)
 
-### Prérequis
+#### 1. Python 3.11+
 
-- Python 3.9+ (3.13 recommandé)
-- Git
-- GitHub CLI (`gh`) — pour publier les versions
-- Lua 5.1 — pour lancer les tests unitaires en local
-- StyLua 2.4.0 — pour le formatage Lua (installé dans `~/.local/bin/stylua.exe`)
-
-### Installation
+Télécharger l'installateur depuis [python.org](https://www.python.org/downloads/) (version **3.13** recommandée) ou via winget :
 
 ```powershell
-# Cloner
-git clone https://github.com/VEAF/VEAF-Mission-Creation-Tools.git
-cd VEAF-Mission-Creation-Tools
-
-# Installer les dépendances (Poetry gère son propre environnement virtuel)
-poetry install              # quality gate + veaf-tools
-poetry install --with build # ajouter PyInstaller (nécessaire pour compiler les .exe)
+winget install --id Python.Python.3.13
 ```
 
-> Utiliser `poetry run <cmd>` pour exécuter n'importe quelle commande Python dans l'environnement Poetry,
-> ou `poetry shell` pour ouvrir une session interactive.
+> **Important :** pendant l'installation graphique, cocher **"Add Python to PATH"**. Sans cette case, `python` et `pip` ne seront pas trouvés dans le terminal.
+
+Vérification :
+
+```powershell
+python --version   # Python 3.11 ou supérieur attendu
+```
+
+#### 2. Poetry
+
+Poetry gère les environnements virtuels Python et les dépendances du projet. La méthode recommandée est via `pipx`, qui isole Poetry dans son propre environnement :
+
+```powershell
+pip install pipx
+pipx ensurepath        # ajoute ~/.local/bin au PATH — redémarrer le terminal ensuite
+pipx install poetry
+```
+
+Vérification :
+
+```powershell
+poetry --version
+```
+
+> `poetry install` crée automatiquement un virtualenv isolé dans le projet. Toutes les commandes du projet s'exécutent ensuite avec le préfixe `poetry run <commande>`.
+
+#### 3. Git
+
+```powershell
+winget install --id Git.Git
+```
+
+Ou télécharger depuis [git-scm.com](https://git-scm.com/download/win).
+
+#### 4. Lua 5.1 (pour les tests unitaires)
+
+Lua 5.1 est requis pour exécuter les tests localement. La version **5.1** est obligatoire — les versions 5.2+ ne sont pas compatibles avec le code DCS.
+
+Via [Scoop](https://scoop.sh/) (gestionnaire de paquets Windows recommandé) :
+
+```powershell
+# Installer Scoop si pas encore présent
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+
+# Installer Lua 5.1
+scoop install lua51
+```
+
+Alternativement, télécharger un binaire depuis [LuaBinaries](https://luabinaries.sourceforge.net/) (`lua-5.1.x_Win64_bin.zip`), extraire et ajouter le dossier au PATH système.
+
+Vérification :
+
+```powershell
+lua -v   # Lua 5.1.x attendu
+```
+
+#### 5. StyLua 2.4.0 (qualité du code Lua)
+
+StyLua formate le code Lua. **La version 2.4.0 est imposée par la CI** — toute autre version fera échouer le job de formatage.
+
+Télécharger `stylua-windows-x86_64.zip` depuis la [page de release v2.4.0](https://github.com/JohnnyMorganz/StyLua/releases/tag/v2.4.0), puis installer :
+
+```powershell
+# Créer le dossier cible
+New-Item -ItemType Directory -Force "$HOME\.local\bin"
+
+# Extraire et placer l'exécutable (adapter le chemin selon où le zip a été extrait)
+Copy-Item "chemin\vers\stylua.exe" "$HOME\.local\bin\stylua.exe"
+
+# Vérifier
+~/.local/bin/stylua.exe --version   # stylua 2.4.0 attendu
+```
+
+#### 6. GitHub CLI — optionnel, uniquement pour publier des versions
+
+```powershell
+winget install --id GitHub.cli
+gh auth login
+```
+
+#### Cloner et initialiser le projet
+
+Une fois tous les prérequis installés :
+
+```powershell
+git clone https://github.com/VEAF/VEAF-Mission-Creation-Tools.git
+cd VEAF-Mission-Creation-Tools
+git checkout develop-v6
+
+# Installer toutes les dépendances Python
+poetry install
+
+# Vérifier que tout fonctionne
+poetry run test-lua   # tests Lua (requiert Lua 5.1)
+poetry run pytest     # tests Python
+```
+
+> Pour compiler les exécutables Windows (`veaf-tools.exe`, etc.), ajouter le groupe `build` :
+> ```powershell
+> poetry install --with build
+> ```
 
 ### Dépendances Python
 

--- a/doc/developer/README.en.md
+++ b/doc/developer/README.en.md
@@ -16,10 +16,7 @@ git checkout develop-v6
 poetry install
 
 # 3. Run Lua tests
-$FAILED=0
-Get-ChildItem test/lua/test_*.lua | Sort-Object Name | ForEach-Object {
-    lua $_.FullName; if ($LASTEXITCODE -ne 0) { $FAILED=1 }
-}
+poetry run test-lua
 
 # 4. Run Python quality gate
 poetry run ruff check src/python
@@ -59,7 +56,7 @@ flowchart TD
 |------|---------|--------|
 | Lua formatting | `stylua --check src/scripts/veaf/` | StyLua Formatting |
 | Lua lint | `luacheck src/scripts/veaf/ --config .luacheckrc` | Luacheck |
-| Lua tests | `lua test/lua/test_*.lua` | Lua Tests |
+| Lua tests | `poetry run test-lua` | Lua Tests |
 | Python lint + format | `poetry run ruff check` + `ruff format --check` | Python Quality |
 | Python types | `poetry run mypy src/python` | Python Quality |
 | Python tests | `poetry run pytest` | Python Quality |

--- a/doc/developer/README.md
+++ b/doc/developer/README.md
@@ -16,10 +16,7 @@ git checkout develop-v6
 poetry install
 
 # 3. Lancer les tests Lua
-$FAILED=0
-Get-ChildItem test/lua/test_*.lua | Sort-Object Name | ForEach-Object {
-    lua $_.FullName; if ($LASTEXITCODE -ne 0) { $FAILED=1 }
-}
+poetry run test-lua
 
 # 4. Lancer la quality gate Python
 poetry run ruff check src/python
@@ -59,7 +56,7 @@ flowchart TD
 |------|----------|--------|
 | Formatage Lua | `stylua --check src/scripts/veaf/` | StyLua Formatting |
 | Lint Lua | `luacheck src/scripts/veaf/ --config .luacheckrc` | Luacheck |
-| Tests Lua | `lua test/lua/test_*.lua` | Lua Tests |
+| Tests Lua | `poetry run test-lua` | Lua Tests |
 | Lint + format Python | `poetry run ruff check` + `ruff format --check` | Python Quality |
 | Types Python | `poetry run mypy src/python` | Python Quality |
 | Tests Python | `poetry run pytest` | Python Quality |


### PR DESCRIPTION
## Summary

- Replace the raw PowerShell loop for Lua tests with `poetry run test-lua` in both README quick start sections (FR + EN)
- Fix the quality gates table in README (FR + EN): `lua test/lua/test_*.lua` → `poetry run test-lua`
- Expand the Option B (manual setup on Windows) section in GUIDE (FR + EN) with detailed step-by-step installation instructions for each prerequisite:
  - Python 3.11+ (winget command, PATH checkbox reminder, verification)
  - Poetry (via pipx, ensurepath, verification)
  - Git (winget)
  - Lua 5.1 (Scoop or LuaBinaries — version 5.1 mandatory, rationale explained)
  - StyLua 2.4.0 (specific version enforced by CI, download + install steps)
  - GitHub CLI (optional, only for releases)
  - Final clone + `poetry install` + verification block

## Test plan

- [ ] Verify `poetry run test-lua` resolves to `veaf_build.lua_tests:main` (defined in `pyproject.toml`)
- [ ] Check that the quality gates table in README no longer references the raw `lua` command
- [ ] Review the expanded Option B section for accuracy on a fresh Windows machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update developer documentation to standardize Lua test execution via Poetry and provide a detailed Windows manual setup guide in both English and French.

Documentation:
- Replace raw Lua PowerShell loop with the `poetry run test-lua` helper in quick start sections of the English and French developer READMEs.
- Update the quality gates tables to reference `poetry run test-lua` for Lua tests instead of the direct `lua` command in both READMEs.
- Expand the Windows manual setup (Option B) in the English and French developer guides with step-by-step installation and verification instructions for Python, Poetry, Git, Lua 5.1, StyLua 2.4.0, and GitHub CLI, plus project initialization and test commands.