### PR TITLE
feat(weather): drop missions.yaml alias — versions.yaml only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- `weather` pipeline step now uses `versions.yaml` exclusively — `missions.yaml` is no longer recognised as an alias; rename any existing `src/missions.yaml` to `src/versions.yaml`
+
 ### Added
 - i18n coverage: all log messages in `mission_builder_worker.py`, `aircrafts_injector_worker.py`, and `waypoints_manager.py` now use `t()` — no more hardcoded English strings; matching French translations added to `fr.json`; tests verify all `t()` keys exist in `en.json` and that `fr.json` covers every `en.json` key
 - Klogg highlight profile for DCS logs added to `tools/klogg/veaf.conf`; GUIDE.md and GUIDE.en.md updated to reference it

--- a/backlog.md
+++ b/backlog.md
@@ -84,6 +84,7 @@
 | Lot FIX-CTLD-NIL — nil crash on ctld.builtFOBS / ctld.logisticUnits in scheduled fns | ~15 min | ✅ |
 | Lot I18N-COVERAGE — i18n coverage tests + fix remaining hardcoded English strings | ~2h30 | ✅ |
 | Lot FIX-CONVERT-V5-LOG-DEFAULT — convert-v5 defaults global_log_level to debug instead of info | ~5 min | ✅ |
+| Lot FIX-VERSIONS-YAML-ONLY — drop missions.yaml alias, use versions.yaml exclusively for weather pipeline | ~15 min | ✅ |
 | **Total** | **~182h** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*
@@ -315,6 +316,22 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 | I18N-COV-005 | Add i18n keys for `lua_config_generator.py` and `waypoints_manager.py` hardcoded strings | `veaf_libs/lua_config_generator.py`, `waypoints_injector/waypoints_manager.py`, `locales/*.json` | fix | 15 min | ✅ |
 
 ---
+
+## Lot FIX-VERSIONS-YAML-ONLY — drop missions.yaml alias for weather pipeline
+
+**Goal**: Remove `missions.yaml` as an accepted alias for the weather pipeline config. `versions.yaml` is the only valid filename. Eliminates confusion with `mission.yaml`.
+
+**Branch**: `feature/versions-yaml-only` → PR #386 → `develop-v6`
+
+| # | Ticket | Files | Type | Effort | Status |
+|---|--------|-------|------|--------|--------|
+| VYO-001 | Remove `missions.yaml` from `V6_PIPELINE_CANDIDATES["weather"]` | `mission_builder/v5_converter.py` | fix | 2 min | ✅ |
+| VYO-002 | Remove legacy WEATHER-001 coexistence guard from `mission_builder_worker.py` | `mission_builder/mission_builder_worker.py` | fix | 5 min | ✅ |
+| VYO-003 | Update `build.py` `_step_file` call and `weather.py` CLI default | `veaf_tools/commands/build.py`, `veaf_tools/commands/weather.py` | fix | 2 min | ✅ |
+| VYO-004 | Update `weather_injector_README.py` and pipeline reference docs | `weather_injector/weather_injector_README.py`, `doc/PIPELINE_REFERENCE*.md` | doc | 5 min | ✅ |
+| VYO-005 | Drop obsolete test `test_versions_not_copied_when_missions_exists` | `test/python/mission_builder/test_mission_builder_defaults.py` | test | 1 min | ✅ |
+
+----
 
 ## Lot FIX-CONVERT-V5-LOG-DEFAULT — convert-v5 defaults global_log_level to debug instead of info
 

--- a/doc/PIPELINE_REFERENCE.en.md
+++ b/doc/PIPELINE_REFERENCE.en.md
@@ -13,7 +13,7 @@ The pipeline runs four optional steps, in this order:
 | `presets` | `src/presets.yaml` | Injects radio frequency presets into human-piloted aircraft groups |
 | `waypoints` | `src/waypoints.yaml` or `waypoints.yaml` | Injects waypoint templates into human-piloted aircraft groups |
 | `aircraft_groups` | `src/aircraft-templates.yaml`, `src/templates.yaml`, or `aircraft-templates.yaml` | Injects aircraft group definitions (slots/spawnable groups) |
-| `weather` | `src/missions.yaml` (legacy, first), `src/versions.yaml`, or `missions.yaml` | Creates multiple mission variants with different weather and time |
+| `weather` | `src/versions.yaml` or `versions.yaml` | Creates multiple mission variants with different weather and time |
 
 Each step is **auto-detected**: it runs if its default config file exists. You can override this behaviour in `mission.yaml`.
 
@@ -323,10 +323,9 @@ Creates multiple `.miz` variants from a single base mission, each with a differe
 ### Default file location
 
 ```
-<mission-folder>/src/missions.yaml  (legacy, checked first)
 <mission-folder>/src/versions.yaml
 
-Also accepted: missions.yaml  (mission root)
+Also accepted: versions.yaml  (mission root)
 ```
 
 ### Schema

