### PR TITLE
feat(build): community_scripts toggle in mission.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Klogg highlight profile for DCS logs added to `tools/klogg/veaf.conf`; GUIDE.md and GUIDE.en.md updated to reference it
+- `community_scripts:` section in `mission.yaml`: individually enable/disable community Lua scripts (MIST, CTLD, CSAR, etc.) — absent section keeps all scripts active
 
 ### Fixed
 - `presets inject`: `presets_assignments` keys now support regex patterns (e.g. `A[-]10C.*`, `FW[-]190.*`) — exact match takes priority, then pattern, then `all` fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - Klogg highlight profile for DCS logs added to `tools/klogg/veaf.conf`; GUIDE.md and GUIDE.en.md updated to reference it
 - `community_scripts:` section in `mission.yaml`: individually enable/disable community Lua scripts (MIST, CTLD, CSAR, etc.) — absent section keeps all scripts active
+- `convert-v5`: generated `mission.yaml` now includes a `community_scripts:` section pre-populated from scripts detected in `published/src/scripts/community/`
 
 ### Fixed
 - `presets inject`: `presets_assignments` keys now support regex patterns (e.g. `A[-]10C.*`, `FW[-]190.*`) — exact match takes priority, then pattern, then `all` fallback

--- a/backlog.md
+++ b/backlog.md
@@ -23,7 +23,7 @@
 |-----|----------|--------|
 | Phase 0 — Restart | ~3h | [archived](backlog-archive.md) |
 | Phase 0b — GitHub cleanup | ~25 min | ⬜ |
-| Lot RADIO-SPECS — DCS radio frequency validation | ~3h | ⬜ |
+| Lot RADIO-SPECS — DCS radio frequency validation | ~3h | ✅ |
 | Lot 1 — INFRA | ~4h15 | [archived](backlog-archive.md) |
 | Lot 2 — CLI | ~2h35 | [archived](backlog-archive.md) |
 | Lot 3 — TUI | ~2h20 | [archived](backlog-archive.md) |
@@ -49,7 +49,7 @@
 | Lot 21 — TYPING | ~20 min | [archived](backlog-archive.md) |
 | Lot 22 — TEST-LAYOUT | ~55 min | [archived](backlog-archive.md) |
 | Lot 23 — DOC-YAML | ~8h20 | [archived](backlog-archive.md) |
-| Lot 24 — DOC-REVIEW | ~2h45 | ⬜ (REV-002 pending) |
+| Lot 24 — DOC-REVIEW | ~2h45 | ✅ |
 | Lot 25 — EXT-YAML | ~2h | [archived](backlog-archive.md) |
 | Lot FIX-SORT — LUADATA FIX | ~15 min | [archived](backlog-archive.md) |
 | Lot 26 — IMC-FEEDBACK | ~2h40 | [archived](backlog-archive.md) |
@@ -78,7 +78,7 @@
 | Lot FIX-AIRCRAFT-DUPLICATE — Duplicate aircraft groups in "add" injection mode | ~20 min | [archived](backlog-archive.md) |
 | Lot FIX-I18N-CONVERT-V5 — Hardcoded English messages in convert-v5 | ~30 min | ✅ |
 | Lot FIX-CONVERT-V5-PRESETS — Per-aircraft radio assignments in convert-v5 presets | ~45 min | ✅ |
-| Lot FEAT-COMMUNITY-TOGGLE — Enable/disable community scripts from mission.yaml | ~2h | ⬜ |
+| Lot FEAT-COMMUNITY-TOGGLE — Enable/disable community scripts from mission.yaml | ~2h | ✅ |
 | Lot FIX-CONVERT-V5-DEFAULT-CWD — `convert-v5` uses current directory by default | ~5 min | ⬜ |
 | Lot FIX-SRS-WARN — false warning when SRS config file is absent | ~10 min | ⬜ |
 | Lot FIX-CTLD-NIL — nil crash on ctld.builtFOBS / ctld.logisticUnits in scheduled fns | ~15 min | ⬜ |
@@ -113,12 +113,12 @@
 
 | # | Ticket | Files | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| COMM-001 | Give each community script a stable ID (key) in `get_community_script_files()` — return `list[dict]` instead of `list[tuple]` | `mission_tools/mission_constants.py` | refactor | 15 min | ⬜ |
-| COMM-002 | Parse `community_scripts:` section in `MissionBuilderWorker.__init__`; filter the list of community scripts to inject based on `enabled:` flags | `mission_builder/mission_builder_worker.py` | feat | 30 min | ⬜ |
-| COMM-003 | Apply the filter in both static trigger (`insert_veaf_trigrules`) and dynamic trigger (`insert_veaf_triggers`) | `mission_builder/mission_builder_worker.py` | feat | 20 min | ⬜ |
-| COMM-004 | Add `community_scripts:` block to the default `mission.yaml` with all scripts listed and `enabled: true` by default, with comments | `src/defaults/mission-folder/mission.yaml` | doc | 15 min | ⬜ |
-| COMM-005 | Update YAML reference doc (`MISSION_YAML_REFERENCE.md` + `.en.md`) with the new section | `doc/MISSION_YAML_REFERENCE.md`, `doc/MISSION_YAML_REFERENCE.en.md` | doc | 20 min | ⬜ |
-| COMM-006 | TDD tests: verify that a script with `enabled: false` is absent from the injected triggers | `test/python/` | test | 20 min | ⬜ |
+| COMM-001 | Give each community script a stable ID (key) in `get_community_script_files()` — return `list[dict]` instead of `list[tuple]` | `mission_tools/mission_constants.py` | refactor | 15 min | ✅ |
+| COMM-002 | Parse `community_scripts:` section in `MissionBuilderWorker.__init__`; filter the list of community scripts to inject based on `enabled:` flags | `mission_builder/mission_builder_worker.py` | feat | 30 min | ✅ |
+| COMM-003 | Apply the filter in both static trigger (`insert_veaf_trigrules`) and dynamic trigger (`insert_veaf_triggers`) | `mission_builder/mission_builder_worker.py` | feat | 20 min | ✅ |
+| COMM-004 | Add `community_scripts:` block to the default `mission.yaml` with all scripts listed and `enabled: true` by default, with comments | `src/defaults/mission-folder/mission.yaml` | doc | 15 min | ✅ |
+| COMM-005 | Update YAML reference doc (`MISSION_YAML_REFERENCE.md` + `.en.md`) with the new section | `doc/MISSION_YAML_REFERENCE.md`, `doc/MISSION_YAML_REFERENCE.en.md` | doc | 20 min | ✅ |
+| COMM-006 | TDD tests: verify that a script with `enabled: false` is absent from the injected triggers | `test/python/` | test | 20 min | ✅ |
 
 ---
 
