### PR TITLE
feat(i18n): translate injectors and radio frequency validator messages to French

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- i18n : tous les messages des injectors (presets, waypoints) et du validateur de fréquences radio sont maintenant traduits en français — plus de messages en anglais dans le log de `veaf-tools build`
 - `presets inject`: radio frequency warnings are now deduplicated by aircraft type — instead of one warning block per group, a single block is emitted per unit type listing all affected groups in parentheses
 - `build`: bundle `presets_injector/data/dcs-radio-specs.yaml` into the PyInstaller executable — fixes `ModuleNotFoundError: No module named 'presets_injector.data'` at runtime
 - `aircraft-groups inject` (mode `add`): skip groups whose name already exists in the mission instead of creating duplicates — prevents DCS crash on FA-18C/F-16C units missing `datalinks` after a v5→v6 conversion

--- a/doc/PIPELINE_REFERENCE.en.md
+++ b/doc/PIPELINE_REFERENCE.en.md
@@ -139,18 +139,37 @@ presets_assignments:
 
 ### Frequency validation
 
-At injection time, every frequency assigned to an aircraft is checked against the hardware specs of that aircraft's radios. If a frequency falls outside all valid ranges, a warning is emitted:
+At injection time, every frequency assigned to an aircraft is checked against the hardware specs of that aircraft's radios.
+
+**Default behaviour (normal build):**
+
+- **Critical aircraft** (`dcs_rejects_on_load: true` in the specs): if a frequency is out of range, a `WARNING` is emitted in the log. These are the aircraft for which DCS raises an error when the mission loads.
+- **Other aircraft**: validation is silent — DCS stores the frequencies but ignores them for out-of-range radios without crashing.
+
+**Automatic report:**
+
+After each preset injection, a file `presets-validation-report.md` is automatically created in the mission folder if at least one aircraft (critical or not) has out-of-range frequencies. The file lists all issues with the invalid values and a YAML snippet to disable them temporarily. If no issues are found, the file is deleted.
 
 ```
-WARNING: Group 'Bassel MiG-19 #1' (MiG-19P): frequency 284.0 MHz is outside all valid radio
-ranges for this aircraft — DCS will reject it at mission load.
+<mission-folder>/presets-validation-report.md
 ```
 
