### PR TITLE
feat(yaml-ux): simplify mission.yaml syntax with unified modules: block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - `weather` pipeline step now uses `versions.yaml` exclusively — `missions.yaml` is no longer recognised as an alias; rename any existing `src/missions.yaml` to `src/versions.yaml`
+- `mission.yaml` syntax simplified: `lua_modules:` + `community_scripts:` merged into a single `modules:` block; mandatory modules use bare null syntax (`MODULE:` with no value) instead of `MODULE: {}`; `enable:` replaced by `enabled:`; block-style lists replace inline `[...]`; generated files include a YAML syntax quick-reference header; legacy keys still accepted with a deprecation warning
 
 ### Added
 - i18n coverage: all log messages in `mission_builder_worker.py`, `aircrafts_injector_worker.py`, and `waypoints_manager.py` now use `t()` — no more hardcoded English strings; matching French translations added to `fr.json`; tests verify all `t()` keys exist in `en.json` and that `fr.json` covers every `en.json` key

--- a/backlog.md
+++ b/backlog.md
@@ -85,7 +85,8 @@
 | Lot I18N-COVERAGE — i18n coverage tests + fix remaining hardcoded English strings | ~2h30 | ✅ |
 | Lot FIX-CONVERT-V5-LOG-DEFAULT — convert-v5 defaults global_log_level to debug instead of info | ~5 min | ✅ |
 | Lot FIX-VERSIONS-YAML-ONLY — drop missions.yaml alias, use versions.yaml exclusively for weather pipeline | ~15 min | ✅ |
-| **Total** | **~182h** | |
+| Lot YAML-UX — Simplification syntaxe mission.yaml | ~8h | ⬜ |
+| **Total** | **~190h** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*
 
@@ -330,6 +331,32 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 | VYO-003 | Update `build.py` `_step_file` call and `weather.py` CLI default | `veaf_tools/commands/build.py`, `veaf_tools/commands/weather.py` | fix | 2 min | ✅ |
 | VYO-004 | Update `weather_injector_README.py` and pipeline reference docs | `weather_injector/weather_injector_README.py`, `doc/PIPELINE_REFERENCE*.md` | doc | 5 min | ✅ |
 | VYO-005 | Drop obsolete test `test_versions_not_copied_when_missions_exists` | `test/python/mission_builder/test_mission_builder_defaults.py` | test | 1 min | ✅ |
+
+----
+
+## Lot YAML-UX — Simplification syntaxe mission.yaml
+
+**Goal**: Rendre `mission.yaml` lisible et modifiable par des utilisateurs non-informaticiens. Réduire les pièges syntaxiques (deux mots-clés pour la même chose, `{}`, `[]` inline, guillemets inconsistants). Unifier `lua_modules` et `community_scripts` en un seul bloc `modules:`.
+
+**Principes directeurs**:
+- Un seul style par construction YAML
+- Même syntaxe pour les modules VEAF et les scripts communautaires
+- Guillemets uniquement quand nécessaire, règle documentée
+- Les listes toujours en style bloc (`-`), jamais inline `[]`
+- `true`/`false` seuls quand pas de config supplémentaire, bloc `enabled:` sinon
+
+**Dépendances**: UX-001 → UX-002 → UX-003 (dans cet ordre). UX-004/005/006 indépendants.
+
+**Branch**: `feature/yaml-ux` → PR → `develop-v6`
+
+| # | Ticket | Description | Files | Type | Effort | Status |
+|---|--------|-------------|-------|------|--------|--------|
+| YAML-UX-001 | `MODULE: {}` → `MODULE:` (null = module obligatoire actif, plus lisible) | Remplacer la génération et le parsing de `{}` pour les modules obligatoires — `null` YAML est équivalent et moins cryptique | `lua_config_generator.py`, `mission_builder_worker.py`, template `mission.yaml`, `config_migrator.py` | feat | 45 min | ⬜ |
+| YAML-UX-002 | Unifier `enable`/`enabled` → `enabled` partout | `lua_modules` utilise `enable`, `community_scripts` et `dcs_bridge` utilisent `enabled` — standardiser sur `enabled`, lire l'ancienne clé avec warning de dépréciation | `lua_config_generator.py`, `mission_builder_worker.py`, `v5_converter.py`, docs, template | feat | 1h | ⬜ |
+| YAML-UX-003 | Fusionner `lua_modules` + `community_scripts` → `modules:` avec syntaxe unifiée | Un seul bloc `modules:` ; syntaxe : `MODULE: true`/`false` (scalaire) ou bloc avec `enabled:` + config ; rétrocompat `lua_modules`/`community_scripts` avec warning pendant 1 version | `lua_config_generator.py`, `mission_builder_worker.py`, `v5_converter.py`, `config_migrator.py`, tests, docs | feat | 3h | ⬜ |
+| YAML-UX-004 | Listes toujours en style bloc (`-`) dans fichiers générés et template | Supprimer `groups: ["A", "B"]` et `enemy_coalitions: [BLUE]` → style bloc dans tous les fichiers générés par `v5_converter.py` et `lua_config_generator.py` | `lua_config_generator.py`, `v5_converter.py`, template `mission.yaml` | feat | 30 min | ⬜ |
+| YAML-UX-005 | En-tête syntaxe YAML dans `mission.yaml` généré + template + doc | Ajouter un bloc commentaire en tête expliquant : indentation espaces, règle des guillemets, style liste bloc, booléens — aussi dans `doc/` | `lua_config_generator.py`, `v5_converter.py`, template `mission.yaml`, `doc/GUIDE*.md` | doc | 30 min | ⬜ |
+| YAML-UX-006 | `migrate-config` : migrer fichiers existants vers nouvelle syntaxe | Ajouter une migration dans `config_migrator.py` pour convertir `lua_modules`/`community_scripts` → `modules:`, `enable` → `enabled`, `{}` → null, listes inline → bloc | `config_migrator.py`, tests | feat | 1h | ⬜ |
 
 ----
 

--- a/src/defaults/mission-folder/mission.yaml
+++ b/src/defaults/mission-folder/mission.yaml
@@ -5,16 +5,29 @@
 #
 # Doc: https://github.com/VEAF/VEAF-Mission-Creation-Tools/blob/master/doc/mission-maker/GUIDE.en.md
 
+# ── YAML syntax quick reference ─────────────────────────────────────────────
+# Indentation: spaces only (never tabs). Each level = 2 spaces.
+# Quotes: only needed when a value contains  :  #  {  [  or starts with a digit.
+#   name: Mon-Vol-01            # OK — no quotes needed
+#   name: "Vol: Aller-Retour"   # required — value contains :
+# Lists: each item on its own line, preceded by  -
+#   groups:
+#     - MIG-29_SOLO
+#     - MIG-21_SOLO
+# Booleans: true / false  (without quotes)
+# Empty value (mandatory modules): MODULE:   (nothing after the colon)
+# ────────────────────────────────────────────────────────────────────────────
+
 # ── Global log level ─────────────────────────────────────────────────────────
 # Forces veaf.ForcedLogLevel in the built mission. Applies to every module.
 # Values: error | warning | info | debug | trace