@@ -130,11 +130,11 @@
 
 | # | Ticket | Files | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| CUSTOM-001 | Add `CustomScript` dataclass + parse `custom_scripts` in `__init__` | `mission_builder_worker.py` | feat | 10 min | 🔄 |
-| CUSTOM-002 | Update warning logic (declared = info, unknown = warning with hint) | `mission_builder_worker.py` | feat | 10 min | 🔄 |
-| CUSTOM-003 | Filter load triggers according to `generate_load_trigger` | `mission_builder_worker.py` | feat | 10 min | 🔄 |
-| CUSTOM-004 | TDD tests (warnings + trigger resolution) | `test_mission_builder_defaults.py` | test | 10 min | 🔄 |
-| CUSTOM-005 | Document the section in the default `mission.yaml` | `src/defaults/mission-folder/mission.yaml` | doc | 5 min | 🔄 |
+| CUSTOM-001 | Add `CustomScript` dataclass + parse `custom_scripts` in `__init__` | `mission_builder_worker.py` | feat | 10 min | ✅ |
+| CUSTOM-002 | Update warning logic (declared = info, unknown = warning with hint) | `mission_builder_worker.py` | feat | 10 min | ✅ |
+| CUSTOM-003 | Filter load triggers according to `generate_load_trigger` | `mission_builder_worker.py` | feat | 10 min | ✅ |
+| CUSTOM-004 | TDD tests (warnings + trigger resolution) | `test_mission_builder_defaults.py` | test | 10 min | ✅ |
+| CUSTOM-005 | Document the section in the default `mission.yaml` | `src/defaults/mission-folder/mission.yaml` | doc | 5 min | ✅ |
 
 ---
 
@@ -148,7 +148,7 @@
 
 | # | Ticket | Files | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| REV-002 | Commit the Klogg profile provided by the user to `tools/klogg/veaf.conf`; update the "Reading the log" section in `GUIDE.md` and `GUIDE.fr.md` to point to this file | `tools/klogg/veaf.conf`, `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | chore | 20 min | ⬜ |
+| REV-002 | Commit the Klogg profile provided by the user to `tools/klogg/veaf.conf`; update the "Reading the log" section in `GUIDE.md` and `GUIDE.fr.md` to point to this file | `tools/klogg/veaf.conf`, `doc/mission-maker/GUIDE.md`, `doc/mission-maker/GUIDE.fr.md` | chore | 20 min | ✅ |
 
 ---
 
@@ -212,12 +212,12 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 
 | # | Ticket | Type | Effort | Status |
 |---|--------|------|--------|--------|
-| RADIO-001 | Extraction script: fetch `panelRadio` from dcs-lua-datamine and generate `dcs-radio-specs.yaml` | feat | 45 min | ⬜ |
-| RADIO-002 | Bundle `dcs-radio-specs.yaml` as package data; load via `importlib.resources` | feat | 15 min | ⬜ |
-| RADIO-003 | `RadioFrequencyValidator`: validate preset frequencies against aircraft specs, warn on mismatch | feat | 45 min | ⬜ |
-| RADIO-004 | Integrate validator into `PresetsInjectorWorker.process_groups()` | feat | 20 min | ⬜ |
-| RADIO-005 | Generate `doc/mission-maker/dcs-radio-specs.md` (human-readable Markdown table) from the YAML | feat | 30 min | ⬜ |
-| RADIO-006 | Unit tests for validator (valid/invalid frequency, unknown aircraft, partial ranges) | feat | 45 min | ⬜ |
+| RADIO-001 | Extraction script: fetch `panelRadio` from dcs-lua-datamine and generate `dcs-radio-specs.yaml` | feat | 45 min | ✅ |
+| RADIO-002 | Bundle `dcs-radio-specs.yaml` as package data; load via `importlib.resources` | feat | 15 min | ✅ |
+| RADIO-003 | `RadioFrequencyValidator`: validate preset frequencies against aircraft specs, warn on mismatch | feat | 45 min | ✅ |
+| RADIO-004 | Integrate validator into `PresetsInjectorWorker.process_groups()` | feat | 20 min | ✅ |
+| RADIO-005 | Generate `doc/mission-maker/dcs-radio-specs.md` (human-readable Markdown table) from the YAML | feat | 30 min | ✅ |
+| RADIO-006 | Unit tests for validator (valid/invalid frequency, unknown aircraft, partial ranges) | feat | 45 min | ✅ |
 
 **Estimated total: ~3h**
 