-The check is **non-blocking**: the mission is still written, but the invalid frequency will cause a DCS error when the mission loads (typically `Invalid frequency X MHz`).
+**Temporarily disabling injection for an aircraft:**
+
+While fixing the presets, you can disable injection for a specific aircraft type by assigning it the value `none` in `presets_assignments`:
+
+```yaml
+presets_assignments:
+  blue:
+    plane:
+      MiG-19P: none   # DCS rejects standard frequencies — fix pending
+```
+
+Once the presets are corrected, remove the `none` line to re-enable injection.
 
 Specs cover 85 player-flyable aircraft and are sourced from [dcs-lua-datamine](https://github.com/Quaggles/dcs-lua-datamine). If an aircraft is not in the database the check is silently skipped.
 
-> **See also**: [`doc/mission-maker/dcs-radio-specs.md`](mission-maker/dcs-radio-specs.md) — full reference table of valid frequency ranges per aircraft.  
+> **See also**: [`doc/mission-maker/dcs-radio-specs.md`](mission-maker/dcs-radio-specs.md) — full reference table of valid frequency ranges and list of critical aircraft.  
 > To regenerate after a DCS update: `poetry run update-radio-specs`
 
 ---

--- a/doc/PIPELINE_REFERENCE.md
+++ b/doc/PIPELINE_REFERENCE.md
@@ -137,18 +137,37 @@ presets_assignments:
 
 ### Validation des fréquences
 
-Lors de l'injection, chaque fréquence assignée à un aéronef est vérifiée par rapport aux spécifications matérielles de ses radios. Si une fréquence est hors de toutes les plages valides, un avertissement est émis :
+Lors de l'injection, chaque fréquence assignée à un aéronef est vérifiée par rapport aux spécifications matérielles de ses radios.
+
+**Comportement par défaut (build normal) :**
+
+- **Appareils critiques** (`dcs_rejects_on_load: true` dans les specs) : si une fréquence est hors plage, un `WARNING` est émis dans le log. Ce sont les appareils pour lesquels DCS lance une erreur au chargement de la mission.
+- **Autres appareils** : la validation est silencieuse — DCS stocke les fréquences mais ne les utilise pas pour les radios hors plage, sans crasher.
+
+**Rapport automatique :**
+
+Après chaque injection de presets, un fichier `presets-validation-report.md` est automatiquement créé dans le dossier mission si au moins un appareil (critique ou non) présente des fréquences hors plage. Ce fichier liste tous les problèmes avec les valeurs invalides et un extrait YAML pour les désactiver temporairement. Si aucun problème n'est détecté, le fichier est supprimé.
 
 ```
-WARNING: Group 'Bassel MiG-19 #1' (MiG-19P): frequency 284.0 MHz is outside all valid radio
-ranges for this aircraft — DCS will reject it at mission load.
+<dossier-mission>/presets-validation-report.md
 ```
 
-La vérification est **non bloquante** : la mission est quand même écrite, mais la fréquence invalide provoquera une erreur DCS au chargement (typiquement `Invalid frequency X MHz`).
+**Désactiver temporairement l'injection pour un appareil :**
+
+Pendant que vous corrigez les presets, vous pouvez désactiver l'injection pour un type d'appareil en lui affectant la valeur `none` dans `presets_assignments` :
+
+```yaml
+presets_assignments:
+  blue:
+    plane:
+      MiG-19P: none   # DCS rejetera les fréquences standard — à corriger
+```
+
+Une fois les presets corrigés, supprimez la ligne `none` pour réactiver l'injection.
 
 Les specs couvrent 85 aéronefs pilotables et sont issues de [dcs-lua-datamine](https://github.com/Quaggles/dcs-lua-datamine). Si un aéronef n'est pas dans la base, la vérification est silencieusement ignorée.
 
-> **Voir aussi** : [`doc/mission-maker/dcs-radio-specs.md`](mission-maker/dcs-radio-specs.md) — table de référence complète des plages de fréquences valides par aéronef.  
+> **Voir aussi** : [`doc/mission-maker/dcs-radio-specs.md`](mission-maker/dcs-radio-specs.md) — table de référence complète des plages de fréquences valides et liste des appareils critiques.  
 > Pour régénérer après une mise à jour DCS : `poetry run update-radio-specs`
 
 ---

--- a/doc/mission-maker/dcs-radio-specs.md
+++ b/doc/mission-maker/dcs-radio-specs.md
@@ -9,6 +9,28 @@ compatible with the target aircraft's radio hardware.
 
 ---
 
+## Critical aircraft (`dcs_rejects_on_load`)
+
+Some aircraft raise a hard DCS error when the mission loads if any preset frequency is outside
+their valid radio range. These are flagged `dcs_rejects_on_load: true` in `dcs-radio-specs.yaml`
+and always emit a `WARNING` during `veaf-tools build`.
+
+Currently known critical aircraft:
+
+| Aircraft | DCS ID | Valid range |
+|----------|--------|-------------|
+| MiG-19P | `MiG-19P` | 100–150 MHz |
+| Gazelle SA342M | `SA342M` | 30–87.975 MHz (FM only) |
+
+For other aircraft, DCS stores the frequencies silently without crashing. Issues are still
+reported in the automatic `presets-validation-report.md` generated after each build.
+
+If you discover another aircraft that causes DCS to reject the mission, add
+`dcs_rejects_on_load: true` to its entry in `src/python/veaf-tools/presets_injector/data/dcs-radio-specs.yaml`
+and open a pull request.
+
+---
+
 ## Fixed-wing aircraft
 
 | Aircraft | DCS ID | Radio | Min (MHz) | Max (MHz) | Modulation |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.8"
+version = "6.3.9"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/presets_injector/__init__.py
+++ b/src/python/veaf-tools/presets_injector/__init__.py
@@ -18,9 +18,11 @@ from .presets_manager import (
     RadioCollection,
     RadioDefinition,
 )
-from .radio_frequency_validator import (
+from .radio_frequency_validator import (  # noqa: F401
     ChannelFrequency,
+    FrequencyIssue,
     FrequencyRange,
+    collect_invalid_channel_frequencies,
     get_valid_ranges,
     validate_frequencies,
     validate_frequency,

--- a/src/python/veaf-tools/presets_injector/data/dcs-radio-specs.yaml
+++ b/src/python/veaf-tools/presets_injector/data/dcs-radio-specs.yaml
@@ -669,6 +669,7 @@ Mi-8MT:
       modulation: AM/FM
 MiG-19P:
   category: plane
+  dcs_rejects_on_load: true
   name: MiG-19P
   radios:
   - name: RSIU-4V Radio
@@ -1198,6 +1199,7 @@ SA342L:
       modulation: AM/FM
 SA342M:
   category: helicopter
+  dcs_rejects_on_load: true
   name: SA342M
   radios:
   - name: FM Radio

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -43,6 +43,8 @@ class PresetsInjectorWorker(GroupInjectorWorker):
         self.presets_manager: PresetsManager = PresetsManager()
         # Pending frequency warnings keyed by unit_type; aggregated before emission.
         self._pending_freq_warnings: dict[str, _PendingFreqWarning] = {}
+        # Resolved frequency issues populated after process_groups(); used by generate_validation_report().
+        self._freq_issues: list[FrequencyIssue] = []
         super().__init__(config_file=presets_file, input_mission=input_mission, output_mission=output_mission)
 
     def load_config(self) -> Any:
@@ -149,30 +151,33 @@ class PresetsInjectorWorker(GroupInjectorWorker):
                     ])
                 yaml_block = "\n".join(yaml_lines)
                 logger.warning(t("presets_injector.freq_warn.disable_tip", yaml_block=yaml_block))
+            # Collect all issues (strict + non-strict) for the validation report before clearing.
+            self._freq_issues = sorted(
+                (
+                    issue
+                    for unit_type, entry in self._pending_freq_warnings.items()
+                    if (issue := collect_invalid_channel_frequencies(
+                        group_names=entry.group_names,
+                        unit_type=unit_type,
+                        channels=entry.channels,
+                        coalition=entry.coalition,
+                        aircraft_category=entry.aircraft_category,
+                    )) is not None
+                ),
+                key=lambda i: (not i.strict, i.unit_type),
+            )
             self._pending_freq_warnings.clear()
 
     def collect_freq_issues(self) -> list[FrequencyIssue]:
-        """Collect ALL radio frequency issues across every pending aircraft type.
+        """Return the resolved frequency issues collected during the last process_groups() call.
 
-        Unlike the normal warning path (which filters by dcs_rejects_on_load), this method
-        returns issues for every aircraft type that has at least one out-of-range channel,
-        regardless of whether DCS would actually reject the mission.
+        Issues are populated during process_groups() before the pending warnings are cleared,
+        so this method is safe to call after work() has completed.
 
         Returns:
             List of FrequencyIssue, strict types first, then informational, both sorted by unit_type.
         """
-        issues: list[FrequencyIssue] = []
-        for unit_type, entry in self._pending_freq_warnings.items():
-            issue = collect_invalid_channel_frequencies(
-                group_names=entry.group_names,
-                unit_type=unit_type,
-                channels=entry.channels,
-                coalition=entry.coalition,
-                aircraft_category=entry.aircraft_category,
-            )
-            if issue:
-                issues.append(issue)
-        return sorted(issues, key=lambda i: (not i.strict, i.unit_type))
+        return self._freq_issues
 
     def generate_validation_report(self, output_path: Path) -> int:
         """Write a Markdown validation report of all radio frequency issues to output_path.

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -199,11 +199,11 @@ class PresetsInjectorWorker(GroupInjectorWorker):
         info_issues = [i for i in issues if not i.strict]
 
         lines: list[str] = [
-            "# Radio Presets Frequency Validation Report",
+            t("presets_injector.report.title"),
             "",
-            f"Generated: {date.today().isoformat()}  ",
-            f"Presets file: `{self.presets_file}`  ",
-            f"Mission: `{self.input_mission}`",
+            f"{t('presets_injector.report.generated', date=date.today().isoformat())}  ",
+            f"{t('presets_injector.report.presets_file', path=self.presets_file)}  ",
+            t("presets_injector.report.mission", path=self.input_mission),
             "",
         ]
 
@@ -212,17 +212,17 @@ class PresetsInjectorWorker(GroupInjectorWorker):
             ranges_str = ", ".join(f"{r.min_mhz}–{r.max_mhz} MHz ({r.modulation})" for r in issue.valid_ranges)
             block = [
                 f"### {issue.unit_type}",
-                f"Groups: {groups_str}  ",
-                f"Valid ranges: {ranges_str}",
+                f"{t('presets_injector.report.groups', groups=groups_str)}  ",
+                t("presets_injector.report.valid_ranges", ranges=ranges_str),
                 "",
-                "| Channel | Title | Frequency (MHz) | Collection | Radio |",
+                t("presets_injector.report.table_header"),
                 "|---------|-------|-----------------|------------|-------|",
             ]
             for ch in issue.invalid_channels:
                 block.append(f"| {ch.channel} | {ch.channel_title or '—'} | {ch.freq_mhz} | {ch.radio_collection} | {ch.radio_key} |")
             block += [
                 "",
-                "**To silence:** add to `presets.yaml`:",
+                t("presets_injector.report.silence_hint"),
                 "```yaml",
                 "presets_assignments:",
                 f"  {issue.coalition}:",
@@ -235,9 +235,9 @@ class PresetsInjectorWorker(GroupInjectorWorker):
 
         if strict_issues:
             lines += [
-                "## ⚠️ Critical — DCS will reject these at mission load",
+                t("presets_injector.report.section_critical"),
                 "",
-                f"*{len(strict_issues)} aircraft type(s) affected.*",
+                t("presets_injector.report.affected_count", count=len(strict_issues)),
                 "",
             ]
             for issue in strict_issues:
@@ -245,16 +245,16 @@ class PresetsInjectorWorker(GroupInjectorWorker):
 
         if info_issues:
             lines += [
-                "## ℹ️ Informational — DCS stores but ignores these frequencies",
+                t("presets_injector.report.section_info"),
                 "",
-                f"*{len(info_issues)} aircraft type(s) affected.*",
+                t("presets_injector.report.affected_count", count=len(info_issues)),
                 "",
             ]
             for issue in info_issues:
                 lines += _render_issue(issue)
 
         if not issues:
-            lines += ["## ✅ All preset frequencies are valid for every aircraft type.", ""]
+            lines += [t("presets_injector.report.all_valid"), ""]
 
         output_path.write_text("\n".join(lines), encoding="utf-8")
         logger.info(t("presets_injector.validation_report.written", path=output_path, count=len(issues)))

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from mission_tools import Group, write_miz
 from veaf_libs.group_injector_worker import GroupInjectorWorker
+from veaf_libs.i18n import t
 from veaf_libs.logger import logger
 from veaf_libs.progress import spinner_context
 
@@ -45,7 +46,7 @@ class PresetsInjectorWorker(GroupInjectorWorker):
             if self.presets_file:
                 presets_manager.read_yaml(self.presets_file)
         except Exception as e:
-            logger.error(f"Failed to load config file {self.presets_file}: {str(e)}", exception_type=RuntimeError)
+            logger.error(t("presets_injector.error.load_config", path=self.presets_file, error=str(e)), exception_type=RuntimeError)
         self.presets_manager = presets_manager
         return presets_manager
 
@@ -102,7 +103,7 @@ class PresetsInjectorWorker(GroupInjectorWorker):
     def process_groups(self, silent: bool = False) -> None:
         """Inject presets into all human-piloted groups."""
         if not silent:
-            logger.info(f"Processing {len(self.groups)} aircraft group{'s' if len(self.groups) > 1 else ''}")
+            logger.info(t("presets_injector.processing_groups", count=len(self.groups)))
 
         nb_units_processed = 0
         for group in [g for g in self.groups.values() if g.human_pilot]:
@@ -118,7 +119,7 @@ class PresetsInjectorWorker(GroupInjectorWorker):
                 nb_units_processed += self.process_units(group, preset_definition)
 
         if not silent:
-            logger.info(f"Injected presets into {nb_units_processed} aircraft{'s' if nb_units_processed > 1 else ''}")
+            logger.info(t("presets_injector.injected", count=nb_units_processed))
 
         # Emit one warning per unit_type, listing all affected groups together.
         for unit_type, entry in self._pending_freq_warnings.items():
@@ -134,34 +135,32 @@ class PresetsInjectorWorker(GroupInjectorWorker):
     def write_mission(self, silent: bool = False) -> None:
         """Write the mission file, including kneeboard pages if generated."""
         if not silent:
-            logger.info("Writing mission file")
+            logger.info(t("group_injector.writing_mission"))
 
         additional_files = {}
         if self.presets_manager.presets_images:
             for preset_name, image in self.presets_manager.presets_images.items():
                 additional_files[f"KNEEBOARD/IMAGES/presets-{preset_name}.png"] = image.getvalue()
             if not silent:
-                logger.info(
-                    f"Added {len(self.presets_manager.presets_images)} kneeboard page{'s' if len(self.presets_manager.presets_images) > 1 else ''} to mission"
-                )
+                logger.info(t("presets_injector.kneeboard_pages", count=len(self.presets_manager.presets_images)))
 
         assert self.dcs_mission is not None
         write_miz(mission=self.dcs_mission, miz_file_path=self.output_mission, additional_files=additional_files)
 
     def work(self, silent: bool = False) -> None:  # type: ignore[override]
         """Main work function."""
-        with spinner_context(f"Reading {self.input_mission}...", silent=silent):
+        with spinner_context(t("group_injector.spinner.reading", path=self.input_mission), silent=silent):
             self.read_mission(silent)
 
         assert self.dcs_mission is not None
         for group in self.dcs_mission.iter_groups():
             self.process_group(group)
 
-        with spinner_context("Processing groups...", silent=silent):
+        with spinner_context(t("presets_injector.spinner.processing_groups"), silent=silent):
             self.process_groups(silent)
 
-        with spinner_context("Generating preset images...", silent=silent):
+        with spinner_context(t("presets_injector.spinner.generating_images"), silent=silent):
             self.presets_manager.generate_presets_images(width=1200, height=None)
 
-        with spinner_context("Writing mission...", silent=silent):
+        with spinner_context(t("group_injector.spinner.writing"), silent=silent):
             self.write_mission(silent)

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -123,23 +123,27 @@ class PresetsInjectorWorker(GroupInjectorWorker):
 
         # Emit one warning per unit_type, listing all affected groups together.
         if self._pending_freq_warnings:
+            warned_unit_types: dict[str, _PendingFreqWarning] = {}
             for unit_type, entry in self._pending_freq_warnings.items():
-                warn_invalid_channel_frequencies(
+                emitted = warn_invalid_channel_frequencies(
                     group_names=entry.group_names,
                     unit_type=unit_type,
                     channels=entry.channels,
                     coalition=entry.coalition,
                     aircraft_category=entry.aircraft_category,
                 )
-            yaml_lines = []
-            for unit_type, entry in self._pending_freq_warnings.items():
-                yaml_lines.extend([
-                    f"      {entry.coalition}:",
-                    f"        {entry.aircraft_category}:",
-                    f"          {unit_type}: none",
-                ])
-            yaml_block = "\n".join(yaml_lines)
-            logger.warning(t("presets_injector.freq_warn.disable_tip", yaml_block=yaml_block))
+                if emitted:
+                    warned_unit_types[unit_type] = entry
+            if warned_unit_types:
+                yaml_lines = []
+                for unit_type, entry in warned_unit_types.items():
+                    yaml_lines.extend([
+                        f"      {entry.coalition}:",
+                        f"        {entry.aircraft_category}:",
+                        f"          {unit_type}: none",
+                    ])
+                yaml_block = "\n".join(yaml_lines)
+                logger.warning(t("presets_injector.freq_warn.disable_tip", yaml_block=yaml_block))
             self._pending_freq_warnings.clear()
 
     def write_mission(self, silent: bool = False) -> None:

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -54,7 +54,10 @@ class PresetsInjectorWorker(GroupInjectorWorker):
             if self.presets_file:
                 presets_manager.read_yaml(self.presets_file)
         except Exception as e:
-            logger.error(t("presets_injector.error.load_config", path=self.presets_file, error=str(e)), exception_type=RuntimeError)
+            logger.error(
+                t("presets_injector.error.load_config", path=self.presets_file, error=str(e)),
+                exception_type=RuntimeError,
+            )
         self.presets_manager = presets_manager
         return presets_manager
 
@@ -144,11 +147,13 @@ class PresetsInjectorWorker(GroupInjectorWorker):
             if warned_unit_types:
                 yaml_lines = []
                 for unit_type, entry in warned_unit_types.items():
-                    yaml_lines.extend([
-                        f"      {entry.coalition}:",
-                        f"        {entry.aircraft_category}:",
-                        f"          {unit_type}: none",
-                    ])
+                    yaml_lines.extend(
+                        [
+                            f"      {entry.coalition}:",
+                            f"        {entry.aircraft_category}:",
+                            f"          {unit_type}: none",
+                        ]
+                    )
                 yaml_block = "\n".join(yaml_lines)
                 logger.warning(t("presets_injector.freq_warn.disable_tip", yaml_block=yaml_block))
             # Collect all issues (strict + non-strict) for the validation report before clearing.
@@ -156,13 +161,16 @@ class PresetsInjectorWorker(GroupInjectorWorker):
                 (
                     issue
                     for unit_type, entry in self._pending_freq_warnings.items()
-                    if (issue := collect_invalid_channel_frequencies(
-                        group_names=entry.group_names,
-                        unit_type=unit_type,
-                        channels=entry.channels,
-                        coalition=entry.coalition,
-                        aircraft_category=entry.aircraft_category,
-                    )) is not None
+                    if (
+                        issue := collect_invalid_channel_frequencies(
+                            group_names=entry.group_names,
+                            unit_type=unit_type,
+                            channels=entry.channels,
+                            coalition=entry.coalition,
+                            aircraft_category=entry.aircraft_category,
+                        )
+                    )
+                    is not None
                 ),
                 key=lambda i: (not i.strict, i.unit_type),
             )
@@ -219,7 +227,9 @@ class PresetsInjectorWorker(GroupInjectorWorker):
                 "|---------|-------|-----------------|------------|-------|",
             ]
             for ch in issue.invalid_channels:
-                block.append(f"| {ch.channel} | {ch.channel_title or '—'} | {ch.freq_mhz} | {ch.radio_collection} | {ch.radio_key} |")
+                block.append(
+                    f"| {ch.channel} | {ch.channel_title or '—'} | {ch.freq_mhz} | {ch.radio_collection} | {ch.radio_key} |"
+                )
             block += [
                 "",
                 t("presets_injector.report.silence_hint"),

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -13,7 +13,7 @@ from veaf_libs.logger import logger
 from veaf_libs.progress import spinner_context
 
 from .presets_manager import PresetDefinition, PresetsManager
-from .radio_frequency_validator import ChannelFrequency, warn_invalid_channel_frequencies
+from .radio_frequency_validator import ChannelFrequency, is_strict, warn_invalid_channel_frequencies
 
 
 @dataclass
@@ -125,14 +125,13 @@ class PresetsInjectorWorker(GroupInjectorWorker):
         if self._pending_freq_warnings:
             warned_unit_types: dict[str, _PendingFreqWarning] = {}
             for unit_type, entry in self._pending_freq_warnings.items():
-                emitted = warn_invalid_channel_frequencies(
+                if warn_invalid_channel_frequencies(
                     group_names=entry.group_names,
                     unit_type=unit_type,
                     channels=entry.channels,
                     coalition=entry.coalition,
                     aircraft_category=entry.aircraft_category,
-                )
-                if emitted:
+                ) and is_strict(unit_type):
                     warned_unit_types[unit_type] = entry
             if warned_unit_types:
                 yaml_lines = []

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -13,7 +13,13 @@ from veaf_libs.logger import logger
 from veaf_libs.progress import spinner_context
 
 from .presets_manager import PresetDefinition, PresetsManager
-from .radio_frequency_validator import ChannelFrequency, is_strict, warn_invalid_channel_frequencies
+from .radio_frequency_validator import (
+    ChannelFrequency,
+    FrequencyIssue,
+    collect_invalid_channel_frequencies,
+    is_strict,
+    warn_invalid_channel_frequencies,
+)
 
 
 @dataclass
@@ -144,6 +150,110 @@ class PresetsInjectorWorker(GroupInjectorWorker):
                 yaml_block = "\n".join(yaml_lines)
                 logger.warning(t("presets_injector.freq_warn.disable_tip", yaml_block=yaml_block))
             self._pending_freq_warnings.clear()
+
+    def collect_freq_issues(self) -> list[FrequencyIssue]:
+        """Collect ALL radio frequency issues across every pending aircraft type.
+
+        Unlike the normal warning path (which filters by dcs_rejects_on_load), this method
+        returns issues for every aircraft type that has at least one out-of-range channel,
+        regardless of whether DCS would actually reject the mission.
+
+        Returns:
+            List of FrequencyIssue, strict types first, then informational, both sorted by unit_type.
+        """
+        issues: list[FrequencyIssue] = []
+        for unit_type, entry in self._pending_freq_warnings.items():
+            issue = collect_invalid_channel_frequencies(
+                group_names=entry.group_names,
+                unit_type=unit_type,
+                channels=entry.channels,
+                coalition=entry.coalition,
+                aircraft_category=entry.aircraft_category,
+            )
+            if issue:
+                issues.append(issue)
+        return sorted(issues, key=lambda i: (not i.strict, i.unit_type))
+
+    def generate_validation_report(self, output_path: Path) -> int:
+        """Write a Markdown validation report of all radio frequency issues to output_path.
+
+        Reports every aircraft type with out-of-range preset frequencies, split into two sections:
+        - Critical (dcs_rejects_on_load): DCS will reject the mission at load.
+        - Informational: DCS stores but ignores the frequencies.
+
+        Args:
+            output_path: Destination .md file.
+
+        Returns:
+            Total number of issues found (0 means all presets are valid).
+        """
+        from datetime import date
+
+        issues = self.collect_freq_issues()
+        strict_issues = [i for i in issues if i.strict]
+        info_issues = [i for i in issues if not i.strict]
+
+        lines: list[str] = [
+            "# Radio Presets Frequency Validation Report",
+            "",
+            f"Generated: {date.today().isoformat()}  ",
+            f"Presets file: `{self.presets_file}`  ",
+            f"Mission: `{self.input_mission}`",
+            "",
+        ]
+
+        def _render_issue(issue: FrequencyIssue) -> list[str]:
+            groups_str = ", ".join(f"`{g}`" for g in issue.group_names)
+            ranges_str = ", ".join(f"{r.min_mhz}–{r.max_mhz} MHz ({r.modulation})" for r in issue.valid_ranges)
+            block = [
+                f"### {issue.unit_type}",
+                f"Groups: {groups_str}  ",
+                f"Valid ranges: {ranges_str}",
+                "",
+                "| Channel | Title | Frequency (MHz) | Collection | Radio |",
+                "|---------|-------|-----------------|------------|-------|",
+            ]
+            for ch in issue.invalid_channels:
+                block.append(f"| {ch.channel} | {ch.channel_title or '—'} | {ch.freq_mhz} | {ch.radio_collection} | {ch.radio_key} |")
+            block += [
+                "",
+                "**To silence:** add to `presets.yaml`:",
+                "```yaml",
+                "presets_assignments:",
+                f"  {issue.coalition}:",
+                f"    {issue.aircraft_category}:",
+                f"      {issue.unit_type}: none",
+                "```",
+                "",
+            ]
+            return block
+
+        if strict_issues:
+            lines += [
+                "## ⚠️ Critical — DCS will reject these at mission load",
+                "",
+                f"*{len(strict_issues)} aircraft type(s) affected.*",
+                "",
+            ]
+            for issue in strict_issues:
+                lines += _render_issue(issue)
+
+        if info_issues:
+            lines += [
+                "## ℹ️ Informational — DCS stores but ignores these frequencies",
+                "",
+                f"*{len(info_issues)} aircraft type(s) affected.*",
+                "",
+            ]
+            for issue in info_issues:
+                lines += _render_issue(issue)
+
+        if not issues:
+            lines += ["## ✅ All preset frequencies are valid for every aircraft type.", ""]
+
+        output_path.write_text("\n".join(lines), encoding="utf-8")
+        logger.info(t("presets_injector.validation_report.written", path=output_path, count=len(issues)))
+        return len(issues)
 
     def write_mission(self, silent: bool = False) -> None:
         """Write the mission file, including kneeboard pages if generated."""

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -122,15 +122,25 @@ class PresetsInjectorWorker(GroupInjectorWorker):
             logger.info(t("presets_injector.injected", count=nb_units_processed))
 
         # Emit one warning per unit_type, listing all affected groups together.
-        for unit_type, entry in self._pending_freq_warnings.items():
-            warn_invalid_channel_frequencies(
-                group_names=entry.group_names,
-                unit_type=unit_type,
-                channels=entry.channels,
-                coalition=entry.coalition,
-                aircraft_category=entry.aircraft_category,
-            )
-        self._pending_freq_warnings.clear()
+        if self._pending_freq_warnings:
+            for unit_type, entry in self._pending_freq_warnings.items():
+                warn_invalid_channel_frequencies(
+                    group_names=entry.group_names,
+                    unit_type=unit_type,
+                    channels=entry.channels,
+                    coalition=entry.coalition,
+                    aircraft_category=entry.aircraft_category,
+                )
+            yaml_lines = []
+            for unit_type, entry in self._pending_freq_warnings.items():
+                yaml_lines.extend([
+                    f"      {entry.coalition}:",
+                    f"        {entry.aircraft_category}:",
+                    f"          {unit_type}: none",
+                ])
+            yaml_block = "\n".join(yaml_lines)
+            logger.warning(t("presets_injector.freq_warn.disable_tip", yaml_block=yaml_block))
+            self._pending_freq_warnings.clear()
 
     def write_mission(self, silent: bool = False) -> None:
         """Write the mission file, including kneeboard pages if generated."""

--- a/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
+++ b/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from veaf_libs.i18n import t
 from veaf_libs.logger import logger
 
 _SPECS: dict[str, Any] | None = None
@@ -150,28 +151,29 @@ def warn_invalid_channel_frequencies(
         return
 
     ranges_str = _format_ranges(valid_ranges)
-    groups_str = ", ".join(f"'{g}'" for g in group_names)
-    groups_label = f"Group {groups_str}" if len(group_names) == 1 else f"Groups {groups_str}"
+    if len(group_names) == 1:
+        groups_label = t("radio_freq.warn.header_single", group=group_names[0], unit_type=unit_type)
+    else:
+        groups_str = ", ".join(f"'{g}'" for g in group_names)
+        groups_label = t("radio_freq.warn.header_plural", groups=groups_str, unit_type=unit_type)
     # Emit one warning per aircraft type (not per group) to avoid flooding the log.
     # List all invalid channels and all affected groups in a single message.
     channel_lines = "\n".join(
-        f"    - channel {ch.channel}" + (f' "{ch.channel_title}"' if ch.channel_title else "") + f": {ch.freq_mhz} MHz"
-        f"  (in radios_collection > {ch.radio_collection} > {ch.radio_key})"
+        t("radio_freq.warn.channel_line_titled", num=ch.channel, title=ch.channel_title, freq=ch.freq_mhz, collection=ch.radio_collection, radio_key=ch.radio_key)
+        if ch.channel_title
+        else t("radio_freq.warn.channel_line", num=ch.channel, freq=ch.freq_mhz, collection=ch.radio_collection, radio_key=ch.radio_key)
         for ch in invalid_channels
     )
-    logger.warning(
-        f"{groups_label} ({unit_type}): the following preset frequencies are not valid"
-        f" for this aircraft and will be rejected by DCS at mission load:\n"
-        f"{channel_lines}\n"
-        f"  Valid ranges for {unit_type}: {ranges_str}\n"
-        f"  These frequencies are probably correct for other aircraft — do NOT change them globally.\n"
-        f"  Instead, add a specific preset for {unit_type} in presets.yaml:\n"
-        f"    presets_assignments:\n"
-        f"      {coalition}:\n"
-        f"        {aircraft_category}:\n"
-        f"          {unit_type}: <your-{unit_type.lower().replace(' ', '-')}-preset>\n"
-        f"  and define that preset with frequencies within: {ranges_str}"
+    unit_type_key = unit_type.lower().replace(" ", "-")
+    footer = t(
+        "radio_freq.warn.footer",
+        unit_type=unit_type,
+        ranges_str=ranges_str,
+        coalition=coalition,
+        aircraft_category=aircraft_category,
+        unit_type_key=unit_type_key,
     )
+    logger.warning(f"{groups_label}\n{channel_lines}\n{footer}")
 
 
 def warn_invalid_frequencies(group_name: str, unit_type: str, freqs_mhz: list[float]) -> None:

--- a/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
+++ b/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
@@ -72,6 +72,24 @@ def get_valid_ranges(unit_type: str) -> list[FrequencyRange] | None:
     return ranges
 
 
+def is_strict(unit_type: str) -> bool:
+    """Return True if out-of-range preset frequencies cause DCS to reject the mission at load.
+
+    Most aircraft silently store or ignore frequencies outside their hardware range. A few
+    (e.g. MiG-19P, SA342M) raise a hard error when loading the mission. Mark those with
+    ``dcs_rejects_on_load: true`` in dcs-radio-specs.yaml.
+
+    Args:
+        unit_type: DCS unit type string.
+
+    Returns:
+        True if the aircraft is known to crash DCS on invalid preset frequencies.
+    """
+    specs = _load_specs()
+    entry = specs.get(unit_type)
+    return bool(entry and entry.get("dcs_rejects_on_load", False))
+
+
 def validate_frequency(unit_type: str, freq_mhz: float) -> bool | None:
     """Check whether freq_mhz is valid for any radio on the given aircraft.
 
@@ -173,7 +191,11 @@ def warn_invalid_channel_frequencies(
         aircraft_category=aircraft_category,
         unit_type_key=unit_type_key,
     )
-    logger.warning(f"{groups_label}\n{channel_lines}\n{footer}")
+    message = f"{groups_label}\n{channel_lines}\n{footer}"
+    if is_strict(unit_type):
+        logger.warning(message)
+    else:
+        logger.debug(message)
     return True
 
 

--- a/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
+++ b/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
@@ -177,9 +177,22 @@ def warn_invalid_channel_frequencies(
     # Emit one warning per aircraft type (not per group) to avoid flooding the log.
     # List all invalid channels and all affected groups in a single message.
     channel_lines = "\n".join(
-        t("radio_freq.warn.channel_line_titled", num=ch.channel, title=ch.channel_title, freq=ch.freq_mhz, collection=ch.radio_collection, radio_key=ch.radio_key)
+        t(
+            "radio_freq.warn.channel_line_titled",
+            num=ch.channel,
+            title=ch.channel_title,
+            freq=ch.freq_mhz,
+            collection=ch.radio_collection,
+            radio_key=ch.radio_key,
+        )
         if ch.channel_title
-        else t("radio_freq.warn.channel_line", num=ch.channel, freq=ch.freq_mhz, collection=ch.radio_collection, radio_key=ch.radio_key)
+        else t(
+            "radio_freq.warn.channel_line",
+            num=ch.channel,
+            freq=ch.freq_mhz,
+            collection=ch.radio_collection,
+            radio_key=ch.radio_key,
+        )
         for ch in invalid_channels
     )
     unit_type_key = unit_type.lower().replace(" ", "-")

--- a/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
+++ b/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
@@ -199,6 +199,68 @@ def warn_invalid_channel_frequencies(
     return True
 
 
+@dataclass
+class FrequencyIssue:
+    """A single aircraft type with its invalid channels, suitable for a validation report.
+
+    Attributes:
+        unit_type: DCS unit type string.
+        group_names: Names of the DCS groups using this unit type.
+        invalid_channels: Channels whose frequency falls outside the aircraft's valid ranges.
+        valid_ranges: All valid frequency ranges for this aircraft.
+        coalition: Coalition of the groups.
+        aircraft_category: DCS aircraft category ("plane" or "helicopter").
+        strict: True if DCS will reject the mission at load for this aircraft.
+    """
+
+    unit_type: str
+    group_names: list[str]
+    invalid_channels: list[ChannelFrequency]
+    valid_ranges: list[FrequencyRange]
+    coalition: str
+    aircraft_category: str
+    strict: bool
+
+
+def collect_invalid_channel_frequencies(
+    group_names: list[str],
+    unit_type: str,
+    channels: list[ChannelFrequency],
+    coalition: str = "blue",
+    aircraft_category: str = "plane",
+) -> FrequencyIssue | None:
+    """Return a FrequencyIssue for channels that are out-of-range for unit_type, or None if all valid.
+
+    Unlike warn_invalid_channel_frequencies, this function does not log anything — it returns
+    structured data for use in validation reports.
+
+    Args:
+        group_names: Names of the DCS groups using this unit type.
+        unit_type: DCS unit type string.
+        channels: All channel frequencies to check.
+        coalition: Coalition of the groups.
+        aircraft_category: DCS aircraft category.
+
+    Returns:
+        A FrequencyIssue if any channel is out-of-range, None otherwise (or if unit type unknown).
+    """
+    valid_ranges = get_valid_ranges(unit_type)
+    if valid_ranges is None:
+        return None
+    invalid_channels = [ch for ch in channels if not any(r.contains(ch.freq_mhz) for r in valid_ranges)]
+    if not invalid_channels:
+        return None
+    return FrequencyIssue(
+        unit_type=unit_type,
+        group_names=group_names,
+        invalid_channels=invalid_channels,
+        valid_ranges=valid_ranges,
+        coalition=coalition,
+        aircraft_category=aircraft_category,
+        strict=is_strict(unit_type),
+    )
+
+
 def warn_invalid_frequencies(group_name: str, unit_type: str, freqs_mhz: list[float]) -> None:
     """Log a warning for each frequency in freqs_mhz that is invalid for unit_type.
 

--- a/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
+++ b/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
@@ -129,7 +129,7 @@ def warn_invalid_channel_frequencies(
     channels: list[ChannelFrequency],
     coalition: str = "blue",
     aircraft_category: str = "plane",
-) -> None:
+) -> bool:
     """Log an actionable warning for each channel whose frequency is invalid for unit_type.
 
     Emits a single warning per aircraft type, listing all affected groups together to avoid
@@ -144,11 +144,11 @@ def warn_invalid_channel_frequencies(
     """
     valid_ranges = get_valid_ranges(unit_type)
     if valid_ranges is None:
-        return
+        return False
 
     invalid_channels = [ch for ch in channels if not any(r.contains(ch.freq_mhz) for r in valid_ranges)]
     if not invalid_channels:
-        return
+        return False
 
     ranges_str = _format_ranges(valid_ranges)
     if len(group_names) == 1:
@@ -174,6 +174,7 @@ def warn_invalid_channel_frequencies(
         unit_type_key=unit_type_key,
     )
     logger.warning(f"{groups_label}\n{channel_lines}\n{footer}")
+    return True
 
 
 def warn_invalid_frequencies(group_name: str, unit_type: str, freqs_mhz: list[float]) -> None:

--- a/src/python/veaf-tools/veaf_libs/group_injector_worker.py
+++ b/src/python/veaf-tools/veaf_libs/group_injector_worker.py
@@ -7,6 +7,7 @@ from typing import Any
 from mission_tools import DcsMission, Group, read_miz, write_miz
 
 from veaf_libs.base_worker import BaseWorker
+from veaf_libs.i18n import t
 from veaf_libs.logger import logger
 from veaf_libs.progress import spinner_context
 
@@ -41,27 +42,27 @@ class GroupInjectorWorker(BaseWorker):
     def read_mission(self, silent: bool = False) -> None:
         """Load the mission from the .miz file."""
         if not silent:
-            logger.info(f"Reading mission file {self.input_mission}")
+            logger.info(t("group_injector.reading_mission", path=self.input_mission))
         assert self.input_mission is not None
         self.dcs_mission = read_miz(self.input_mission)
 
     def write_mission(self, silent: bool = False) -> None:
         """Write the modified mission to output_mission."""
         if not silent:
-            logger.info("Writing mission file")
+            logger.info(t("group_injector.writing_mission"))
         assert self.dcs_mission is not None
         write_miz(mission=self.dcs_mission, miz_file_path=self.output_mission)
 
     def work(self, silent: bool = False) -> Path | None:
         """Read mission, iterate groups, process each, write mission."""
-        with spinner_context(f"Reading {self.input_mission}...", silent=silent):
+        with spinner_context(t("group_injector.spinner.reading", path=self.input_mission), silent=silent):
             self.read_mission(silent)
 
         assert self.dcs_mission is not None
         for group in self.dcs_mission.iter_groups():
             self.process_group(group)
 
-        with spinner_context("Writing mission...", silent=silent):
+        with spinner_context(t("group_injector.spinner.writing"), silent=silent):
             self.write_mission(silent)
 
         return self.output_mission

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -319,6 +319,19 @@
   "cmd.inject_presets.opt.validate_report": "Write a Markdown validation report of all frequency issues to this file (reports ALL aircraft types, not only DCS-critical ones).",
   "presets_injector.validation_report.written": "Validation report written to {path} ({count} issue(s) found).",
 
+  "presets_injector.report.title": "# Radio Presets Frequency Validation Report",
+  "presets_injector.report.generated": "Generated: {date}",
+  "presets_injector.report.presets_file": "Presets file: `{path}`",
+  "presets_injector.report.mission": "Mission: `{path}`",
+  "presets_injector.report.groups": "Groups: {groups}",
+  "presets_injector.report.valid_ranges": "Valid ranges: {ranges}",
+  "presets_injector.report.table_header": "| Channel | Title | Frequency (MHz) | Collection | Radio |",
+  "presets_injector.report.silence_hint": "**To silence:** add to `presets.yaml`:",
+  "presets_injector.report.section_critical": "## \u26a0\ufe0f Critical \u2014 DCS will reject these at mission load",
+  "presets_injector.report.section_info": "## \u2139\ufe0f Informational \u2014 DCS stores but ignores these frequencies",
+  "presets_injector.report.affected_count": "*{count} aircraft type(s) affected.*",
+  "presets_injector.report.all_valid": "## \u2705 All preset frequencies are valid for every aircraft type.",
+
   "cmd.prepare.opt.force": "Do not ask before replacing existing files (same as pressing A).",
 
   "cmd.extract_waypoints.opt.interactive": "Interactive mode: select which groups to extract.",

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -480,5 +480,29 @@
   "tui.select_command": "Select a command",
 
   "update.new_version": "[yellow]⚠ A newer version of veaf-tools is available: [bold]{latest}[/bold] (you have {current})[/yellow]",
-  "update.run_updater": "[yellow]  Run [bold]veaf-tools-updater[/bold] to update.[/yellow]"
+  "update.run_updater": "[yellow]  Run [bold]veaf-tools-updater[/bold] to update.[/yellow]",
+
+  "group_injector.reading_mission": "Reading mission file {path}",
+  "group_injector.writing_mission": "Writing mission file",
+  "group_injector.spinner.reading": "Reading {path}...",
+  "group_injector.spinner.writing": "Writing mission...",
+
+  "presets_injector.error.load_config": "Failed to load config file {path}: {error}",
+  "presets_injector.processing_groups": "Processing {count} aircraft group(s)",
+  "presets_injector.injected": "Injected presets into {count} aircraft(s)",
+  "presets_injector.kneeboard_pages": "Added {count} kneeboard page(s) to mission",
+  "presets_injector.spinner.processing_groups": "Processing groups...",
+  "presets_injector.spinner.generating_images": "Generating preset images...",
+
+  "waypoints_injector.error.load_config": "Failed to load waypoints file {path}: {error}",
+  "waypoints_injector.injected": "Injected waypoints into {count} aircraft group(s)",
+  "waypoints_injector.spinner.processing_groups": "Processing groups and injecting waypoints...",
+
+  "radio_freq.warn.header_single": "Group '{group}' ({unit_type}): the following preset frequencies are not valid for this aircraft and will be rejected by DCS at mission load:",
+  "radio_freq.warn.header_plural": "Groups {groups} ({unit_type}): the following preset frequencies are not valid for this aircraft and will be rejected by DCS at mission load:",
+  "radio_freq.warn.channel_line": "    - channel {num}: {freq} MHz  (in radios_collection > {collection} > {radio_key})",
+  "radio_freq.warn.channel_line_titled": "    - channel {num} \"{title}\": {freq} MHz  (in radios_collection > {collection} > {radio_key})",
+  "radio_freq.warn.footer": "  Valid ranges for {unit_type}: {ranges_str}\n  These frequencies are probably correct for other aircraft — do NOT change them globally.\n  Instead, add a specific preset for {unit_type} in presets.yaml:\n    presets_assignments:\n      {coalition}:\n        {aircraft_category}:\n          {unit_type}: <your-{unit_type_key}-preset>\n  and define that preset with frequencies within: {ranges_str}",
+
+  "pipeline.injecting_aircraft_mode": "Pipeline: injecting aircraft groups from {path} (mode={mode})"
 }

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -504,5 +504,7 @@
   "radio_freq.warn.channel_line_titled": "    - channel {num} \"{title}\": {freq} MHz  (in radios_collection > {collection} > {radio_key})",
   "radio_freq.warn.footer": "  Valid ranges for {unit_type}: {ranges_str}\n  These frequencies are probably correct for other aircraft — do NOT change them globally.\n  Instead, add a specific preset for {unit_type} in presets.yaml:\n    presets_assignments:\n      {coalition}:\n        {aircraft_category}:\n          {unit_type}: <your-{unit_type_key}-preset>\n  and define that preset with frequencies within: {ranges_str}",
 
-  "pipeline.injecting_aircraft_mode": "Pipeline: injecting aircraft groups from {path} (mode={mode})"
+  "pipeline.injecting_aircraft_mode": "Pipeline: injecting aircraft groups from {path} (mode={mode})",
+
+  "presets_injector.freq_warn.disable_tip": "To silence these warnings temporarily while you fix the presets, add 'none' for these aircraft types in presets.yaml:\n  presets_assignments:\n{yaml_block}\n  Once the presets are corrected, remove those 'none' lines to re-enable injection."
 }

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -316,6 +316,8 @@
   "cmd.inject_presets.opt.mission": "Mission name; will inject in the mission with this name (most recent .miz file); can be set to a .miz file.",
   "cmd.inject_presets.opt.output_mission": "Mission file to save; defaults to the same as input.",
   "cmd.inject_presets.opt.presets_file": "Configuration file containing the presets.",
+  "cmd.inject_presets.opt.validate_report": "Write a Markdown validation report of all frequency issues to this file (reports ALL aircraft types, not only DCS-critical ones).",
+  "presets_injector.validation_report.written": "Validation report written to {path} ({count} issue(s) found).",
 
   "cmd.prepare.opt.force": "Do not ask before replacing existing files (same as pressing A).",
 

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -321,6 +321,19 @@
   "cmd.inject_presets.opt.validate_report": "Enregistre un rapport Markdown de validation des fréquences dans ce fichier (signale TOUS les types d'appareils, pas seulement les critiques DCS).",
   "presets_injector.validation_report.written": "Rapport de validation écrit dans {path} ({count} problème(s) trouvé(s)).",
 
+  "presets_injector.report.title": "# Rapport de validation des fréquences radio",
+  "presets_injector.report.generated": "Généré le : {date}",
+  "presets_injector.report.presets_file": "Fichier presets : `{path}`",
+  "presets_injector.report.mission": "Mission : `{path}`",
+  "presets_injector.report.groups": "Groupes : {groups}",
+  "presets_injector.report.valid_ranges": "Plages valides : {ranges}",
+  "presets_injector.report.table_header": "| Canal | Titre | Fréquence (MHz) | Collection | Radio |",
+  "presets_injector.report.silence_hint": "**Pour masquer :** ajouter dans `presets.yaml` :",
+  "presets_injector.report.section_critical": "## \u26a0\ufe0f Critique \u2014 DCS rejettera ces fréquences au chargement de la mission",
+  "presets_injector.report.section_info": "## \u2139\ufe0f Informatif \u2014 DCS stocke ces fréquences mais les ignore",
+  "presets_injector.report.affected_count": "*{count} type(s) d'appareil concerné(s).*",
+  "presets_injector.report.all_valid": "## \u2705 Toutes les fréquences de préréglage sont valides pour chaque type d'appareil.",
+
   "cmd.prepare.opt.force": "Ne pas demander de confirmation avant de remplacer les fichiers existants (équivalent à appuyer sur A).",
 
   "cmd.extract_waypoints.opt.interactive": "Mode interactif : sélectionner les groupes à extraire.",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -318,6 +318,8 @@
   "cmd.inject_presets.opt.mission": "Nom de mission ; injectera dans la mission portant ce nom (fichier .miz le plus récent) ; peut être un fichier .miz.",
   "cmd.inject_presets.opt.output_mission": "Fichier de mission de sortie ; par défaut identique au fichier d'entrée.",
   "cmd.inject_presets.opt.presets_file": "Fichier de configuration contenant les préréglages radio.",
+  "cmd.inject_presets.opt.validate_report": "Enregistre un rapport Markdown de validation des fréquences dans ce fichier (signale TOUS les types d'appareils, pas seulement les critiques DCS).",
+  "presets_injector.validation_report.written": "Rapport de validation écrit dans {path} ({count} problème(s) trouvé(s)).",
 
   "cmd.prepare.opt.force": "Ne pas demander de confirmation avant de remplacer les fichiers existants (équivalent à appuyer sur A).",
 

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -482,5 +482,29 @@
   "tui.select_command": "Sélectionner une commande",
 
   "update.new_version": "[yellow]⚠ Une nouvelle version de veaf-tools est disponible : [bold]{latest}[/bold] (vous avez {current})[/yellow]",
-  "update.run_updater": "[yellow]  Lancez [bold]veaf-tools-updater[/bold] pour mettre à jour.[/yellow]"
+  "update.run_updater": "[yellow]  Lancez [bold]veaf-tools-updater[/bold] pour mettre à jour.[/yellow]",
+
+  "group_injector.reading_mission": "Lecture du fichier mission {path}",
+  "group_injector.writing_mission": "Écriture du fichier mission",
+  "group_injector.spinner.reading": "Lecture de {path}...",
+  "group_injector.spinner.writing": "Écriture de la mission...",
+
+  "presets_injector.error.load_config": "Impossible de charger le fichier de configuration {path} : {error}",
+  "presets_injector.processing_groups": "Traitement de {count} groupe(s) d'aéronefs",
+  "presets_injector.injected": "Préréglages injectés dans {count} aéronef(s)",
+  "presets_injector.kneeboard_pages": "{count} page(s) de kneeboard ajoutée(s) à la mission",
+  "presets_injector.spinner.processing_groups": "Traitement des groupes...",
+  "presets_injector.spinner.generating_images": "Génération des images de préréglages...",
+
+  "waypoints_injector.error.load_config": "Impossible de charger le fichier de waypoints {path} : {error}",
+  "waypoints_injector.injected": "Waypoints injectés dans {count} groupe(s) d'aéronefs",
+  "waypoints_injector.spinner.processing_groups": "Traitement des groupes et injection des waypoints...",
+
+  "radio_freq.warn.header_single": "Groupe '{group}' ({unit_type}) : les fréquences de préréglage suivantes ne sont pas valides pour cet aéronef et seront rejetées par DCS au chargement de la mission :",
+  "radio_freq.warn.header_plural": "Groupes {groups} ({unit_type}) : les fréquences de préréglage suivantes ne sont pas valides pour cet aéronef et seront rejetées par DCS au chargement de la mission :",
+  "radio_freq.warn.channel_line": "    - canal {num} : {freq} MHz  (dans radios_collection > {collection} > {radio_key})",
+  "radio_freq.warn.channel_line_titled": "    - canal {num} \"{title}\" : {freq} MHz  (dans radios_collection > {collection} > {radio_key})",
+  "radio_freq.warn.footer": "  Plages valides pour {unit_type} : {ranges_str}\n  Ces fréquences sont probablement correctes pour d'autres aéronefs — ne les modifiez PAS globalement.\n  Ajoutez plutôt un préréglage spécifique pour {unit_type} dans presets.yaml :\n    presets_assignments:\n      {coalition}:\n        {aircraft_category}:\n          {unit_type}: <votre-préréglage-{unit_type_key}>\n  et définissez ce préréglage avec des fréquences comprises dans : {ranges_str}",
+
+  "pipeline.injecting_aircraft_mode": "Pipeline : injection des groupes aériens depuis {path} (mode={mode})"
 }

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -506,5 +506,7 @@
   "radio_freq.warn.channel_line_titled": "    - canal {num} \"{title}\" : {freq} MHz  (dans radios_collection > {collection} > {radio_key})",
   "radio_freq.warn.footer": "  Plages valides pour {unit_type} : {ranges_str}\n  Ces fréquences sont probablement correctes pour d'autres aéronefs — ne les modifiez PAS globalement.\n  Ajoutez plutôt un préréglage spécifique pour {unit_type} dans presets.yaml :\n    presets_assignments:\n      {coalition}:\n        {aircraft_category}:\n          {unit_type}: <votre-préréglage-{unit_type_key}>\n  et définissez ce préréglage avec des fréquences comprises dans : {ranges_str}",
 
-  "pipeline.injecting_aircraft_mode": "Pipeline : injection des groupes aériens depuis {path} (mode={mode})"
+  "pipeline.injecting_aircraft_mode": "Pipeline : injection des groupes aériens depuis {path} (mode={mode})",
+
+  "presets_injector.freq_warn.disable_tip": "Pour masquer ces avertissements pendant que vous corrigez les préréglages, ajoutez 'none' pour ces types d'appareils dans presets.yaml :\n  presets_assignments:\n{yaml_block}\n  Une fois les préréglages corrigés, supprimez ces lignes 'none' pour réactiver l'injection."
 }

