### PR TITLE
docs(developer): rewrite overview page for new contributors

### DIFF
--- a/doc/developer/README.en.md
+++ b/doc/developer/README.en.md
@@ -8,7 +8,7 @@ This project delivers two things: **Lua scripts** that run inside DCS World miss
 
 ### Runtime layer — Lua inside DCS
 
-`src/scripts/veaf/` contains 34 Lua modules loaded inside DCS World missions while the mission is running. These scripts do not execute on your PC — they execute inside the simulator, on the server hosting the mission. They handle features such as QRAs, combat zones, dynamic weather, radio menus, and more.
+`src/scripts/veaf/` contains the Lua modules loaded inside DCS World missions while the mission is running. These scripts do not execute on your PC — they execute inside the simulator, on the server hosting the mission. They handle features such as QRAs, combat zones, dynamic weather, radio menus, and more.
 
 Lua 5.1 is the scripting language embedded in DCS World. There are no external libraries, no package manager — just plain `.lua` files.
 
@@ -16,7 +16,7 @@ Lua 5.1 is the scripting language embedded in DCS World. There are no external l
 
 `src/python/veaf-tools/` is a CLI tool that manipulates `.miz` files (DCS missions, which are ZIP archives). It injects Lua scripts, configuration, and weather data into a mission *before* it is launched.
 
-`veaf_build/` is the orchestrator that concatenates the 34 Lua modules into a single file, compiles Windows `.exe` files, and publishes GitHub releases.
+`veaf_build/` is the orchestrator that concatenates the Lua modules into a single file, compiles Windows `.exe` files, and publishes GitHub releases.
 
 ### How the two layers connect
 
@@ -25,7 +25,7 @@ The Python tools produce a `published.zip`. That ZIP is consumed by mission make
 ```mermaid
 flowchart LR
     subgraph DT["On your PC — build"]
-        lua["src/scripts/veaf/*.lua<br/>(34 modules)"]
+        lua["src/scripts/veaf/*.lua<br/>(Lua modules)"]
         py["veaf-tools.exe<br/>(Python CLI)"]
     end
     subgraph zip["published.zip"]
@@ -63,34 +63,32 @@ flowchart LR
 
 ---
 
-## Quick environment check
+## Initial environment check
 
-Once the environment is set up (see [GUIDE.md](GUIDE.md#development-environment)):
+Do this once after following the [setup guide](GUIDE.md#development-environment), to confirm everything is correctly installed:
 
 ```powershell
-# Clone and set up
 git clone https://github.com/VEAF/VEAF-Mission-Creation-Tools.git
 cd VEAF-Mission-Creation-Tools
 git checkout develop-v6
 poetry install
 
