### PR TITLE
fix(multi): convert-v5 cwd/log defaults, SRS absent-file warning, ctld nil guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `convert-v5`: `global_log_level` now defaults to `info` instead of `debug` when no log level is found in `missionConfig.lua`
 - `convert-v5`: command now accepts being called without arguments (uses current directory by default); `no_args_is_help=True` removed
 - `veafRadio`: SRS config file absence no longer emits a warning — downgraded to `debug` when the file does not exist on disk
-- `veafGrass`, `veafSpawnGround`, `veafSpawnEffects`: nil-safe guards added around `ctld.builtFOBS`, `ctld.logisticUnits`, `ctld.beaconCount` — prevents crash when CTLD is not loaded or not yet initialized
+- `veafGrass`, `veafSpawnGround`, `veafSpawnEffects`: nil-safe guards added around `ctld.builtFOBS`, `ctld.logisticUnits`, `ctld.beaconCount` — prevent crashes when CTLD is not loaded or not yet initialized
 - `presets inject`: `presets_assignments` keys now support regex patterns (e.g. `A[-]10C.*`, `FW[-]190.*`) — exact match takes priority, then pattern, then `all` fallback
 - `convert-v5` presets: per-aircraft radio assignments are now extracted from `radioSettings` — warbird aircraft (e.g. Bf-109K-4) are auto-assigned to `{coalition}_warbird`, VHF-primary aircraft (e.g. I-16, Spitfire) get a new `{coalition}_vhf_primary` preset; hardcoded and typePattern entries emit explicit warnings listing the recommended preset
 - i18n : tous les messages des injectors (presets, waypoints) et du validateur de fréquences radio sont maintenant traduits en français — plus de messages en anglais dans le log de `veaf-tools build`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `convert-v5`: generated `mission.yaml` now includes a `community_scripts:` section pre-populated from scripts detected in `published/src/scripts/community/`
 
 ### Fixed
+- `convert-v5`: `global_log_level` now defaults to `info` instead of `debug` when no log level is found in `missionConfig.lua`
+- `convert-v5`: command now accepts being called without arguments (uses current directory by default); `no_args_is_help=True` removed
+- `veafRadio`: SRS config file absence no longer emits a warning — downgraded to `debug` when the file does not exist on disk
+- `veafGrass`, `veafSpawnGround`, `veafSpawnEffects`: nil-safe guards added around `ctld.builtFOBS`, `ctld.logisticUnits`, `ctld.beaconCount` — prevents crash when CTLD is not loaded or not yet initialized
 - `presets inject`: `presets_assignments` keys now support regex patterns (e.g. `A[-]10C.*`, `FW[-]190.*`) — exact match takes priority, then pattern, then `all` fallback
 - `convert-v5` presets: per-aircraft radio assignments are now extracted from `radioSettings` — warbird aircraft (e.g. Bf-109K-4) are auto-assigned to `{coalition}_warbird`, VHF-primary aircraft (e.g. I-16, Spitfire) get a new `{coalition}_vhf_primary` preset; hardcoded and typePattern entries emit explicit warnings listing the recommended preset
 - i18n : tous les messages des injectors (presets, waypoints) et du validateur de fréquences radio sont maintenant traduits en français — plus de messages en anglais dans le log de `veaf-tools build`

--- a/backlog.md
+++ b/backlog.md
@@ -79,11 +79,11 @@
 | Lot FIX-I18N-CONVERT-V5 — Hardcoded English messages in convert-v5 | ~30 min | ✅ |
 | Lot FIX-CONVERT-V5-PRESETS — Per-aircraft radio assignments in convert-v5 presets | ~45 min | ✅ |
 | Lot FEAT-COMMUNITY-TOGGLE — Enable/disable community scripts from mission.yaml | ~2h | ✅ |
-| Lot FIX-CONVERT-V5-DEFAULT-CWD — `convert-v5` uses current directory by default | ~5 min | ⬜ |
-| Lot FIX-SRS-WARN — false warning when SRS config file is absent | ~10 min | ⬜ |
-| Lot FIX-CTLD-NIL — nil crash on ctld.builtFOBS / ctld.logisticUnits in scheduled fns | ~15 min | ⬜ |
+| Lot FIX-CONVERT-V5-DEFAULT-CWD — `convert-v5` uses current directory by default | ~5 min | ✅ |
+| Lot FIX-SRS-WARN — false warning when SRS config file is absent | ~10 min | ✅ |
+| Lot FIX-CTLD-NIL — nil crash on ctld.builtFOBS / ctld.logisticUnits in scheduled fns | ~15 min | ✅ |
 | Lot I18N-COVERAGE — i18n coverage tests + fix remaining hardcoded English strings | ~2h30 | ⬜ |