--- a/backlog.md
+++ b/backlog.md
@@ -119,6 +119,7 @@
 | COMM-004 | Add `community_scripts:` block to the default `mission.yaml` with all scripts listed and `enabled: true` by default, with comments | `src/defaults/mission-folder/mission.yaml` | doc | 15 min | ✅ |
 | COMM-005 | Update YAML reference doc (`MISSION_YAML_REFERENCE.md` + `.en.md`) with the new section | `doc/MISSION_YAML_REFERENCE.md`, `doc/MISSION_YAML_REFERENCE.en.md` | doc | 20 min | ✅ |
 | COMM-006 | TDD tests: verify that a script with `enabled: false` is absent from the injected triggers | `test/python/` | test | 20 min | ✅ |
+| COMM-007 | `convert-v5`: detect community scripts present in `published/src/scripts/community/` and emit `community_scripts:` section in generated `mission.yaml` | `mission_builder/v5_converter.py`, `test_v5_converter.py` | feat | 20 min | ✅ |
 
 ---
 

--- a/doc/MISSION_YAML_REFERENCE.en.md
+++ b/doc/MISSION_YAML_REFERENCE.en.md
@@ -299,6 +299,39 @@ See the respective module pages for full schema:
 
 ---
 
+### `community_scripts:`
+
+Allows enabling or disabling individual community Lua scripts (MIST, CTLD, CSAR, etc.) injected into the mission. When this section is absent, **all** community scripts are included.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `<id>.enabled` | `bool` | `true` | Enables (`true`) or disables (`false`) the script identified by `<id>` |
+
+**Available identifiers**
+
+| ID | Script |
+|----|--------|
+| `mist` | MIST (Mission Scripting Tools) |
+| `stts` | DCS-SimpleTextToSpeech |
+| `weathermark` | WeatherMark |
+| `ctld` | CTLD (Combat Transport & Logistics Dispatcher) |
+| `aien` | AIEN (AI Enhancement) |
+| `csar` | CSAR (Combat Search and Rescue) |
+| `hercules` | Hercules Cargo |
+| `skynet` | Skynet IADS |
+| `tum` | The Universal Mission (TUM) |
+
+```yaml
+community_scripts:
+  ctld:   { enabled: true }
+  csar:   { enabled: true }
+  skynet: { enabled: false }   # disabled for this mission
+```
+
+> An unknown identifier in this section triggers a build warning and is ignored.
+
+---
+
 ### `custom_scripts:`
 
 Declares custom Lua scripts present in `src/scripts/` that are not part of the standard VEAF v6 set.  

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -301,7 +301,7 @@ Voir les pages respectives pour le schéma complet :
 
 ### `community_scripts:`
 
-Permet d'activer ou désactiver individuellement les scripts Lua communautaires (MIST, CTLD, CSAR, etc.) injectés dans la mission. Lorsque cette section est absente, **tous** les scripts communautaires sont inclus.
+Permet d'activer ou de désactiver individuellement les scripts Lua communautaires (MIST, CTLD, CSAR, etc.) injectés dans la mission. Lorsque cette section est absente, **tous** les scripts communautaires sont inclus.
 
 | Champ | Type | Défaut | Description |
 |-------|------|---------|-------------|

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -299,6 +299,39 @@ Voir les pages respectives pour le schéma complet :
 
 ---
 
+### `community_scripts:`
+
+Permet d'activer ou désactiver individuellement les scripts Lua communautaires (MIST, CTLD, CSAR, etc.) injectés dans la mission. Lorsque cette section est absente, **tous** les scripts communautaires sont inclus.
+
+| Champ | Type | Défaut | Description |
+|-------|------|---------|-------------|
+| `<id>.enabled` | `bool` | `true` | Active (`true`) ou désactive (`false`) le script identifié par `<id>` |
+
+**Identifiants disponibles**
+
+| ID | Script |
+|----|--------|
+| `mist` | MIST (Mission Scripting Tools) |
+| `stts` | DCS-SimpleTextToSpeech |
+| `weathermark` | WeatherMark |
+| `ctld` | CTLD (Combat Transport & Logistics Dispatcher) |
+| `aien` | AIEN (AI Enhancement) |
+| `csar` | CSAR (Combat Search and Rescue) |
+| `hercules` | Hercules Cargo |
+| `skynet` | Skynet IADS |
+| `tum` | The Universal Mission (TUM) |
+
+```yaml
+community_scripts:
+  ctld:   { enabled: true }
+  csar:   { enabled: true }
+  skynet: { enabled: false }   # désactivé pour cette mission
+```
+
+> Un identifiant inconnu dans cette section déclenche un warning au build et est ignoré.
+
+---
+
 ### `custom_scripts:`
 
 Déclare les scripts Lua custom présents dans `src/scripts/` qui ne font pas partie du jeu standard VEAF v6.  

--- a/src/defaults/mission-folder/mission.yaml
+++ b/src/defaults/mission-folder/mission.yaml
@@ -203,6 +203,21 @@
 #     - path: src/scripts/FgTools.lua
 #       generate_load_trigger: false  # override: loaded manually from mission-script.lua
 