-# Verify everything works
-poetry run test-lua   # Lua module tests (31 suites)
-poetry run pytest     # Python tool tests
+poetry run test-lua   # should show "OK" for every suite
+poetry run pytest     # should show "passed" with no failures
 ```
 
 ---
 
-## Quality Gates
+## Quality Gates — before each commit
 
-Before any commit, these commands must pass without errors:
+These commands must pass without errors before committing. CI also runs them automatically — a failing job blocks the merge.
 
 | What was changed | Commands to run |
 |-----------------|----------------|
-| Lua files (`src/scripts/veaf/`) | `~/.local/bin/stylua.exe --check src/scripts/veaf/` then `poetry run test-lua` |
+| Lua files (`src/scripts/veaf/`) | `stylua --check src/scripts/veaf/` then `poetry run test-lua` |
 | Python code (`src/python/`) | `poetry run ruff check src/python` then `poetry run mypy src/python` then `poetry run pytest` |
 
-CI runs all of this automatically on every PR. A failing job blocks the merge.
+> On Windows, `stylua` is installed at `~/.local/bin/stylua.exe` by default (see [setup guide](GUIDE.md#5-stylua-240-lua-code-quality)).
 
 ---
 

--- a/doc/developer/README.en.md
+++ b/doc/developer/README.en.md
@@ -1,70 +1,100 @@
 # Developer Guide
 
-Contribute to the VEAF Mission Creation Tools — a hybrid Lua + Python project with 34 runtime modules and a CLI toolkit.
+This project delivers two things: **Lua scripts** that run inside DCS World missions, and **Python tools** that prepare those missions before launch. The two layers are independent — you can contribute to one without touching the other.
 
 ---
 
-## Quick Start — Clone to Tests in 5 Minutes
+## The two layers
+
+### Runtime layer — Lua inside DCS
+
+`src/scripts/veaf/` contains 34 Lua modules loaded inside DCS World missions while the mission is running. These scripts do not execute on your PC — they execute inside the simulator, on the server hosting the mission. They handle features such as QRAs, combat zones, dynamic weather, radio menus, and more.
+
+Lua 5.1 is the scripting language embedded in DCS World. There are no external libraries, no package manager — just plain `.lua` files.
+
+### Build layer — Python
+
+`src/python/veaf-tools/` is a CLI tool that manipulates `.miz` files (DCS missions, which are ZIP archives). It injects Lua scripts, configuration, and weather data into a mission *before* it is launched.
+
+`veaf_build/` is the orchestrator that concatenates the 34 Lua modules into a single file, compiles Windows `.exe` files, and publishes GitHub releases.
+
+### How the two layers connect
+
+The Python tools produce a `published.zip`. That ZIP is consumed by mission makers to embed VEAF scripts into their own DCS missions.
+
+```mermaid
+flowchart LR
+    subgraph DT["On your PC — build"]
+        lua["src/scripts/veaf/*.lua<br/>(34 modules)"]
+        py["veaf-tools.exe<br/>(Python CLI)"]
+    end
+    subgraph zip["published.zip"]
+        bundle["veaf-scripts.lua<br/>(concatenated modules)"]
+    end
+    subgraph RT["On the DCS server — runtime"]
+        mission[".miz\n(DCS mission)"]
+        dcs["DCS World"]
+    end
+    lua --> bundle
+    py -->|injects into| mission
+    bundle -->|copied into| mission
+    mission -->|loaded by| dcs
+```
+
+---
+
+## Where to start?
+
+**You want to modify a Lua script** (add a feature, fix a bug in a module):
+
+1. Read the [Lua Runtime Scripts](GUIDE.md#lua-runtime-scripts) section of the guide
+2. Edit the file in `src/scripts/veaf/`
+3. Run `poetry run test-lua` to check nothing is broken
+
+**You want to modify the Python tools** (`veaf-tools.exe` CLI, build pipeline):
+
+1. Read the [Python Tools](GUIDE.md#python-tools) section of the guide
+2. Edit the code in `src/python/veaf-tools/`
+3. Run `poetry run pytest` to check
+
+**You are starting from scratch and have nothing installed:**
+
+→ The [Development Environment](GUIDE.md#development-environment) section walks through every installation step (Python, Poetry, Lua, StyLua).
+
+---
+
+## Quick environment check
+
+Once the environment is set up (see [GUIDE.md](GUIDE.md#development-environment)):
 
 ```powershell
-# 1. Clone
+# Clone and set up
 git clone https://github.com/VEAF/VEAF-Mission-Creation-Tools.git
 cd VEAF-Mission-Creation-Tools
 git checkout develop-v6
-
-# 2. Install Python dependencies (requires Poetry)
 poetry install
 
