### PR TITLE
fix(presets): deduplicate radio frequency warnings by unit type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- `presets inject`: radio frequency warnings are now deduplicated by aircraft type — instead of one warning block per group, a single block is emitted per unit type listing all affected groups in parentheses
 - `build`: bundle `presets_injector/data/dcs-radio-specs.yaml` into the PyInstaller executable — fixes `ModuleNotFoundError: No module named 'presets_injector.data'` at runtime
 - `aircraft-groups inject` (mode `add`): skip groups whose name already exists in the mission instead of creating duplicates — prevents DCS crash on FA-18C/F-16C units missing `datalinks` after a v5→v6 conversion
 - `convert-v5`, `generate-config`, `migrate-config`: mandatory Lua modules (UNITS, TIME, CACHE, EVENTS, MARKERS, COMMANDS) are now emitted as `{}` in `mission.yaml` instead of `enable: true`, which would cause a build error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.7"
+version = "6.3.8"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -23,6 +23,11 @@ class PresetsInjectorWorker(GroupInjectorWorker):
         self.presets_file = presets_file
         self.groups: dict[str, Group] = {}
         self.presets_manager: PresetsManager = PresetsManager()
+        # Pending frequency warnings keyed by unit_type; aggregated before emission.
+        self._pending_freq_warnings: dict[
+            str,
+            dict[str, list[str] | list[ChannelFrequency] | str],
+        ] = {}
         super().__init__(config_file=presets_file, input_mission=input_mission, output_mission=output_mission)
 
     def load_config(self) -> Any:
@@ -70,13 +75,16 @@ class PresetsInjectorWorker(GroupInjectorWorker):
                 for ch in radio.channels
                 if isinstance(ch.freq, (int, float))
             ]
-            warn_invalid_channel_frequencies(
-                group_name=group.name or "",
-                unit_type=group.unit_type,
-                channels=channel_freqs,
-                coalition=group.coalition or "blue",
-                aircraft_category=group.aircraft_type or "plane",
-            )
+            # Collect instead of warning immediately; emit aggregated per unit_type later.
+            key = group.unit_type
+            if key not in self._pending_freq_warnings:
+                self._pending_freq_warnings[key] = {
+                    "group_names": [],
+                    "channels": channel_freqs,
+                    "coalition": group.coalition or "blue",
+                    "aircraft_category": group.aircraft_type or "plane",
+                }
+            self._pending_freq_warnings[key]["group_names"].append(group.name or "")  # type: ignore[union-attr]
 
         return nb_units_processed
 
@@ -100,6 +108,17 @@ class PresetsInjectorWorker(GroupInjectorWorker):
 
         if not silent:
             logger.info(f"Injected presets into {nb_units_processed} aircraft{'s' if nb_units_processed > 1 else ''}")
+
+        # Emit one warning per unit_type, listing all affected groups together.
+        for unit_type, entry in self._pending_freq_warnings.items():
+            warn_invalid_channel_frequencies(
+                group_names=entry["group_names"],  # type: ignore[arg-type]
+                unit_type=unit_type,
+                channels=entry["channels"],  # type: ignore[arg-type]
+                coalition=entry["coalition"],  # type: ignore[arg-type]
+                aircraft_category=entry["aircraft_category"],  # type: ignore[arg-type]
+            )
+        self._pending_freq_warnings.clear()
 
     def write_mission(self, silent: bool = False) -> None:
         """Write the mission file, including kneeboard pages if generated."""

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -2,6 +2,7 @@
 Worker module for the VEAF Presets Injector Package.
 """
 
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,16 @@ from .presets_manager import PresetDefinition, PresetsManager
 from .radio_frequency_validator import ChannelFrequency, warn_invalid_channel_frequencies
 
 
+@dataclass
+class _PendingFreqWarning:
+    """Aggregated data for a deferred radio-frequency warning keyed by unit_type."""
+
+    group_names: list[str] = field(default_factory=list)
+    channels: list[ChannelFrequency] = field(default_factory=list)
+    coalition: str = "blue"
+    aircraft_category: str = "plane"
+
+
 class PresetsInjectorWorker(GroupInjectorWorker):
     """
     Worker class that provides presets injection features.
@@ -24,10 +35,7 @@ class PresetsInjectorWorker(GroupInjectorWorker):
         self.groups: dict[str, Group] = {}
         self.presets_manager: PresetsManager = PresetsManager()
         # Pending frequency warnings keyed by unit_type; aggregated before emission.
