### PR TITLE
fix(build): bundle presets_injector/data/dcs-radio-specs.yaml into PyInstaller exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- `build`: bundle `presets_injector/data/dcs-radio-specs.yaml` into the PyInstaller executable — fixes `ModuleNotFoundError: No module named 'presets_injector.data'` at runtime
 - `aircraft-groups inject` (mode `add`): skip groups whose name already exists in the mission instead of creating duplicates — prevents DCS crash on FA-18C/F-16C units missing `datalinks` after a v5→v6 conversion
 - `convert-v5`, `generate-config`, `migrate-config`: mandatory Lua modules (UNITS, TIME, CACHE, EVENTS, MARKERS, COMMANDS) are now emitted as `{}` in `mission.yaml` instead of `enable: true`, which would cause a build error
 - `convert-v5`: `_BASE_ALWAYS_ON` now includes COMMANDS (previously missing) and is derived from the canonical `MANDATORY_MODULES` set

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.6"
+version = "6.3.7"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/veaf_build/worker.py
+++ b/veaf_build/worker.py
@@ -358,6 +358,11 @@ class BuildAndReleaseWorker:
                 extra: list[tuple[Path, str]] = [(locales_dir, "veaf_libs/locales")]
                 if modules_json_path:
                     extra.append((modules_json_path, "."))
+                radio_specs_yaml = (
+                    self.src_dir / "python" / "veaf-tools" / "presets_injector" / "data" / "dcs-radio-specs.yaml"
+                )
+                if radio_specs_yaml.exists():
+                    extra.append((radio_specs_yaml, "presets_injector/data"))
                 self._build_pyinstaller_executable(
                     "veaf-tools",
                     self.src_dir / "python" / "veaf-tools" / "veaf-tools.py",


### PR DESCRIPTION
## Problem

`ModuleNotFoundError: No module named 'presets_injector.data'` at runtime when using the distributed EXE.

The `build_python_executables` method was building `veaf-tools` via the programmatic PyInstaller API without including `dcs-radio-specs.yaml` in the bundled data. The `.spec` file was correct but unused by this code path.

## Fix

Add `presets_injector/data/dcs-radio-specs.yaml` to `extra_data` when calling `_build_pyinstaller_executable` for `veaf-tools`.

## Summary by Sourcery

Bundle the DCS radio specs YAML into the veaf-tools PyInstaller executable to fix runtime module loading, and bump the project patch version.

Bug Fixes:
- Ensure presets_injector/data/dcs-radio-specs.yaml is included as bundled data when building the veaf-tools PyInstaller executable, preventing ModuleNotFoundError at runtime.

Build:
- Extend the PyInstaller build configuration to add presets_injector/data/dcs-radio-specs.yaml as extra bundled data for veaf-tools.

Documentation:
- Document the PyInstaller bundling fix in the changelog.

Chores:
- Bump the veaf-tools package version from 6.3.6 to 6.3.7.