--- a/src/python/veaf-tools/veaf_tools/commands/build.py
+++ b/src/python/veaf-tools/veaf_tools/commands/build.py
@@ -154,11 +154,16 @@ def build(
     if presets_path:
         logger.info(t("pipeline.injecting_presets", path=presets_path))
         console.print(t("pipeline.console.presets", file=presets_path.name))
-        PresetsInjectorWorker(
+        presets_worker = PresetsInjectorWorker(
             presets_file=presets_path,
             input_mission=p_output_mission,
             output_mission=p_output_mission,
-        ).work()
+        )
+        presets_worker.work()
+        report_path = p_mission_folder / "presets-validation-report.md"
+        issue_count = presets_worker.generate_validation_report(report_path)
+        if issue_count == 0 and report_path.exists():
+            report_path.unlink()
 
     waypoints_path = _step_file("waypoints", "src/waypoints.yaml", "waypoints.yaml")
     if waypoints_path:

--- a/src/python/veaf-tools/veaf_tools/commands/build.py
+++ b/src/python/veaf-tools/veaf_tools/commands/build.py
@@ -152,7 +152,7 @@ def build(
 
     presets_path = _step_file("presets", "src/presets.yaml")
     if presets_path:
-        logger.info(f"Pipeline: injecting radio presets from {presets_path}")
+        logger.info(t("pipeline.injecting_presets", path=presets_path))
         console.print(t("pipeline.console.presets", file=presets_path.name))
         PresetsInjectorWorker(
             presets_file=presets_path,
@@ -162,7 +162,7 @@ def build(
 
     waypoints_path = _step_file("waypoints", "src/waypoints.yaml", "waypoints.yaml")
     if waypoints_path:
-        logger.info(f"Pipeline: injecting waypoints from {waypoints_path}")
+        logger.info(t("pipeline.injecting_waypoints", path=waypoints_path))
         console.print(t("pipeline.console.waypoints", file=waypoints_path.name))
         WaypointsInjectorWorker(
             waypoints_file=waypoints_path,
@@ -181,7 +181,7 @@ def build(
         validator = AircraftGroupsYAMLValidator(aircraft_path)
         is_valid, _ = validator.validate()
         if is_valid:
-            logger.info(f"Pipeline: injecting aircraft groups from {aircraft_path} (mode={aircraft_mode})")
+            logger.info(t("pipeline.injecting_aircraft_mode", path=aircraft_path, mode=aircraft_mode))
             console.print(t("pipeline.console.aircraft", file=aircraft_path.name, mode=aircraft_mode))
             AircraftGroupsInjectorWorker(
                 input_yaml=aircraft_path,
@@ -203,7 +203,7 @@ def build(
 
     weather_path = _step_file("weather", "src/missions.yaml", "src/versions.yaml", "missions.yaml")
     if weather_path:
-        logger.info(f"Pipeline: injecting weather variants from {weather_path}")
+        logger.info(t("pipeline.injecting_weather", path=weather_path))
         console.print(t("pipeline.console.weather", file=weather_path.name))
         weather_worker = WeatherInjectorWorker(
             config_file=weather_path,

--- a/src/python/veaf-tools/veaf_tools/commands/inject_presets.py
+++ b/src/python/veaf-tools/veaf_tools/commands/inject_presets.py
@@ -29,6 +29,7 @@ def inject_presets(
     ),
     output_mission: str | None = typer.Argument(None, help=t("cmd.inject_presets.opt.output_mission")),
     presets_file: str = typer.Option(DEFAULT_PRESETS_FILE, help=t("cmd.inject_presets.opt.presets_file")),
+    validate_report: str | None = typer.Option(None, help=t("cmd.inject_presets.opt.validate_report")),
     pause: bool = typer.Option(False, help=PAUSE_HELP),
 ) -> None:
 
@@ -64,6 +65,10 @@ def inject_presets(
         presets_file=p_presets_file, input_mission=p_input_mission, output_mission=p_output_mission
     )
     worker.work()
+
+    if validate_report is not None:
+        report_path = resolve_path(path=validate_report, default_path=Path("presets-validation-report.md"))
+        worker.generate_validation_report(report_path)
 
     console.print(t("msg.work_done"))
     if pause:

--- a/src/python/veaf-tools/waypoints_injector/waypoints_injector_worker.py
+++ b/src/python/veaf-tools/waypoints_injector/waypoints_injector_worker.py
@@ -52,7 +52,10 @@ class WaypointsInjectorWorker(GroupInjectorWorker):
             if self.waypoints_file:
                 waypoints_manager.read_yaml(self.waypoints_file)
         except Exception as e:
-            logger.error(t("waypoints_injector.error.load_config", path=self.waypoints_file, error=str(e)), exception_type=RuntimeError)
+            logger.error(
+                t("waypoints_injector.error.load_config", path=self.waypoints_file, error=str(e)),
+                exception_type=RuntimeError,
+            )
         self.waypoints_manager = waypoints_manager
         return waypoints_manager
 

--- a/src/python/veaf-tools/waypoints_injector/waypoints_injector_worker.py
+++ b/src/python/veaf-tools/waypoints_injector/waypoints_injector_worker.py
@@ -17,6 +17,7 @@ from rich.table import Table
 from rich.text import Text
 from veaf_libs.base_worker import BaseWorker
 from veaf_libs.group_injector_worker import GroupInjectorWorker
+from veaf_libs.i18n import t
 from veaf_libs.logger import logger
 from veaf_libs.progress import spinner_context
 
@@ -51,7 +52,7 @@ class WaypointsInjectorWorker(GroupInjectorWorker):
             if self.waypoints_file:
                 waypoints_manager.read_yaml(self.waypoints_file)
         except Exception as e:
-            logger.error(f"Failed to load waypoints file {self.waypoints_file}: {str(e)}", exception_type=RuntimeError)
+            logger.error(t("waypoints_injector.error.load_config", path=self.waypoints_file, error=str(e)), exception_type=RuntimeError)
         self.waypoints_manager = waypoints_manager
         return waypoints_manager
 
@@ -69,7 +70,7 @@ class WaypointsInjectorWorker(GroupInjectorWorker):
     def read_mission(self, silent: bool = False) -> None:
         """Load the mission and collect all groups."""
         if not silent:
-            logger.info(f"Reading mission file {self.input_mission}")
+            logger.info(t("group_injector.reading_mission", path=self.input_mission))
         assert self.input_mission is not None
         self.dcs_mission = read_miz(self.input_mission)
         logger.debug("Searching for all aircraft groups")
@@ -79,7 +80,7 @@ class WaypointsInjectorWorker(GroupInjectorWorker):
     def process_groups(self, silent: bool = False) -> None:
         """Process all aircraft groups and inject waypoints."""
         if not silent:
-            logger.info(f"Processing {len(self.groups)} aircraft group{'s' if len(self.groups) > 1 else ''}")
+            logger.info(t("presets_injector.processing_groups", count=len(self.groups)))
 
         nb_groups_processed = 0
         if not self.waypoints_manager:
@@ -104,9 +105,7 @@ class WaypointsInjectorWorker(GroupInjectorWorker):
                 )
 
         if not silent:
-            logger.info(
-                f"Injected waypoints into {nb_groups_processed} aircraft group{'s' if nb_groups_processed > 1 else ''}"
-            )
+            logger.info(t("waypoints_injector.injected", count=nb_groups_processed))
 
     def _inject_waypoints_into_group(self, group: Group, waypoints: list[WaypointDefinition]) -> None:
         """Inject waypoints into a specific group."""
@@ -126,7 +125,7 @@ class WaypointsInjectorWorker(GroupInjectorWorker):
     def write_mission(self, silent: bool = False) -> None:
         """Write the mission file."""
         if not silent:
-            logger.info("Writing mission file")
+            logger.info(t("group_injector.writing_mission"))
 
         assert self.dcs_mission is not None
         write_miz(mission=self.dcs_mission, miz_file_path=self.output_mission)
@@ -134,15 +133,15 @@ class WaypointsInjectorWorker(GroupInjectorWorker):
     def work(self, silent: bool = False) -> None:
         """Main work function."""
         # Load the mission from the .miz file
-        with spinner_context(f"Reading {self.input_mission}...", silent=silent):
+        with spinner_context(t("group_injector.spinner.reading", path=self.input_mission), silent=silent):
             self.read_mission(silent)
 
         # Process all aircraft groups
-        with spinner_context("Processing groups and injecting waypoints...", silent=silent):
+        with spinner_context(t("waypoints_injector.spinner.processing_groups"), silent=silent):
             self.process_groups(silent)
 
         # Write the mission file
-        with spinner_context("Writing mission...", silent=silent):
+        with spinner_context(t("group_injector.spinner.writing"), silent=silent):
             self.write_mission(silent)
 
 

--- a/test/python/mission_builder/test_v5_converter.py
+++ b/test/python/mission_builder/test_v5_converter.py
@@ -6,10 +6,9 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from veaf_libs.i18n import current_language, set_language, t
-
 from mission_builder.config_migrator import MigrationResult
 from mission_builder.v5_converter import ConversionReport, PipelineFile, V5Converter
+from veaf_libs.i18n import current_language, set_language, t
 
 # ---------------------------------------------------------------------------
 # ConversionReport.to_markdown() — empty / minimal state

--- a/test/python/mission_builder/test_v5_pipeline_converters.py
+++ b/test/python/mission_builder/test_v5_pipeline_converters.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 import luadata
 import yaml
-
 from mission_builder.v5_pipeline_converters import (
     _extract_lua_table_text,
     _normalize_date,

--- a/test/python/mission_tools/test_miz_tools.py
+++ b/test/python/mission_tools/test_miz_tools.py
@@ -5,7 +5,6 @@ import zipfile
 from pathlib import Path
 
 import pytest
-
 from mission_tools.miz_tools import DcsMission, Group, create_miz, read_miz, write_miz
 
 # ---------------------------------------------------------------------------

--- a/test/python/presets_injector/test_presets_injector_worker.py
+++ b/test/python/presets_injector/test_presets_injector_worker.py
@@ -220,30 +220,39 @@ class TestProcessGroups(unittest.TestCase):
 class TestGenerateValidationReport(unittest.TestCase):
     """Tests for collect_freq_issues() and generate_validation_report()."""
 
-    def _make_worker_with_pending(self) -> PresetsInjectorWorker:
-        """Return a worker with one strict and one non-strict pending warning pre-loaded."""
-        from presets_injector.presets_injector_worker import _PendingFreqWarning
-        from presets_injector.radio_frequency_validator import ChannelFrequency
+    def _make_worker_with_issues(self) -> PresetsInjectorWorker:
+        """Return a worker with _freq_issues pre-loaded (one strict, one non-strict)."""
+        from presets_injector.radio_frequency_validator import ChannelFrequency, FrequencyIssue, FrequencyRange
 
         worker = _make_worker()
-        # MiG-19P is strict (dcs_rejects_on_load: true in real specs); mock both via _SPECS patch
-        strict_ch = ChannelFrequency(freq_mhz=284.0, radio_key="radio_uhf", radio_collection="blue_radios",
-                                     radio_title="UHF", channel=1, channel_title="TACTICAL")
-        non_strict_ch = ChannelFrequency(freq_mhz=284.0, radio_key="radio_uhf", radio_collection="blue_radios",
-                                          radio_title="UHF", channel=1, channel_title="TACTICAL")
-        worker._pending_freq_warnings["MiG-19P"] = _PendingFreqWarning(
-            group_names=["Bandit MiG #1"],
-            channels=[strict_ch],
-            coalition="blue",
-            aircraft_category="plane",
-        )
-        worker._pending_freq_warnings["Ka-50"] = _PendingFreqWarning(
-            group_names=["Helo #1"],
-            channels=[non_strict_ch],
-            coalition="blue",
-            aircraft_category="helicopter",
-        )
+        strict_range = FrequencyRange(min_mhz=100.0, max_mhz=150.0, modulation="AM/FM")
+        non_strict_range = FrequencyRange(min_mhz=20.0, max_mhz=59.9, modulation="AM/FM")
+        ch = ChannelFrequency(freq_mhz=284.0, radio_key="radio_uhf", radio_collection="blue_radios",
+                              radio_title="UHF", channel=1, channel_title="TACTICAL")
+        worker._freq_issues = [
+            FrequencyIssue(
+                unit_type="MiG-19P",
+                group_names=["Bandit MiG #1"],
+                invalid_channels=[ch],
+                valid_ranges=[strict_range],
+                coalition="blue",
+                aircraft_category="plane",
+                strict=True,
+            ),
+            FrequencyIssue(
+                unit_type="Ka-50",
+                group_names=["Helo #1"],
+                invalid_channels=[ch],
+                valid_ranges=[non_strict_range],
+                coalition="blue",
+                aircraft_category="helicopter",
+                strict=False,
+            ),
+        ]
         return worker
+
+    # Keep old name as alias so test methods below still work
+    _make_worker_with_pending = _make_worker_with_issues
 
     def test_collect_freq_issues_returns_issues_for_known_types(self) -> None:
         worker = self._make_worker_with_pending()

--- a/test/python/presets_injector/test_presets_injector_worker.py
+++ b/test/python/presets_injector/test_presets_injector_worker.py
@@ -220,6 +220,10 @@ class TestProcessGroups(unittest.TestCase):
 class TestGenerateValidationReport(unittest.TestCase):
     """Tests for collect_freq_issues() and generate_validation_report()."""
 
+    def setUp(self) -> None:
+        from veaf_libs.i18n import set_language
+        set_language("en")
+
     def _make_worker_with_issues(self) -> PresetsInjectorWorker:
         """Return a worker with _freq_issues pre-loaded (one strict, one non-strict)."""
         from presets_injector.radio_frequency_validator import ChannelFrequency, FrequencyIssue, FrequencyRange

--- a/test/python/presets_injector/test_presets_injector_worker.py
+++ b/test/python/presets_injector/test_presets_injector_worker.py
@@ -217,5 +217,78 @@ class TestProcessGroups(unittest.TestCase):
         worker.process_groups(silent=False)
 
 
+class TestGenerateValidationReport(unittest.TestCase):
+    """Tests for collect_freq_issues() and generate_validation_report()."""
+
+    def _make_worker_with_pending(self) -> PresetsInjectorWorker:
+        """Return a worker with one strict and one non-strict pending warning pre-loaded."""
+        from presets_injector.presets_injector_worker import _PendingFreqWarning
+        from presets_injector.radio_frequency_validator import ChannelFrequency
+
+        worker = _make_worker()
+        # MiG-19P is strict (dcs_rejects_on_load: true in real specs); mock both via _SPECS patch
+        strict_ch = ChannelFrequency(freq_mhz=284.0, radio_key="radio_uhf", radio_collection="blue_radios",
+                                     radio_title="UHF", channel=1, channel_title="TACTICAL")
+        non_strict_ch = ChannelFrequency(freq_mhz=284.0, radio_key="radio_uhf", radio_collection="blue_radios",
+                                          radio_title="UHF", channel=1, channel_title="TACTICAL")
+        worker._pending_freq_warnings["MiG-19P"] = _PendingFreqWarning(
+            group_names=["Bandit MiG #1"],
+            channels=[strict_ch],
+            coalition="blue",
+            aircraft_category="plane",
+        )
+        worker._pending_freq_warnings["Ka-50"] = _PendingFreqWarning(
+            group_names=["Helo #1"],
+            channels=[non_strict_ch],
+            coalition="blue",
+            aircraft_category="helicopter",
+        )
+        return worker
+
+    def test_collect_freq_issues_returns_issues_for_known_types(self) -> None:
+        worker = self._make_worker_with_pending()
+        issues = worker.collect_freq_issues()
+        unit_types = {i.unit_type for i in issues}
+        # MiG-19P has invalid UHF freq; Ka-50 has UHF freq outside its 20-59 MHz range
+        self.assertIn("MiG-19P", unit_types)
+        self.assertIn("Ka-50", unit_types)
+
+    def test_collect_freq_issues_strict_sorted_first(self) -> None:
+        worker = self._make_worker_with_pending()
+        issues = worker.collect_freq_issues()
+        if len(issues) >= 2:
+            strict_issues = [i for i in issues if i.strict]
+            non_strict_issues = [i for i in issues if not i.strict]
+            if strict_issues and non_strict_issues:
+                self.assertLess(issues.index(strict_issues[0]), issues.index(non_strict_issues[0]))
+
+    def test_generate_validation_report_creates_file(self) -> None:
+        worker = self._make_worker_with_pending()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "report.md"
+            count = worker.generate_validation_report(report_path)
+            self.assertTrue(report_path.exists())
+            self.assertGreater(count, 0)
+
+    def test_generate_validation_report_content(self) -> None:
+        worker = self._make_worker_with_pending()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "report.md"
+            worker.generate_validation_report(report_path)
+            content = report_path.read_text(encoding="utf-8")
+            self.assertIn("# Radio Presets Frequency Validation Report", content)
+            self.assertIn("MiG-19P", content)
+
+    def test_generate_validation_report_empty_when_no_issues(self) -> None:
+        worker = _make_worker()
+        # No pending warnings → all valid
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "report.md"
+            count = worker.generate_validation_report(report_path)
+            self.assertEqual(count, 0)
+            content = report_path.read_text(encoding="utf-8")
+            self.assertIn("All preset frequencies are valid", content)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/presets_injector/test_radio_frequency_validator.py
+++ b/test/python/presets_injector/test_radio_frequency_validator.py
@@ -12,6 +12,7 @@ from presets_injector.radio_frequency_validator import (
     warn_invalid_channel_frequencies,
     warn_invalid_frequencies,
 )
+from veaf_libs.i18n import set_language
 
 _MOCK_SPECS = {
     "FA-18C_hornet": {
@@ -186,6 +187,7 @@ def _make_ch(freq: float, channel: int = 1, channel_title: str = "TACTICAL UNIFO
 
 class TestWarnInvalidChannelFrequencies(unittest.TestCase):
     def setUp(self):
+        set_language("en")
         self._patcher = patch("presets_injector.radio_frequency_validator._SPECS", _MOCK_SPECS)
         self._patcher.start()
 

--- a/test/python/presets_injector/test_radio_frequency_validator.py
+++ b/test/python/presets_injector/test_radio_frequency_validator.py
@@ -32,6 +32,7 @@ _MOCK_SPECS = {
     "MiG-19P": {
         "name": "MiG-19P",
         "category": "plane",
+        "dcs_rejects_on_load": True,
         "radios": [
             {
                 "name": "RSIU-4V Radio",

--- a/test/python/test_yaml_validator.py
+++ b/test/python/test_yaml_validator.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import typer
-
 from veaf_libs.yaml_validator import _hint_key, validate_yaml_file
 
 

--- a/test/python/veaf_libs/test_dcs_units_parser.py
+++ b/test/python/veaf_libs/test_dcs_units_parser.py
@@ -4,7 +4,6 @@ import textwrap
 from pathlib import Path
 
 import pytest
-
 from veaf_libs.dcs_units_parser import (
     DcsUnit,
     _is_meaningful_attribute,

--- a/test/python/veaf_libs/test_lua_config_generator.py
+++ b/test/python/veaf_libs/test_lua_config_generator.py
@@ -1,11 +1,10 @@
 """Tests for veaf_libs.lua_config_generator."""
 
-import re
 import logging
+import re
 
 import pytest
 import typer
-
 from veaf_libs.lua_config_generator import (
     MANDATORY_MODULES,
     _emit_lua_string,

--- a/test/python/veaf_libs/test_tui.py
+++ b/test/python/veaf_libs/test_tui.py
@@ -4,7 +4,6 @@ import sys
 from unittest.mock import patch
 
 import pytest
-
 from veaf_libs.tui import _COMMAND_MAP, COMMANDS, ArgPrompt, CommandSpec, run_wizard
 
 

--- a/test/python/veaf_libs/test_user_config.py
+++ b/test/python/veaf_libs/test_user_config.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
 from veaf_libs import user_config
 from veaf_libs.user_config import (
     _invalidate_cache,

--- a/test/python/waypoints_injector/test_waypoints_injector_worker.py
+++ b/test/python/waypoints_injector/test_waypoints_injector_worker.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from mission_tools import DcsMission, Group
-
 from waypoints_injector.waypoints_injector_worker import (
     WaypointsExtractorWorker,
     WaypointsInjectorWorker,

--- a/test/python/waypoints_injector/test_waypoints_manager.py
+++ b/test/python/waypoints_injector/test_waypoints_manager.py
@@ -7,7 +7,6 @@ import unittest
 from pathlib import Path
 
 import yaml
-
 from waypoints_injector.waypoints_manager import FlightPlanDefinition, WaypointDefinition, WaypointsManager
 
 

--- a/test/python/weather_injector/test_weather_injector_worker.py
+++ b/test/python/weather_injector/test_weather_injector_worker.py
@@ -11,7 +11,6 @@ from typing import Any
 
 import typer
 import yaml
-
 from weather_injector.models import MissionConfig, Position, VersionConfig
 from weather_injector.weather_injector_worker import WeatherInjectorWorker
 

--- a/test/python/weather_injector/utils/test_lua_converter.py
+++ b/test/python/weather_injector/utils/test_lua_converter.py
@@ -7,7 +7,6 @@ import unittest
 from pathlib import Path
 
 import typer
-
 from weather_injector.utils.lua_converter import LuaToYamlConverter
 
 


### PR DESCRIPTION
## Problème\n\nTous les messages des workers d'injection (presets, waypoints) et du validateur de fréquences radio étaient en anglais codé en dur, alors que le reste du build est traduit via i18n.\n\n## Changements\n\n**Nouvelles clés i18n** (`en.json` + `fr.json`) :\n- `group_injector.*` — lecture/écriture mission, spinners\n- `presets_injector.*` — erreur de config, processing, injected, kneeboard, spinners\n- `waypoints_injector.*` — erreur de config, injected, spinner\n- `radio_freq.warn.*` — header (singular/plural), channel lines, footer advice block\n- `pipeline.injecting_aircraft_mode` — message pipeline avec mode\n\n**Fichiers Python mis à jour** :\n- `group_injector_worker.py` — `read_mission`, `write_mission`, spinners\n- `presets_injector_worker.py` — tous les messages\n- `waypoints_injector_worker.py` — tous les messages\n- `radio_frequency_validator.py` — warning complet traduit\n- `build.py` — 4 `logger.info` pipeline\n\n**Tests** : `set_language(\"en\")` dans `setUp` pour que les assertions anglaises restent valides.

## Summary by Sourcery

Localize injector and radio frequency validator messages through the existing i18n system and update the build pipeline logging accordingly.

Enhancements:
- Replace hard-coded English log and spinner messages in group, presets, and waypoints injectors with i18n-based translations.
- Localize radio frequency validation warnings, including headers, channel lines, and footer guidance, via i18n keys.
- Use i18n keys for build pipeline logging when injecting presets, waypoints, aircraft groups, and weather, and bump the project version.

Build:
- Update project version in pyproject.toml to reflect the localization changes.

Documentation:
- Document the i18n behavior change for injector and radio frequency validator logs in the changelog.

Tests:
- Ensure radio frequency validator tests explicitly set the language to English so existing assertions remain valid.