-        self._pending_freq_warnings: dict[
-            str,
-            dict[str, list[str] | list[ChannelFrequency] | str],
-        ] = {}
+        self._pending_freq_warnings: dict[str, _PendingFreqWarning] = {}
         super().__init__(config_file=presets_file, input_mission=input_mission, output_mission=output_mission)
 
     def load_config(self) -> Any:
@@ -76,15 +84,18 @@ class PresetsInjectorWorker(GroupInjectorWorker):
                 if isinstance(ch.freq, (int, float))
             ]
             # Collect instead of warning immediately; emit aggregated per unit_type later.
+            # Merge channel_freqs so subsequent groups with the same unit_type don't lose their invalids.
             key = group.unit_type
             if key not in self._pending_freq_warnings:
-                self._pending_freq_warnings[key] = {
-                    "group_names": [],
-                    "channels": channel_freqs,
-                    "coalition": group.coalition or "blue",
-                    "aircraft_category": group.aircraft_type or "plane",
-                }
-            self._pending_freq_warnings[key]["group_names"].append(group.name or "")  # type: ignore[union-attr]
+                self._pending_freq_warnings[key] = _PendingFreqWarning(
+                    coalition=group.coalition or "blue",
+                    aircraft_category=group.aircraft_type or "plane",
+                )
+            entry = self._pending_freq_warnings[key]
+            entry.group_names.append(group.name or "")
+            for ch in channel_freqs:
+                if ch not in entry.channels:
+                    entry.channels.append(ch)
 
         return nb_units_processed
 
@@ -112,11 +123,11 @@ class PresetsInjectorWorker(GroupInjectorWorker):
         # Emit one warning per unit_type, listing all affected groups together.
         for unit_type, entry in self._pending_freq_warnings.items():
             warn_invalid_channel_frequencies(
-                group_names=entry["group_names"],  # type: ignore[arg-type]
+                group_names=entry.group_names,
                 unit_type=unit_type,
-                channels=entry["channels"],  # type: ignore[arg-type]
-                coalition=entry["coalition"],  # type: ignore[arg-type]
-                aircraft_category=entry["aircraft_category"],  # type: ignore[arg-type]
+                channels=entry.channels,
+                coalition=entry.coalition,
+                aircraft_category=entry.aircraft_category,
             )
         self._pending_freq_warnings.clear()
 

