### PR TITLE
fix(convert-v5): extract per-aircraft radio assignments from radioSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- `presets inject`: `presets_assignments` keys now support regex patterns (e.g. `A[-]10C.*`, `FW[-]190.*`) — exact match takes priority, then pattern, then `all` fallback
 - `convert-v5` presets: per-aircraft radio assignments are now extracted from `radioSettings` — warbird aircraft (e.g. Bf-109K-4) are auto-assigned to `{coalition}_warbird`, VHF-primary aircraft (e.g. I-16, Spitfire) get a new `{coalition}_vhf_primary` preset; hardcoded and typePattern entries emit explicit warnings listing the recommended preset
 - i18n : tous les messages des injectors (presets, waypoints) et du validateur de fréquences radio sont maintenant traduits en français — plus de messages en anglais dans le log de `veaf-tools build`
 - `presets inject`: radio frequency warnings are now deduplicated by aircraft type — instead of one warning block per group, a single block is emitted per unit type listing all affected groups in parentheses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- `convert-v5` presets: per-aircraft radio assignments are now extracted from `radioSettings` — warbird aircraft (e.g. Bf-109K-4) are auto-assigned to `{coalition}_warbird`, VHF-primary aircraft (e.g. I-16, Spitfire) get a new `{coalition}_vhf_primary` preset; hardcoded and typePattern entries emit explicit warnings listing the recommended preset
 - i18n : tous les messages des injectors (presets, waypoints) et du validateur de fréquences radio sont maintenant traduits en français — plus de messages en anglais dans le log de `veaf-tools build`
 - `presets inject`: radio frequency warnings are now deduplicated by aircraft type — instead of one warning block per group, a single block is emitted per unit type listing all affected groups in parentheses
 - `build`: bundle `presets_injector/data/dcs-radio-specs.yaml` into the PyInstaller executable — fixes `ModuleNotFoundError: No module named 'presets_injector.data'` at runtime

--- a/backlog.md
+++ b/backlog.md
@@ -96,6 +96,7 @@
 | CVPRE-001 | Parse `radioSettings` table and detect per-aircraft radio layouts (warbird, VHF-primary, hardcoded) | `v5_pipeline_converters.py` | fix | 30 min | ✅ |
 | CVPRE-002 | Auto-assign warbird and VHF-primary aircraft in `presets_assignments`; emit warnings for typePattern and hardcoded entries | `v5_pipeline_converters.py` | fix | 10 min | ✅ |
 | CVPRE-003 | Add i18n messages for new warnings; add 28 unit tests | `locales/en.json`, `locales/fr.json`, `test_v5_pipeline_converters.py` | feat | 5 min | ✅ |
+| CVPRE-004 | Support regex patterns as `unit_type` keys in `presets_assignments` (exact > pattern > `all`) | `presets_manager.py`, `test_presets.py` | feat | 20 min | ✅ |
 
 ---
 

--- a/backlog.md
+++ b/backlog.md
@@ -77,10 +77,25 @@
 | Lot CMT-YAML-DOCS — doc comments and links in generated `mission.yaml` files | ~45 min | [archived](backlog-archive.md) |
 | Lot FIX-AIRCRAFT-DUPLICATE — Duplicate aircraft groups in "add" injection mode | ~20 min | [archived](backlog-archive.md) |
 | Lot FIX-I18N-CONVERT-V5 — Hardcoded English messages in convert-v5 | ~30 min | ✅ |
+| Lot FIX-CONVERT-V5-PRESETS — Per-aircraft radio assignments in convert-v5 presets | ~45 min | ✅ |
 | Lot FEAT-COMMUNITY-TOGGLE — Enable/disable community scripts from mission.yaml | ~2h | ⬜ |
-| **Total** | **~181h15** | |
+| **Total** | **~182h** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*
+
+---
+
+## Lot FIX-CONVERT-V5-PRESETS — Per-aircraft radio assignments in convert-v5 presets
+
+**Goal**: Fix `convert-v5` so that per-aircraft radio specificity from `radioSettings` is preserved in the generated `presets.yaml`.
+
+**Branch**: `fix/convert-v5-presets-per-aircraft` → PR #381 → `develop-v6`
+
+| # | Ticket | Files | Type | Effort | Status |
+|---|--------|-------|------|--------|--------|
+| CVPRE-001 | Parse `radioSettings` table and detect per-aircraft radio layouts (warbird, VHF-primary, hardcoded) | `v5_pipeline_converters.py` | fix | 30 min | ✅ |
+| CVPRE-002 | Auto-assign warbird and VHF-primary aircraft in `presets_assignments`; emit warnings for typePattern and hardcoded entries | `v5_pipeline_converters.py` | fix | 10 min | ✅ |
+| CVPRE-003 | Add i18n messages for new warnings; add 28 unit tests | `locales/en.json`, `locales/fr.json`, `test_v5_pipeline_converters.py` | feat | 5 min | ✅ |
 
 ---
 

--- a/doc/PIPELINE_REFERENCE.en.md
+++ b/doc/PIPELINE_REFERENCE.en.md
@@ -100,7 +100,7 @@ presets_assignments:
   <coalition>:                          # blue | red
     <category>:                         # plane | helicopter
       all: <preset-name>               # default preset for all aircraft of this type
-      <aircraft-type>: <preset-name>   # override for a specific DCS aircraft type (e.g. A-10C_2)
+      <aircraft-type>: <preset-name>   # override for a specific DCS type (e.g. A-10C_2) or a regex pattern (e.g. A[-]10C.*)
 ```
 
 ### Minimal example

--- a/doc/PIPELINE_REFERENCE.md
+++ b/doc/PIPELINE_REFERENCE.md
@@ -98,7 +98,7 @@ presets_assignments:
   <coalition>:                          # blue | red
     <catégorie>:                        # plane | helicopter
       all: <nom-préréglage>            # préréglage par défaut pour tous les aéronefs de ce type
-      <type-aéronef>: <nom-préréglage> # surcharge pour un type DCS spécifique (ex: A-10C_2)
+      <type-aéronef>: <nom-préréglage> # surcharge pour un type DCS exact (ex: A-10C_2) ou un pattern regex (ex: A[-]10C.*)
 ```
 
 ### Exemple minimal

--- a/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
+++ b/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
@@ -207,7 +207,7 @@ def _parse_radio_settings_entries(content: str) -> list[_RadioEntry]:
         if radio_section_m:
             radio_block = _extract_block_at(block_text, radio_section_m.end() - 1)
             if radio_block:
-                for rm in re.finditer(r'\[(\d+)\]\s*=\s*\{', radio_block):
+                for rm in re.finditer(r"\[(\d+)\]\s*=\s*\{", radio_block):
                     idx = int(rm.group(1))
                     sub_block = _extract_block_at(radio_block, rm.end() - 1)
                     if sub_block:
@@ -805,9 +805,7 @@ def convert_presets(v5_path: Path, v6_path: Path) -> list[str]:
     for coalition in ("blue", "red"):
         warbird_preset_name = f"{coalition}_warbird"
         if warbird_preset_name in presets_collection.get(f"{coalition}_presets", {}):
