### PR TITLE
fix(build): validate mission.yaml syntax with localised error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- `build.py`, `mission_builder_worker.py`: catch `yaml.YAMLError` when loading `mission.yaml` — display a clear, localised error message (file, line, column, plain-language hint) instead of crashing with a Python traceback
+
+### Documentation
+- `MISSION_YAML_REFERENCE.md`, `MISSION_YAML_REFERENCE.en.md`: added "Syntax errors" section explaining the new error messages and common causes
+
 ### Changed
 - `mkdocs.yml`, `docs.yml`: deploy documentation to `veaf.github.io/documentation/` (was `veaf.github.io/VEAF-Mission-Creation-Tools-v6/`)
 - Documentation: French is now the default language; English (`*.en.md`) is the secondary language — all 35 documentation page pairs renamed accordingly

--- a/backlog.md
+++ b/backlog.md
@@ -66,7 +66,8 @@
 | Lot FIX-MARKERS-INIT — Ajout de `veafMarkers.initialize()` manquante | ~5 min | ✅ |
 | Lot FIX-MISSING-INIT — `initialize()` manquante sur 4 modules Lua | ~20 min | ✅ |
 | Lot 27 — DOC-FR-MERGE | ~6h | ✅ |
-| **Total** | **~173h45** | |
+| Lot FIX-YAML-SYNTAX — Erreur YAML non gérée dans build et mission_builder_worker | ~15 min | ✅ |
+| **Total** | **~173h60** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*
 
@@ -138,6 +139,21 @@
 | DOC-FR-007 | Merge contenu v5 → `veafSkynetIadsHelper.md` (FR + EN) | `doc/mission-maker/scripts/veafSkynetIadsHelper.*` | chore | 20 min | ✅ |
 | DOC-FR-008 | Merge contenu v5 → `veafWeather.md` (FR + EN) | `doc/mission-maker/scripts/veafWeather.*` | chore | 20 min | ✅ |
 | DOC-FR-009 | Vérifier `presets.md` v5 et identifier l'équivalent v6 | TBD | chore | 15 min | ✅ (déjà dans GUIDE.md) |
+
+---
+
+## Lot FIX-YAML-SYNTAX — Erreur YAML non gérée dans build et mission_builder_worker
+
+**Goal**: Intercepter les erreurs de syntaxe YAML dans `mission.yaml` pour afficher un message clair au lieu d'un traceback Python.
+
+**Context**: Un `yaml.YAMLError` non géré dans `build.py` (peek du nom) et `mission_builder_worker.py` (chargement complet) causait un crash avec traceback. Le message d'erreur natif de PyYAML (fichier, ligne, colonne, contexte) est propagé via `logger.error`.
+
+**Branch**: `fix/yaml-syntax-error` → PR → `develop-v6`
+
+| # | Ticket | Files | Type | Effort | Status |
+|---|--------|-------|------|--------|--------|
+| YAML-SYNTAX-001 | Gérer `yaml.YAMLError` dans `build.py` (peek mission name) | `src/python/veaf-tools/veaf_tools/commands/build.py` | fix | 5 min | ✅ |
+| YAML-SYNTAX-002 | Gérer `yaml.YAMLError` dans `mission_builder_worker.py` (chargement complet) | `src/python/veaf-tools/mission_builder/mission_builder_worker.py` | fix | 5 min | ✅ |
 
 ---
 

--- a/doc/MISSION_YAML_REFERENCE.en.md
+++ b/doc/MISSION_YAML_REFERENCE.en.md
@@ -72,6 +72,30 @@ lua_modules:
 
 ---
 
+## Syntax errors
+
+If `mission.yaml` contains a YAML syntax error (wrong indentation, a missing colon, a tab character…), `veaf-tools build` stops immediately and displays a clear message indicating the file name, the line and column of the problem, and a plain-language hint on how to fix it:
+
+```
+Syntax error in mission.yaml, line 81, column 4.
+  The error starts near line 34, column 3.
+  → Check the indentation around these lines. YAML uses spaces only (never tabs).
+    All items in the same block must be aligned at the same column.
+```
+
+Common causes:
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `indentation` hint | A block is indented differently from the rest | Align the key with its siblings |
+| `tab` hint | A tab character was used instead of spaces | Replace all tabs with spaces in your editor |
+| `colon` hint | A key is missing its `:` separator | Write `key: value`, not `key value` |
+
+!!! tip
+    Most text editors can visualise whitespace characters — enable this option to quickly spot tab/space mix-ups.
+
+---
+
 ## Top-level sections
 
 ### `global_log_level`

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -74,7 +74,7 @@ lua_modules:
 
 ## Erreurs de syntaxe
 