-# 3. Run Lua tests
-poetry run test-lua
-
-# 4. Run Python quality gate
-poetry run ruff check src/python
-poetry run mypy src/python
-poetry run pytest
+# Verify everything works
+poetry run test-lua   # Lua module tests (31 suites)
+poetry run pytest     # Python tool tests
 ```
-
----
-
-## Architecture at a Glance
-
-```mermaid
-flowchart TD
-    subgraph RT["RUNTIME — Lua in DCS"]
-        scripts["34 Lua modules<br/>src/scripts/veaf/"]
-    end
-    subgraph DT["DESIGN-TIME — Python CLI"]
-        tools["veaf-tools.exe<br/>src/python/veaf-tools/"]
-        build["veaf-build<br/>veaf_build/"]
-    end
-    DT -->|produces| zip(["published.zip"])
-    zip -->|consumed by| RT
-```
-
-| Layer | Language | Location | Purpose |
-|-------|----------|----------|----------|
-| Runtime | Lua 5.1 | `src/scripts/veaf/` | Executes inside DCS missions |
-| CLI Tools | Python 3.11+ | `src/python/veaf-tools/` | `.miz` file manipulation |
-| Build | Python | `veaf_build/` | Build & release orchestrator |
-| Tests | Lua + Python | `test/` | Unit tests for both layers |
 
 ---
 
 ## Quality Gates
 
-| Gate | Command | CI Job |
-|------|---------|--------|
-| Lua formatting | `stylua --check src/scripts/veaf/` | StyLua Formatting |
-| Lua lint | `luacheck src/scripts/veaf/ --config .luacheckrc` | Luacheck |
-| Lua tests | `poetry run test-lua` | Lua Tests |
-| Python lint + format | `poetry run ruff check` + `ruff format --check` | Python Quality |
-| Python types | `poetry run mypy src/python` | Python Quality |
-| Python tests | `poetry run pytest` | Python Quality |
+Before any commit, these commands must pass without errors:
+
+| What was changed | Commands to run |
+|-----------------|----------------|
+| Lua files (`src/scripts/veaf/`) | `~/.local/bin/stylua.exe --check src/scripts/veaf/` then `poetry run test-lua` |
+| Python code (`src/python/`) | `poetry run ruff check src/python` then `poetry run mypy src/python` then `poetry run pytest` |
+
+CI runs all of this automatically on every PR. A failing job blocks the merge.
 
 ---
 
-## Full Reference
+## Full reference
 
-The [complete Developer Guide](GUIDE.md) covers repository layout, coding conventions, build pipeline, and contributing workflow.
-
-See also: [Testing Guide](../TESTING.md)
+- [Complete Developer Guide](GUIDE.md) — repository layout, coding conventions, build pipeline, contributing workflow
+- [Testing Guide](../TESTING.md) — Lua and Python test infrastructure in detail

--- a/doc/developer/README.md
+++ b/doc/developer/README.md
@@ -1,70 +1,100 @@
 # Guide du développeur
 
-Contribuez aux VEAF Mission Creation Tools — un projet hybride Lua + Python avec 34 modules runtime et un toolkit CLI.
+Ce projet fournit deux choses : des **scripts Lua** qui s'exécutent dans des missions DCS World, et des **outils Python** qui préparent ces missions avant le lancement. Les deux couches sont indépendantes — on peut contribuer à l'une sans toucher à l'autre.
 
 ---
 
-## Démarrage rapide — Du clone aux tests en 5 minutes
+## Les deux couches du projet
+
+### Couche runtime — Lua dans DCS
+
+`src/scripts/veaf/` contient 34 modules Lua chargés à l'intérieur des missions DCS au moment où la mission tourne. Ces scripts ne s'exécutent pas sur ton PC — ils s'exécutent dans le simulateur, sur le serveur qui héberge la mission. Ils gèrent des fonctionnalités comme les QRA, les zones de combat, la météo dynamique, la radio, etc.
+
+Lua 5.1 est le langage de script embarqué dans DCS World. Il n'y a pas de bibliothèque externe, pas de package manager — juste des fichiers `.lua` purs.
+
+### Couche build — Python
+
+`src/python/veaf-tools/` est un outil CLI qui manipule les fichiers `.miz` (les missions DCS, qui sont des archives ZIP). Il injecte les scripts Lua, la configuration, et les données météo dans la mission *avant* son lancement.
+
+`veaf_build/` est l'orchestrateur qui concatène les 34 modules Lua en un seul fichier, compile les `.exe` Windows, et publie les releases GitHub.
+
+### Comment les deux couches se connectent
+
+Les outils Python produisent un `published.zip`. Ce ZIP est consommé par les créateurs de missions pour intégrer les scripts VEAF dans leurs propres missions DCS.
+
+```mermaid
+flowchart LR
+    subgraph DT["Sur ton PC — build"]
+        lua["src/scripts/veaf/*.lua<br/>(34 modules)"]
+        py["veaf-tools.exe<br/>(outil CLI Python)"]
+    end
+    subgraph zip["published.zip"]
+        bundle["veaf-scripts.lua<br/>(modules concaténés)"]
+    end
+    subgraph RT["Sur le serveur DCS — runtime"]
+        mission[".miz\n(mission DCS)"]
+        dcs["DCS World"]
+    end
+    lua --> bundle
+    py -->|injecte dans| mission
+    bundle -->|copié dans| mission
+    mission -->|chargé par| dcs
+```
+
+---
+
+## Par où commencer ?
+
+**Tu veux modifier un script Lua** (ajouter une fonctionnalité, corriger un bug dans les modules) :
+
+1. Lis la section [Scripts Lua runtime](GUIDE.md#scripts-lua-runtime) du guide
+2. Modifie le fichier dans `src/scripts/veaf/`
+3. Lance `poetry run test-lua` pour vérifier que rien n'est cassé
+
+**Tu veux modifier les outils Python** (la CLI `veaf-tools.exe`, le pipeline de build) :
+
+1. Lis la section [Outils Python](GUIDE.md#outils-python) du guide
+2. Modifie le code dans `src/python/veaf-tools/`
+3. Lance `poetry run pytest` pour vérifier
+
+**Tu démarres de zéro et n'as rien d'installé** :
+
+→ La [section Environnement de développement](GUIDE.md#environnement-de-développement) détaille toutes les installations pas-à-pas (Python, Poetry, Lua, StyLua).
+
+---
+
+## Vérification rapide de l'environnement
+
+Une fois l'environnement configuré (voir [GUIDE.md](GUIDE.md#environnement-de-développement)) :
 
 ```powershell