-# Remove or set to "info" before deploying to players.
+# Remove or set to info before deploying to players.
 #
 # global_log_level: debug
 
 # ── Mission identity ─────────────────────────────────────────────────────────
 # mission:
-#   name: "My-Mission"          # shown in radio menus and log messages
+#   name: My-Mission            # shown in radio menus and log messages
 #   export_path: null           # null = default DCS Saved Games path
 #   era: MODERN                 # MODERN | COLD_WAR | WW2
 
@@ -26,101 +39,110 @@
 #   password_mm_hashes:         # SHA-256 hashes to restrict Mission Master access
 #     - "<SHA-256 hash>"
 
-# ── Per-module configuration ──────────────────────────────────────────────────
-# Enable, disable, or override the log level of individual VEAF Lua modules.
-# Modules not listed here are enabled with their default settings.
+# ── Module configuration ──────────────────────────────────────────────────────
+# Enable or disable VEAF modules and community scripts in one unified block.
+# Mandatory modules (bare MODULE: with no value) are always active.
+# Optional module shorthand:  MODULE: true   or   MODULE: false
+# With extra config:
+#   MODULE:
+#     enabled: true
+#     logLevel: debug
 #
-# lua_modules:
-#   # ── Infrastructure (always active — configurable but enable/disable not allowed) ──
-#   UNITS:    {}    # logLevel: debug
-#   TIME:     {}
-#   CACHE:    {}
-#   EVENTS:   {}
-#   MARKERS:  {}
-#   COMMANDS: {}
+# modules:
+#   # ── Infrastructure (mandatory — always active) ────────────────────────────
+#   UNITS:
+#   TIME:
+#   CACHE:
+#   EVENTS:
+#   MARKERS:
+#   COMMANDS:
 #   # ── Core ─────────────────────────────────────────────────────────────────
-#   SECURITY:    { enable: true }
-#   RADIO:
-#     enable: true
-#     init:
-#       help_menus: true
-#   GROUNDAI:    { enable: true }
+#   SECURITY: true
+#   RADIO: true
+#   # RADIO:
+#   #   enabled: true
+#   #   init:
+#   #     help_menus: true
+#   GROUNDAI: true
 #   SHORTCUTS:
-#     enable: true
+#     enabled: true
 #     shortcuts:
-#       - name: "smoke"
-#         description: "Smoke command shortcut"
-#         command: "/_smoke"
+#       - name: smoke
+#         description: Smoke command shortcut
+#         command: /_smoke
 #         bypass_security: false
 #   NAMEDPOINTS:
-#     enable: true
+#     enabled: true
 #     custom_points:
-#       # - name: "Battle Area Alpha"
+#       # - name: Battle Area Alpha
 #       #   lat: "41.123456"
 #       #   lon: "44.987654"
-#   SPAWN:       { enable: true }
+#   SPAWN: true
 #   # ── Features ─────────────────────────────────────────────────────────────
 #   ASSETS:
-#     enable: true
+#     enabled: true
 #     assets:
 #       - sort: 1
-#         name: "T1-Arco-1"
-#         description: "Arco-1 (KC-135)"
+#         name: T1-Arco-1
+#         description: Arco-1 (KC-135)
 #         information: "Tacan 64Y\nU290.50 (20)"
-#   MOVE:        { enable: true }
-#   GRASS:       { enable: true }
+#   MOVE: true
+#   GRASS: true
 #   SANCTUARY:
-#     enable: true
+#     enabled: true
 #     sanctuary_zones:
-#       - name: "Base Alpha"
+#       - name: Base Alpha
 #         polygon_units:
-#           - "Sanctuary-Unit-1"
-#           - "Sanctuary-Unit-2"
+#           - Sanctuary-Unit-1
+#           - Sanctuary-Unit-2
 #         coalition: BLUE
 #         delay_warning: 30
 #         delay_spawn: 60
-#   WEATHER:     { enable: true }
-#   REMOTE:      { enable: true }
-#   AIRBASES:    { enable: true }
-#   MISSILEGUARDIAN: { enable: true }
-#   INTERPRETER: { enable: true }
+#   WEATHER: true
+#   REMOTE: true
+#   AIRBASES: true
+#   MISSILEGUARDIAN: true
+#   INTERPRETER: true
 #   # ── Combat ───────────────────────────────────────────────────────────────
-#   CASMISSION:       { enable: true }
-#   TRANSPORTMISSION: { enable: true }
-#   COMBATMISSION:    { enable: true }
+#   CASMISSION: true
+#   TRANSPORTMISSION: true
+#   COMBATMISSION: true
 #   COMBATZONE:
-#     enable: true
+#     enabled: true
 #     combat_zone_settings:
-#       event_message_combatzonecomplete: "Combat Zone complete!"
+#       event_message_combatzonecomplete: Combat Zone complete!
 #       watchdog_check_interval: 30
-#       radio_menu_name: "Combat Zones"
-#       combat_zone_menu_name: "Combat Zone Operations"
-#       operation_menu_name: "Operations"
+#       radio_menu_name: Combat Zones
 #     combat_zones:
 #       - type: zone
-#         zone_name: "CZ-Alpha"
-#         friendly_name: "Alpha Zone"
+#         zone_name: CZ-Alpha
+#         friendly_name: Alpha Zone
 #         training: false
-#       - type: operation
-#         zone_name: "CZ-Op-Alpha"
-#         tasking_orders:
-#           - zone_name: "CZ-Alpha"
-#           - zone_name: "CZ-Bravo"
-#             dependencies: ["CZ-Alpha"]
-#   QRA:         { enable: true }
+#   QRA: true
 #   AIRWAVES:
-#     enable: true
+#     enabled: true
 #     airwave_zones:
-#       - name: "BVR Zone"
+#       - name: BVR Zone
 #         start: true
-#         player_coalitions: [BLUE]
+#         player_coalitions:
+#           - BLUE
 #         zone_center_coordinates: "N41°00'00\" E044°00'00\""
 #         zone_radius: 50000
 #         delay_between_waves: 120
 #         waves:
-#           - groups: "su27-2ship"
+#           - groups: su27-2ship
 #             delay: 0
-#   CARRIER: { enable: true }
+#   CARRIER: true
+#   # ── Community scripts ─────────────────────────────────────────────────────
+#   mist: true
+#   stts: true
+#   weathermark: true
+#   ctld: true
+#   aien: true
+#   csar: true
+#   hercules: true
+#   skynet: true
+#   tum: true
 
 # ── External modules ─────────────────────────────────────────────────────────
 # external_modules:
@@ -138,126 +160,78 @@
 #     # csar.xxx = value pairs go here (e.g. enableAllslots: true)
 
 # ── QRA (Quick Reaction Alert) ────────────────────────────────────────────────
-# Requires QRA module enabled in lua_modules above.
+# Requires QRA module enabled in modules above.
 # qra:
 #   silence_all: false
 #   definitions:
-#     - name: "Base QRA"
+#     - name: Base QRA
 #       coalition: RED