-| Lot FIX-CONVERT-V5-LOG-DEFAULT — convert-v5 defaults global_log_level to debug instead of info | ~5 min | ⬜ |
+| Lot FIX-CONVERT-V5-LOG-DEFAULT — convert-v5 defaults global_log_level to debug instead of info | ~5 min | ✅ |
 | **Total** | **~182h** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*
@@ -236,7 +236,7 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 
 | # | Ticket | Files | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| CVCWD-001 | Remove `no_args_is_help=True` from `@app.command` decorator | `veaf_tools/commands/convert_v5.py` | fix | 5 min | ⬜ |
+| CVCWD-001 | Remove `no_args_is_help=True` from `@app.command` decorator | `veaf_tools/commands/convert_v5.py` | fix | 5 min | ✅ |
 
 ---
 
@@ -256,7 +256,7 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 
 | # | Ticket | Files | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| SRS-001 | Check `lfs.attributes` before `loadfile`; downgrade absent-file log to `debug` | `src/scripts/veaf/veafRadio.lua` | fix | 10 min | ⬜ |
+| SRS-001 | Check `lfs.attributes` before `loadfile`; downgrade absent-file log to `debug` | `src/scripts/veaf/veafRadio.lua` | fix | 10 min | ✅ |
 
 ---
 
@@ -278,9 +278,9 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 
 | # | Ticket | Files | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| CTLD-001 | Extend ctld guard in `veafGrass.lua` (~line 1003) | `src/scripts/veaf/veafGrass.lua` | fix | 5 min | ⬜ |
-| CTLD-002 | Add ctld guard in `veafSpawnGround.lua` (~line 182) | `src/scripts/veaf/veafSpawnGround.lua` | fix | 5 min | ⬜ |
-| CTLD-003 | Extend ctld guard in `veafSpawnEffects.lua` (~line 32) | `src/scripts/veaf/veafSpawnEffects.lua` | fix | 5 min | ⬜ |
+| CTLD-001 | Extend ctld guard in `veafGrass.lua` (~line 1003) | `src/scripts/veaf/veafGrass.lua` | fix | 5 min | ✅ |
+| CTLD-002 | Add ctld guard in `veafSpawnGround.lua` (~line 182) | `src/scripts/veaf/veafSpawnGround.lua` | fix | 5 min | ✅ |
+| CTLD-003 | Extend ctld guard in `veafSpawnEffects.lua` (~line 32) | `src/scripts/veaf/veafSpawnEffects.lua` | fix | 5 min | ✅ |
 
 ---
 
@@ -328,7 +328,7 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 
 | # | Ticket | Files | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| CVLOG-001 | Change fallback `'debug'` → `'info'` in `_build_mission_yaml_lines` | `src/python/veaf-tools/mission_builder/v5_converter.py` | fix | 5 min | ⬜ |
+| CVLOG-001 | Change fallback `'debug'` → `'info'` in `_build_mission_yaml_lines` | `src/python/veaf-tools/mission_builder/v5_converter.py` | fix | 5 min | ✅ |
 
 ---
 