--- a/doc/PIPELINE_REFERENCE.md
+++ b/doc/PIPELINE_REFERENCE.md
@@ -13,7 +13,7 @@ Le pipeline exécute quatre étapes optionnelles, dans cet ordre :
 | `presets` | `src/presets.yaml` | Injecte les préréglages de fréquences radio dans les groupes d'avions pilotés par des humains |
 | `waypoints` | `src/waypoints.yaml` ou `waypoints.yaml` | Injecte des modèles de points de cheminement dans les groupes d'avions pilotés par des humains |
 | `aircraft_groups` | `src/aircraft-templates.yaml`, `src/templates.yaml` ou `aircraft-templates.yaml` | Injecte des définitions de groupes d'aéronefs (slots/groupes à spawner) |
-| `weather` | `src/missions.yaml` (legacy, prioritaire), `src/versions.yaml` ou `missions.yaml` | Crée plusieurs variantes de mission avec différentes météos et heures |
+| `weather` | `src/versions.yaml` ou `versions.yaml` | Crée plusieurs variantes de mission avec différentes météos et heures |
 
 Chaque étape est **auto-détectée** : elle s'exécute si son fichier de config par défaut existe. Vous pouvez modifier ce comportement dans `mission.yaml`.
 
@@ -321,10 +321,9 @@ Crée plusieurs variantes `.miz` à partir d'une mission de base, chacune avec u
 ### Emplacement par défaut
 
 ```
-<dossier-mission>/src/missions.yaml  (legacy, vérifié en premier)
 <dossier-mission>/src/versions.yaml
 
-Aussi accepté : missions.yaml  (racine du dossier mission)
+Aussi accepté : versions.yaml  (racine du dossier mission)
 ```
 
 ### Schéma

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -436,7 +436,6 @@ class MissionBuilderWorker(BaseWorker):
             "waypoints.yaml": {"pipeline": "waypoints"},
             "presets.yaml": {"pipeline": "presets"},
             "versions.yaml": {"pipeline": "weather"},
-            "missions.yaml": {"pipeline": "weather"},
         }
         for f in defaults_folder.rglob("*"):
             if f.is_file():
@@ -470,16 +469,6 @@ class MissionBuilderWorker(BaseWorker):
                                     f"You can safely delete it."
                                 )
                             continue
-                # WEATHER-001: skip copying versions.yaml if legacy missions.yaml already exists
-                if f.name == "versions.yaml":
-                    legacy_weather = self.mission_folder / "src" / "missions.yaml"
-                    if legacy_weather.exists():
-                        logger.warning(
-                            "Legacy weather config 'src/missions.yaml' found. "
-                            "Skipping copy of default 'src/versions.yaml'. "
-                            "Consider renaming 'missions.yaml' \u2192 'versions.yaml'."
-                        )
-                        continue
                 relative_path = f.relative_to(defaults_folder).parent.as_posix()
                 relative_path = self.mission_folder / relative_path / f.name
                 if not relative_path.exists():

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -54,7 +54,7 @@ V6_PIPELINE_CANDIDATES: dict[str, list[str]] = {
     "presets": ["src/presets.yaml"],
     "waypoints": ["src/waypoints.yaml"],
     "aircraft_groups": ["src/aircraft-templates.yaml", "src/templates.yaml"],
-    "weather": ["src/missions.yaml", "src/versions.yaml"],
+    "weather": ["src/versions.yaml"],
 }
 
 #: v5 source file paths (what a v5 mission folder typically contains).

--- a/src/python/veaf-tools/veaf_tools/commands/build.py
+++ b/src/python/veaf-tools/veaf_tools/commands/build.py
@@ -206,7 +206,7 @@ def build(
                 "You can safely delete it, or enable 'aircraft_groups' in mission.yaml."
             )
 
-    weather_path = _step_file("weather", "src/missions.yaml", "src/versions.yaml", "missions.yaml")
+    weather_path = _step_file("weather", "src/versions.yaml", "versions.yaml")
     if weather_path:
         logger.info(t("pipeline.injecting_weather", path=weather_path))
         console.print(t("pipeline.console.weather", file=weather_path.name))

--- a/src/python/veaf-tools/veaf_tools/commands/weather.py
+++ b/src/python/veaf-tools/veaf_tools/commands/weather.py
@@ -21,7 +21,7 @@ def inject_weather(
     readme: bool = typer.Option(False, help=README_HELP),
     verbose: bool = typer.Option(False, help=VERBOSE_HELP),
     mission_name_or_file: str | None = typer.Argument(DEFAULT_MISSION_FILE, help=t("cmd.inject_weather.opt.mission")),
-    config_file: str = typer.Option("missions.yaml", help=t("cmd.inject_weather.opt.config_file")),
+    config_file: str = typer.Option("versions.yaml", help=t("cmd.inject_weather.opt.config_file")),
     convert_lua: bool = typer.Option(False, "--convert-lua", help=t("cmd.inject_weather.opt.convert_lua")),
     pause: bool = typer.Option(False, help=PAUSE_HELP),
 ) -> None:

--- a/src/python/veaf-tools/weather_injector/weather_injector_README.py
+++ b/src/python/veaf-tools/weather_injector/weather_injector_README.py
@@ -18,7 +18,7 @@ Create multiple versions of a DCS mission with different weather conditions and 
 
 ### 1. Create Configuration File
 