-#       enemy_coalitions: [BLUE]
-#       trigger_zone: "QRA zone"
+#       enemy_coalitions:
+#         - BLUE
+#       trigger_zone: QRA zone
 #       zone_radius: 30000
 #       groups_by_enemy_count:
 #         - enemy_count: 1
-#           groups: ["Group1", "Group2"]
+#           groups:
+#             - Group1
+#             - Group2
 #           random_pick: 1
 #       delay_before_rearming: 30
 #       delay_before_activating: 30
 
 # ── CAP missions ──────────────────────────────────────────────────────────────
-# Requires COMBATMISSION module enabled in lua_modules above.
+# Requires COMBATMISSION module enabled in modules above.
 # cap_missions:
-#   - group_name: "CAP Group"
-#     menu_name: "CAP"
-#     briefing: "CAP mission briefing"
+#   - group_name: CAP Group
+#     menu_name: CAP
+#     briefing: CAP mission briefing
 #     default: false
 #     activated: true
 
 # ── Combat missions ───────────────────────────────────────────────────────────
-# Requires COMBATMISSION module enabled in lua_modules above.
+# Requires COMBATMISSION module enabled in modules above.
 # combat_missions:
-#   - name: "Mission Name"
-#     friendly_name: "Display Name"
+#   - name: Mission Name
+#     friendly_name: Display Name
 #     secured: false
 #     radio_menu_enabled: true
 #     briefing: |
 #       Multi-line briefing text here.
 #     elements:
-#       - name: "Element Name"
-#         groups: ["Group1", "Group2"]
+#       - name: Element Name
+#         groups:
+#           - Group1
+#           - Group2
 #         scalable: true
 
 # ── DCS Bridge ───────────────────────────────────────────────────────────────
 # Optionally inject dcs-bridge.lua as the very first DO SCRIPT FILE trigger.
-# dcs-bridge provides a TCP socket link between DCS and an external server.
-# See: https://github.com/VEAF/VEAF-dcs-bridge
-#
-# When lua_path is absent, dcs-bridge.lua is downloaded automatically from GitHub.
-# When lua_path is set, the file is read from the given path (absolute or relative
-# to the mission folder).
-#
 # dcs_bridge:
 #   enabled: false
 #   lua_path: null      # optional — auto-download when absent
 
 # ── Custom scripts ────────────────────────────────────────────────────────────
-# Declare Lua scripts in src/scripts/ that are not part of the standard VEAF v6 set.
-# Declared scripts are included in the mission without a warning.
-# By default each declared script gets a DCS load trigger (generate_load_trigger: true).
-# Set generate_load_trigger: false when the script is loaded manually (e.g. from mission-script.lua).
-#
 # custom_scripts:
-#   generate_load_trigger: true     # global default for all scripts below
+#   generate_load_trigger: true
 #   scripts:
 #     - path: src/scripts/FgMission.lua
 #     - path: src/scripts/FgTools.lua
-#       generate_load_trigger: false  # override: loaded manually from mission-script.lua
-
-# ── Community scripts ─────────────────────────────────────────────────────────
-# Set enabled: false to exclude a community script from the built mission.
-# All scripts are enabled by default when this section is absent.
-#
-# community_scripts:
-#   mist:         { enabled: true }   # MIST (Mission Scripting Tools)
-#   stts:         { enabled: true }   # DCS-SimpleTextToSpeech
-#   weathermark:  { enabled: true }   # WeatherMark
-#   ctld:         { enabled: true }   # CTLD (Combined Arms Transport & Logistics Dispatcher)
-#   aien:         { enabled: true }   # AIEN (AI Enhancement)
-#   csar:         { enabled: true }   # CSAR (Combat Search and Rescue)
-#   hercules:     { enabled: true }   # Hercules Cargo
-#   skynet:       { enabled: true }   # Skynet IADS
-#   tum:          { enabled: true }   # The Universal Mission (TUM)
+#       generate_load_trigger: false
 
 # ── Build pipeline ────────────────────────────────────────────────────────────
-# Controls which optional injection steps run after the base build.
-# By default each step is auto-detected: it runs if its config file is found.
-#
-# Default file locations checked automatically (relative to this folder):
-#   presets       → src/presets.yaml
-#   waypoints     → src/waypoints.yaml
-#   aircraft_groups → src/aircraft-templates.yaml  (also: src/templates.yaml)
-#   weather       → src/versions.yaml              (also: src/missions.yaml  legacy)
-#
-# Set a step to false to disable it even when its file exists.
-# Use a `file:` key to point to a non-default location.
-# For aircraft_groups, `mode` controls injection behaviour (add | replace).
-#
 # pipeline:
-#   presets: false                       # skip even if src/presets.yaml exists
-#   waypoints: true                      # always run (file must exist)
+#   presets: false
+#   waypoints: true
 #   aircraft_groups:
-#     file: src/my-aircraft.yaml        # non-default path
-#     mode: replace                     # add (default) or replace
-#   weather: false                       # skip weather variants
+#     file: src/my-aircraft.yaml
+#     mode: replace
+#   weather: false
 
 # ── Version pinning ──────────────────────────────────────────────────────────────────────────────
-# Declare the veaf-tools version this mission is compatible with.
-# veaf-tools-updater.exe skips releases that don’t match the constraint.
-#
-# Supported formats (NPM-style prefixes):
-#   version: "6"         # accept any 6.x.x
-#   version: "6.1"       # accept any 6.1.x
-#   version: "6.1.3"     # accept exactly 6.1.3
-#   version: "^6.1.3"    # compatible: >=6.1.3, <7.0.0 (same major)
-#   version: "~6.1.3"    # approximate: >=6.1.3, <6.2.0 (same major.minor)
-#
 # veaf_tools:
 #   version: "6"         # accept any 6.x.x
+
 # ── Build profiles ────────────────────────────────────────────────────────────
-# Named overrides applied when building with: veaf-tools build --profile <name>
-# Keys in the profile deep-merge onto the base config above.
-# Lists are replaced, not concatenated.
-#
 # profiles:
 #   TEST:
 #     global_log_level: debug

--- a/src/python/veaf-tools/mission_builder/config_migrator.py
+++ b/src/python/veaf-tools/mission_builder/config_migrator.py
@@ -283,8 +283,8 @@ class ConfigMigrator:
         )
 
     def _build_yaml_snippet(self, enabled_modules: list[str]) -> str:
-        """Generate a ``lua_modules:`` YAML block for ``mission.yaml``."""
-        lines: list[str] = ["lua_modules:"]
+        """Generate a ``modules:`` YAML block for ``mission.yaml``."""
+        lines: list[str] = ["modules:"]
         enabled_set = set(enabled_modules)
 
         for mod in get_modules():
@@ -295,7 +295,7 @@ class ConfigMigrator:
                 lines.extend(yaml_module_entry(yaml_key, mid))
             else:
                 lines.append(f"  # {yaml_key}:")
-                lines.append("  #   enable: false  # not found in missionConfig.lua")
+                lines.append("  #   enabled: false  # not found in missionConfig.lua")
 
         return "\n".join(lines)
 

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -56,6 +56,50 @@ class CustomScript:
     generate_load_trigger: bool | None = field(default=None)
 
 