-# 1. Cloner
+# Cloner et préparer
 git clone https://github.com/VEAF/VEAF-Mission-Creation-Tools.git
 cd VEAF-Mission-Creation-Tools
 git checkout develop-v6
-
-# 2. Installer les dépendances Python (nécessite Poetry)
 poetry install
 
-# 3. Lancer les tests Lua
-poetry run test-lua
-
-# 4. Lancer la quality gate Python
-poetry run ruff check src/python
-poetry run mypy src/python
-poetry run pytest
+# Vérifier que tout fonctionne
+poetry run test-lua   # tests des modules Lua (31 suites)
+poetry run pytest     # tests des outils Python
 ```
-
----
-
-## Architecture en un coup d'œil
-
-```mermaid
-flowchart TD
-    subgraph RT["RUNTIME — Lua dans DCS"]
-        scripts["34 modules Lua<br/>src/scripts/veaf/"]
-    end
-    subgraph DT["DESIGN-TIME — CLI Python"]
-        tools["veaf-tools.exe<br/>src/python/veaf-tools/"]
-        build["veaf-build<br/>veaf_build/"]
-    end
-    DT -->|produit| zip(["published.zip"])
-    zip -->|consommé par| RT
-```
-
-| Couche | Langage | Emplacement | Rôle |
-|--------|---------|-------------|------|
-| Runtime | Lua 5.1 | `src/scripts/veaf/` | S'exécute dans les missions DCS |
-| Outils CLI | Python 3.11+ | `src/python/veaf-tools/` | Manipulation de fichiers `.miz` |
-| Build | Python | `veaf_build/` | Orchestrateur de build & release |
-| Tests | Lua + Python | `test/` | Tests unitaires des deux couches |
 
 ---
 
 ## Quality Gates
 
-| Gate | Commande | Job CI |
-|------|----------|--------|
-| Formatage Lua | `stylua --check src/scripts/veaf/` | StyLua Formatting |
-| Lint Lua | `luacheck src/scripts/veaf/ --config .luacheckrc` | Luacheck |
-| Tests Lua | `poetry run test-lua` | Lua Tests |
-| Lint + format Python | `poetry run ruff check` + `ruff format --check` | Python Quality |
-| Types Python | `poetry run mypy src/python` | Python Quality |
-| Tests Python | `poetry run pytest` | Python Quality |
+Avant tout commit, ces commandes doivent passer sans erreur :
+
+| Ce qui est modifié | Commandes à lancer |
+|--------------------|-------------------|
+| Fichiers Lua (`src/scripts/veaf/`) | `~/.local/bin/stylua.exe --check src/scripts/veaf/` puis `poetry run test-lua` |
+| Code Python (`src/python/`) | `poetry run ruff check src/python` puis `poetry run mypy src/python` puis `poetry run pytest` |
+
+La CI vérifie tout cela automatiquement à chaque PR. Un job rouge bloque le merge.
 
 ---
 
 ## Référence complète
 
-Le [guide développeur complet](GUIDE.md) couvre l'organisation du dépôt, les conventions de code, le pipeline de build, et le workflow de contribution.
-
-Voir aussi : [Guide de test](../TESTING.md)
+- [Guide développeur complet](GUIDE.md) — organisation du dépôt, conventions de code, pipeline de build, workflow de contribution
+- [Guide de test](../TESTING.md) — infrastructure de test Lua et Python en détail

--- a/doc/developer/README.md
+++ b/doc/developer/README.md
@@ -8,7 +8,7 @@ Ce projet fournit deux choses : des **scripts Lua** qui s'exécutent dans des mi
 
 ### Couche runtime — Lua dans DCS
 
-`src/scripts/veaf/` contient 34 modules Lua chargés à l'intérieur des missions DCS au moment où la mission tourne. Ces scripts ne s'exécutent pas sur ton PC — ils s'exécutent dans le simulateur, sur le serveur qui héberge la mission. Ils gèrent des fonctionnalités comme les QRA, les zones de combat, la météo dynamique, la radio, etc.
+`src/scripts/veaf/` contient les modules Lua chargés à l'intérieur des missions DCS au moment où la mission tourne. Ces scripts ne s'exécutent pas sur ton PC — ils s'exécutent dans le simulateur, sur le serveur qui héberge la mission. Ils gèrent des fonctionnalités comme les QRA, les zones de combat, la météo dynamique, la radio, etc.
 
 Lua 5.1 est le langage de script embarqué dans DCS World. Il n'y a pas de bibliothèque externe, pas de package manager — juste des fichiers `.lua` purs.
 
@@ -16,7 +16,7 @@ Lua 5.1 est le langage de script embarqué dans DCS World. Il n'y a pas de bibli
 
 `src/python/veaf-tools/` est un outil CLI qui manipule les fichiers `.miz` (les missions DCS, qui sont des archives ZIP). Il injecte les scripts Lua, la configuration, et les données météo dans la mission *avant* son lancement.
 
-`veaf_build/` est l'orchestrateur qui concatène les 34 modules Lua en un seul fichier, compile les `.exe` Windows, et publie les releases GitHub.
+`veaf_build/` est l'orchestrateur qui concatène les modules Lua en un seul fichier, compile les `.exe` Windows, et publie les releases GitHub.
 
 ### Comment les deux couches se connectent
 
@@ -25,7 +25,7 @@ Les outils Python produisent un `published.zip`. Ce ZIP est consommé par les cr
 ```mermaid
 flowchart LR
     subgraph DT["Sur ton PC — build"]