-Create `missions.yaml`:
+Create `versions.yaml`:
 
 ```yaml
 # Geographic position for solar calculations
@@ -51,7 +51,7 @@ versions:
 ### 2. Run Weather and Time Versions
 
 ```bash
-veaf-tools weather-and-time base_mission.miz --config-file missions.yaml
+veaf-tools weather-and-time base_mission.miz --config-file versions.yaml
 ```
 
 This creates:
@@ -185,7 +185,7 @@ Without avwx-engine, basic pattern matching is used for common METAR elements.
 Mission files are created in the same directory as the configuration file, named after each version:
 
 ```
-missions.yaml          (configuration)
+versions.yaml          (configuration)
 dawn.miz               (created)
 noon.miz               (created)
 dusk.miz               (created)
@@ -196,7 +196,7 @@ dusk.miz               (created)
 ### Custom Output Directory
 
 ```bash
-veaf-tools weather-and-time missions.yaml --output-dir ./output_missions
+veaf-tools weather-and-time versions.yaml --output-dir ./output_missions
 ```
 
 ### Independent Versions

--- a/test/python/mission_builder/test_mission_builder_defaults.py
+++ b/test/python/mission_builder/test_mission_builder_defaults.py
@@ -138,8 +138,8 @@ class TestCompleteDefaultsOrphanWarning(unittest.TestCase):
         self.assertTrue(orphan_warnings, "Expected at least one orphan warning")
 
 
-class TestWeatherAliasCoexistence(unittest.TestCase):
-    """WEATHER-001/002: versions.yaml copy skipped when legacy missions.yaml is present (FIX-WEATHER-ALIAS)."""
+class TestWeatherDefaultsCopy(unittest.TestCase):
+    """versions.yaml is copied from defaults when absent from the mission folder."""
 
     def _run_with_warnings(self, mission_folder: Path, defaults_folder: Path, mission_yaml: dict) -> list[str]:
         from unittest.mock import patch
@@ -159,25 +159,8 @@ class TestWeatherAliasCoexistence(unittest.TestCase):
 
         return warnings
 
-    def test_versions_not_copied_when_missions_exists(self) -> None:
-        """versions.yaml is NOT copied if src/missions.yaml already exists in mission folder."""
-        tmpdir = Path(tempfile.mkdtemp())
-        self.addCleanup(shutil.rmtree, tmpdir)
-        defaults_folder = tmpdir / "published" / "src" / "defaults" / "mission-folder"
-        _seed_defaults(defaults_folder, "versions.yaml")
-        (tmpdir / "src").mkdir(parents=True, exist_ok=True)
-        (tmpdir / "src" / "missions.yaml").write_text("# legacy weather config", encoding="utf-8")
-
-        warnings = self._run_with_warnings(tmpdir, defaults_folder, {})
-
-        self.assertFalse((tmpdir / "src" / "versions.yaml").exists(), "versions.yaml must not be created")
-        self.assertTrue(
-            any("missions.yaml" in w for w in warnings),
-            f"Expected a warning mentioning missions.yaml; got: {warnings}",
-        )
-
     def test_versions_copied_when_missions_absent(self) -> None:
-        """versions.yaml IS copied normally when no legacy missions.yaml exists."""
+        """versions.yaml IS copied normally when no versions.yaml exists yet."""
         tmpdir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, tmpdir)
         defaults_folder = tmpdir / "published" / "src" / "defaults" / "mission-folder"


### PR DESCRIPTION
## Summary

- `missions.yaml` no longer accepted as weather config — `versions.yaml` exclusively
- Removes legacy coexistence guard (WEATHER-001) from `mission_builder_worker.py`
- Updates `v5_converter.py`, `build.py`, `weather.py` CLI default, `weather_injector_README.py`, and both `PIPELINE_REFERENCE` docs
- Drops obsolete test `test_versions_not_copied_when_missions_exists`

**Migration**: rename `src/missions.yaml` → `src/versions.yaml` in any existing mission folder.

## Test plan

- [ ] `poetry run pytest` — 1028 passed, 1 skipped
- [ ] `poetry run ruff check src/python/ --fix` — no issues
- [ ] `poetry run mypy src/python/veaf-tools/` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce use of versions.yaml as the sole weather configuration file and remove legacy missions.yaml support across code, docs, and tests.

Enhancements:
- Simplify weather pipeline detection and v5 conversion to recognize only versions.yaml and drop missions.yaml aliases.
- Update weather CLI default config file name and README examples to use versions.yaml consistently.
- Adjust mission builder defaults handling to always copy versions.yaml when missing, without legacy coexistence guards.

Documentation:
- Revise English and French pipeline reference docs to document versions.yaml as the only supported weather config path.
- Note the change in the changelog, including migration guidance to rename src/missions.yaml to src/versions.yaml.

Tests:
- Remove obsolete test for missions.yaml coexistence and update remaining test to validate copying behavior when versions.yaml is absent.