+# ── Community scripts ─────────────────────────────────────────────────────────
+# Set enabled: false to exclude a community script from the built mission.
+# All scripts are enabled by default when this section is absent.
+#
+# community_scripts:
+#   mist:         { enabled: true }   # MIST (Mission Scripting Tools)
+#   stts:         { enabled: true }   # DCS-SimpleTextToSpeech
+#   weathermark:  { enabled: true }   # WeatherMark
+#   ctld:         { enabled: true }   # CTLD (Combined Arms Transport & Logistics Dispatcher)
+#   aien:         { enabled: true }   # AIEN (AI Enhancement)
+#   csar:         { enabled: true }   # CSAR (Combat Search and Rescue)
+#   hercules:     { enabled: true }   # Hercules Cargo
+#   skynet:       { enabled: true }   # Skynet IADS
+#   tum:          { enabled: true }   # The Universal Mission (TUM)
+
 # ── Build pipeline ────────────────────────────────────────────────────────────
 # Controls which optional injection steps run after the base build.
 # By default each step is auto-detected: it runs if its config file is found.

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -198,22 +198,27 @@ class MissionBuilderWorker(BaseWorker):
                 f"'community_scripts' in mission.yaml must be a mapping (got {type(comm_raw).__name__}); ignoring."
             )
             comm_raw = None
-        if comm_raw is None:
+        # Empty dict {} is treated the same as absent: all scripts remain active.
+        if not comm_raw:
             self.enabled_community_script_ids: set[str] | None = None
         else:
-            all_ids = {s["id"] for s in get_community_script_files()}
-            self.enabled_community_script_ids = set()
-            for script_id, script_cfg in (comm_raw or {}).items():
+            # Opt-out semantics: start with all ids enabled, remove those explicitly disabled.
+            all_community_scripts = get_community_script_files()
+            all_ids = {s["id"] for s in all_community_scripts}
+            self.enabled_community_script_ids = set(all_ids)
+            for script_id, script_cfg in comm_raw.items():
                 if script_id not in all_ids:
                     logger.warning(f"Unknown community script id {script_id!r} in 'community_scripts:'; ignoring.")
                     continue
                 enabled = True
                 if isinstance(script_cfg, dict):
                     enabled = bool(script_cfg.get("enabled", True))
-                elif script_cfg is not None:
+                elif script_cfg is None:
+                    enabled = False
+                else:
                     enabled = bool(script_cfg)
-                if enabled:
-                    self.enabled_community_script_ids.add(script_id)
+                if not enabled:
+                    self.enabled_community_script_ids.discard(script_id)
 
         # Parse dcs_bridge section from mission.yaml
         dcsb_cfg: dict = self.mission_yaml.get("dcs_bridge") or {}

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -190,6 +190,31 @@ class MissionBuilderWorker(BaseWorker):
                     per_script_trigger = None
                 self.custom_scripts.append(CustomScript(path=Path(path).name, generate_load_trigger=per_script_trigger))
 
+        # Parse community_scripts section from mission.yaml
+        # None means "all enabled" (no section present); a set means only those ids are enabled.
+        comm_raw = self.mission_yaml.get("community_scripts")
+        if comm_raw is not None and not isinstance(comm_raw, dict):
+            logger.warning(
+                f"'community_scripts' in mission.yaml must be a mapping (got {type(comm_raw).__name__}); ignoring."
+            )
+            comm_raw = None
+        if comm_raw is None:
+            self.enabled_community_script_ids: set[str] | None = None
+        else:
+            all_ids = {s["id"] for s in get_community_script_files()}
+            self.enabled_community_script_ids = set()
+            for script_id, script_cfg in (comm_raw or {}).items():
+                if script_id not in all_ids:
+                    logger.warning(f"Unknown community script id {script_id!r} in 'community_scripts:'; ignoring.")
+                    continue
+                enabled = True
+                if isinstance(script_cfg, dict):
+                    enabled = bool(script_cfg.get("enabled", True))
+                elif script_cfg is not None:
+                    enabled = bool(script_cfg)
+                if enabled:
+                    self.enabled_community_script_ids.add(script_id)
+
         # Parse dcs_bridge section from mission.yaml
         dcsb_cfg: dict = self.mission_yaml.get("dcs_bridge") or {}
         self.dcs_bridge_enabled: bool = bool(dcsb_cfg.get("enabled", False))
@@ -227,18 +252,26 @@ class MissionBuilderWorker(BaseWorker):
 
         return self.collected_veaf_script_files
 
+    def _active_community_scripts(self) -> list[dict[str, str]]:
+        """Return community script descriptors filtered by enabled_community_script_ids."""
+        all_scripts = get_community_script_files()
+        if self.enabled_community_script_ids is None:
+            return all_scripts
+        return [s for s in all_scripts if s["id"] in self.enabled_community_script_ids]
+
     def get_collected_community_script_files(self) -> dict[str, bytes]:
         if self.collected_community_script_files:
             return self.collected_community_script_files
 
-        # Preprocess the community script files
+        file_patterns: list[tuple[str, str]] = [(s["path"], s["dest"]) for s in self._active_community_scripts()]
+
         scripts_folder: Path = self.scripts_path or (self.mission_folder / "published")
         self.collected_community_script_files = collect_files_from_globs(
-            base_folder=scripts_folder, file_patterns=get_community_script_files()
+            base_folder=scripts_folder, file_patterns=file_patterns
         )
-        if len(self.collected_community_script_files) < len(get_community_script_files()):
+        if len(self.collected_community_script_files) < len(file_patterns):
             self.signal_missing_required_files_after_collection(
-                get_community_script_files(), self.collected_community_script_files, scripts_folder
+                file_patterns, self.collected_community_script_files, scripts_folder
             )
         return self.collected_community_script_files
 
@@ -750,9 +783,9 @@ class MissionBuilderWorker(BaseWorker):
         dynamic_script_loading_trigger = (
             'a_do_script("env.info(\\"DYNAMIC VEAF scripts loading from \\"..VEAF_DYNAMIC_SCRIPTSPATH)");'
         )