-        lua["src/scripts/veaf/*.lua<br/>(34 modules)"]
+        lua["src/scripts/veaf/*.lua<br/>(modules Lua)"]
         py["veaf-tools.exe<br/>(outil CLI Python)"]
     end
     subgraph zip["published.zip"]
@@ -63,34 +63,32 @@ flowchart LR
 
 ---
 
-## Vérification rapide de l'environnement
+## Vérification initiale de l'environnement
 
-Une fois l'environnement configuré (voir [GUIDE.md](GUIDE.md#environnement-de-développement)) :
+À faire une seule fois après avoir suivi le [guide de setup](GUIDE.md#environnement-de-développement), pour confirmer que tout est bien installé :
 
 ```powershell
-# Cloner et préparer
 git clone https://github.com/VEAF/VEAF-Mission-Creation-Tools.git
 cd VEAF-Mission-Creation-Tools
 git checkout develop-v6
 poetry install
 
-# Vérifier que tout fonctionne
-poetry run test-lua   # tests des modules Lua (31 suites)
-poetry run pytest     # tests des outils Python
+poetry run test-lua   # doit afficher "OK" pour toutes les suites
+poetry run pytest     # doit afficher "passed" sans échec
 ```
 
 ---
 
-## Quality Gates
+## Quality Gates — avant chaque commit
 
-Avant tout commit, ces commandes doivent passer sans erreur :
+Ces commandes doivent passer sans erreur avant de committer. La CI les exécute aussi automatiquement — un job rouge bloque le merge.
 
 | Ce qui est modifié | Commandes à lancer |
 |--------------------|-------------------|
-| Fichiers Lua (`src/scripts/veaf/`) | `~/.local/bin/stylua.exe --check src/scripts/veaf/` puis `poetry run test-lua` |
+| Fichiers Lua (`src/scripts/veaf/`) | `stylua --check src/scripts/veaf/` puis `poetry run test-lua` |
 | Code Python (`src/python/`) | `poetry run ruff check src/python` puis `poetry run mypy src/python` puis `poetry run pytest` |
 
-La CI vérifie tout cela automatiquement à chaque PR. Un job rouge bloque le merge.
+> Sur Windows, `stylua` est installé dans `~/.local/bin/stylua.exe` par défaut (voir [guide de setup](GUIDE.md#5-stylua-240-qualité-du-code-lua)).
 
 ---
 


### PR DESCRIPTION
## Summary

Rewrites the developer overview page (`README.md` / `README.en.md`) with an explanation-first structure aimed at someone who has never seen the project.

**Before:** the page opened with a block of PowerShell commands and a Mermaid diagram with no prose — a reader unfamiliar with DCS or the project architecture had no way to understand what they were looking at.

**After:**
- Plain-language explanation of the two independent layers (Lua runtime inside DCS World vs Python build tools on the developer's machine) and how they connect
- "Where to start?" section that routes contributors based on what they actually want to change (Lua vs Python, or starting from scratch)
- Quick environment check kept but moved *after* the context
- Quality gates simplified to a "what did you change?" table rather than a flat list of commands
- All detailed setup instructions remain in GUIDE.md (linked), keeping the overview page readable

## Test plan

- [ ] Read the page as if you've never seen the project — does the first section answer "what is this?"
- [ ] Check that the "Where to start?" links resolve correctly in MkDocs
- [ ] Verify the Mermaid diagram renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rewrite the developer overview README (English and French) to better explain the project architecture and guide new contributors.

Documentation:
- Clarify the relationship between the Lua runtime scripts and Python build tools in both English and French developer READMEs.
- Add contributor-oriented "where to start" guidance with links into the full developer guide and testing guide.
- Restructure quick-start and quality gate sections to focus on environment verification and change-based checks.