+def _normalize_mission_yaml(yaml_data: dict) -> dict:
+    """Normalize legacy mission.yaml keys to the current unified format.
+
+    - ``modules:`` (new) is split into ``lua_modules`` + ``community_scripts``
+      for internal processing.  If both ``modules:`` and the legacy keys are
+      present, ``modules:`` takes precedence and a warning is emitted.
+    - Deprecated ``lua_modules:`` / ``community_scripts:`` keys are accepted
+      with a deprecation warning.
+
+    Args:
+        yaml_data: Parsed mission.yaml content dict.
+
+    Returns:
+        Normalized dict (shallow copy when changes are needed).
+    """
+    modules_raw = yaml_data.get("modules")
+    has_legacy = yaml_data.get("lua_modules") is not None or yaml_data.get("community_scripts") is not None
+
+    if modules_raw is not None:
+        if has_legacy:
+            logger.warning(
+                "'modules:' and 'lua_modules:'/'community_scripts:' both present — 'modules:' takes precedence"
+            )
+        if not isinstance(modules_raw, dict):
+            logger.warning(f"'modules' in mission.yaml must be a mapping (got {type(modules_raw).__name__}); ignoring.")
+            return yaml_data
+
+        all_community_ids = {s["id"] for s in get_community_script_files()}
+        lua_mods = {k: v for k, v in modules_raw.items() if k not in all_community_ids}
+        comm_scripts = {k: v for k, v in modules_raw.items() if k in all_community_ids}
+
+        result = dict(yaml_data)
+        result["lua_modules"] = lua_mods
+        result["community_scripts"] = comm_scripts
+        return result
+
+    if has_legacy:
+        logger.warning(
+            t("builder.modules_deprecated")
+        )
+
+    return yaml_data
+
+
 class MissionBuilderWorker(BaseWorker):
     """
     Worker class that builds a mission, based on a folder containing the mission files, and on the VEAF Mission Creation Tools package.
@@ -97,6 +141,7 @@ class MissionBuilderWorker(BaseWorker):
             with mission_yaml_path.open("r", encoding="utf-8") as fh:
                 raw_yaml: dict = yaml.safe_load(fh) or {}
             self.mission_yaml = resolve_profile(raw_yaml, profile_name)
+            self.mission_yaml = _normalize_mission_yaml(self.mission_yaml)
         build_cfg: dict = self.mission_yaml.get("build") or {}
         self.pipeline_cfg = self.mission_yaml.get("pipeline") or {}
 
@@ -456,7 +501,7 @@ class MissionBuilderWorker(BaseWorker):
                             continue
                     elif "lua_module" in mapping:
                         mod_cfg = (self.mission_yaml.get("lua_modules") or {}).get(mapping["lua_module"])
-                        if isinstance(mod_cfg, dict) and mod_cfg.get("enable") is False:
+                        if isinstance(mod_cfg, dict) and not mod_cfg.get("enabled", mod_cfg.get("enable", True)):
                             logger.debug(
                                 f"Skipping default '{f.name}': lua_module '{mapping['lua_module']}' is disabled"
                             )

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -93,9 +93,7 @@ def _normalize_mission_yaml(yaml_data: dict) -> dict:
         return result
 
     if has_legacy:
-        logger.warning(
-            t("builder.modules_deprecated")
-        )
+        logger.warning(t("builder.modules_deprecated"))
 
     return yaml_data
 

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -1069,7 +1069,6 @@ class V5Converter:
         else:
             lines.append("# pipeline: {}  # no pipeline config files detected in src/")
 
-
         # ── Build configuration ────────────────────────────────────────────
         lines += [
             "",

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -855,12 +855,15 @@ class V5Converter:
 
         lines += [
             "# ── Module configuration ─────────────────────────────────────────────────────",
-            "# Enable or disable individual VEAF Lua modules.",
-            "# Mandatory modules (marked with {}) are always active and cannot be disabled.",
-            "# To disable an optional module, set enable: false instead of removing it.",
+            "# Enable or disable VEAF modules and community scripts.",
+            "# Mandatory modules (bare MODULE: with no value) are always active.",
+            "# To disable an optional module: MODULE: false",
+            "# To enable with extra config: MODULE:",
+            "#   enabled: true",
+            "#   ...",
             f"# Doc: {_DOC_BASE}#configuring-modules",
             "#",
-            "lua_modules:",
+            "modules:",
         ]
 
         enabled_modules = mr.enabled_modules if mr else []
@@ -919,6 +922,16 @@ class V5Converter:
                     lines.append("    airwave_zones:")
                     lines.extend(_yaml_list_block(mr.airwave_zones_extracted, indent=4))
 
+        # Community scripts appended at end of modules: block
+        all_community = get_community_script_files()
+        detected_comm = report.detected_community_script_ids
+        if all_community:
+            lines.append("  # ── Community scripts ──────────────────────────────────────────────────────")
+            lines.append("  # Set to false to exclude a script from the built mission.")
+            for script in all_community:
+                sid = script["id"]
+                val = "true" if sid in detected_comm else "false"
+                lines.append(f"  {sid}: {val}")
         lines.append("")
 
         # ── External modules (Skynet) ──────────────────────────────────────
@@ -952,19 +965,26 @@ class V5Converter:
                 if coalition := qra.get("coalition"):
                     lines.append(f"      coalition: {coalition}")
                 if enemies := qra.get("enemy_coalitions"):
-                    lines.append(f"      enemy_coalitions: [{', '.join(enemies)}]")
+                    lines.append("      enemy_coalitions:")
+                    for e in enemies:
+                        lines.append(f"        - {e}")
                 if tz := qra.get("trigger_zone"):
-                    lines.append(f'      trigger_zone: "{tz}"')
+                    lines.append(f"      trigger_zone: {tz}")
                 if zr := qra.get("zone_radius"):
                     lines.append(f"      zone_radius: {zr}")
                 if sg := qra.get("simple_groups"):
-                    lines.append(f"      simple_groups: [{', '.join(repr(g) for g in sg)}]")
+                    lines.append("      simple_groups:")
+                    for g in sg:
+                        lines.append(f"        - {g}")
                 if gbc := qra.get("groups_by_enemy_count"):
                     lines.append("      groups_by_enemy_count:")
                     for entry in gbc:
                         lines.append(f"        - enemy_count: {entry['enemy_count']}")
-                        gs = ", ".join(f'"{g}"' for g in entry.get("groups", []))
-                        lines.append(f"          groups: [{gs}]")
+                        groups = entry.get("groups", [])
+                        if groups:
+                            lines.append("          groups:")
+                            for g in groups:
+                                lines.append(f"            - {g}")
                         lines.append(f"          random_pick: {entry.get('random_pick', 1)}")
                 if dbr := qra.get("delay_before_rearming"):
                     lines.append(f"      delay_before_rearming: {dbr}")
@@ -1013,8 +1033,9 @@ class V5Converter:
                     for elem in elems:
                         lines.append(f'      - name: "{elem.get("name", "")}"')
                         if gs := elem.get("groups"):
-                            gs_yaml = ", ".join(f'"{g}"' for g in gs)
-                            lines.append(f"        groups: [{gs_yaml}]")
+                            lines.append("        groups:")
+                            for g in gs:
+                                lines.append(f"          - {g}")
                         lines.append(f"        scalable: {'true' if elem.get('scalable', True) else 'false'}")
             lines.append("")
 
@@ -1048,21 +1069,6 @@ class V5Converter:
         else:
             lines.append("# pipeline: {}  # no pipeline config files detected in src/")
 
-        # ── Community scripts ──────────────────────────────────────────────
-        all_community = get_community_script_files()
-        detected = report.detected_community_script_ids
-        lines += [
-            "",
-            "# ── Community scripts ────────────────────────────────────────────────────────",
-            "# Set enabled: false to exclude a community script from the built mission.",
-            "#",
-            "community_scripts:",
-        ]
-        for script in all_community:
-            sid = script["id"]
-            enabled_str = "true" if sid in detected else "false"
-            lines.append(f"  {sid}: {{enabled: {enabled_str}}}")
-        lines.append("")
 
         # ── Build configuration ────────────────────────────────────────────
         lines += [

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -476,6 +476,7 @@
   "pipeline.injecting_aircraft_mode": "Pipeline: injecting aircraft groups from {path} (mode={mode})",
   "presets_injector.freq_warn.disable_tip": "To silence these warnings temporarily while you fix the presets, add 'none' for these aircraft types in presets.yaml:\n  presets_assignments:\n{yaml_block}\n  Once the presets are corrected, remove those 'none' lines to re-enable injection.",
   "builder.lua_modules_found": "Found lua_modules section in {path}; will generate veaf-config.lua",
+  "builder.modules_deprecated": "Deprecated: 'lua_modules:' and 'community_scripts:' are replaced by 'modules:' — please update your mission.yaml",
   "builder.log_level_found": "Found global_log_level={level} in {path}",
   "builder.dev_mode_active": "Dev mode: VEAF scripts resolved from local dev repo (build/veaf-scripts.lua)",
   "builder.scripts_folder_missing": "Scripts folder {path} does not exist!",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -476,6 +476,7 @@
   "pipeline.injecting_aircraft_mode": "Pipeline : injection des groupes aériens depuis {path} (mode={mode})",
   "presets_injector.freq_warn.disable_tip": "Pour masquer ces avertissements pendant que vous corrigez les préréglages, ajoutez 'none' pour ces types d'appareils dans presets.yaml :\n  presets_assignments:\n{yaml_block}\n  Une fois les préréglages corrigés, supprimez ces lignes 'none' pour réactiver l'injection.",
   "builder.lua_modules_found": "Section lua_modules trouvée dans {path} ; veaf-config.lua sera généré",
+  "builder.modules_deprecated": "Déprécié : 'lua_modules:' et 'community_scripts:' sont remplacés par 'modules:' — merci de mettre à jour votre mission.yaml",
   "builder.log_level_found": "global_log_level={level} trouvé dans {path}",
   "builder.dev_mode_active": "Mode développement : scripts VEAF résolus depuis le dépôt local (build/veaf-scripts.lua)",
   "builder.scripts_folder_missing": "Le dossier scripts {path} n'existe pas !",

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -74,6 +74,7 @@ _MODULE_INIT_PARAMS: dict[str, list[tuple[str, object]]] = {
 _SKIP_SETCONFIG_KEYS: frozenset[str] = frozenset(
     {
         "enable",
+        "enabled",
         "logLevel",
         "init",
         "assets",
@@ -90,6 +91,22 @@ _SKIP_SETCONFIG_KEYS: frozenset[str] = frozenset(
 #: Module IDs that do NOT have a global ``initialize()`` function.
 #: Their data (zones, etc.) is emitted directly without an ``initialize()`` call.
 _NO_INIT_MODULES: frozenset[str] = frozenset({"AIRWAVES"})
+
+#: YAML syntax quick-reference block prepended to every generated mission.yaml.
+_YAML_SYNTAX_HEADER: list[str] = [
+    "# ── YAML syntax quick reference ─────────────────────────────────────────────",
+    "# Indentation: spaces only (never tabs). Each level = 2 spaces.",
+    "# Quotes: only needed when a value contains  :  #  {  [  or starts with a digit.",
+    "#   name: Mon-Vol-01            # OK — no quotes needed",
+    '#   name: "Vol: Aller-Retour"   # required — value contains :',
+    "# Lists: each item on its own line, preceded by  -",
+    "#   groups:",
+    "#     - MIG-29_SOLO",
+    "#     - MIG-21_SOLO",
+    "# Booleans: true / false  (without quotes)",
+    "# Empty value (mandatory modules): MODULE:   (nothing after the colon)",
+    "# ────────────────────────────────────────────────────────────────────────────",
+]
 
 #: Cosmetic category groupings for YAML template and generated Lua output.
 _MODULE_CATEGORIES: dict[str, list[str]] = {
@@ -134,12 +151,55 @@ def yaml_module_entry(yaml_key: str, module_id: str) -> list[str]:
         module_id: The canonical module ID used to look up mandatory status.
 
     Returns:
-        One line ``["  key: {}"]`` for mandatory modules, or two lines
-        ``["  key:", "    enable: true"]`` for optional ones.
+        One line ``["  key:"]`` for mandatory modules (null value = always active),
+        or two lines ``["  key:", "    enabled: true"]`` for optional ones.
     """
     if module_id in MANDATORY_MODULES:
-        return [f"  {yaml_key}: {{}}"]
-    return [f"  {yaml_key}:", "    enable: true"]
+        return [f"  {yaml_key}:"]
+    return [f"  {yaml_key}:", "    enabled: true"]
+
+
+def _get_module_enabled(cfg: dict, default: bool = True) -> bool:
+    """Read the enabled flag from a module config dict.
+
+    Accepts both ``enabled`` (preferred) and the deprecated ``enable`` key.
+
+    Args:
+        cfg: Module configuration dict.
+        default: Value returned when neither key is present.
+
+    Returns:
+        Boolean enabled state.
+    """
+    if "enabled" in cfg:
+        return bool(cfg["enabled"])
+    if "enable" in cfg:
+        return bool(cfg["enable"])
+    return default
+
+
+def _normalize_module_cfg(value: object) -> dict:
+    """Normalize a raw module config value to a dict.
+
+    Handles the three valid forms in ``modules:`` / ``lua_modules:``:
+
+    - ``None``  (bare ``MODULE:`` in YAML) → ``{}``  (mandatory: no config)
+    - ``True`` / ``False`` scalar → ``{"enabled": <bool>}``
+    - ``dict`` → returned as-is
+
+    Args:
+        value: Raw YAML value for the module key.
+
+    Returns:
+        Normalized dict suitable for further processing.
+    """
+    if value is None:
+        return {}
+    if isinstance(value, bool):
+        return {"enabled": value}
+    if isinstance(value, dict):
+        return value
+    return {}
 
 
 #: Dependency graph: module_id → list of module IDs it requires.
@@ -602,7 +662,7 @@ def _resolve_deps(effective: dict) -> dict:
 
     For each enabled module that declares dependencies in ``_MODULE_DEPS``,
     any dependency that is absent or explicitly disabled is auto-added with