-            warnings.append(
-                t("convert_v5.warn.warbird_preset", preset=warbird_preset_name, coalition=coalition)
-            )
+            warnings.append(t("convert_v5.warn.warbird_preset", preset=warbird_preset_name, coalition=coalition))
 
     output: dict[str, Any] = {
         "radios_collection": radios_collection,

--- a/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
+++ b/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
@@ -745,7 +745,9 @@ def convert_presets(v5_path: Path, v6_path: Path) -> list[str]:
             # FM-only or other — leave under the "all" fallback
             continue
 
-        presets_assignments[entry.coalition].setdefault("plane", {})[entry.aircraft] = target_preset
+        # radioSettings carries no plane/helicopter category — assign to both
+        for category in ("plane", "helicopter"):
+            presets_assignments[entry.coalition].setdefault(category, {})[entry.aircraft] = target_preset
 
     # Emit warbird warnings after processing all entries (so we know which were assigned)
     for coalition in ("blue", "red"):

--- a/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
+++ b/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
@@ -622,9 +622,13 @@ def convert_presets(v5_path: Path, v6_path: Path) -> list[str]:
     - ``presets_assignments:`` — ``all`` → standard preset for planes and
       helicopters of each coalition.
 
-    .. note::
-        Per-aircraft overrides (warbirds, historic aircraft) are not extracted
-        from ``radioSettings``.  A warning is emitted listing items to review.
+    Per-aircraft and per-pattern assignments are extracted from ``radioSettings``:
+
+    - Exact ``type`` entries and ``typePattern`` regex entries are both written
+      as keys in ``presets_assignments`` (the v6 injector supports regex keys).
+    - Warbird aircraft are assigned ``{coalition}_warbird``.
+    - VHF-primary aircraft get a new ``{coalition}_vhf_primary`` preset.
+    - Fully hardcoded entries (no preset table references) emit a warning.
     """
     warnings: list[str] = []
     content = v5_path.read_text(encoding="utf-8")
@@ -711,24 +715,6 @@ def convert_presets(v5_path: Path, v6_path: Path) -> list[str]:
 
         # Aircraft whose radio [1] is UHF are covered by the "all: standard" fallback
         if radio1_source == "uhf":
-            continue
-
-        if entry.is_pattern:
-            # typePattern entries cannot be represented as exact keys in presets_assignments
-            if radio1_source in ("warbird", "vhf"):
-                recommended = (
-                    f"{entry.coalition}_warbird"
-                    if radio1_source == "warbird"
-                    else f"{entry.coalition}_vhf_primary"
-                )
-                warnings.append(
-                    t(
-                        "convert_v5.warn.radio_type_pattern_skip",
-                        aircraft=entry.aircraft,
-                        coalition=entry.coalition,
-                        preset=recommended,
-                    )
-                )
             continue
 
         if radio1_source == "warbird":

--- a/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
+++ b/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
@@ -775,6 +775,16 @@ def convert_presets(v5_path: Path, v6_path: Path) -> list[str]:
                     "title": f"{entry.coalition.capitalize()} coalition - VHF primary",
                     "radios": {"radio_1": vhf_radio_name},
                 }
+        elif radio1_source == "fm":
+            target_preset = f"{entry.coalition}_fm_primary"
+            fm_radio_name = f"radio_fm_{entry.coalition}"
+            if fm_radio_name not in radios_collection.get(f"{entry.coalition}_radios", {}):
+                continue
+            if target_preset not in presets_collection.get(f"{entry.coalition}_presets", {}):
+                presets_collection.setdefault(f"{entry.coalition}_presets", {})[target_preset] = {
+                    "title": f"{entry.coalition.capitalize()} coalition - FM primary",
+                    "radios": {"radio_1": fm_radio_name},
+                }
         elif radio1_source is None:
             # Fully hardcoded frequencies — no preset mapping possible
             warnings.append(
@@ -786,7 +796,6 @@ def convert_presets(v5_path: Path, v6_path: Path) -> list[str]:
             )
             continue
         else:
-            # FM-only or other — leave under the "all" fallback
             continue
 
         for cat in _detect_category(entry.aircraft, entry.is_pattern, helicopter_types):

--- a/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
+++ b/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
@@ -188,15 +188,15 @@ def _parse_radio_settings_entries(content: str) -> list[_RadioEntry]:
             continue
 
         # Skip nested sub-tables (["Radio"], ["channels"], etc.) which lack type info
-        m_type = re.search(r'\btype\s*=\s*"([^"]+)"', block_text)
-        m_typepattern = re.search(r'\btypePattern\s*=\s*"([^"]+)"', block_text)
+        m_type = re.search(r'\btype\s*=\s*[\'"]([^\'"]+)[\'"]', block_text)
+        m_typepattern = re.search(r'\btypePattern\s*=\s*[\'"]([^\'"]+)[\'"]', block_text)
         if not m_type and not m_typepattern:
             continue
 
         aircraft = (m_type or m_typepattern).group(1)  # type: ignore[union-attr]
         is_pattern = m_typepattern is not None
 
-        m_coal = re.search(r'\bcoalition\s*=\s*"([^"]+)"', block_text)
+        m_coal = re.search(r'\bcoalition\s*=\s*[\'"]([^\'"]+)[\'"]', block_text)
         if not m_coal:
             continue
         coalition = m_coal.group(1).lower()

--- a/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
+++ b/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -79,6 +80,148 @@ def _extract_lua_table_text(content: str, table_name: str) -> str | None:
                 if depth == 0:
                     return content[start : i + 1]
     return None
+
+
+def _extract_block_at(text: str, open_brace_pos: int) -> str | None:
+    """Return the brace-enclosed text starting at *open_brace_pos*.
+
+    Args:
+        text: Source text containing the block.
+        open_brace_pos: Index of the opening ``{`` character.
+
+    Returns:
+        Slice from the opening ``{`` to its matching ``}``, inclusive,
+        or ``None`` if the braces are unmatched.
+    """
+    depth = 0
+    in_str = False
+    sc: str | None = None
+    esc = False
+    for i in range(open_brace_pos, len(text)):
+        c = text[i]
+        if esc:
+            esc = False
+            continue
+        if c == "\\" and in_str:
+            esc = True
+            continue
+        if c in ('"', "'") and not in_str:
+            in_str, sc = True, c
+        elif in_str and c == sc:
+            in_str = False
+        elif not in_str:
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[open_brace_pos : i + 1]
+    return None
+
+
+@dataclass
+class _RadioEntry:
+    """Per-aircraft entry parsed from the v5 ``radioSettings`` table."""
+
+    entry_key: str
+    aircraft: str
+    is_pattern: bool
+    coalition: str
+    radio_sources: dict[int, str | None] = field(default_factory=dict)
+    """Maps DCS radio index (1-based) to source: ``"uhf"``, ``"vhf"``, ``"fm"``,
+    ``"warbird"``, or ``None`` for hardcoded frequencies."""
+
+
+#: Ordered checks to identify which standard preset table a radio block references.
+#: First match wins (warbird > fm > vhf > uhf).
+_RADIO_SOURCE_CHECKS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"radioPresetsWarbird(?:Blue|Red)\s*\["), "warbird"),
+    (re.compile(r'radioPresets(?:Blue|Red)\["##RADIO3_'), "fm"),
+    (re.compile(r'radioPresets(?:Blue|Red)\["##RADIO2_'), "vhf"),
+    (re.compile(r'radioPresets(?:Blue|Red)\["##RADIO1_'), "uhf"),
+]
+
+
+def _detect_radio_block_source(block_text: str) -> str | None:
+    """Return which standard preset source *block_text* references, or ``None``.
+
+    Args:
+        block_text: Raw Lua text of a single radio ``[N] = { … }`` block.
+
+    Returns:
+        One of ``"uhf"``, ``"vhf"``, ``"fm"``, ``"warbird"``, or ``None``
+        when the block uses only hardcoded frequency literals.
+    """
+    for pattern, source in _RADIO_SOURCE_CHECKS:
+        if pattern.search(block_text):
+            return source
+    return None
+
+
+def _parse_radio_settings_entries(content: str) -> list[_RadioEntry]:
+    """Parse all entries from the v5 ``radioSettings`` table.
+
+    Each entry describes one aircraft type / coalition combination and which
+    standard preset source each DCS radio slot references.
+
+    Args:
+        content: Full text of the v5 ``radioSettings.lua`` file.
+
+    Returns:
+        List of :class:`_RadioEntry` instances, one per entry found.
+        Entries without a ``type`` / ``typePattern`` field are skipped.
+    """
+    table_text = _extract_lua_table_text(content, "radioSettings")
+    if not table_text:
+        return []
+
+    entries: list[_RadioEntry] = []
+    entry_pattern = re.compile(r'\["([^"]+)"\]\s*=\s*\{')
+
+    for m in entry_pattern.finditer(table_text):
+        entry_key = m.group(1)
+        block_start = m.end() - 1
+        block_text = _extract_block_at(table_text, block_start)
+        if not block_text:
+            continue
+
+        # Skip nested sub-tables (["Radio"], ["channels"], etc.) which lack type info
+        m_type = re.search(r'\btype\s*=\s*"([^"]+)"', block_text)
+        m_typepattern = re.search(r'\btypePattern\s*=\s*"([^"]+)"', block_text)
+        if not m_type and not m_typepattern:
+            continue
+
+        aircraft = (m_type or m_typepattern).group(1)  # type: ignore[union-attr]
+        is_pattern = m_typepattern is not None
+
+        m_coal = re.search(r'\bcoalition\s*=\s*"([^"]+)"', block_text)
+        if not m_coal:
+            continue
+        coalition = m_coal.group(1).lower()
+
+        # Parse radio sources from ["Radio"] = { [N] = { … }, … }
+        radio_sources: dict[int, str | None] = {}
+        radio_section_m = re.search(r'\["Radio"\]\s*=\s*\{', block_text)
+        if radio_section_m:
+            radio_block = _extract_block_at(block_text, radio_section_m.end() - 1)
+            if radio_block:
+                for rm in re.finditer(r'\[(\d+)\]\s*=\s*\{', radio_block):
+                    idx = int(rm.group(1))
+                    sub_block = _extract_block_at(radio_block, rm.end() - 1)
+                    if sub_block:
+                        radio_sources[idx] = _detect_radio_block_source(sub_block)
+
+        entries.append(
+            _RadioEntry(
+                entry_key=entry_key,
+                aircraft=aircraft,
+                is_pattern=is_pattern,
+                coalition=coalition,
+                radio_sources=radio_sources,
+            )
+        )
+
+    return entries
 
 
 def _parse_lua_table(content: str, table_name: str) -> dict[str, Any] | None:
@@ -554,11 +697,77 @@ def convert_presets(v5_path: Path, v6_path: Path) -> list[str]:
                 "title": f"{cap} coalition - warbird",
                 "radios": {"radio_1": warbird_radio_name},
             }
-            warnings.append(t("convert_v5.warn.warbird_preset", preset=warbird_preset_name, coalition=coalition))
 
     if not radios_collection:
         warnings.append(t("convert_v5.warn.no_preset_tables", filename=v5_path.name))
         return warnings
+
+    # Per-aircraft assignments extracted from radioSettings
+    for entry in _parse_radio_settings_entries(content):
+        if not entry.radio_sources or entry.coalition not in presets_assignments:
+            continue
+
+        radio1_source = entry.radio_sources.get(1)
+
+        # Aircraft whose radio [1] is UHF are covered by the "all: standard" fallback
+        if radio1_source == "uhf":
+            continue
+
+        if entry.is_pattern:
+            # typePattern entries cannot be represented as exact keys in presets_assignments
+            if radio1_source in ("warbird", "vhf"):
+                recommended = (
+                    f"{entry.coalition}_warbird"
+                    if radio1_source == "warbird"
+                    else f"{entry.coalition}_vhf_primary"
+                )
+                warnings.append(
+                    t(
+                        "convert_v5.warn.radio_type_pattern_skip",
+                        aircraft=entry.aircraft,
+                        coalition=entry.coalition,
+                        preset=recommended,
+                    )
+                )
+            continue
+
+        if radio1_source == "warbird":
+            target_preset = f"{entry.coalition}_warbird"
+            if target_preset not in presets_collection.get(f"{entry.coalition}_presets", {}):
+                continue
+        elif radio1_source == "vhf":
+            target_preset = f"{entry.coalition}_vhf_primary"
+            vhf_radio_name = f"radio_vhf_{entry.coalition}"
+            if vhf_radio_name not in radios_collection.get(f"{entry.coalition}_radios", {}):
+                continue
+            if target_preset not in presets_collection.get(f"{entry.coalition}_presets", {}):
+                presets_collection.setdefault(f"{entry.coalition}_presets", {})[target_preset] = {
+                    "title": f"{entry.coalition.capitalize()} coalition - VHF primary",
+                    "radios": {"radio_1": vhf_radio_name},
+                }
+        elif radio1_source is None:
+            # Fully hardcoded frequencies — no preset mapping possible
+            warnings.append(
+                t(
+                    "convert_v5.warn.radio_hardcoded_skip",
+                    aircraft=entry.aircraft,
+                    coalition=entry.coalition,
+                )
+            )
+            continue
+        else:
+            # FM-only or other — leave under the "all" fallback
+            continue
+
+        presets_assignments[entry.coalition].setdefault("plane", {})[entry.aircraft] = target_preset
+
+    # Emit warbird warnings after processing all entries (so we know which were assigned)
+    for coalition in ("blue", "red"):
+        warbird_preset_name = f"{coalition}_warbird"
+        if warbird_preset_name in presets_collection.get(f"{coalition}_presets", {}):
+            warnings.append(
+                t("convert_v5.warn.warbird_preset", preset=warbird_preset_name, coalition=coalition)
+            )
 
     output: dict[str, Any] = {
         "radios_collection": radios_collection,

--- a/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
+++ b/src/python/veaf-tools/mission_builder/v5_pipeline_converters.py
@@ -14,8 +14,10 @@ convert_pipeline_file(step, v5_path, v6_path, *, icao_callback=None)
 
 from __future__ import annotations
 
+import importlib.resources
 import json
 import re
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -611,6 +613,47 @@ def _parse_custom_preset_table(content: str, table_name: str) -> list[float]:
     return [v for _, v in sorted(freq_by_key.items())]
 
 
+def _load_helicopter_types() -> set[str]:
+    """Return the set of DCS unit type names classified as helicopters in dcs-radio-specs.yaml."""
+    bundle_path = Path(getattr(sys, "_MEIPASS", "")) / "presets_injector" / "data" / "dcs-radio-specs.yaml"
+    if bundle_path.exists():
+        raw = bundle_path.read_text(encoding="utf-8")
+    else:
+        pkg = importlib.resources.files("presets_injector.data")
+        raw = (pkg / "dcs-radio-specs.yaml").read_text(encoding="utf-8")  # type: ignore[arg-type]
+    specs: dict[str, Any] = yaml.safe_load(raw) or {}
+    return {name for name, info in specs.items() if isinstance(info, dict) and info.get("category") == "helicopter"}
+
+
+def _detect_category(aircraft: str, is_pattern: bool, helicopter_types: set[str]) -> list[str]:
+    """Return the list of assignment categories for an aircraft entry.
+
+    Args:
+        aircraft: Exact DCS unit type name or regex pattern (when ``is_pattern`` is True).
+        is_pattern: Whether ``aircraft`` is a ``typePattern`` regex.
+        helicopter_types: Set of known DCS helicopter unit type names.
+
+    Returns:
+        A list containing ``"helicopter"``, ``"plane"``, or both.
+    """
+    if is_pattern:
+        helis_matched = any(_safe_fullmatch(aircraft, h) for h in helicopter_types)
+        # Since we cannot enumerate all plane types, conservatively assign to both
+        # categories when the pattern matches at least one helicopter.
+        if helis_matched:
+            return ["helicopter", "plane"]
+        return ["plane"]
+    return ["helicopter"] if aircraft in helicopter_types else ["plane"]
+
+
+def _safe_fullmatch(pattern: str, text: str) -> bool:
+    """Return True if ``pattern`` fully matches ``text``, False on error or no match."""
+    try:
+        return bool(re.fullmatch(pattern, text))
+    except re.error:
+        return False
+
+
 def convert_presets(v5_path: Path, v6_path: Path) -> list[str]:
     """Convert v5 ``radioSettings.lua`` → v6 ``presets.yaml``.
 
@@ -632,6 +675,7 @@ def convert_presets(v5_path: Path, v6_path: Path) -> list[str]:
     """
     warnings: list[str] = []
     content = v5_path.read_text(encoding="utf-8")
+    helicopter_types = _load_helicopter_types()
 
     radios_collection: dict[str, Any] = {}
     presets_collection: dict[str, Any] = {}
@@ -745,9 +789,8 @@ def convert_presets(v5_path: Path, v6_path: Path) -> list[str]:
             # FM-only or other — leave under the "all" fallback
             continue
 
-        # radioSettings carries no plane/helicopter category — assign to both
-        for category in ("plane", "helicopter"):
-            presets_assignments[entry.coalition].setdefault(category, {})[entry.aircraft] = target_preset
+        for cat in _detect_category(entry.aircraft, entry.is_pattern, helicopter_types):
+            presets_assignments[entry.coalition].setdefault(cat, {})[entry.aircraft] = target_preset
 
     # Emit warbird warnings after processing all entries (so we know which were assigned)
     for coalition in ("blue", "red"):

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -79,7 +79,11 @@ class PresetsInjectorWorker(GroupInjectorWorker):
                     if "frequency" in group.group_dcs:
                         del group.group_dcs["frequency"]
                 elif first_freq := preset_definition.get_freq_of_first_channel_of_first_radio():
-                    group.group_dcs["frequency"] = first_freq
+                    # FM-primary radios (Gazelle, Ka-50…) have HumanRadio in VHF/UHF range:
+                    # injecting the FM channel freq would make the ME flag it as invalid.
+                    first_radio_type = next(iter(preset_definition.radios.values())).radio_type
+                    if first_radio_type != "fm":
+                        group.group_dcs["frequency"] = first_freq
 
         if preset_definition != PresetDefinition.EMPTY and group.unit_type:
             channel_freqs = [

--- a/src/python/veaf-tools/presets_injector/presets_manager.py
+++ b/src/python/veaf-tools/presets_injector/presets_manager.py
@@ -18,6 +18,7 @@ This module provides classes to manage radio presets.
 # TODO add modulation
 
 import io
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar
@@ -452,17 +453,41 @@ class PresetAssignmentCollection:
                     preset_assignments_aircraft_type_dict[unit_type] = preset_assignment
         return result
 
+    @staticmethod
+    def _match_unit_type(d: dict[str, "PresetAssignment"], unit_type: str) -> "PresetAssignment | None":
+        """Look up *unit_type* in *d* with exact-match priority, then regex pattern fallback.
+
+        Args:
+            d: Mapping of unit_type key → PresetAssignment (may contain regex patterns).
+            unit_type: DCS aircraft type string to look up.
+
+        Returns:
+            The matching :class:`PresetAssignment`, or ``None`` if no key matches.
+            The ``"all"`` wildcard key is intentionally excluded — callers handle it separately.
+        """
+        if unit_type in d:
+            return d[unit_type]
+        for key, assignment in d.items():
+            if key == "all":
+                continue
+            try:
+                if re.fullmatch(key, unit_type):
+                    return assignment
+            except re.error:
+                pass
+        return None
+
     def get_preset_for(
         self, coalition: str = "all", aircraft_type: str = "all", unit_type: str = "all"
     ) -> PresetAssignment | None:
+        def _unit(d: dict[str, "PresetAssignment"]) -> "PresetAssignment | None":
+            return self._match_unit_type(d, unit_type) or d.get("all")
+
         return (
-            self.preset_assignments_dict.get(coalition, {}).get(aircraft_type, {}).get(unit_type)
-            or self.preset_assignments_dict.get(coalition, {}).get(aircraft_type, {}).get("all")
-            or self.preset_assignments_dict.get(coalition, {}).get("all", {}).get(unit_type)
-            or self.preset_assignments_dict.get("all", {}).get(aircraft_type, {}).get(unit_type)
-            or self.preset_assignments_dict.get("all", {}).get(aircraft_type, {}).get("all")
-            or self.preset_assignments_dict.get("all", {}).get("all", {}).get(unit_type)
-            or self.preset_assignments_dict.get("all", {}).get("all", {}).get("all")
+            _unit(self.preset_assignments_dict.get(coalition, {}).get(aircraft_type, {}))
+            or _unit(self.preset_assignments_dict.get(coalition, {}).get("all", {}))
+            or _unit(self.preset_assignments_dict.get("all", {}).get(aircraft_type, {}))
+            or _unit(self.preset_assignments_dict.get("all", {}).get("all", {}))
         )
 
 

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -225,7 +225,6 @@
   "convert_v5.warning.init_commented": "line {line}: {var}.initialize() commented out (veaf-config.lua handles init)",
   "convert_v5.warning.no_converter": "No converter implemented for pipeline step '{step}'",
   "convert_v5.warn.warbird_preset": "Warbird preset '{preset}' created for coalition '{coalition}'. Aircraft with typePattern entries (e.g. FW-190 variants) must be added manually to presets_assignments.",
-  "convert_v5.warn.radio_type_pattern_skip": "'{aircraft}' ({coalition}): typePattern entry — add manually to presets_assignments with preset '{preset}'.",
   "convert_v5.warn.radio_hardcoded_skip": "'{aircraft}' ({coalition}): uses hardcoded frequencies — no preset assignment generated, review manually.",
   "convert_v5.warn.no_preset_tables": "No standard preset tables (radioPresetsBlue/Red) found in {filename}",
   "convert_v5.warn.review_presets": "Review {filename}: only standard UHF/VHF/FM presets generated. Warbirds and other special aircraft may need manual presets_assignments entries.",

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -224,7 +224,9 @@
 
   "convert_v5.warning.init_commented": "line {line}: {var}.initialize() commented out (veaf-config.lua handles init)",
   "convert_v5.warning.no_converter": "No converter implemented for pipeline step '{step}'",
-  "convert_v5.warn.warbird_preset": "Warbird preset '{preset}' created for coalition '{coalition}'. Add aircraft-type entries to presets_assignments manually (e.g. Bf-109K-4, FW-190A-8, …).",
+  "convert_v5.warn.warbird_preset": "Warbird preset '{preset}' created for coalition '{coalition}'. Aircraft with typePattern entries (e.g. FW-190 variants) must be added manually to presets_assignments.",
+  "convert_v5.warn.radio_type_pattern_skip": "'{aircraft}' ({coalition}): typePattern entry — add manually to presets_assignments with preset '{preset}'.",
+  "convert_v5.warn.radio_hardcoded_skip": "'{aircraft}' ({coalition}): uses hardcoded frequencies — no preset assignment generated, review manually.",
   "convert_v5.warn.no_preset_tables": "No standard preset tables (radioPresetsBlue/Red) found in {filename}",
   "convert_v5.warn.review_presets": "Review {filename}: only standard UHF/VHF/FM presets generated. Warbirds and other special aircraft may need manual presets_assignments entries.",
   "convert_v5.warn.parse_failed": "Could not parse {filename}: {exc}",

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -224,7 +224,7 @@
 
   "convert_v5.warning.init_commented": "line {line}: {var}.initialize() commented out (veaf-config.lua handles init)",
   "convert_v5.warning.no_converter": "No converter implemented for pipeline step '{step}'",
-  "convert_v5.warn.warbird_preset": "Warbird preset '{preset}' created for coalition '{coalition}'. Aircraft with typePattern entries (e.g. FW-190 variants) must be added manually to presets_assignments.",
+  "convert_v5.warn.warbird_preset": "Warbird preset '{preset}' created for coalition '{coalition}'. Aircraft assignments (exact types and typePattern regex) have been auto-generated in presets_assignments — review and adjust if needed.",
   "convert_v5.warn.radio_hardcoded_skip": "'{aircraft}' ({coalition}): uses hardcoded frequencies — no preset assignment generated, review manually.",
   "convert_v5.warn.no_preset_tables": "No standard preset tables (radioPresetsBlue/Red) found in {filename}",
   "convert_v5.warn.review_presets": "Review {filename}: only standard UHF/VHF/FM presets generated. Warbirds and other special aircraft may need manual presets_assignments entries.",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -228,7 +228,9 @@
 
   "convert_v5.warning.init_commented": "ligne {line} : {var}.initialize() mis en commentaire (veaf-config.lua gère l'initialisation)",
   "convert_v5.warning.no_converter": "Aucun convertisseur implémenté pour l'étape de pipeline '{step}'",
-  "convert_v5.warn.warbird_preset": "Préréglage warbird '{preset}' créé pour la coalition '{coalition}'. Ajoutez manuellement des entrées de type d'aéronef dans presets_assignments (ex. Bf-109K-4, FW-190A-8, …).",
+  "convert_v5.warn.warbird_preset": "Préréglage warbird '{preset}' créé pour la coalition '{coalition}'. Les entrées typePattern (ex. variantes FW-190) doivent être ajoutées manuellement dans presets_assignments.",
+  "convert_v5.warn.radio_type_pattern_skip": "'{aircraft}' ({coalition}) : entrée typePattern — ajoutez manuellement dans presets_assignments avec le préréglage '{preset}'.",
+  "convert_v5.warn.radio_hardcoded_skip": "'{aircraft}' ({coalition}) : fréquences codées en dur — aucune assignation de préréglage générée, à vérifier manuellement.",
   "convert_v5.warn.no_preset_tables": "Aucune table de préréglages standard (radioPresetsBlue/Red) trouvée dans {filename}",
   "convert_v5.warn.review_presets": "Vérifiez {filename} : seuls les préréglages UHF/VHF/FM standard ont été générés. Les warbirds et autres aéronefs spéciaux peuvent nécessiter des entrées manuelles dans presets_assignments.",
   "convert_v5.warn.parse_failed": "Impossible d'analyser {filename} : {exc}",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -228,7 +228,7 @@
 
   "convert_v5.warning.init_commented": "ligne {line} : {var}.initialize() mis en commentaire (veaf-config.lua gère l'initialisation)",
   "convert_v5.warning.no_converter": "Aucun convertisseur implémenté pour l'étape de pipeline '{step}'",
-  "convert_v5.warn.warbird_preset": "Préréglage warbird '{preset}' créé pour la coalition '{coalition}'. Les entrées typePattern (ex. variantes FW-190) doivent être ajoutées manuellement dans presets_assignments.",
+  "convert_v5.warn.warbird_preset": "Préréglage warbird '{preset}' créé pour la coalition '{coalition}'. Les assignations d'aéronefs (types exacts et regex typePattern) ont été générées automatiquement dans presets_assignments — vérifiez et ajustez si nécessaire.",
   "convert_v5.warn.radio_hardcoded_skip": "'{aircraft}' ({coalition}) : fréquences codées en dur — aucune assignation de préréglage générée, à vérifier manuellement.",
   "convert_v5.warn.no_preset_tables": "Aucune table de préréglages standard (radioPresetsBlue/Red) trouvée dans {filename}",
   "convert_v5.warn.review_presets": "Vérifiez {filename} : seuls les préréglages UHF/VHF/FM standard ont été générés. Les warbirds et autres aéronefs spéciaux peuvent nécessiter des entrées manuelles dans presets_assignments.",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -229,7 +229,6 @@
   "convert_v5.warning.init_commented": "ligne {line} : {var}.initialize() mis en commentaire (veaf-config.lua gère l'initialisation)",
   "convert_v5.warning.no_converter": "Aucun convertisseur implémenté pour l'étape de pipeline '{step}'",
   "convert_v5.warn.warbird_preset": "Préréglage warbird '{preset}' créé pour la coalition '{coalition}'. Les entrées typePattern (ex. variantes FW-190) doivent être ajoutées manuellement dans presets_assignments.",
-  "convert_v5.warn.radio_type_pattern_skip": "'{aircraft}' ({coalition}) : entrée typePattern — ajoutez manuellement dans presets_assignments avec le préréglage '{preset}'.",
   "convert_v5.warn.radio_hardcoded_skip": "'{aircraft}' ({coalition}) : fréquences codées en dur — aucune assignation de préréglage générée, à vérifier manuellement.",
   "convert_v5.warn.no_preset_tables": "Aucune table de préréglages standard (radioPresetsBlue/Red) trouvée dans {filename}",
   "convert_v5.warn.review_presets": "Vérifiez {filename} : seuls les préréglages UHF/VHF/FM standard ont été générés. Les warbirds et autres aéronefs spéciaux peuvent nécessiter des entrées manuelles dans presets_assignments.",

--- a/test/python/mission_builder/test_v5_pipeline_converters.py
+++ b/test/python/mission_builder/test_v5_pipeline_converters.py
@@ -18,10 +18,12 @@ from pathlib import Path
 import luadata
 import yaml
 from mission_builder.v5_pipeline_converters import (
+    _detect_radio_block_source,
     _extract_lua_table_text,
     _normalize_date,
     _parse_custom_preset_table,
     _parse_preset_table,
+    _parse_radio_settings_entries,
     convert_aircraft_groups,
     convert_pipeline_file,
     convert_presets,
@@ -324,6 +326,258 @@ class TestConvertPresets(unittest.TestCase):
         v6 = self.tmp / "presets.yaml"
         warns = convert_presets(v5, v6)
         self.assertTrue(any(v6.name in w for w in warns))
+
+
+class TestDetectRadioBlockSource(unittest.TestCase):
+    def test_uhf_detected(self) -> None:
+        block = '{ ["channels"] = { [1] = radioPresetsBlue["##RADIO1_01##"] } }'
+        self.assertEqual(_detect_radio_block_source(block), "uhf")
+
+    def test_vhf_detected(self) -> None:
+        block = '{ ["channels"] = { [1] = radioPresetsBlue["##RADIO2_01##"] } }'
+        self.assertEqual(_detect_radio_block_source(block), "vhf")
+
+    def test_fm_detected(self) -> None:
+        block = '{ ["channels"] = { [1] = radioPresetsBlue["##RADIO3_01##"] } }'
+        self.assertEqual(_detect_radio_block_source(block), "fm")
+
+    def test_warbird_detected(self) -> None:
+        block = '{ ["channels"] = { [1] = radioPresetsWarbirdBlue["##RADIO_FuG16_01##"] } }'
+        self.assertEqual(_detect_radio_block_source(block), "warbird")
+
+    def test_hardcoded_returns_none(self) -> None:
+        block = '{ ["channels"] = { [1] = 284.000, [2] = 251.0 } }'
+        self.assertIsNone(_detect_radio_block_source(block))
+
+    def test_red_coalition_uhf_detected(self) -> None:
+        block = '{ ["channels"] = { [1] = radioPresetsRed["##RADIO1_01##"] } }'
+        self.assertEqual(_detect_radio_block_source(block), "uhf")
+
+
+class TestParseRadioSettingsEntries(unittest.TestCase):
+    _LUA_STANDARD = """
+radioSettings = {
+    ["blue F-16C"] = {
+        type = "F-16C_50",
+        coalition = "blue",
+        country = nil,
+        ["Radio"] = {
+            [1] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO1_01##"] } },
+            [2] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO2_01##"] } },
+            [3] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO3_01##"] } },
+        },
+    },
+}
+"""
+
+    _LUA_WARBIRD = """
+radioSettings = {
+    ["blue Bf-109K-4"] = {
+        type = "Bf-109K-4",
+        coalition = "blue",
+        country = nil,
+        ["Radio"] = {
+            [1] = { ["channels"] = { [1] = radioPresetsWarbirdBlue["##RADIO_FuG16_01##"] } },
+        },
+    },
+}
+"""
+
+    _LUA_VHF_PRIMARY = """
+radioSettings = {
+    ["blue I-16"] = {
+        type = "I-16",
+        coalition = "blue",
+        country = nil,
+        ["Radio"] = {
+            [1] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO2_01##"] } },
+        },
+    },
+}
+"""
+
+    _LUA_TYPE_PATTERN = """
+radioSettings = {
+    ["blue FW-190s"] = {
+        typePattern = "FW[-]190.*",
+        coalition = "blue",
+        country = nil,
+        ["Radio"] = {
+            [1] = { ["channels"] = { [1] = radioPresetsWarbirdBlue["##RADIO_FuG16_01##"] } },
+        },
+    },
+}
+"""
+
+    _LUA_HARDCODED = """
+radioSettings = {
+    ["blue AJS37"] = {
+        type = "AJS37",
+        coalition = "blue",
+        country = nil,
+        ["Radio"] = {
+            [1] = { ["channels"] = { [1] = 284.000, [2] = 271.500 } },
+        },
+    },
+}
+"""
+
+    def test_standard_entry_parsed(self) -> None:
+        entries = _parse_radio_settings_entries(self._LUA_STANDARD)
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertEqual(e.aircraft, "F-16C_50")
+        self.assertFalse(e.is_pattern)
+        self.assertEqual(e.coalition, "blue")
+        self.assertEqual(e.radio_sources[1], "uhf")
+        self.assertEqual(e.radio_sources[2], "vhf")
+        self.assertEqual(e.radio_sources[3], "fm")
+
+    def test_warbird_entry_parsed(self) -> None:
+        entries = _parse_radio_settings_entries(self._LUA_WARBIRD)
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertEqual(e.aircraft, "Bf-109K-4")
+        self.assertEqual(e.radio_sources[1], "warbird")
+
+    def test_vhf_primary_entry_parsed(self) -> None:
+        entries = _parse_radio_settings_entries(self._LUA_VHF_PRIMARY)
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertEqual(e.aircraft, "I-16")
+        self.assertEqual(e.radio_sources[1], "vhf")
+
+    def test_type_pattern_entry_parsed(self) -> None:
+        entries = _parse_radio_settings_entries(self._LUA_TYPE_PATTERN)
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertTrue(e.is_pattern)
+        self.assertEqual(e.aircraft, "FW[-]190.*")
+        self.assertEqual(e.radio_sources[1], "warbird")
+
+    def test_hardcoded_entry_radio_source_is_none(self) -> None:
+        entries = _parse_radio_settings_entries(self._LUA_HARDCODED)
+        self.assertEqual(len(entries), 1)
+        self.assertIsNone(entries[0].radio_sources.get(1))
+
+    def test_no_radio_settings_returns_empty(self) -> None:
+        entries = _parse_radio_settings_entries("x = 1")
+        self.assertEqual(entries, [])
+
+
+class TestConvertPresetsPerAircraftAssignments(unittest.TestCase):
+    """convert_presets must generate per-aircraft assignments for non-standard radio layouts."""
+
+    def setUp(self) -> None:
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp_dir.name)
+
+    def tearDown(self) -> None:
+        self._tmp_dir.cleanup()
+
+    def _write_lua(self, content: str) -> Path:
+        p = self.tmp / "radioSettings.lua"
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def _lua(self, extra_settings: str = "") -> str:
+        return (
+            'radioPresetsBlue = { ["##RADIO1_01##"] = 284.0, ["##RADIO2_01##"] = 134.0 }\n'
+            'radioPresetsWarbirdBlue = { ["##RADIO_FuG16_01##"] = 38.4 }\n'
+            + extra_settings
+        )
+
+    def test_warbird_aircraft_assigned_warbird_preset(self) -> None:
+        lua = self._lua("""
+radioSettings = {
+    ["blue Bf109"] = { type = "Bf-109K-4", coalition = "blue", country = nil,
+        ["Radio"] = { [1] = { ["channels"] = { [1] = radioPresetsWarbirdBlue["##RADIO_FuG16_01##"] } } }
+    },
+}
+""")
+        v5 = self._write_lua(lua)
+        v6 = self.tmp / "presets.yaml"
+        convert_presets(v5, v6)
+        data = yaml.safe_load(v6.read_text())
+        assignments = data["presets_assignments"]["blue"]["plane"]
+        self.assertEqual(assignments.get("Bf-109K-4"), "blue_warbird")
+
+    def test_vhf_primary_aircraft_gets_vhf_primary_preset(self) -> None:
+        lua = self._lua("""
+radioSettings = {
+    ["blue I16"] = { type = "I-16", coalition = "blue", country = nil,
+        ["Radio"] = { [1] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO2_01##"] } } }
+    },
+}
+""")
+        v5 = self._write_lua(lua)
+        v6 = self.tmp / "presets.yaml"
+        convert_presets(v5, v6)
+        data = yaml.safe_load(v6.read_text())
+        assignments = data["presets_assignments"]["blue"]["plane"]
+        self.assertEqual(assignments.get("I-16"), "blue_vhf_primary")
+        # Preset must also be created
+        self.assertIn("blue_vhf_primary", data["presets_collection"]["blue_presets"])
+
+    def test_vhf_primary_preset_uses_vhf_radio(self) -> None:
+        lua = self._lua("""
+radioSettings = {
+    ["blue I16"] = { type = "I-16", coalition = "blue", country = nil,
+        ["Radio"] = { [1] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO2_01##"] } } }
+    },
+}
+""")
+        v5 = self._write_lua(lua)
+        v6 = self.tmp / "presets.yaml"
+        convert_presets(v5, v6)
+        data = yaml.safe_load(v6.read_text())
+        preset = data["presets_collection"]["blue_presets"]["blue_vhf_primary"]
+        self.assertEqual(preset["radios"]["radio_1"], "radio_vhf_blue")
+
+    def test_standard_aircraft_not_duplicated_in_assignments(self) -> None:
+        lua = self._lua("""
+radioSettings = {
+    ["blue F16"] = { type = "F-16C_50", coalition = "blue", country = nil,
+        ["Radio"] = {
+            [1] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO1_01##"] } },
+            [2] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO2_01##"] } },
+        }
+    },
+}
+""")
+        v5 = self._write_lua(lua)
+        v6 = self.tmp / "presets.yaml"
+        convert_presets(v5, v6)
+        data = yaml.safe_load(v6.read_text())
+        assignments = data["presets_assignments"]["blue"]["plane"]
+        # F-16C_50 starts with UHF radio → covered by "all", no explicit entry needed
+        self.assertNotIn("F-16C_50", assignments)
+
+    def test_type_pattern_entry_emits_warning(self) -> None:
+        lua = self._lua("""
+radioSettings = {
+    ["blue FW190s"] = { typePattern = "FW[-]190.*", coalition = "blue", country = nil,
+        ["Radio"] = { [1] = { ["channels"] = { [1] = radioPresetsWarbirdBlue["##RADIO_FuG16_01##"] } } }
+    },
+}
+""")
+        v5 = self._write_lua(lua)
+        v6 = self.tmp / "presets.yaml"
+        warns = convert_presets(v5, v6)
+        self.assertTrue(any("FW[-]190.*" in w for w in warns))
+
+    def test_hardcoded_entry_emits_warning(self) -> None:
+        lua = self._lua("""
+radioSettings = {
+    ["blue AJS37"] = { type = "AJS37", coalition = "blue", country = nil,
+        ["Radio"] = { [1] = { ["channels"] = { [1] = 284.000 } } }
+    },
+}
+""")
+        v5 = self._write_lua(lua)
+        v6 = self.tmp / "presets.yaml"
+        warns = convert_presets(v5, v6)
+        self.assertTrue(any("AJS37" in w for w in warns))
 
 
 class TestConvertAircraftGroups(unittest.TestCase):

--- a/test/python/mission_builder/test_v5_pipeline_converters.py
+++ b/test/python/mission_builder/test_v5_pipeline_converters.py
@@ -614,13 +614,13 @@ radioSettings = {
         self.assertEqual(data["presets_assignments"]["blue"]["plane"].get("F16.*"), "blue_vhf_primary")
         self.assertIn("blue_vhf_primary", data["presets_collection"]["blue_presets"])
 
-    def test_fm_only_aircraft_produces_no_assignment(self) -> None:
+    def test_fm_primary_aircraft_assigned_fm_primary_preset(self) -> None:
         lua = (
             'radioPresetsBlue = { ["##RADIO1_01##"] = 284.0, ["##RADIO2_01##"] = 134.0, ["##RADIO3_01##"] = 30.5 }\n'
             'radioPresetsWarbirdBlue = { ["##RADIO_FuG16_01##"] = 38.4 }\n'
             """
 radioSettings = {
-    ["blue UH1"] = { type = "UH-1H", coalition = "blue", country = nil,
+    ["blue Gazelles"] = { typePattern = "SA342.+", coalition = "blue", country = nil,
         ["Radio"] = { [1] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO3_01##"] } } }
     },
 }
@@ -631,9 +631,10 @@ radioSettings = {
         convert_presets(v5, v6)
         data = yaml.safe_load(v6.read_text())
         heli = data["presets_assignments"]["blue"]["helicopter"]
-        plane = data["presets_assignments"]["blue"]["plane"]
-        self.assertNotIn("UH-1H", heli)
-        self.assertNotIn("UH-1H", plane)
+        self.assertEqual(heli.get("SA342.+"), "blue_fm_primary")
+        self.assertIn("blue_fm_primary", data["presets_collection"]["blue_presets"])
+        preset = data["presets_collection"]["blue_presets"]["blue_fm_primary"]
+        self.assertEqual(preset["radios"]["radio_1"], "radio_fm_blue")
 
     def test_red_coalition_warbird_assigned(self) -> None:
         lua = (

--- a/test/python/mission_builder/test_v5_pipeline_converters.py
+++ b/test/python/mission_builder/test_v5_pipeline_converters.py
@@ -553,7 +553,7 @@ radioSettings = {
         # F-16C_50 starts with UHF radio → covered by "all", no explicit entry needed
         self.assertNotIn("F-16C_50", assignments)
 
-    def test_type_pattern_entry_emits_warning(self) -> None:
+    def test_type_pattern_entry_assigned(self) -> None:
         lua = self._lua("""
 radioSettings = {
     ["blue FW190s"] = { typePattern = "FW[-]190.*", coalition = "blue", country = nil,
@@ -563,8 +563,10 @@ radioSettings = {
 """)
         v5 = self._write_lua(lua)
         v6 = self.tmp / "presets.yaml"
-        warns = convert_presets(v5, v6)
-        self.assertTrue(any("FW[-]190.*" in w for w in warns))
+        convert_presets(v5, v6)
+        data = yaml.safe_load(v6.read_text())
+        assignments = data["presets_assignments"]["blue"]["plane"]
+        self.assertEqual(assignments.get("FW[-]190.*"), "blue_warbird")
 
     def test_hardcoded_entry_emits_warning(self) -> None:
         lua = self._lua("""

--- a/test/python/mission_builder/test_v5_pipeline_converters.py
+++ b/test/python/mission_builder/test_v5_pipeline_converters.py
@@ -599,6 +599,60 @@ radioSettings = {
         warns = convert_presets(v5, v6)
         self.assertTrue(any("AJS37" in w for w in warns))
 
+    def test_type_pattern_vhf_primary_assigned(self) -> None:
+        lua = self._lua("""
+radioSettings = {
+    ["blue VHF types"] = { typePattern = "F16.*", coalition = "blue", country = nil,
+        ["Radio"] = { [1] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO2_01##"] } } }
+    },
+}
+""")
+        v5 = self._write_lua(lua)
+        v6 = self.tmp / "presets.yaml"
+        convert_presets(v5, v6)
+        data = yaml.safe_load(v6.read_text())
+        self.assertEqual(data["presets_assignments"]["blue"]["plane"].get("F16.*"), "blue_vhf_primary")
+        self.assertIn("blue_vhf_primary", data["presets_collection"]["blue_presets"])
+
+    def test_fm_only_aircraft_produces_no_assignment(self) -> None:
+        lua = (
+            'radioPresetsBlue = { ["##RADIO1_01##"] = 284.0, ["##RADIO2_01##"] = 134.0, ["##RADIO3_01##"] = 30.5 }\n'
+            'radioPresetsWarbirdBlue = { ["##RADIO_FuG16_01##"] = 38.4 }\n'
+            """
+radioSettings = {
+    ["blue UH1"] = { type = "UH-1H", coalition = "blue", country = nil,
+        ["Radio"] = { [1] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO3_01##"] } } }
+    },
+}
+"""
+        )
+        v5 = self._write_lua(lua)
+        v6 = self.tmp / "presets.yaml"
+        convert_presets(v5, v6)
+        data = yaml.safe_load(v6.read_text())
+        heli = data["presets_assignments"]["blue"]["helicopter"]
+        plane = data["presets_assignments"]["blue"]["plane"]
+        self.assertNotIn("UH-1H", heli)
+        self.assertNotIn("UH-1H", plane)
+
+    def test_red_coalition_warbird_assigned(self) -> None:
+        lua = (
+            'radioPresetsRed = { ["##RADIO1_01##"] = 251.0, ["##RADIO2_01##"] = 127.0 }\n'
+            'radioPresetsWarbirdRed = { ["##RADIO_FuG16_01##"] = 38.4 }\n'
+            """
+radioSettings = {
+    ["red Bf109"] = { type = "Bf-109K-4", coalition = "red", country = nil,
+        ["Radio"] = { [1] = { ["channels"] = { [1] = radioPresetsWarbirdRed["##RADIO_FuG16_01##"] } } }
+    },
+}
+"""
+        )
+        v5 = self._write_lua(lua)
+        v6 = self.tmp / "presets.yaml"
+        convert_presets(v5, v6)
+        data = yaml.safe_load(v6.read_text())
+        self.assertEqual(data["presets_assignments"]["red"]["plane"].get("Bf-109K-4"), "red_warbird")
+
 
 class TestConvertAircraftGroups(unittest.TestCase):
     def setUp(self) -> None:

--- a/test/python/mission_builder/test_v5_pipeline_converters.py
+++ b/test/python/mission_builder/test_v5_pipeline_converters.py
@@ -499,8 +499,9 @@ radioSettings = {
         v6 = self.tmp / "presets.yaml"
         convert_presets(v5, v6)
         data = yaml.safe_load(v6.read_text())
-        assignments = data["presets_assignments"]["blue"]["plane"]
-        self.assertEqual(assignments.get("Bf-109K-4"), "blue_warbird")
+        # Assigned under both plane and helicopter (radioSettings carries no category info)
+        self.assertEqual(data["presets_assignments"]["blue"]["plane"].get("Bf-109K-4"), "blue_warbird")
+        self.assertEqual(data["presets_assignments"]["blue"]["helicopter"].get("Bf-109K-4"), "blue_warbird")
 
     def test_vhf_primary_aircraft_gets_vhf_primary_preset(self) -> None:
         lua = self._lua("""
@@ -567,6 +568,7 @@ radioSettings = {
         data = yaml.safe_load(v6.read_text())
         assignments = data["presets_assignments"]["blue"]["plane"]
         self.assertEqual(assignments.get("FW[-]190.*"), "blue_warbird")
+        self.assertEqual(data["presets_assignments"]["blue"]["helicopter"].get("FW[-]190.*"), "blue_warbird")
 
     def test_hardcoded_entry_emits_warning(self) -> None:
         lua = self._lua("""

--- a/test/python/mission_builder/test_v5_pipeline_converters.py
+++ b/test/python/mission_builder/test_v5_pipeline_converters.py
@@ -499,9 +499,8 @@ radioSettings = {
         v6 = self.tmp / "presets.yaml"
         convert_presets(v5, v6)
         data = yaml.safe_load(v6.read_text())
-        # Assigned under both plane and helicopter (radioSettings carries no category info)
         self.assertEqual(data["presets_assignments"]["blue"]["plane"].get("Bf-109K-4"), "blue_warbird")
-        self.assertEqual(data["presets_assignments"]["blue"]["helicopter"].get("Bf-109K-4"), "blue_warbird")
+        self.assertNotIn("Bf-109K-4", data["presets_assignments"]["blue"]["helicopter"])
 
     def test_vhf_primary_aircraft_gets_vhf_primary_preset(self) -> None:
         lua = self._lua("""
@@ -568,7 +567,24 @@ radioSettings = {
         data = yaml.safe_load(v6.read_text())
         assignments = data["presets_assignments"]["blue"]["plane"]
         self.assertEqual(assignments.get("FW[-]190.*"), "blue_warbird")
-        self.assertEqual(data["presets_assignments"]["blue"]["helicopter"].get("FW[-]190.*"), "blue_warbird")
+        self.assertNotIn("FW[-]190.*", data["presets_assignments"]["blue"]["helicopter"])
+
+    def test_helicopter_aircraft_assigned_to_helicopter_category(self) -> None:
+        lua = self._lua("""
+radioSettings = {
+    ["blue Mi8"] = { type = "Mi-8MT", coalition = "blue", country = nil,
+        ["Radio"] = {
+            [1] = { ["channels"] = { [1] = radioPresetsBlue["##RADIO2_01##"] } },
+        }
+    },
+}
+""")
+        v5 = self._write_lua(lua)
+        v6 = self.tmp / "presets.yaml"
+        convert_presets(v5, v6)
+        data = yaml.safe_load(v6.read_text())
+        self.assertEqual(data["presets_assignments"]["blue"]["helicopter"].get("Mi-8MT"), "blue_vhf_primary")
+        self.assertNotIn("Mi-8MT", data["presets_assignments"]["blue"]["plane"])
 
     def test_hardcoded_entry_emits_warning(self) -> None:
         lua = self._lua("""

--- a/test/python/presets_injector/test_presets.py
+++ b/test/python/presets_injector/test_presets.py
@@ -426,5 +426,76 @@ class TestPresets(unittest.TestCase):
         self.assertFalse(yaml_path.exists())
 
 
+class TestPresetAssignmentCollectionPatternMatching(unittest.TestCase):
+    """get_preset_for must match unit_type keys that are regex patterns."""
+
+    def _make_collection(self, assignments: dict) -> PresetAssignmentCollection:
+        """Build a minimal PresetAssignmentCollection from a nested dict of preset names."""
+        preset_def = PresetDefinition(name="std", title="Standard")
+        preset_collection = PresetCollection(name="col")
+
+        result = PresetAssignmentCollection()
+        for coalition, ctypes in assignments.items():
+            result.preset_assignments_dict.setdefault(coalition, {})
+            for atype, units in ctypes.items():
+                result.preset_assignments_dict[coalition].setdefault(atype, {})
+                for unit_type, _ in units.items():
+                    pa = PresetAssignment(
+                        coalition=coalition,
+                        aircraft_type=atype,
+                        unit_type=unit_type,
+                        preset_definition=preset_def,
+                    )
+                    result.preset_assignments_dict[coalition][atype][unit_type] = pa
+        return result
+
+    def test_exact_match_still_works(self) -> None:
+        col = self._make_collection({"blue": {"plane": {"F-16C_50": "std"}}})
+        result = col.get_preset_for("blue", "plane", "F-16C_50")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.unit_type, "F-16C_50")  # type: ignore[union-attr]
+
+    def test_pattern_match_fw190(self) -> None:
+        col = self._make_collection({"blue": {"plane": {"FW[-]190.*": "std"}}})
+        result = col.get_preset_for("blue", "plane", "FW-190A-8")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.unit_type, "FW[-]190.*")  # type: ignore[union-attr]
+
+    def test_pattern_match_a10c(self) -> None:
+        col = self._make_collection({"blue": {"plane": {"A[-]10C.*": "std"}}})
+        self.assertIsNotNone(col.get_preset_for("blue", "plane", "A-10C"))
+        self.assertIsNotNone(col.get_preset_for("blue", "plane", "A-10CII"))
+
+    def test_exact_takes_priority_over_pattern(self) -> None:
+        exact_def = PresetDefinition(name="exact", title="Exact")
+        pattern_def = PresetDefinition(name="patt", title="Pattern")
+        col = PresetAssignmentCollection()
+        col.preset_assignments_dict["blue"] = {
+            "plane": {
+                "F-16C_50": PresetAssignment(coalition="blue", aircraft_type="plane", unit_type="F-16C_50", preset_definition=exact_def),
+                "F[-]16.*": PresetAssignment(coalition="blue", aircraft_type="plane", unit_type="F[-]16.*", preset_definition=pattern_def),
+            }
+        }
+        result = col.get_preset_for("blue", "plane", "F-16C_50")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.preset_definition, exact_def)  # type: ignore[union-attr]
+
+    def test_all_fallback_when_no_pattern_matches(self) -> None:
+        col = self._make_collection({"blue": {"plane": {"all": "std"}}})
+        result = col.get_preset_for("blue", "plane", "SomeUnknownAircraft")
+        self.assertIsNotNone(result)
+
+    def test_no_match_returns_none(self) -> None:
+        col = self._make_collection({"blue": {"plane": {"F-16C_50": "std"}}})
+        result = col.get_preset_for("blue", "plane", "A-10C")
+        self.assertIsNone(result)
+
+    def test_pattern_not_matched_when_partial(self) -> None:
+        # Pattern must match the full string (fullmatch, not search)
+        col = self._make_collection({"blue": {"plane": {"F-16": "std"}}})
+        result = col.get_preset_for("blue", "plane", "F-16C_50")
+        self.assertIsNone(result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/presets_injector/test_presets_injector_worker.py
+++ b/test/python/presets_injector/test_presets_injector_worker.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 
 from mission_tools import Group
 from presets_injector.presets_injector_worker import PresetsInjectorWorker
-from presets_injector.presets_manager import PresetDefinition
+from presets_injector.presets_manager import Channel, PresetDefinition, RadioDefinition
 
 
 def _make_worker(presets_file: Path | None = None) -> PresetsInjectorWorker:
@@ -47,7 +47,9 @@ class TestLoadConfig(unittest.TestCase):
 class TestAddGroup(unittest.TestCase):
     def test_add_group_with_name_stored(self) -> None:
         worker = _make_worker()
-        group = Group(group_dcs={"name": "F-16 Alpha"}, aircraft_type="plane", country="USA", coalition="blue", name="F-16 Alpha")
+        group = Group(
+            group_dcs={"name": "F-16 Alpha"}, aircraft_type="plane", country="USA", coalition="blue", name="F-16 Alpha"
+        )
         worker.add_group(group)
         self.assertIn("F-16 Alpha", worker.groups)
 
@@ -61,8 +63,12 @@ class TestAddGroup(unittest.TestCase):
         worker = _make_worker()
         group = Group(
             group_dcs={"name": "Human Group"},
-            aircraft_type="plane", country="USA", coalition="blue",
-            name="Human Group", unit_type="F-16C_50", human_pilot=True,
+            aircraft_type="plane",
+            country="USA",
+            coalition="blue",
+            name="Human Group",
+            unit_type="F-16C_50",
+            human_pilot=True,
         )
         worker.add_group(group)
         stored = worker.groups["Human Group"]
@@ -73,8 +79,11 @@ class TestAddGroup(unittest.TestCase):
         worker = _make_worker()
         group = Group(
             group_dcs={"name": "Player Group"},
-            aircraft_type="plane", country="Russia", coalition="red",
-            name="Player Group", human_pilot=True,
+            aircraft_type="plane",
+            country="Russia",
+            coalition="red",
+            name="Player Group",
+            human_pilot=True,
         )
         worker.add_group(group)
         self.assertTrue(worker.groups["Player Group"].human_pilot)
@@ -83,15 +92,24 @@ class TestAddGroup(unittest.TestCase):
         worker = _make_worker()
         group = Group(
             group_dcs={"name": "AI Group"},
-            aircraft_type="plane", country="USA", coalition="blue",
-            name="AI Group", human_pilot=False,
+            aircraft_type="plane",
+            country="USA",
+            coalition="blue",
+            name="AI Group",
+            human_pilot=False,
         )
         worker.add_group(group)
         self.assertFalse(worker.groups["AI Group"].human_pilot)
 
     def test_add_group_no_units(self) -> None:
         worker = _make_worker()
-        group = Group(group_dcs={"name": "No Units Group"}, aircraft_type="plane", country="USA", coalition="blue", name="No Units Group")
+        group = Group(
+            group_dcs={"name": "No Units Group"},
+            aircraft_type="plane",
+            country="USA",
+            coalition="blue",
+            name="No Units Group",
+        )
         worker.add_group(group)
         self.assertIn("No Units Group", worker.groups)
         self.assertFalse(worker.groups["No Units Group"].human_pilot)
@@ -154,6 +172,28 @@ class TestProcessUnits(unittest.TestCase):
         )
         count = worker.process_units(group, PresetDefinition.EMPTY)
         self.assertEqual(count, 0)
+
+    def test_process_units_vhf_preset_updates_group_frequency(self) -> None:
+        worker = _make_worker()
+        group = self._make_group()
+        preset = PresetDefinition("vhf_preset")
+        radio = RadioDefinition("radio_vhf_blue", radio_type="vhf")
+        radio.channels = [Channel(1, freq=134.0)]
+        preset.add_radio(radio)
+        worker.process_units(group, preset)
+        self.assertAlmostEqual(group.group_dcs["frequency"], 134.0)
+
+    def test_process_units_fm_preset_does_not_update_group_frequency(self) -> None:
+        worker = _make_worker()
+        group = self._make_group()
+        original_freq = group.group_dcs["frequency"]
+        preset = PresetDefinition("fm_preset")
+        radio = RadioDefinition("radio_fm_blue", radio_type="fm")
+        radio.channels = [Channel(1, freq=31.0)]
+        preset.add_radio(radio)
+        worker.process_units(group, preset)
+        # FM frequency must not overwrite group.frequency (Gazelle/Ka-50 HumanRadio issue)
+        self.assertEqual(group.group_dcs["frequency"], original_freq)
 
 
 class TestProcessGroups(unittest.TestCase):
@@ -222,6 +262,7 @@ class TestGenerateValidationReport(unittest.TestCase):
 
     def setUp(self) -> None:
         from veaf_libs.i18n import set_language
+
         set_language("en")
 
     def _make_worker_with_issues(self) -> PresetsInjectorWorker:
@@ -231,8 +272,14 @@ class TestGenerateValidationReport(unittest.TestCase):
         worker = _make_worker()
         strict_range = FrequencyRange(min_mhz=100.0, max_mhz=150.0, modulation="AM/FM")
         non_strict_range = FrequencyRange(min_mhz=20.0, max_mhz=59.9, modulation="AM/FM")
-        ch = ChannelFrequency(freq_mhz=284.0, radio_key="radio_uhf", radio_collection="blue_radios",
-                              radio_title="UHF", channel=1, channel_title="TACTICAL")
+        ch = ChannelFrequency(
+            freq_mhz=284.0,
+            radio_key="radio_uhf",
+            radio_collection="blue_radios",
+            radio_title="UHF",
+            channel=1,
+            channel_title="TACTICAL",
+        )
         worker._freq_issues = [
             FrequencyIssue(
                 unit_type="MiG-19P",


### PR DESCRIPTION
## Summary

- Parse `radioSettings` table in `convert_presets` to detect non-standard radio layouts
- Warbird aircraft (radio[1] = FuG16/warbird freqs) → auto-assigned to `{coalition}_warbird`
- VHF-primary aircraft (radio[1] = VHF range, e.g. I-16, Spitfire, P-47D) → new `{coalition}_vhf_primary` preset + explicit assignment
- `typePattern` entries and fully hardcoded aircraft → explicit warning with recommended preset name
- New helpers: `_extract_block_at`, `_RadioEntry`, `_detect_radio_block_source`, `_parse_radio_settings_entries`
- 28 new tests covering all new functions and behaviors

## Root cause

`convert-v5` previously generated only `all: {coalition}_standard` in `presets_assignments`, losing all per-aircraft specificity from the v5 `radioSettings` table. Aircraft like Bf-109 and I-16 received UHF frequencies (225–390 MHz) injected into their VHF/FuG16 radios (valid range 38–150 MHz), breaking radio assignment entirely.

## Test plan
- [x] `poetry run pytest test/python/mission_builder/test_v5_pipeline_converters.py` — 59 passed
- [x] `poetry run ruff check src/python/ --fix` — no issues
- [x] `poetry run mypy src/python/veaf-tools/` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract per-aircraft radio layout information from v5 radioSettings when converting presets to v6 to preserve correct radio assignments.

Bug Fixes:
- Fix loss of per-aircraft radio layout specificity in convert-v5 that caused incorrect UHF/VHF assignments for aircraft like Bf-109 and I-16.

Enhancements:
- Add parsing of v5 radioSettings entries to infer radio source per aircraft and coalition, including support for warbird and VHF-primary layouts.
- Automatically assign warbird aircraft to {coalition}_warbird presets and create/assign {coalition}_vhf_primary presets for VHF-primary aircraft when needed.
- Emit explicit warnings for typePattern-based and hardcoded radioSettings entries, including recommended presets when applicable.

Documentation:
- Document the fix and new preset assignment behavior in the changelog.

Tests:
- Add unit tests for detecting radio block sources, parsing radioSettings entries, and validating per-aircraft preset assignment behavior in convert_presets.