-Si `mission.yaml` contient une erreur de syntaxe YAML (mauvaise indentation, deux-points manquant, caractère de tabulation…), `veaf-tools build` s'arrête immédiatement et affiche un message clair indiquant le nom du fichier, la ligne et la colonne du problème, ainsi qu'une aide en langage courant pour corriger l'erreur :
+Si `mission.yaml` contient une erreur de syntaxe YAML (mauvaise indentation, deux-points manquants, caractère de tabulation…), `veaf-tools build` s'arrête immédiatement et affiche un message clair indiquant le nom du fichier, la ligne et la colonne du problème, ainsi qu'une aide en langage courant pour corriger l'erreur :
 
 ```
 Erreur de syntaxe dans mission.yaml, ligne 81, colonne 4.

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -72,6 +72,30 @@ lua_modules:
 
 ---
 
+## Erreurs de syntaxe
+
+Si `mission.yaml` contient une erreur de syntaxe YAML (mauvaise indentation, deux-points manquant, caractère de tabulation…), `veaf-tools build` s'arrête immédiatement et affiche un message clair indiquant le nom du fichier, la ligne et la colonne du problème, ainsi qu'une aide en langage courant pour corriger l'erreur :
+
+```
+Erreur de syntaxe dans mission.yaml, ligne 81, colonne 4.
+  L'erreur débute vers la ligne 34, colonne 3.
+  → Vérifiez l'indentation autour de ces lignes. YAML utilise uniquement des espaces (jamais de tabulations).
+    Tous les éléments d'un même bloc doivent être alignés à la même colonne.
+```
+
+Causes fréquentes :
+
+| Symptôme | Cause | Correction |
+|----------|-------|------------|
+| astuce `indentation` | Un bloc est indenté différemment du reste | Aligner la clé avec ses voisines |
+| astuce `tabulation` | Un caractère de tabulation a été utilisé à la place d'espaces | Remplacer toutes les tabulations par des espaces dans l'éditeur |
+| astuce `deux-points` | Il manque le séparateur `:` après une clé | Écrire `clé: valeur` et non `clé valeur` |
+
+!!! tip
+    La plupart des éditeurs de texte peuvent visualiser les caractères d'espacement — activez cette option pour repérer rapidement les mélanges tabulations/espaces.
+
+---
+
 ## Sections de premier niveau
 
 ### `global_log_level`

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -27,6 +27,7 @@ from veaf_libs.lua_config_generator import generate_config_lua
 from veaf_libs.lua_module_scanner import get_modules
 from veaf_libs.paths import resolve_path
 from veaf_libs.progress import spinner_context
+from veaf_libs.yaml_validator import validate_yaml_file
 
 # Lua files that are always expected in src/scripts/ of a VEAF v6 mission folder.
 # Any other .lua file found there is flagged as a potential v5 residue.
@@ -76,6 +77,7 @@ class MissionBuilderWorker(BaseWorker):
         self.pipeline_cfg: dict = {}
         mission_yaml_path = mission_folder / "mission.yaml"
         if mission_yaml_path.exists():
+            validate_yaml_file(mission_yaml_path)
             with mission_yaml_path.open("r", encoding="utf-8") as fh:
                 raw_yaml: dict = yaml.safe_load(fh) or {}
             self.mission_yaml = resolve_profile(raw_yaml, profile_name)

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -67,6 +67,14 @@
   "builder.missing_files": "Missing files from {folder}: {files}",
   "builder.update_hint": "Try updating the veaf-tools package using veaf-tools-updater.exe!",
 
+  "yaml.error.syntax": "Syntax error in [bold]{filename}[/bold], line {line}, column {col}.",
+  "yaml.error.syntax_unknown": "Syntax error in [bold]{filename}[/bold].",
+  "yaml.error.context": "  The error starts near line {line}, column {col}.",
+  "yaml.error.hint.indentation": "  → Check the indentation around these lines. YAML uses spaces only (never tabs).\n    All items in the same block must be aligned at the same column.",
+  "yaml.error.hint.tab": "  → YAML does not allow tab characters for indentation.\n    Replace all tabs with spaces in your text editor.",
+  "yaml.error.hint.colon": "  → A key is probably missing its colon ':' separator.\n    Every YAML key must be written as:  key: value",
+  "yaml.error.hint.generic": "  → Open the file in a text editor and check the structure near the indicated line.\n    Make sure all indentation uses spaces (not tabs).",
+
   "weather.loading_config": "Loading configuration from {path}",
   "weather.config_loaded": "Configuration loaded: {count} version(s) to create",
   "weather.creating_version": "[{index}/{total}] Creating version: {name}",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -67,6 +67,14 @@
   "builder.missing_files": "Fichiers manquants dans {folder} : {files}",
   "builder.update_hint": "Essayez de mettre à jour le paquet veaf-tools avec veaf-tools-updater.exe !",
 
+  "yaml.error.syntax": "Erreur de syntaxe dans [bold]{filename}[/bold], ligne {line}, colonne {col}.",
+  "yaml.error.syntax_unknown": "Erreur de syntaxe dans [bold]{filename}[/bold].",
+  "yaml.error.context": "  L'erreur débute vers la ligne {line}, colonne {col}.",
+  "yaml.error.hint.indentation": "  → Vérifiez l'indentation autour de ces lignes. YAML utilise uniquement des espaces (jamais de tabulations).\n    Tous les éléments d'un même bloc doivent être alignés à la même colonne.",
+  "yaml.error.hint.tab": "  → YAML n'autorise pas les tabulations pour l'indentation.\n    Remplacez toutes les tabulations par des espaces dans votre éditeur de texte.",
+  "yaml.error.hint.colon": "  → Il manque probablement un deux-points ':' après une clé.\n    Chaque clé YAML doit être écrite ainsi :  clé: valeur",
+  "yaml.error.hint.generic": "  → Ouvrez le fichier dans un éditeur de texte et vérifiez la structure autour de la ligne indiquée.\n    Assurez-vous que toute l'indentation utilise des espaces (et non des tabulations).",
+
   "weather.loading_config": "Chargement de la configuration depuis {path}",
   "weather.config_loaded": "Configuration chargée : {count} version(s) à créer",
   "weather.creating_version": "[{index}/{total}] Création de la version : {name}",

--- a/src/python/veaf-tools/veaf_libs/yaml_validator.py
+++ b/src/python/veaf-tools/veaf_libs/yaml_validator.py
@@ -53,9 +53,7 @@ def validate_yaml_file(path: Path) -> None:
         else:
             msg = t("yaml.error.syntax_unknown", filename=path.name)
 
-        if context_mark is not None and (
-            problem_mark is None or context_mark.line != problem_mark.line
-        ):
+        if context_mark is not None and (problem_mark is None or context_mark.line != problem_mark.line):
             msg += "\n" + t(
                 "yaml.error.context",
                 line=context_mark.line + 1,

--- a/src/python/veaf-tools/veaf_libs/yaml_validator.py
+++ b/src/python/veaf-tools/veaf_libs/yaml_validator.py
@@ -1,0 +1,67 @@
+"""YAML file validation with user-friendly, localised error reporting."""
+
+from pathlib import Path
+
+import yaml
+
+from veaf_libs.i18n import t
+from veaf_libs.logger import logger
+
+
+def _hint_key(problem: str) -> str:
+    """Return the i18n hint key that best matches the PyYAML error problem string.
+
+    Args:
+        problem: The raw problem string from a yaml.YAMLError exception.
+
+    Returns:
+        An i18n key from the ``yaml.error.hint.*`` namespace.
+    """
+    if "cannot start any token" in problem or "\t" in problem:
+        return "yaml.error.hint.tab"
+    if "could not find expected ':'" in problem:
+        return "yaml.error.hint.colon"
+    if any(kw in problem for kw in ("block mapping", "block end", "block sequence")):
+        return "yaml.error.hint.indentation"
+    return "yaml.error.hint.generic"
+
+
+def validate_yaml_file(path: Path) -> None:
+    """Validate a YAML file for syntax errors and report them in plain language.
+
+    Tries to parse *path* with :func:`yaml.safe_load`. If a
+    :exc:`yaml.YAMLError` is raised, the function builds a localised,
+    human-readable error message (file name, line, column, contextual hint)
+    and forwards it to :func:`veaf_libs.logger.logger.error`, which prints
+    the message and raises :exc:`typer.Abort` to terminate the CLI cleanly.
+
+    Args:
+        path: Path to the YAML file to validate.
+    """
+    try:
+        with path.open(encoding="utf-8") as fh:
+            yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        problem_mark = getattr(exc, "problem_mark", None)
+        context_mark = getattr(exc, "context_mark", None)
+        problem: str = getattr(exc, "problem", None) or str(exc)
+
+        if problem_mark is not None:
+            line = problem_mark.line + 1
+            col = problem_mark.column + 1
+            msg = t("yaml.error.syntax", filename=path.name, line=line, col=col)
+        else:
+            msg = t("yaml.error.syntax_unknown", filename=path.name)
+
+        if context_mark is not None and (
+            problem_mark is None or context_mark.line != problem_mark.line
+        ):
+            msg += "\n" + t(
+                "yaml.error.context",
+                line=context_mark.line + 1,
+                col=context_mark.column + 1,
+            )
+
+        msg += "\n" + t(_hint_key(problem))
+
+        logger.error(msg)

--- a/src/python/veaf-tools/veaf_tools/commands/build.py
+++ b/src/python/veaf-tools/veaf_tools/commands/build.py
@@ -9,6 +9,7 @@ from mission_builder import MissionBuilderREADME, MissionBuilderWorker
 from presets_injector import PresetsInjectorWorker
 from rich.markdown import Markdown
 from veaf_libs.paths import resolve_path
+from veaf_libs.yaml_validator import validate_yaml_file
 from waypoints_injector import WaypointsInjectorWorker
 from weather_injector import WeatherInjectorWorker
 
@@ -87,6 +88,7 @@ def build(
 
     mission_yaml_path = p_mission_folder / "mission.yaml"
     if mission_name_or_file == DEFAULT_MISSION_FILE and mission_yaml_path.exists():
+        validate_yaml_file(mission_yaml_path)
         with mission_yaml_path.open("r", encoding="utf-8") as fh:
             _peek_yaml: dict = yaml.safe_load(fh) or {}
         _yaml_mission_name: str | None = (_peek_yaml.get("mission") or {}).get("name")

--- a/test/python/test_yaml_validator.py
+++ b/test/python/test_yaml_validator.py
@@ -1,0 +1,80 @@
+"""Unit tests for veaf_libs.yaml_validator."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import typer
+
+from veaf_libs.yaml_validator import _hint_key, validate_yaml_file
+
+
+class TestHintKey(unittest.TestCase):
+    def test_tab_character(self) -> None:
+        self.assertEqual(_hint_key("found character '\t' that cannot start any token"), "yaml.error.hint.tab")
+
+    def test_cannot_start_any_token(self) -> None:
+        self.assertEqual(_hint_key("cannot start any token"), "yaml.error.hint.tab")
+
+    def test_missing_colon(self) -> None:
+        self.assertEqual(_hint_key("could not find expected ':'"), "yaml.error.hint.colon")
+
+    def test_block_mapping(self) -> None:
+        self.assertEqual(_hint_key("expected <block end>, but found '<block mapping start>'"), "yaml.error.hint.indentation")
+
+    def test_block_end(self) -> None:
+        self.assertEqual(_hint_key("expected <block end>"), "yaml.error.hint.indentation")
+
+    def test_block_sequence(self) -> None:
+        self.assertEqual(_hint_key("while parsing a block sequence"), "yaml.error.hint.indentation")
+
+    def test_generic_fallback(self) -> None:
+        self.assertEqual(_hint_key("something completely unexpected"), "yaml.error.hint.generic")
+
+
+class TestValidateYamlFile(unittest.TestCase):
+    def _write(self, content: str) -> Path:
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8")
+        f.write(content)
+        f.close()
+        return Path(f.name)
+
+    def test_valid_yaml_passes(self) -> None:
+        path = self._write("key: value\nother: 42\n")
+        validate_yaml_file(path)  # must not raise
+
+    def test_indentation_error_calls_logger(self) -> None:
+        path = self._write("parent:\n  child: 1\n   bad: 2\n")
+        with patch("veaf_libs.yaml_validator.logger") as mock_log:
+            mock_log.error.side_effect = typer.Abort()
+            with self.assertRaises(typer.Abort):
+                validate_yaml_file(path)
+            args = mock_log.error.call_args[0][0]
+            self.assertIn("yaml.error.hint.indentation", _hint_key("expected <block end>"))
+            self.assertIn(path.name, args)
+
+    def test_tab_error_calls_logger(self) -> None:
+        path = self._write("key: value\n\tchild: bad\n")
+        with patch("veaf_libs.yaml_validator.logger") as mock_log:
+            mock_log.error.side_effect = typer.Abort()
+            with self.assertRaises(typer.Abort):
+                validate_yaml_file(path)
+            args = mock_log.error.call_args[0][0]
+            self.assertIn(path.name, args)
+
+    def test_error_message_contains_line_number(self) -> None:
+        path = self._write("key: value\n  bad_indent: 1\n    worse: 2\n")
+        with patch("veaf_libs.yaml_validator.logger") as mock_log:
+            mock_log.error.side_effect = typer.Abort()
+            with self.assertRaises(typer.Abort):
+                validate_yaml_file(path)
+            args = mock_log.error.call_args[0][0]
+            # line number must appear in the message
+            self.assertRegex(args, r"\d+")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/test_yaml_validator.py
+++ b/test/python/test_yaml_validator.py
@@ -36,8 +36,16 @@ class TestHintKey(unittest.TestCase):
 
 
 class TestValidateYamlFile(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
     def _write(self, content: str) -> Path:
-        f = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8")
+        f = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False, encoding="utf-8", dir=self._tmp.name
+        )
         f.write(content)
         f.close()
         return Path(f.name)


### PR DESCRIPTION
## Summary

- Adds \`veaf_libs/yaml_validator.py\`: preemptive YAML syntax validation before loading \`mission.yaml\`
- On error, displays a structured i18n message (file, line, column, plain-language hint) instead of a Python traceback
- Hints cover the three most common cases: wrong indentation, tab characters, missing colon separator
- Messages translated in English and French via the existing i18n system
- Adds 11 unit tests in \`test/python/test_yaml_validator.py\`
- Adds a "Syntax errors" section in \`MISSION_YAML_REFERENCE\` (EN + FR)

## Example output (French)

\`\`\`
Erreur de syntaxe dans mission.yaml, ligne 81, colonne 4.
  L'erreur débute vers la ligne 34, colonne 3.
  → Vérifiez l'indentation autour de ces lignes. YAML utilise uniquement des espaces (jamais de tabulations).
    Tous les éléments d'un même bloc doivent être alignés à la même colonne.
\`\`\`

## Test plan

- [x] \`poetry run pytest\` — 893 passed
- [x] \`poetry run ruff check src/python/ --fix\` — no issues
- [x] \`poetry run mypy src/python/veaf-tools/\` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate mission.yaml syntax before loading and surface localized, user-friendly error messages instead of Python tracebacks in build-related commands.

Bug Fixes:
- Catch yaml.YAMLError when loading mission.yaml in build and mission_builder_worker commands to prevent crashes and report structured errors.

Enhancements:
- Introduce a reusable YAML validator that maps common parser errors to localized plain-language hints for indentation, tabs, and missing colons.

Documentation:
- Add English and French "Syntax errors" sections to the mission.yaml reference explaining new error messages, common causes, and editor tips.

Tests:
- Add unit tests for the YAML validator hint selection and validation behavior, including logging and line/column reporting.

Chores:
- Update backlog to track and document the YAML syntax error handling work.