-        for file in get_community_script_files():
+        for file in self._active_community_scripts():
             dynamic_script_loading_trigger += (
-                f'a_do_script("assert(loadfile(VEAF_DYNAMIC_SCRIPTSPATH .. \\"{file[0]}\\"))()");'
+                f'a_do_script("assert(loadfile(VEAF_DYNAMIC_SCRIPTSPATH .. \\"{file["path"]}\\"))()");'
             )
         dynamic_script_loading_trigger += (
             'a_do_script("assert(loadfile(VEAF_DYNAMIC_SCRIPTSPATH .. \\"/src/scripts/VeafDynamicLoader.lua\\"))()");'
@@ -885,9 +918,9 @@ class MissionBuilderWorker(BaseWorker):
         dynamic_script_loading_actions.extend(
             {
                 "predicate": "a_do_script",
-                "text": f'assert(loadfile(VEAF_DYNAMIC_SCRIPTSPATH .. "{file[0]}"))()',
+                "text": f'assert(loadfile(VEAF_DYNAMIC_SCRIPTSPATH .. "{file["path"]}"))()',
             }
-            for file in get_community_script_files()
+            for file in self._active_community_scripts()
         )
         dynamic_script_loading_actions.append(
             {

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml  # type: ignore[import-untyped]
+from mission_tools.mission_constants import get_community_script_files
 from veaf_libs.i18n import t
 from veaf_libs.lua_config_generator import MANDATORY_MODULES, yaml_module_entry
 from veaf_libs.lua_module_scanner import get_modules
@@ -123,6 +124,8 @@ class ConversionReport:
     """``True`` if ``mission.yaml`` already existed before conversion."""
     pipeline_files: list[PipelineFile] = field(default_factory=list)
     """Pipeline config files detected under ``src/``."""
+    detected_community_script_ids: set[str] = field(default_factory=set)
+    """IDs of community scripts found in ``published/src/scripts/community/``."""
 
     # ── missionConfig.lua migration ────────────────────────────────────────
     migration_result: MigrationResult | None = None
@@ -623,6 +626,14 @@ class V5Converter:
 
         report.mission_yaml_existed = (folder / "mission.yaml").exists()
 
+        # Detect which community scripts are present in published/src/scripts/community/
+        community_folder = folder / "published" / "src" / "scripts" / "community"
+        if community_folder.is_dir():
+            present_filenames = {p.name for p in community_folder.iterdir() if p.is_file()}
+            for script in get_community_script_files():
+                if Path(script["path"]).name in present_filenames:
+                    report.detected_community_script_ids.add(script["id"])
+
         for step, v6_candidates in V6_PIPELINE_CANDIDATES.items():
             # Check v6-format files first (already converted or freshly created)
             for rel in v6_candidates:
@@ -1036,6 +1047,22 @@ class V5Converter:
             lines.extend(pipeline_lines)
         else:
             lines.append("# pipeline: {}  # no pipeline config files detected in src/")
+
+        # ── Community scripts ──────────────────────────────────────────────
+        all_community = get_community_script_files()
+        detected = report.detected_community_script_ids
+        lines += [
+            "",
+            "# ── Community scripts ────────────────────────────────────────────────────────",
+            "# Set enabled: false to exclude a community script from the built mission.",
+            "#",
+            "community_scripts:",
+        ]
+        for script in all_community:
+            sid = script["id"]
+            enabled_str = "true" if sid in detected else "false"
+            lines.append(f"  {sid}: {{enabled: {enabled_str}}}")
+        lines.append("")
 
         # ── Build configuration ────────────────────────────────────────────
         lines += [

--- a/src/python/veaf-tools/mission_tools/mission_constants.py
+++ b/src/python/veaf-tools/mission_tools/mission_constants.py
@@ -13,20 +13,28 @@ def get_legacy_script_files() -> list[tuple[str, str]]:
     ]
 
 
-def get_community_script_files() -> list[tuple[str, str]]:
-    """Get list of community LUA files. Those can be in published or in the scripts folder, depending on the --dynamic-mode option"""
+def get_community_script_files() -> list[dict[str, str]]:
+    """Get list of community LUA files.
+
+    Each entry is a dict with keys:
+        - ``id``: stable identifier used in ``community_scripts:`` section of ``mission.yaml``
+        - ``path``: source path relative to the scripts root
+        - ``dest``: destination location inside the ``.miz`` archive
+
+    Returns:
+        List of community script descriptors.
+    """
 
     return [
-        # The community scripts
-        ("src/scripts/community/mist.lua", DEFAULT_SCRIPTS_LOCATION),
-        ("src/scripts/community/DCS-SimpleTextToSpeech.lua", DEFAULT_SCRIPTS_LOCATION),
-        ("src/scripts/community/WeatherMark.lua", DEFAULT_SCRIPTS_LOCATION),
-        ("src/scripts/community/CTLD.lua", DEFAULT_SCRIPTS_LOCATION),
-        ("src/scripts/community/AIEN.lua", DEFAULT_SCRIPTS_LOCATION),
-        ("src/scripts/community/CSAR.lua", DEFAULT_SCRIPTS_LOCATION),
-        ("src/scripts/community/Hercules_Cargo.lua", DEFAULT_SCRIPTS_LOCATION),
-        ("src/scripts/community/skynet-iads-compiled.lua", DEFAULT_SCRIPTS_LOCATION),
-        ("src/scripts/community/TheUniversalMission.lua", DEFAULT_SCRIPTS_LOCATION),
+        {"id": "mist", "path": "src/scripts/community/mist.lua", "dest": DEFAULT_SCRIPTS_LOCATION},
+        {"id": "stts", "path": "src/scripts/community/DCS-SimpleTextToSpeech.lua", "dest": DEFAULT_SCRIPTS_LOCATION},
+        {"id": "weathermark", "path": "src/scripts/community/WeatherMark.lua", "dest": DEFAULT_SCRIPTS_LOCATION},
+        {"id": "ctld", "path": "src/scripts/community/CTLD.lua", "dest": DEFAULT_SCRIPTS_LOCATION},
+        {"id": "aien", "path": "src/scripts/community/AIEN.lua", "dest": DEFAULT_SCRIPTS_LOCATION},
+        {"id": "csar", "path": "src/scripts/community/CSAR.lua", "dest": DEFAULT_SCRIPTS_LOCATION},
+        {"id": "hercules", "path": "src/scripts/community/Hercules_Cargo.lua", "dest": DEFAULT_SCRIPTS_LOCATION},
+        {"id": "skynet", "path": "src/scripts/community/skynet-iads-compiled.lua", "dest": DEFAULT_SCRIPTS_LOCATION},
+        {"id": "tum", "path": "src/scripts/community/TheUniversalMission.lua", "dest": DEFAULT_SCRIPTS_LOCATION},
     ]
 
 

--- a/test/python/mission_builder/test_community_scripts_toggle.py
+++ b/test/python/mission_builder/test_community_scripts_toggle.py
@@ -38,6 +38,14 @@ class TestCommunityScriptsToggleParsing(unittest.TestCase):
         worker = _make_worker(yaml)
         self.assertEqual(worker.enabled_community_script_ids, ALL_IDS)
 
+    def test_only_disabled_script_absent(self) -> None:
+        """Only listing one script as disabled leaves all others active (opt-out semantics)."""
+        worker = _make_worker("community_scripts:\n  skynet: {enabled: false}\n")
+        assert worker.enabled_community_script_ids is not None
+        self.assertNotIn("skynet", worker.enabled_community_script_ids)
+        self.assertIn("mist", worker.enabled_community_script_ids)
+        self.assertIn("ctld", worker.enabled_community_script_ids)
+
     def test_one_script_disabled(self) -> None:
         """A single script with enabled: false is absent from enabled_community_script_ids."""
         worker = _make_worker("community_scripts:\n  ctld: {enabled: false}\n")
@@ -57,17 +65,40 @@ class TestCommunityScriptsToggleParsing(unittest.TestCase):
         self.assertNotIn("csar", worker.enabled_community_script_ids)
         self.assertIn("mist", worker.enabled_community_script_ids)
 
-    def test_empty_section_enables_nothing(self) -> None:
-        """An empty community_scripts: section produces an empty enabled set."""
+    def test_empty_section_treated_as_absent(self) -> None:
+        """An empty community_scripts: {} section is treated as absent — all scripts active."""
         worker = _make_worker("community_scripts: {}\n")
-        self.assertIsNotNone(worker.enabled_community_script_ids)
-        self.assertEqual(worker.enabled_community_script_ids, set())
+        self.assertIsNone(worker.enabled_community_script_ids)
 
-    def test_unknown_id_is_ignored(self) -> None:
-        """An unknown script id in community_scripts: is silently ignored."""
+    def test_unknown_id_is_ignored_with_warning(self) -> None:
+        """An unknown script id in community_scripts: is ignored (a warning is emitted)."""
         worker = _make_worker("community_scripts:\n  unknown_tool: {enabled: true}\n")
         assert worker.enabled_community_script_ids is not None
         self.assertNotIn("unknown_tool", worker.enabled_community_script_ids)
+
+    def test_boolean_shorthand_true(self) -> None:
+        """ctld: true enables ctld (non-dict shorthand)."""
+        worker = _make_worker("community_scripts:\n  ctld: true\n")
+        assert worker.enabled_community_script_ids is not None
+        self.assertIn("ctld", worker.enabled_community_script_ids)
+
+    def test_boolean_shorthand_false(self) -> None:
+        """ctld: false disables ctld (non-dict shorthand)."""
+        worker = _make_worker("community_scripts:\n  ctld: false\n")
+        assert worker.enabled_community_script_ids is not None
+        self.assertNotIn("ctld", worker.enabled_community_script_ids)
+
+    def test_null_value_disables_script(self) -> None:
+        """ctld: null disables ctld (null is not truthy)."""
+        worker = _make_worker("community_scripts:\n  ctld: ~\n")
+        assert worker.enabled_community_script_ids is not None
+        self.assertNotIn("ctld", worker.enabled_community_script_ids)
+
+    def test_empty_dict_value_enables_script(self) -> None:
+        """ctld: {} enables ctld (empty dict → enabled defaults to true)."""
+        worker = _make_worker("community_scripts:\n  ctld: {}\n")
+        assert worker.enabled_community_script_ids is not None
+        self.assertIn("ctld", worker.enabled_community_script_ids)
 
     def test_non_dict_section_treated_as_absent(self) -> None:
         """A non-dict community_scripts value is ignored; all scripts remain active."""
@@ -98,6 +129,18 @@ class TestActiveCommunityScripts(unittest.TestCase):
         result = worker._active_community_scripts()
         result_ids = {s["id"] for s in result}
         self.assertEqual(result_ids, {"mist", "ctld"})
+
+    def test_disabled_script_absent_from_active_scripts_and_paths(self) -> None:
+        """A script disabled via YAML is absent from _active_community_scripts and its path is not present."""
+        worker = _make_worker("community_scripts:\n  skynet: {enabled: false}\n")
+        active = worker._active_community_scripts()
+        active_ids = {s["id"] for s in active}
+        active_paths = [s["path"] for s in active]
+        self.assertNotIn("skynet", active_ids)
+        self.assertFalse(any("skynet" in p for p in active_paths))
+        # All other community scripts remain active
+        self.assertIn("mist", active_ids)
+        self.assertIn("ctld", active_ids)
 
 
 if __name__ == "__main__":

--- a/test/python/mission_builder/test_community_scripts_toggle.py
+++ b/test/python/mission_builder/test_community_scripts_toggle.py
@@ -1,0 +1,104 @@
+"""Tests for community_scripts toggle parsing in MissionBuilderWorker — COMM-002/COMM-006."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from mission_builder.mission_builder_worker import MissionBuilderWorker
+from mission_tools.mission_constants import get_community_script_files
+
+
+def _make_worker(yaml_content: str) -> MissionBuilderWorker:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mission_dir = Path(tmpdir)
+        (mission_dir / "mission.yaml").write_text(yaml_content, encoding="utf-8")
+        return MissionBuilderWorker(
+            mission_folder=mission_dir,
+            output_mission=mission_dir / "out.miz",
+            dynamic_mode=None,
+        )
+
+
+ALL_IDS = {s["id"] for s in get_community_script_files()}
+
+
+class TestCommunityScriptsToggleParsing(unittest.TestCase):
+    """Unit tests for community_scripts: section parsing."""
+
+    def test_no_section_enables_all(self) -> None:
+        """Without community_scripts section, enabled_community_script_ids is None (all active)."""
+        worker = _make_worker("")
+        self.assertIsNone(worker.enabled_community_script_ids)
+
+    def test_all_enabled_true_yields_all_ids(self) -> None:
+        """When all scripts are listed with enabled: true, all ids are present."""
+        yaml = "community_scripts:\n" + "".join(f"  {sid}: {{enabled: true}}\n" for sid in ALL_IDS)
+        worker = _make_worker(yaml)
+        self.assertEqual(worker.enabled_community_script_ids, ALL_IDS)
+
+    def test_one_script_disabled(self) -> None:
+        """A single script with enabled: false is absent from enabled_community_script_ids."""
+        worker = _make_worker("community_scripts:\n  ctld: {enabled: false}\n")
+        assert worker.enabled_community_script_ids is not None
+        self.assertNotIn("ctld", worker.enabled_community_script_ids)
+
+    def test_multiple_scripts_disabled(self) -> None:
+        """Multiple scripts disabled are all absent."""
+        worker = _make_worker(
+            "community_scripts:\n"
+            "  ctld: {enabled: false}\n"
+            "  csar: {enabled: false}\n"
+            "  mist: {enabled: true}\n"
+        )
+        assert worker.enabled_community_script_ids is not None
+        self.assertNotIn("ctld", worker.enabled_community_script_ids)
+        self.assertNotIn("csar", worker.enabled_community_script_ids)
+        self.assertIn("mist", worker.enabled_community_script_ids)
+
+    def test_empty_section_enables_nothing(self) -> None:
+        """An empty community_scripts: section produces an empty enabled set."""
+        worker = _make_worker("community_scripts: {}\n")
+        self.assertIsNotNone(worker.enabled_community_script_ids)
+        self.assertEqual(worker.enabled_community_script_ids, set())
+
+    def test_unknown_id_is_ignored(self) -> None:
+        """An unknown script id in community_scripts: is silently ignored."""
+        worker = _make_worker("community_scripts:\n  unknown_tool: {enabled: true}\n")
+        assert worker.enabled_community_script_ids is not None
+        self.assertNotIn("unknown_tool", worker.enabled_community_script_ids)
+
+    def test_non_dict_section_treated_as_absent(self) -> None:
+        """A non-dict community_scripts value is ignored; all scripts remain active."""
+        worker = _make_worker("community_scripts: not-a-dict\n")
+        self.assertIsNone(worker.enabled_community_script_ids)
+
+
+class TestActiveCommunityScripts(unittest.TestCase):
+    """Unit tests for _active_community_scripts helper."""
+
+    def test_none_returns_all(self) -> None:
+        """_active_community_scripts returns all scripts when enabled_community_script_ids is None."""
+        worker: MissionBuilderWorker = object.__new__(MissionBuilderWorker)
+        worker.enabled_community_script_ids = None
+        result = worker._active_community_scripts()
+        self.assertEqual(result, get_community_script_files())
+
+    def test_empty_set_returns_nothing(self) -> None:
+        """_active_community_scripts returns empty list when no ids are enabled."""
+        worker: MissionBuilderWorker = object.__new__(MissionBuilderWorker)
+        worker.enabled_community_script_ids = set()
+        self.assertEqual(worker._active_community_scripts(), [])
+
+    def test_subset_returns_matching_scripts(self) -> None:
+        """_active_community_scripts returns only scripts whose id is in the enabled set."""
+        worker: MissionBuilderWorker = object.__new__(MissionBuilderWorker)
+        worker.enabled_community_script_ids = {"mist", "ctld"}
+        result = worker._active_community_scripts()
+        result_ids = {s["id"] for s in result}
+        self.assertEqual(result_ids, {"mist", "ctld"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/mission_builder/test_v5_converter.py
+++ b/test/python/mission_builder/test_v5_converter.py
@@ -434,6 +434,50 @@ class TestV5ConverterIntegration(unittest.TestCase):
             yaml_content = (folder / "mission.yaml").read_text()
             self.assertIn('name: "OpenTraining"', yaml_content)
 
+    def _make_community_folder(self, folder: Path, filenames: list[str]) -> None:
+        comm_dir = folder / "published" / "src" / "scripts" / "community"
+        comm_dir.mkdir(parents=True)
+        for name in filenames:
+            (comm_dir / name).write_text("-- stub\n", encoding="utf-8")
+
+    def test_scan_detects_present_community_scripts(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            self._make_missionconfig(folder, "-- test\n")
+            self._make_community_folder(folder, ["mist.lua", "CTLD.lua"])
+            report = V5Converter().convert(folder, backup=False)
+            self.assertIn("mist", report.detected_community_script_ids)
+            self.assertIn("ctld", report.detected_community_script_ids)
+            self.assertNotIn("skynet", report.detected_community_script_ids)
+
+    def test_scan_no_community_folder_yields_empty_set(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            self._make_missionconfig(folder, "-- test\n")
+            report = V5Converter().convert(folder, backup=False)
+            self.assertEqual(report.detected_community_script_ids, set())
+
+    def test_mission_yaml_community_scripts_section_present(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            self._make_missionconfig(folder, "-- test\n")
+            self._make_community_folder(folder, ["mist.lua", "CTLD.lua"])
+            V5Converter().convert(folder, backup=False)
+            yaml_content = (folder / "mission.yaml").read_text()
+            self.assertIn("community_scripts:", yaml_content)
+            self.assertIn("mist: {enabled: true}", yaml_content)
+            self.assertIn("ctld: {enabled: true}", yaml_content)
+            self.assertIn("skynet: {enabled: false}", yaml_content)
+
+    def test_mission_yaml_community_scripts_all_false_when_no_community_folder(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            self._make_missionconfig(folder, "-- test\n")
+            V5Converter().convert(folder, backup=False)
+            yaml_content = (folder / "mission.yaml").read_text()
+            self.assertIn("community_scripts:", yaml_content)
+            self.assertNotIn("enabled: true", yaml_content.split("community_scripts:")[1].split("# ──")[0])
+
 
 # ---------------------------------------------------------------------------
 # IMC-002 — annotated missionConfig.lua embedded in report

--- a/test/python/mission_tools/test_mission_constants.py
+++ b/test/python/mission_tools/test_mission_constants.py
@@ -26,13 +26,15 @@ class TestGetterFunctions(unittest.TestCase):
             self.assertIsInstance(item, tuple)
             self.assertEqual(len(item), 2)
 
-    def test_community_scripts_returns_list_of_tuples(self) -> None:
+    def test_community_scripts_returns_list_of_dicts(self) -> None:
         result = get_community_script_files()
         self.assertIsInstance(result, list)
         self.assertTrue(len(result) > 0)
         for item in result:
-            self.assertIsInstance(item, tuple)
-            self.assertEqual(len(item), 2)
+            self.assertIsInstance(item, dict)
+            self.assertIn("id", item)
+            self.assertIn("path", item)
+            self.assertIn("dest", item)
 
     def test_veaf_script_files_returns_nonempty(self) -> None:
         result = get_veaf_script_files()
@@ -62,7 +64,7 @@ class TestGetterFunctions(unittest.TestCase):
         self.assertTrue(any("veaf-scripts-debug" in p for p in paths))
 
     def test_community_scripts_include_mist(self) -> None:
-        paths = [item[0] for item in get_community_script_files()]
+        paths = [item["path"] for item in get_community_script_files()]
         self.assertTrue(any("mist.lua" in p for p in paths))
 
     def test_all_getter_return_types(self) -> None:


### PR DESCRIPTION
## Summary
- `get_community_script_files()` refactored to return `list[dict]` with stable `id`/`path`/`dest` keys (COMM-001)
- `MissionBuilderWorker` parses a new `community_scripts:` section in `mission.yaml`; absent section keeps all scripts active (COMM-002/003)
- Filter applied to both static (`insert_veaf_trigrules`) and dynamic (`insert_veaf_triggers`) trigger generation
- Default `mission.yaml` and both YAML reference docs updated with the new section (COMM-004/005)
- 10 new unit tests covering parsing, filtering, empty set, and unknown-id handling (COMM-006)

## Test plan
- [ ] `poetry run pytest test/python/mission_builder/ --no-cov` → 269 passed
- [ ] Build a mission with `community_scripts: { skynet: { enabled: false } }` — verify `skynet-iads-compiled.lua` absent from the `.miz`
- [ ] Build without `community_scripts:` section — verify all scripts present as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configurable toggling of community Lua scripts in missions via a new mission.yaml section and wire it through script collection and trigger generation.

New Features:
- Introduce a community_scripts section in mission.yaml to enable or disable individual community Lua scripts by stable identifier.
- Support per-mission filtering of community scripts in both static and dynamic trigger generation based on configured enablement flags.

Enhancements:
- Refactor community script descriptors to use stable id/path/dest dictionaries instead of tuples and centralize filtering through a helper.
- Warn on invalid community_scripts configuration values and unknown script identifiers while keeping defaults unchanged when the section is absent.

Documentation:
- Document the community_scripts section and available script identifiers in both English and French mission YAML reference docs, and add commented examples to the default mission.yaml.

Tests:
- Add unit tests covering community_scripts parsing, enabling/disabling behavior, handling of empty and invalid configurations, and active script selection helper behavior.

Chores:
- Update backlog and task tracking statuses to mark related COMM, CUSTOM, RADIO, and REV items as completed.
- Record the new community_scripts configuration capability in the changelog.