-    ``enable: true`` and a ``logger.warning`` is emitted.  The loop repeats
+    ``enabled: true`` and a ``logger.warning`` is emitted.  The loop repeats
     until no more changes are needed (handles transitive dependency chains).
     """
     changed = True
@@ -610,24 +670,25 @@ def _resolve_deps(effective: dict) -> dict:
         changed = False
         for mod_id, deps in _MODULE_DEPS.items():
             cfg = effective.get(mod_id, {})
-            if isinstance(cfg, dict) and cfg.get("enable") is False:
+            if isinstance(cfg, dict) and not _get_module_enabled(cfg, True):
                 continue  # explicitly disabled — skip dep check
             if mod_id not in effective:
                 continue  # not requested — skip
             for dep in deps:
                 dep_cfg = effective.get(dep, {})
-                if isinstance(dep_cfg, dict) and dep_cfg.get("enable") is False:
+                if isinstance(dep_cfg, dict) and not _get_module_enabled(dep_cfg, True):
                     logger.warning(
                         f"Module '{mod_id}' requires '{dep}' but '{dep}' is disabled — auto-enabling '{dep}'"
                     )
-                    dep_cfg["enable"] = True
+                    dep_cfg["enabled"] = True
+                    dep_cfg.pop("enable", None)
                     effective[dep] = dep_cfg
                     changed = True
                 elif dep not in effective:
                     logger.warning(
                         f"Module '{mod_id}' requires '{dep}' which is not configured — auto-enabling '{dep}'"
                     )
-                    effective[dep] = {"enable": True}
+                    effective[dep] = {"enabled": True}
                     changed = True
     return effective
 
@@ -710,7 +771,9 @@ def generate_config_lua(
         lines.append("")
 
     # ── Module configuration + initialization ─────────────────────────────
-    lua_modules: dict = mission_yaml.get("lua_modules") or {}
+    # Accept both `modules:` (new) and `lua_modules:` (legacy) keys.
+    raw_lua_modules: dict = mission_yaml.get("lua_modules") or {}
+    lua_modules: dict = {k: _normalize_module_cfg(v) for k, v in raw_lua_modules.items()}
     qra_section: dict = mission_yaml.get("qra") or {}
     cap_missions: list = mission_yaml.get("cap_missions") or []
     combat_missions_data: list = mission_yaml.get("combat_missions") or []
@@ -719,12 +782,13 @@ def generate_config_lua(
     ctld_cfg: dict = external_modules.get("ctld") or {}
 
     if lua_modules:
-        # ── MODUX-002: error on mandatory modules with any enable key ────
+        # ── MODUX-002: error on mandatory modules with any enable/enabled key ──
         effective_modules: dict = dict(lua_modules)
         for mandatory_id in MANDATORY_MODULES:
             mcfg = effective_modules.get(mandatory_id, {})
-            if isinstance(mcfg, dict) and "enable" in mcfg:
-                logger.error(t("builder.mandatory_module_enable", module=mandatory_id, value=mcfg["enable"]))
+            if isinstance(mcfg, dict) and ("enable" in mcfg or "enabled" in mcfg):
+                bad_val = mcfg.get("enabled", mcfg.get("enable"))
+                logger.error(t("builder.mandatory_module_enable", module=mandatory_id, value=bad_val))
 
         # ── MODUX-003: auto-resolve missing/disabled dependencies ─────────
         effective_modules = _resolve_deps(effective_modules)
@@ -753,7 +817,7 @@ def generate_config_lua(
                 lines.append(f"-- ── {cat} ──")
                 lines.append("")
 
-            enabled = mod_cfg.get("enable", True)
+            enabled = _get_module_enabled(mod_cfg, True)
             log_level: str | None = mod_cfg.get("logLevel")
 
             if not enabled:
@@ -843,6 +907,8 @@ def generate_mission_yaml_template(
         All others are commented out.  If *None*, all modules appear
         as commented-out examples.
     """
+    from mission_tools.mission_constants import get_community_script_files
+
     if modules is None:
         modules = get_modules()
     enabled_set: set[str] = enabled_module_ids or set()