--- a/dev/presentation VMCT v6.html
+++ b/dev/presentation VMCT v6.html
@@ -135,7 +135,8 @@ const SL=[
   {i:"📡",h:"Validation des fréquences radio",d:"inject-presets vérifie que chaque fréquence de preset est dans la plage valide pour l'avion concerné (données extraites de dcs-lua-datamine). Warning explicite avec la plage attendue."},
   {i:"✈️",h:"Presets per-aircraft & patterns regex",d:"convert-v5 extrait les assignments radio par type d'avion depuis radioSettings. Les clés <code>presets_assignments</code> supportent les regex (ex : <code>A[-]10C.*</code>) — exact > pattern > <code>all</code>."},
   {i:"🌉",h:"dcs-bridge — pont DCS optionnel",d:"Section <code>dcs_bridge:</code> dans mission.yaml — injecte dcs-bridge.lua dans le .miz pour exposer une API réseau DCS. Désactivé par défaut, zéro overhead si absent."},
-  {i:"🔄",h:"convert-v5 génère community_scripts",d:"La conversion v5→v6 détecte les scripts présents dans <code>published/src/scripts/community/</code> et pré-remplit la section <code>community_scripts:</code> avec les bons flags enabled."}]},
+  {i:"🔄",h:"convert-v5 génère community_scripts",d:"La conversion v5→v6 détecte les scripts présents dans <code>published/src/scripts/community/</code> et pré-remplit la section <code>community_scripts:</code> avec les bons flags enabled."}],
+note:"<span style='color:var(--gold);font-weight:700'>dcs-bridge</span> est un outil tiers (<a href='https://github.com/DCS-BR-Tools/dcs-bridge' style='color:#c8a855'>DCS-BR-Tools/dcs-bridge</a>) qui expose une API réseau depuis DCS — utilisé par des outils externes (SRS, bots Discord, tableaux de bord…). La section <code>dcs_bridge:</code> dans mission.yaml injecte et configure le script automatiquement."},
 {t:"section",num:"3 — BUILD",title:"Pipeline de build",sub:"Même workflow, outillage entièrement repensé"},
 {t:"flow"},
 {t:"features",title:"Ce qui change sous le capot",items:[
@@ -349,8 +350,9 @@ function rCode(){
 }
 
 function rFeatures(s){
+  const noteHtml=s.note?`<div style="margin-top:10px;background:rgba(232,160,32,.07);border:1px solid rgba(232,160,32,.25);padding:9px 13px;font-size:13px;color:#c8a855">${s.note}</div>`:'';
   return `<div class="lbl" style="margin-bottom:2px">${s.title}</div>
-  <div class="feat-grid">${s.items.map(i=>`<div class="feat-card"><div class="ficon">${i.i}</div><div><div class="ftitle">${i.h}</div><div class="fdesc">${i.d}</div></div></div>`).join('')}</div>`;
+  <div class="feat-grid">${s.items.map(i=>`<div class="feat-card"><div class="ficon">${i.i}</div><div><div class="ftitle">${i.h}</div><div class="fdesc">${i.d}</div></div></div>`).join('')}</div>${noteHtml}`;
 }
 
 function rFlow(){

--- a/dev/presentation VMCT v6.html
+++ b/dev/presentation VMCT v6.html
@@ -129,7 +129,13 @@ const SL=[
   {i:"🔗",h:"Dépendances auto-résolues",d:"Module désactivé requis ? Activé automatiquement avec un warning. Chaînes transitives résolues."},
   {i:"🎛️",h:"Profils de build",d:"veaf-tools build --profile TEST — deep-merge sur la config de base. Listes remplacées."},
   {i:"📦",h:"CTLD & CSAR YAML-first",d:"external_modules.ctld/.csar génèrent le bloc Lua + initialize() dans veaf-config.lua."},
-  {i:"📜",h:"Scripts custom déclarés",d:"Nouvelle section <code>custom_scripts:</code> — déclare des scripts Lua dans <code>src/scripts/</code> sans convention de nommage. Option <code>generate_load_trigger: false</code> pour opt-out du trigger DCS."}]},
+  {i:"📜",h:"Scripts custom déclarés",d:"Section <code>custom_scripts:</code> — déclare des scripts Lua dans <code>src/scripts/</code> sans convention de nommage. Option <code>generate_load_trigger: false</code> pour opt-out du trigger DCS."},
+  {i:"🔀",h:"Scripts communautaires toggleables",d:"Section <code>community_scripts:</code> — active ou désactive individuellement MIST, CTLD, CSAR, Skynet, TUM… Sémantique opt-out : seuls les scripts explicitement désactivés sont exclus du build."}]},
+{t:"features",title:"Nouveautés récentes",items:[
+  {i:"📡",h:"Validation des fréquences radio",d:"inject-presets vérifie que chaque fréquence de preset est dans la plage valide pour l'avion concerné (données extraites de dcs-lua-datamine). Warning explicite avec la plage attendue."},
+  {i:"✈️",h:"Presets per-aircraft & patterns regex",d:"convert-v5 extrait les assignments radio par type d'avion depuis radioSettings. Les clés <code>presets_assignments</code> supportent les regex (ex : <code>A[-]10C.*</code>) — exact > pattern > <code>all</code>."},
+  {i:"🌉",h:"dcs-bridge — pont DCS optionnel",d:"Section <code>dcs_bridge:</code> dans mission.yaml — injecte dcs-bridge.lua dans le .miz pour exposer une API réseau DCS. Désactivé par défaut, zéro overhead si absent."},
+  {i:"🔄",h:"convert-v5 génère community_scripts",d:"La conversion v5→v6 détecte les scripts présents dans <code>published/src/scripts/community/</code> et pré-remplit la section <code>community_scripts:</code> avec les bons flags enabled."}]},
 {t:"section",num:"3 — BUILD",title:"Pipeline de build",sub:"Même workflow, outillage entièrement repensé"},
 {t:"flow"},
 {t:"features",title:"Ce qui change sous le capot",items:[
@@ -171,6 +177,7 @@ const NOTES=[
 "Insister sur la validation : en v5, erreur de config = crash DCS. En v6, le build valide tout avant. La séparation YAML/Lua est intentionnelle.",
 "Montrer la lisibilité vs missionConfig.lua. La clé veaf_tools.version est lue par l'updater. Syntaxe semver : '6' = toute 6.x.x, '^6.3' = compatible, '~6.3.1' = patch only.",
 "Les profils de build : logs debug pour testeurs, logs warning pour serveur public — sans toucher au fichier de config.",
+"Fonctionnalités ajoutées après la première version de la présentation. La validation radio utilise les données de dcs-lua-datamine — 150+ appareils couverts. Le toggle community_scripts évite de supprimer manuellement des scripts du .miz.",
 "Le workflow est identique à la v5 côté utilisateur. Ce qui change : fiabilité, validation, warnings préventifs.",
 "Le pipeline vu user est le même qu'en v5. La vraie valeur : le build intercepte les problèmes avant DCS.",
 "Le warning sur les .lua résiduels v5 est critique lors de la migration. L'édition à la volée dans le .miz est utile pour debug sur serveur distant sans accès au build.",
@@ -313,8 +320,7 @@ function rCommands(){
 
 function rCode(){
   return `<div class="lbl">Exemple mission.yaml</div>
-<div class="code-blk"><span class="cc"># Modules Lua actifs</span>
-<span class="ck">lua_modules</span>:
+<div class="code-blk" style="font-size:13px"><span class="ck">lua_modules</span>:
   - <span class="ck">name</span>: <span class="cv">UNITS</span>          <span class="cc"># obligatoire</span>
     <span class="ck">enable</span>: <span class="cs">true</span>
   - <span class="ck">name</span>: <span class="cv">QRA_MANAGER</span>
@@ -331,12 +337,13 @@ function rCode(){
     <span class="ck">global_log_level</span>: <span class="cv">warning</span>
 
 <span class="ck">external_modules</span>:
-  <span class="ck">ctld</span>:
-    <span class="ck">enable</span>: <span class="cs">true</span>
-  <span class="ck">csar</span>:
-    <span class="ck">enable</span>: <span class="cs">true</span>
+  <span class="ck">ctld</span>: { <span class="ck">enable</span>: <span class="cs">true</span> }
+  <span class="ck">csar</span>: { <span class="ck">enable</span>: <span class="cs">true</span> }
 
-<span class="cc"># Épingler la version veaf-tools pour cette mission</span>
+<span class="cc"># Scripts communautaires — opt-out : ne lister que ce qu'on veut désactiver</span>
+<span class="ck">community_scripts</span>:
+  <span class="ck">skynet</span>: { <span class="ck">enabled</span>: <span class="cs">false</span> }   <span class="cc"># pas de Skynet pour cette mission</span>
+
 <span class="ck">veaf_tools</span>:
   <span class="ck">version</span>: <span class="cv">"^6.3"</span></div>`;
 }
@@ -516,8 +523,12 @@ function rTests(){
       <div class="lbl">La garantie en v6</div>
       <div style="display:flex;flex-direction:column;gap:10px;margin-top:10px">
         <div style="background:var(--bg3);border-left:3px solid #27ae60;padding:16px 18px">
-          <div style="font-family:var(--raj);font-size:20px;color:#27ae60;margin-bottom:4px">915+ tests Lua</div>
-          <div style="font-size:14px;color:var(--muted)">31 suites simulant l'environnement DCS (timer, coalition, world…) hors DCS</div>
+          <div style="font-family:var(--raj);font-size:20px;color:#27ae60;margin-bottom:4px">1 818 tests Lua</div>
+          <div style="font-size:14px;color:var(--muted)">32 suites simulant l'environnement DCS (timer, coalition, world…) hors DCS</div>
+        </div>
+        <div style="background:var(--bg3);border-left:3px solid #27ae60;padding:16px 18px">
+          <div style="font-family:var(--raj);font-size:20px;color:#27ae60;margin-bottom:4px">1 026 tests Python</div>
+          <div style="font-size:14px;color:var(--muted)">Couverture du pipeline de build : YAML, presets, convert-v5, validation radio…</div>
         </div>
         <div style="background:var(--bg3);border-left:3px solid #27ae60;padding:16px 18px">
           <div style="font-family:var(--raj);font-size:20px;color:#27ae60;margin-bottom:4px">CI automatique sur chaque PR</div>

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -819,7 +819,7 @@ class V5Converter:
             "# Remove or set to 'info' before deploying to players.",
             f"# Doc: {_DOC_BASE}#debug-logging",
             "#",
-            f"global_log_level: {extracted_ll or 'debug'}",
+            f"global_log_level: {extracted_ll or 'info'}",
             "",
         ]
 

--- a/src/python/veaf-tools/veaf_tools/commands/convert_v5.py
+++ b/src/python/veaf-tools/veaf_tools/commands/convert_v5.py
@@ -16,7 +16,7 @@ from veaf_tools.app import (
 )
 
 
-@app.command(no_args_is_help=True, help=t("cmd.convert_v5.help.long"))
+@app.command(help=t("cmd.convert_v5.help.long"))
 def convert_v5(
     mission_folder: str = typer.Argument(
         ".",

--- a/src/scripts/veaf/veafGrass.lua
+++ b/src/scripts/veaf/veafGrass.lua
@@ -1001,8 +1001,12 @@ function veafGrass.buildFarpUnits(farp, grassRunwayUnits, groupName, hiddenOnMFD
     name = farp.groupName
   end
   if ctld then
-    table.insert(ctld.builtFOBS, name)
-    table.insert(ctld.logisticUnits, name)
+    if ctld.builtFOBS then
+      table.insert(ctld.builtFOBS, name)
+    end
+    if ctld.logisticUnits then
+      table.insert(ctld.logisticUnits, name)
+    end
   end
 
   local farpUnitNameCounter = 1

--- a/src/scripts/veaf/veafRadio.lua
+++ b/src/scripts/veaf/veafRadio.lua
@@ -935,7 +935,9 @@ function veafRadio.initialize(skipHelpMenus, dontCreateMenus)
           veaf.loggers.get(veafRadio.Id):warn(string.format("Error while loading SRS configuration file [%s]", srsConfigPath))
         end
       else
-        veaf.loggers.get(veafRadio.Id):debug(string.format("SRS configuration file not found [%s] - SRS integration disabled", srsConfigPath))
+        veaf.loggers
+          .get(veafRadio.Id)
+          :debug(string.format("SRS configuration file not found [%s] - SRS integration disabled", srsConfigPath))
       end
     end
   end

--- a/src/scripts/veaf/veafRadio.lua
+++ b/src/scripts/veaf/veafRadio.lua
@@ -918,19 +918,24 @@ function veafRadio.initialize(skipHelpMenus, dontCreateMenus)
     --local test = l_lfs.currentdir()
     --veaf.loggers.get(veafRadio.Id):debug(string.format("test = %s", tostring(test)))
     if srsConfigPath then
-      -- execute the script
-      local file = loadfile(srsConfigPath)
-      if file then
-        file()
-        veaf.loggers.get(veafRadio.Id):info("SRS configuration file loaded")
-        if STTS then
-          STTS.MP3_FOLDER = l_lfs.writedir() .. "\\..\\..\\Music"
-          veaf.loggers.get(veafRadio.Id):trace(string.format("STTS.SRS_PORT = %s", tostring(STTS.SRS_PORT)))
-          veaf.loggers.get(veafRadio.Id):trace(string.format("STTS.DIRECTORY = %s", tostring(STTS.DIRECTORY)))
-          veaf.loggers.get(veafRadio.Id):trace(string.format("STTS.EXECUTABLE = %s", tostring(STTS.EXECUTABLE)))
+      local fileAttrs = l_lfs.attributes(srsConfigPath)
+      if fileAttrs then
+        -- execute the script
+        local file = loadfile(srsConfigPath)
+        if file then
+          file()
+          veaf.loggers.get(veafRadio.Id):info("SRS configuration file loaded")
+          if STTS then
+            STTS.MP3_FOLDER = l_lfs.writedir() .. "\\..\\..\\Music"
+            veaf.loggers.get(veafRadio.Id):trace(string.format("STTS.SRS_PORT = %s", tostring(STTS.SRS_PORT)))
+            veaf.loggers.get(veafRadio.Id):trace(string.format("STTS.DIRECTORY = %s", tostring(STTS.DIRECTORY)))
+            veaf.loggers.get(veafRadio.Id):trace(string.format("STTS.EXECUTABLE = %s", tostring(STTS.EXECUTABLE)))
+          end
+        else
+          veaf.loggers.get(veafRadio.Id):warn(string.format("Error while loading SRS configuration file [%s]", srsConfigPath))
         end
       else
-        veaf.loggers.get(veafRadio.Id):warn(string.format("Error while loading SRS configuration file [%s]", srsConfigPath))
+        veaf.loggers.get(veafRadio.Id):debug(string.format("SRS configuration file not found [%s] - SRS integration disabled", srsConfigPath))
       end
     end
   end

--- a/src/scripts/veaf/veafSpawnEffects.lua
+++ b/src/scripts/veaf/veafSpawnEffects.lua
@@ -29,7 +29,7 @@ function veafSpawn.spawnLogistic(spawnSpot, radius, country, silent, hiddenOnMFD
 
   if unitName then
     veaf.loggers.get(veafSpawn.Id):debug(string.format("spawnLogistic: inserting %s into CTLD logistics list", unitName))
-    if ctld then
+    if ctld and ctld.logisticUnits then
       table.insert(ctld.logisticUnits, unitName)
     end
 

--- a/src/scripts/veaf/veafSpawnGround.lua
+++ b/src/scripts/veaf/veafSpawnGround.lua
@@ -178,33 +178,39 @@ function veafSpawn.spawnFob(spawnSpot, radius, name, country, fobtype, side, hdg
   }
   mist.dynAddStatic(_tower)
 
-  --make it able to deploy crates and pickup troops
-  table.insert(ctld.logisticUnits, _fobName)
-  table.insert(ctld.builtFOBS, _fobName)
-
   -- add the FOB to the named points
   local _namedPoint = _spawnPosition
   _namedPoint.atc = true
   _namedPoint.runways = {}
 
-  -- spawn a beacon
-  local _beaconPoint = {
-    z = _tower.y + BEACON_DISTANCE * math.sin(mist.utils.toRadian(_hdg)),
-    x = _tower.x + BEACON_DISTANCE * math.cos(mist.utils.toRadian(_hdg)),
-    y = _spawnPosition.y,
-  }
-  ctld.beaconCount = ctld.beaconCount + 1
-  local _radioBeaconName = "FOB Beacon #" .. ctld.beaconCount
-  local _radioBeaconDetails = ctld.createRadioBeacon(_beaconPoint, _side, _country, _radioBeaconName, nil, true)
-  ctld.fobBeacons[_fobName] = { vhf = _radioBeaconDetails.vhf, uhf = _radioBeaconDetails.uhf, fm = _radioBeaconDetails.fm }
-  if _radioBeaconDetails ~= nil then
-    _namedPoint.tacan = string.format(
-      "ADF : %.2f KHz - %.2f MHz - %.2f MHz FM",
-      _radioBeaconDetails.vhf / 1000,
-      _radioBeaconDetails.uhf / 1000000,
-      _radioBeaconDetails.fm / 1000000
-    )
-    veaf.loggers.get(veafSpawn.Id):trace("_namedPoint.tacan=%s", veaf.lp(_namedPoint.tacan))
+  if ctld then
+    --make it able to deploy crates and pickup troops
+    if ctld.logisticUnits then
+      table.insert(ctld.logisticUnits, _fobName)
+    end
+    if ctld.builtFOBS then
+      table.insert(ctld.builtFOBS, _fobName)
+    end
+
+    -- spawn a beacon
+    local _beaconPoint = {
+      z = _tower.y + BEACON_DISTANCE * math.sin(mist.utils.toRadian(_hdg)),
+      x = _tower.x + BEACON_DISTANCE * math.cos(mist.utils.toRadian(_hdg)),
+      y = _spawnPosition.y,
+    }
+    ctld.beaconCount = ctld.beaconCount + 1
+    local _radioBeaconName = "FOB Beacon #" .. ctld.beaconCount
+    local _radioBeaconDetails = ctld.createRadioBeacon(_beaconPoint, _side, _country, _radioBeaconName, nil, true)
+    ctld.fobBeacons[_fobName] = { vhf = _radioBeaconDetails.vhf, uhf = _radioBeaconDetails.uhf, fm = _radioBeaconDetails.fm }
+    if _radioBeaconDetails ~= nil then
+      _namedPoint.tacan = string.format(
+        "ADF : %.2f KHz - %.2f MHz - %.2f MHz FM",
+        _radioBeaconDetails.vhf / 1000,
+        _radioBeaconDetails.uhf / 1000000,
+        _radioBeaconDetails.fm / 1000000
+      )
+      veaf.loggers.get(veafSpawn.Id):trace("_namedPoint.tacan=%s", veaf.lp(_namedPoint.tacan))
+    end
   end
   trigger.action.outTextForCoalition(
     _side,

--- a/src/scripts/veaf/veafSpawnGround.lua
+++ b/src/scripts/veaf/veafSpawnGround.lua
@@ -193,23 +193,25 @@ function veafSpawn.spawnFob(spawnSpot, radius, name, country, fobtype, side, hdg
     end
 
     -- spawn a beacon
-    local _beaconPoint = {
-      z = _tower.y + BEACON_DISTANCE * math.sin(mist.utils.toRadian(_hdg)),
-      x = _tower.x + BEACON_DISTANCE * math.cos(mist.utils.toRadian(_hdg)),
-      y = _spawnPosition.y,
-    }
-    ctld.beaconCount = ctld.beaconCount + 1
-    local _radioBeaconName = "FOB Beacon #" .. ctld.beaconCount
-    local _radioBeaconDetails = ctld.createRadioBeacon(_beaconPoint, _side, _country, _radioBeaconName, nil, true)
-    ctld.fobBeacons[_fobName] = { vhf = _radioBeaconDetails.vhf, uhf = _radioBeaconDetails.uhf, fm = _radioBeaconDetails.fm }
-    if _radioBeaconDetails ~= nil then
-      _namedPoint.tacan = string.format(
-        "ADF : %.2f KHz - %.2f MHz - %.2f MHz FM",
-        _radioBeaconDetails.vhf / 1000,
-        _radioBeaconDetails.uhf / 1000000,
-        _radioBeaconDetails.fm / 1000000
-      )
-      veaf.loggers.get(veafSpawn.Id):trace("_namedPoint.tacan=%s", veaf.lp(_namedPoint.tacan))
+    if ctld.beaconCount and ctld.fobBeacons then
+      local _beaconPoint = {
+        z = _tower.y + BEACON_DISTANCE * math.sin(mist.utils.toRadian(_hdg)),
+        x = _tower.x + BEACON_DISTANCE * math.cos(mist.utils.toRadian(_hdg)),
+        y = _spawnPosition.y,
+      }
+      ctld.beaconCount = ctld.beaconCount + 1
+      local _radioBeaconName = "FOB Beacon #" .. ctld.beaconCount
+      local _radioBeaconDetails = ctld.createRadioBeacon(_beaconPoint, _side, _country, _radioBeaconName, nil, true)
+      if _radioBeaconDetails ~= nil then
+        ctld.fobBeacons[_fobName] = { vhf = _radioBeaconDetails.vhf, uhf = _radioBeaconDetails.uhf, fm = _radioBeaconDetails.fm }
+        _namedPoint.tacan = string.format(
+          "ADF : %.2f KHz - %.2f MHz - %.2f MHz FM",
+          _radioBeaconDetails.vhf / 1000,
+          _radioBeaconDetails.uhf / 1000000,
+          _radioBeaconDetails.fm / 1000000
+        )
+        veaf.loggers.get(veafSpawn.Id):trace("_namedPoint.tacan=%s", veaf.lp(_namedPoint.tacan))
+      end
     end
   end
   trigger.action.outTextForCoalition(

--- a/test/python/mission_builder/test_v5_converter.py
+++ b/test/python/mission_builder/test_v5_converter.py
@@ -484,12 +484,9 @@ class TestV5ConverterIntegration(unittest.TestCase):
             self._make_missionconfig(folder, "-- no log level here\n")
             V5Converter().convert(folder, backup=False)
             yaml_content = (folder / "mission.yaml").read_text()
-            # Should default to 'info', never 'debug'
             log_line = next((l for l in yaml_content.splitlines() if "global_log_level" in l and not l.strip().startswith("#")), None)
             self.assertIsNotNone(log_line)
-            assert log_line is not None
-            self.assertIn("info", log_line)
-            self.assertNotIn("debug", log_line)
+            self.assertEqual(log_line.strip(), "global_log_level: info")
 
 
 # ---------------------------------------------------------------------------

--- a/test/python/mission_builder/test_v5_converter.py
+++ b/test/python/mission_builder/test_v5_converter.py
@@ -477,6 +477,19 @@ class TestV5ConverterIntegration(unittest.TestCase):
             yaml_content = (folder / "mission.yaml").read_text()
             self.assertIn("community_scripts:", yaml_content)
             self.assertNotIn("enabled: true", yaml_content.split("community_scripts:")[1].split("# ──")[0])
+    def test_mission_yaml_global_log_level_defaults_to_info(self) -> None:
+        """When no global_log_level is found in missionConfig, generated yaml uses 'info' not 'debug'."""
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            self._make_missionconfig(folder, "-- no log level here\n")
+            V5Converter().convert(folder, backup=False)
+            yaml_content = (folder / "mission.yaml").read_text()
+            # Should default to 'info', never 'debug'
+            log_line = next((l for l in yaml_content.splitlines() if "global_log_level" in l and not l.strip().startswith("#")), None)
+            self.assertIsNotNone(log_line)
+            assert log_line is not None
+            self.assertIn("info", log_line)
+            self.assertNotIn("debug", log_line)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **CVCWD-001** — `convert-v5` no longer shows help when called without args; uses current directory by default
- **CVLOG-001** — `convert-v5` generated `global_log_level` defaults to `info` instead of `debug` when no value found in `missionConfig.lua`
- **SRS-001** — `veafRadio`: SRS config file absence no longer emits a `warn`; `lfs.attributes` check added, missing file logs at `debug`
- **CTLD-001/002/003** — nil-safe guards around `ctld.builtFOBS`, `ctld.logisticUnits`, `ctld.beaconCount` in `veafGrass`, `veafSpawnGround`, `veafSpawnEffects`

## Test plan
- [ ] 1027 Python tests pass (1 new test: `test_mission_yaml_global_log_level_defaults_to_info`)
- [ ] 32 Lua test suites pass
- [ ] `ruff` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align convert-v5 defaults and Lua-side CTLD/SRS integrations with safer behavior and update docs and tests accordingly.

Bug Fixes:
- Make convert-v5 accept being called without arguments by defaulting the mission folder to the current directory.
- Default generated mission.yaml global_log_level to info when no value is found in missionConfig.lua instead of debug.
- Avoid spurious warnings when the SRS configuration file is absent by checking file existence first and logging at debug level when missing.
- Prevent nil-access crashes in CTLD integrations by guarding ctld.builtFOBS, ctld.logisticUnits, and ctld.beaconCount in veafGrass, veafSpawnGround, and veafSpawnEffects.

Documentation:
- Update the VMCT v6 presentation to document community_scripts toggling, recent features, configuration examples, and refreshed test statistics.
- Document the new convert-v5 defaults and CTLD/SRS fixes in the changelog and backlog.

Tests:
- Add a Python test ensuring mission.yaml global_log_level defaults to info when no level is present in missionConfig.lua.

Chores:
- Mark the related FIX tickets as completed in the backlog.