--- a/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
+++ b/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
@@ -123,7 +123,7 @@ def _format_ranges(ranges: list[FrequencyRange]) -> str:
 
 
 def warn_invalid_channel_frequencies(
-    group_name: str,
+    group_names: list[str],
     unit_type: str,
     channels: list[ChannelFrequency],
     coalition: str = "blue",
@@ -131,11 +131,14 @@ def warn_invalid_channel_frequencies(
 ) -> None:
     """Log an actionable warning for each channel whose frequency is invalid for unit_type.
 
+    Emits a single warning per aircraft type, listing all affected groups together to avoid
+    repeating the same block for every group that uses the same preset.
+
     Args:
-        group_name: Name of the DCS group.
+        group_names: Names of the DCS groups using this unit type and preset.
         unit_type: DCS unit type string (e.g. "MiG-19P").
         channels: List of ChannelFrequency carrying radio name, channel number, and frequency.
-        coalition: Coalition of the group ("blue", "red", …).
+        coalition: Coalition of the groups ("blue", "red", …).
         aircraft_category: DCS aircraft category ("plane" or "helicopter").
     """
     valid_ranges = get_valid_ranges(unit_type)
@@ -147,15 +150,17 @@ def warn_invalid_channel_frequencies(
         return
 
     ranges_str = _format_ranges(valid_ranges)
-    # Emit one warning per group (not per channel) to avoid flooding the log.
-    # List all invalid channels in a single message.
+    groups_str = ", ".join(f"'{g}'" for g in group_names)
+    groups_label = f"Group {groups_str}" if len(group_names) == 1 else f"Groups {groups_str}"
+    # Emit one warning per aircraft type (not per group) to avoid flooding the log.
+    # List all invalid channels and all affected groups in a single message.
     channel_lines = "\n".join(
         f"    - channel {ch.channel}" + (f' "{ch.channel_title}"' if ch.channel_title else "") + f": {ch.freq_mhz} MHz"
         f"  (in radios_collection > {ch.radio_collection} > {ch.radio_key})"
         for ch in invalid_channels
     )
     logger.warning(
-        f"Group '{group_name}' ({unit_type}): the following preset frequencies are not valid"
+        f"{groups_label} ({unit_type}): the following preset frequencies are not valid"
         f" for this aircraft and will be rejected by DCS at mission load:\n"
         f"{channel_lines}\n"
         f"  Valid ranges for {unit_type}: {ranges_str}\n"

--- a/test/python/presets_injector/test_radio_frequency_validator.py
+++ b/test/python/presets_injector/test_radio_frequency_validator.py
@@ -195,7 +195,7 @@ class TestWarnInvalidChannelFrequencies(unittest.TestCase):
     def test_warns_with_presets_yaml_path(self):
         channels = [_make_ch(125.0, 1), _make_ch(284.0, 2, "TACTICAL UNIFORM")]
         with patch("presets_injector.radio_frequency_validator.logger") as mock_logger:
-            warn_invalid_channel_frequencies("Bassel MiG-19 #1", "MiG-19P", channels, "blue", "plane")
+            warn_invalid_channel_frequencies(["Bassel MiG-19 #1"], "MiG-19P", channels, "blue", "plane")
             mock_logger.warning.assert_called_once()
             msg = mock_logger.warning.call_args[0][0]
             self.assertIn("284.0 MHz", msg)
@@ -212,19 +212,19 @@ class TestWarnInvalidChannelFrequencies(unittest.TestCase):
 
     def test_no_warning_when_all_valid(self):
         with patch("presets_injector.radio_frequency_validator.logger") as mock_logger:
-            warn_invalid_channel_frequencies("Some Group", "MiG-19P", [_make_ch(120.0)])
+            warn_invalid_channel_frequencies(["Some Group"], "MiG-19P", [_make_ch(120.0)])
             mock_logger.warning.assert_not_called()
 
     def test_no_warning_for_unknown_aircraft(self):
         with patch("presets_injector.radio_frequency_validator.logger") as mock_logger:
-            warn_invalid_channel_frequencies("Some Group", "Unknown-Aircraft", [_make_ch(284.0)])
+            warn_invalid_channel_frequencies(["Some Group"], "Unknown-Aircraft", [_make_ch(284.0)])
             mock_logger.warning.assert_not_called()
 
     def test_multiple_invalid_channels_single_warning(self):
         # All invalid channels for the same group must be reported in one warning, not one per channel.
         channels = [_make_ch(284.0, 1), _make_ch(300.0, 2)]
         with patch("presets_injector.radio_frequency_validator.logger") as mock_logger:
-            warn_invalid_channel_frequencies("Some Group", "MiG-19P", channels)
+            warn_invalid_channel_frequencies(["Some Group"], "MiG-19P", channels)
             self.assertEqual(mock_logger.warning.call_count, 1)
             msg = mock_logger.warning.call_args[0][0]
             self.assertIn("284.0 MHz", msg)


### PR DESCRIPTION
## Problem

When multiple groups share the same aircraft type and get the same invalid preset frequencies, the same warning block was repeated once per group, flooding the log.

## Fix

- `warn_invalid_channel_frequencies` now accepts `group_names: list[str]` instead of a single `group_name`
- The worker collects invalid findings per `unit_type` during `process_units`, then emits one aggregated warning per type at the end of `process_groups`, listing all affected groups: `Groups 'Bassel MiG-19 #1', 'Bassel MiG-19 #2', 'Bassel MiG-19 #3' (MiG-19P): ...`

## Summary by Sourcery

Deduplicate radio frequency warnings by aggregating invalid preset findings per aircraft type and logging a single warning that lists all affected groups.

Bug Fixes:
- Prevent repeated radio frequency warning blocks when multiple groups share the same aircraft type and invalid presets by emitting one warning per unit type.

Enhancements:
- Refactor radio frequency validation to accept multiple group names and aggregate group information in warning messages.

Build:
- Bump project version from 6.3.7 to 6.3.8 in pyproject configuration.

Documentation:
- Document the deduplicated radio frequency warning behavior in the changelog.

Tests:
- Update radio frequency validator tests to cover the new multi-group warning interface and behavior.