@@ -851,6 +917,10 @@ def generate_mission_yaml_template(
 
     # ── File header ───────────────────────────────────────────────────────
     lines.extend(_yaml_comment("generated.mission_yaml.header"))
+    lines.append("")
+
+    # ── YAML syntax quick reference (UX-005) ─────────────────────────────
+    lines.extend(_YAML_SYNTAX_HEADER)
     lines.append("")
 
     # ── Global log level ──────────────────────────────────────────────────
@@ -862,36 +932,34 @@ def generate_mission_yaml_template(
     # ── Mission identity ──────────────────────────────────────────────────
     lines.extend(_yaml_comment("generated.mission_yaml.section.mission"))
     lines.append("# mission:")
-    lines.append('#   name: "My Mission"          # shown in radio menus and log messages')
-    lines.append("#   export_path: null           # null = default DCS Saved Games path")
-    lines.append("#   era: MODERN                 # MODERN | COLD_WAR | WW2")
-    lines.append(f"#   language: en                # {t('generated.mission_yaml.field.language')}")
+    lines.append("#   name: My-Mission              # shown in radio menus and log messages")
+    lines.append("#   export_path: null             # null = default DCS Saved Games path")
+    lines.append("#   era: MODERN                   # MODERN | COLD_WAR | WW2")
+    lines.append(f"#   language: en                  # {t('generated.mission_yaml.field.language')}")
     lines.append("")
 
     # ── Security ──────────────────────────────────────────────────────────
     lines.extend(_yaml_comment("generated.mission_yaml.section.security"))
     lines.append("# security:")
-    lines.append("#   disabled: true              # true = no password required (default)")
-    lines.append("#   password_hashes:            # add SHA-256 hashes to restrict access")
+    lines.append("#   disabled: true                # true = no password required (default)")
+    lines.append("#   password_hashes:              # add SHA-256 hashes to restrict access")
     lines.append('#     - "<SHA-256 hash>"')
     lines.append("")
 
     # ── Generic settings ──────────────────────────────────────────────────
     lines.extend(_yaml_comment("generated.mission_yaml.section.settings"))
     lines.append("# settings:")
-    lines.append('#   MY_SETTING: "value"')
+    lines.append("#   MY_SETTING: my-value")
     lines.append("")
 
-    # ── Module configuration ──────────────────────────────────────────────
+    # ── Module configuration (UX-003: unified modules: block) ────────────
     lines.extend(_yaml_comment("generated.mission_yaml.section.modules"))
     lines.append("#")
-    lines.append("lua_modules:")
+    lines.append("modules:")
 
-    # Emit module entries in recommended order
+    # Emit VEAF module entries in recommended order
     ordered_ids = _MODULE_INIT_ORDER
     all_module_map = {m["id"]: m for m in modules}
-
-    # Emit all modules grouped by category, enabled ones uncommented, others commented
     all_ordered = [mid for mid in ordered_ids if mid in all_module_map]
     remaining = [mid for mid in all_module_map if mid not in set(ordered_ids)]
 
@@ -915,17 +983,23 @@ def generate_mission_yaml_template(
             if mid == "ASSETS":
                 lines.append("    # assets:  # list of asset entries")
                 lines.append("    #   - sort: 1")
-                lines.append('    #     name: "T1-Arco"')
-                lines.append('    #     description: "Arco (KC-135)"')
-                lines.append('    #     information: "Tacan 64Y\\nU290.50"')
+                lines.append("    #     name: T1-Arco")
+                lines.append('#     #     description: "Arco (KC-135)"')
+                lines.append('#     #     information: "Tacan 64Y\\nU290.50"')
             elif mid == "NAMEDPOINTS":
                 lines.append("    # custom_points:  # list of custom POIs")
-                lines.append('    #   - name: "Battle Area Alpha"')
+                lines.append("    #   - name: Battle Area Alpha")
                 lines.append('    #     lat: "41.123456"')
                 lines.append('    #     lon: "44.987654"')
         else:
             lines.append(f"  # {yaml_key}:")
-            lines.append("  #   enable: false")
+            lines.append("  #   enabled: false")
+
+    # Emit community script entries in the same modules: block (UX-003)
+    lines.append("  # ── Community scripts ──")
+    for script in get_community_script_files():
+        sid = script["id"]
+        lines.append(f"  # {sid}: true")
 
     # ── External modules ──────────────────────────────────────────────────
     lines.append("")
@@ -953,19 +1027,22 @@ def generate_mission_yaml_template(
         "# qra:",
         "#   silence_all: false",
         "#   definitions:",
-        '#     - name: "Base QRA"',
+        "#     - name: Base QRA",
         "#       coalition: RED           # RED | BLUE | NEUTRAL",
-        "#       enemy_coalitions: [BLUE]",
-        '#       trigger_zone: "QRA zone"',
+        "#       enemy_coalitions:",
+        "#         - BLUE",
+        "#       trigger_zone: QRA zone",
         "#       zone_radius: 30000",
         "#       groups_by_enemy_count:",
         "#         - enemy_count: 1",
-        '#           groups: ["Group1", "Group2"]',
+        "#           groups:",
+        "#             - Group1",
+        "#             - Group2",
         "#           random_pick: 1       # how many groups to pick randomly",
         "#       delay_before_rearming: 30",
         "#       delay_before_activating: 30",
         "#       # react_on_helicopters: true",
-        '#       # airport_link: "Kutaisi"',
+        "#       # airport_link: Kutaisi",
     ]
 
     # ── CAP missions ──────────────────────────────────────────────────────
@@ -973,9 +1050,9 @@ def generate_mission_yaml_template(
     lines.extend(_yaml_comment("generated.mission_yaml.section.cap"))
     lines += [
         "# cap_missions:",
-        '#   - group_name: "CAP Group"',
-        '#     menu_name: "CAP"',
-        '#     briefing: "CAP mission briefing"',
+        "#   - group_name: CAP Group",
+        "#     menu_name: CAP",
+        "#     briefing: CAP mission briefing",
         "#     default: false",
         "#     activated: true",
     ]
@@ -985,15 +1062,17 @@ def generate_mission_yaml_template(
     lines.extend(_yaml_comment("generated.mission_yaml.section.combat"))
     lines += [
         "# combat_missions:",
-        '#   - name: "Mission Name"',
-        '#     friendly_name: "Display Name"',
+        "#   - name: Mission Name",
+        "#     friendly_name: Display Name",
         "#     secured: false",
         "#     radio_menu_enabled: true",
         "#     briefing: |",
         "#       Multi-line briefing text here.",
         "#     elements:",
-        '#       - name: "Element Name"',
-        '#         groups: ["Group1", "Group2"]',
+        "#       - name: Element Name",
+        "#         groups:",
+        "#           - Group1",
+        "#           - Group2",
         "#         scalable: true",
     ]
 

--- a/test/python/mission_builder/test_config_migrator.py
+++ b/test/python/mission_builder/test_config_migrator.py
@@ -175,20 +175,20 @@ class TestYamlSnippet(unittest.TestCase):
         )
         lines = snippet.splitlines()
 
-        # Any mandatory module that appears uncommented must use `key: {}`, not `enable:`
+        # Any mandatory module that appears uncommented must use bare null `key:`, not `enable:`
         for mandatory in MANDATORY_MODULES:
             uncommented = [ln for ln in lines if mandatory in ln and not ln.lstrip().startswith("#")]
             if not uncommented:
                 continue  # module not in enabled_set for this input — skip
-            mandatory_lines = [ln for ln in uncommented if ln.strip() == f"{mandatory}: {{}}"]
-            self.assertNotEqual(mandatory_lines, [], f"{mandatory} must be emitted as '{mandatory}: {{}}'")
+            mandatory_lines = [ln for ln in uncommented if ln.strip() == f"{mandatory}:"]
+            self.assertNotEqual(mandatory_lines, [], f"{mandatory} must be emitted as bare null '{mandatory}:'")
             enable_lines = [ln for ln in uncommented if "enable:" in ln]
             self.assertEqual(enable_lines, [], f"{mandatory} must not have 'enable:' in yaml snippet")
 
-        # Non-mandatory enabled module must still use enable: true
+        # Non-mandatory enabled module must use enabled: true
         self.assertTrue(
-            any("enable: true" in ln and not ln.lstrip().startswith("#") for ln in lines),
-            "At least one non-mandatory module must be emitted with 'enable: true'",
+            any("enabled: true" in ln and not ln.lstrip().startswith("#") for ln in lines),
+            "At least one non-mandatory module must be emitted with 'enabled: true'",
         )
 
 
@@ -899,7 +899,7 @@ class _IntegrationMixin:
     def test_yaml_snippet_is_valid_yaml(self) -> None:
         loaded = yaml.safe_load(self._result.yaml_snippet)  # type: ignore[attr-defined]
         self.assertIsNotNone(loaded)  # type: ignore[attr-defined]
-        self.assertIn("lua_modules", loaded)  # type: ignore[attr-defined]
+        self.assertIn("modules", loaded)  # type: ignore[attr-defined]
 
     def test_no_uncommented_veaf_dofile_in_output(self) -> None:
         for line in self._result.new_content.splitlines():  # type: ignore[attr-defined]

--- a/test/python/mission_builder/test_v5_converter.py
+++ b/test/python/mission_builder/test_v5_converter.py
@@ -386,7 +386,7 @@ class TestV5ConverterIntegration(unittest.TestCase):
             self._make_missionconfig(folder, "veafRadio.initialize()\n")
             V5Converter().convert(folder, backup=False)
             yaml_content = (folder / "mission.yaml").read_text()
-            self.assertIn("lua_modules:", yaml_content)
+            self.assertIn("modules:", yaml_content)
 
     def test_mission_yaml_contains_pipeline_section(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -464,10 +464,10 @@ class TestV5ConverterIntegration(unittest.TestCase):
             self._make_community_folder(folder, ["mist.lua", "CTLD.lua"])
             V5Converter().convert(folder, backup=False)
             yaml_content = (folder / "mission.yaml").read_text()
-            self.assertIn("community_scripts:", yaml_content)
-            self.assertIn("mist: {enabled: true}", yaml_content)
-            self.assertIn("ctld: {enabled: true}", yaml_content)
-            self.assertIn("skynet: {enabled: false}", yaml_content)
+            self.assertIn("modules:", yaml_content)
+            self.assertIn("mist: true", yaml_content)
+            self.assertIn("ctld: true", yaml_content)
+            self.assertIn("skynet: false", yaml_content)
 
     def test_mission_yaml_community_scripts_all_false_when_no_community_folder(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -475,8 +475,13 @@ class TestV5ConverterIntegration(unittest.TestCase):
             self._make_missionconfig(folder, "-- test\n")
             V5Converter().convert(folder, backup=False)
             yaml_content = (folder / "mission.yaml").read_text()
-            self.assertIn("community_scripts:", yaml_content)
-            self.assertNotIn("enabled: true", yaml_content.split("community_scripts:")[1].split("# ──")[0])
+            self.assertIn("modules:", yaml_content)
+            # All community script IDs must appear with ": false" (no community folder → none detected)
+            from mission_tools.mission_constants import get_community_script_files
+            for script in get_community_script_files():
+                sid = script["id"]
+                self.assertIn(f"  {sid}: false", yaml_content)
+                self.assertNotIn(f"  {sid}: true", yaml_content)
     def test_mission_yaml_global_log_level_defaults_to_info(self) -> None:
         """When no global_log_level is found in missionConfig, generated yaml uses 'info' not 'debug'."""
         with tempfile.TemporaryDirectory() as td:

--- a/test/python/veaf_libs/test_config_generator.py
+++ b/test/python/veaf_libs/test_config_generator.py
@@ -436,7 +436,7 @@ class TestGenerateMissionYamlTemplate(unittest.TestCase):
 
         result = generate_mission_yaml_template()
         self.assertIsInstance(result, str)
-        self.assertIn("lua_modules:", result)
+        self.assertIn("modules:", result)
         self.assertIn("# qra:", result)
         self.assertIn("# cap_missions:", result)
         self.assertIn("# combat_missions:", result)

--- a/test/python/veaf_libs/test_lua_config_generator.py
+++ b/test/python/veaf_libs/test_lua_config_generator.py
@@ -279,7 +279,7 @@ def test_mandatory_module_config_only_passes(caplog):
 
 
 def test_mandatory_module_no_enable_in_yaml_template():
-    """generate_mission_yaml_template must emit 'key: {}' for mandatory modules, never 'enable:'."""
+    """generate_mission_yaml_template must emit bare 'key:' (null) for mandatory modules, never 'enable:'."""
     template = generate_mission_yaml_template(enabled_module_ids=MANDATORY_MODULES | {"RADIO"})
     lines = template.splitlines()
 
@@ -287,15 +287,15 @@ def test_mandatory_module_no_enable_in_yaml_template():
         uncommented = [ln for ln in lines if mandatory in ln and not ln.lstrip().startswith("#")]
         assert uncommented, f"{mandatory} must appear uncommented in the template"
         assert not any("enable:" in ln for ln in uncommented), f"{mandatory} must not have 'enable:'"
+        # Mandatory modules must be emitted as bare null: "  KEY:" with nothing after the colon
         assert any(
-            ln.strip().startswith(f"{mandatory}: {{}}") or ln.strip().startswith(f'"{mandatory}": {{}}')
-            for ln in uncommented
-        ), f"{mandatory} must be emitted as 'key: {{}}'"
+            ln.strip() == f"{mandatory}:" for ln in uncommented
+        ), f"{mandatory} must be emitted as bare null 'key:'"
 
-    # Non-mandatory enabled module must still use enable: true (on the indented sub-key line)
+    # Non-mandatory enabled module must use enabled: true (not enable:)
     assert any(
-        ln.strip() == "enable: true" and not ln.startswith("#") for ln in lines
-    ), "RADIO (non-mandatory) must produce an 'enable: true' line"
+        ln.strip() == "enabled: true" and not ln.startswith("#") for ln in lines
+    ), "RADIO (non-mandatory) must produce an 'enabled: true' line"
 
 
 def test_non_mandatory_disabled_no_error(caplog):
@@ -317,7 +317,7 @@ def test_dep_auto_resolution_missing_dep(caplog):
     with caplog.at_level(logging.WARNING, logger="veaf-tools"):
         result = _resolve_deps(effective)
     assert "UNITS" in result
-    assert result["UNITS"].get("enable") is True
+    assert result["UNITS"].get("enabled") is True
     assert any("UNITS" in msg for msg in caplog.messages)
 
 
@@ -327,7 +327,7 @@ def test_dep_auto_resolution_disabled_dep(caplog):
     effective = {"SPAWN": {}, "UNITS": {"enable": False, "logLevel": "debug"}}
     with caplog.at_level(logging.WARNING, logger="veaf-tools"):
         result = _resolve_deps(effective)
-    assert result["UNITS"].get("enable") is True
+    assert result["UNITS"].get("enabled") is True
     # Other config must be preserved (Sourcery fix)
     assert result["UNITS"].get("logLevel") == "debug"
     assert any("UNITS" in msg for msg in caplog.messages)


### PR DESCRIPTION
## Summary

- Merges `lua_modules:` + `community_scripts:` into a single `modules:` block — one place for all module toggles (VEAF and community scripts)
- Mandatory modules now use bare null syntax (`CACHE:`) instead of confusing `CACHE: {}` 
- Standardises `enabled:` key (deprecates `enable:`); both still accepted for backward compat
- Replaces inline `[...]` arrays with block-style lists (`- item`)
- Adds a YAML syntax quick-reference header to all generated/template files to help non-developer mission makers
- Legacy `lua_modules:` / `community_scripts:` still accepted with a deprecation warning

## Test plan

- [x] All existing tests updated and passing (`poetry run pytest --no-cov`)
- [x] Quality gate clean (`ruff check` + `mypy`)
- [ ] Manual: convert a v5 mission with `convert-v5` and verify `modules:` section in output
- [ ] Manual: build a mission using the new `modules:` syntax and verify Lua config is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Simplify mission.yaml syntax and module configuration for better readability and unify handling of VEAF modules and community scripts.

New Features:
- Introduce a unified modules: block that configures both VEAF modules and community scripts in mission.yaml.
- Add a YAML syntax quick-reference header to generated and template mission.yaml files to guide non-technical mission makers.

Enhancements:
- Standardize module enablement on an enabled flag while still accepting the deprecated enable key for backward compatibility.
- Represent mandatory modules using bare null YAML syntax (MODULE:) instead of empty maps (MODULE: {}).
- Normalize mission.yaml input to support the new modules: block while preserving compatibility with legacy lua_modules: and community_scripts: keys via deprecation warnings.
- Update YAML generation in converters, templates, and migrators to use block-style lists consistently and the new modules: layout.
- Improve auto-resolution of module dependencies and defaults to work with the new enabled semantics and unified module configuration.

Tests:
- Adjust existing tests to assert the presence and shape of the new modules: block, YAML syntax, and community script defaults in generated mission.yaml files.