### PR TITLE
feat(yaml-ux): module shorthand, uppercase community IDs, category sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - `weather` pipeline step now uses `versions.yaml` exclusively — `missions.yaml` is no longer recognised as an alias; rename any existing `src/missions.yaml` to `src/versions.yaml`
 - `mission.yaml` syntax simplified: `lua_modules:` + `community_scripts:` merged into a single `modules:` block; mandatory modules use bare null syntax (`MODULE:` with no value) instead of `MODULE: {}`; `enable:` replaced by `enabled:`; block-style lists replace inline `[...]`; generated files include a YAML syntax quick-reference header; legacy keys still accepted with a deprecation warning
+- `convert-v5`: modules in generated `mission.yaml` are now sorted by category (Infrastructure → Core → Features → Combat → External); optional modules without extra config use `MODULE: true` shorthand instead of two-line block; community script IDs are emitted in uppercase (`MIST`, `STTS`, …); parser accepts uppercase or lowercase community IDs
 
 ### Added
 - i18n coverage: all log messages in `mission_builder_worker.py`, `aircrafts_injector_worker.py`, and `waypoints_manager.py` now use `t()` — no more hardcoded English strings; matching French translations added to `fr.json`; tests verify all `t()` keys exist in `en.json` and that `fr.json` covers every `en.json` key

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -83,9 +83,10 @@ def _normalize_mission_yaml(yaml_data: dict) -> dict:
             logger.warning(f"'modules' in mission.yaml must be a mapping (got {type(modules_raw).__name__}); ignoring.")
             return yaml_data
 
-        all_community_ids = {s["id"] for s in get_community_script_files()}
-        lua_mods = {k: v for k, v in modules_raw.items() if k not in all_community_ids}
-        comm_scripts = {k: v for k, v in modules_raw.items() if k in all_community_ids}
+        # IDs are lowercase in code; YAML may use uppercase (e.g. MIST).
+        all_community_ids_lower = {s["id"].lower() for s in get_community_script_files()}
+        lua_mods = {k: v for k, v in modules_raw.items() if k.lower() not in all_community_ids_lower}
+        comm_scripts = {k.lower(): v for k, v in modules_raw.items() if k.lower() in all_community_ids_lower}
 
         result = dict(yaml_data)
         result["lua_modules"] = lua_mods

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -29,7 +29,7 @@ from typing import Any
 import yaml  # type: ignore[import-untyped]
 from mission_tools.mission_constants import get_community_script_files
 from veaf_libs.i18n import t
-from veaf_libs.lua_config_generator import MANDATORY_MODULES, yaml_module_entry, yaml_syntax_header
+from veaf_libs.lua_config_generator import MANDATORY_MODULES, MODULE_CATEGORIES, yaml_module_entry, yaml_syntax_header
 from veaf_libs.lua_module_scanner import get_modules
 
 from mission_builder.config_migrator import ConfigMigrator, MigrationResult
@@ -902,25 +902,28 @@ class V5Converter:
         all_mods = get_modules()
 
         # Modules explicitly enabled (from missionConfig.lua or always-on base set)
-        enabled_found = [m["id"] for m in all_mods if m["id"] in enabled_set]
+        enabled_by_id = {m["id"] for m in all_mods if m["id"] in enabled_set}
 
-        if enabled_found:
-            lines.append(t("converter.yaml.modules.active"))
-            for mid in enabled_found:
+        # Emit modules grouped by category in declaration order
+        for category, cat_mods in MODULE_CATEGORIES.items():
+            cat_enabled = [mid for mid in cat_mods if mid in enabled_by_id]
+            if not cat_enabled:
+                continue
+            lines.append(f"  # {category}")
+            for mid in cat_enabled:
                 yaml_key = f'"{mid}"' if not _re.match(r"^[A-Za-z_]\w*$", mid) else mid
-                lines.extend(yaml_module_entry(yaml_key, mid))
-                # For ASSETS, inject the extracted asset list directly under the module entry
+                # Detect whether extra config will follow (block style needed)
+                has_config = bool(
+                    (mid == "ASSETS" and mr and mr.assets_extracted)
+                    or (mid == "SHORTCUTS" and mr and mr.shortcuts_extracted)
+                    or (mid == "SANCTUARY" and mr and mr.sanctuary_zones_extracted)
+                    or (mid == "COMBATZONE" and mr and (mr.combat_zone_settings_extracted or mr.combat_zones_extracted))
+                    or (mid == "AIRWAVES" and mr and mr.airwave_zones_extracted)
+                )
+                lines.extend(yaml_module_entry(yaml_key, mid, has_config=has_config))
+                # Inject extracted config under the module entry
                 if mid == "ASSETS" and mr and mr.assets_extracted:
                     lines.append("    assets:")
-                    _ASSET_STR_KEYS = (
-                        "name",
-                        "description",
-                        "information",
-                        "jtac",
-                        "freq",
-                        "linked",
-                        "mod",
-                    )
                     for asset in mr.assets_extracted:
                         first = True
                         for k, v in asset.items():
@@ -953,7 +956,15 @@ class V5Converter:
                     lines.append("    airwave_zones:")
                     lines.extend(_yaml_list_block(mr.airwave_zones_extracted, indent=4))
 
-        # Community scripts appended at end of modules: block
+        # Emit any enabled module not in any known category (safety net)
+        categorized = {mid for mods in MODULE_CATEGORIES.values() for mid in mods}
+        uncategorized = [mid for mid in enabled_by_id if mid not in categorized]
+        if uncategorized:
+            for mid in sorted(uncategorized):
+                yaml_key = f'"{mid}"' if not _re.match(r"^[A-Za-z_]\w*$", mid) else mid
+                lines.extend(yaml_module_entry(yaml_key, mid))
+
+        # Community scripts appended at end of modules: block (IDs in uppercase)
         all_community = get_community_script_files()
         detected_comm = report.detected_community_script_ids
         if all_community:
@@ -962,7 +973,7 @@ class V5Converter:
             for script in all_community:
                 sid = script["id"]
                 val = "true" if sid in detected_comm else "false"
-                lines.append(f"  {sid}: {val}")
+                lines.append(f"  {sid.upper()}: {val}")
         lines.append("")
 
         # ── External modules (Skynet) ──────────────────────────────────────

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -116,7 +116,7 @@ def yaml_syntax_header() -> list[str]:
 
 
 #: Cosmetic category groupings for YAML template and generated Lua output.
-_MODULE_CATEGORIES: dict[str, list[str]] = {
+MODULE_CATEGORIES: dict[str, list[str]] = {
     "Infrastructure": ["UNITS", "TIME", "CACHE", "EVENTS", "MARKERS", "COMMANDS"],
     "Core": ["SECURITY", "RADIO", "GROUNDAI", "SHORTCUTS", "NAMEDPOINTS", "SPAWN"],
     "Features": [
@@ -143,27 +143,33 @@ _MODULE_CATEGORIES: dict[str, list[str]] = {
 }
 
 #: Flat module→category reverse lookup (built once at module load time).
-_MODULE_TO_CATEGORY: dict[str, str] = {mod_id: cat for cat, ids in _MODULE_CATEGORIES.items() for mod_id in ids}
+_MODULE_TO_CATEGORY: dict[str, str] = {mod_id: cat for cat, ids in MODULE_CATEGORIES.items() for mod_id in ids}
 
 #: Modules that are mandatory (infrastructure tier).
 #: These are always active; specifying ``enable`` (true or false) for them is an error.
 MANDATORY_MODULES: frozenset[str] = frozenset({"UNITS", "TIME", "CACHE", "EVENTS", "MARKERS", "COMMANDS"})
 
 
-def yaml_module_entry(yaml_key: str, module_id: str) -> list[str]:
+def yaml_module_entry(yaml_key: str, module_id: str, has_config: bool = False) -> list[str]:
     """Return the YAML lines for one enabled module entry in ``mission.yaml``.
 
     Args:
         yaml_key: The (possibly quoted) YAML key string, e.g. ``RADIO`` or ``"MY-MOD"``.
         module_id: The canonical module ID used to look up mandatory status.
+        has_config: When ``True``, emit block style (``key:\\n  enabled: true``) so
+            callers can append extra config keys underneath. When ``False`` (default),
+            emit the compact shorthand ``key: true`` for optional modules.
 
     Returns:
         One line ``["  key:"]`` for mandatory modules (null value = always active),
-        or two lines ``["  key:", "    enabled: true"]`` for optional ones.
+        ``["  key: true"]`` for optional modules without extra config, or
+        ``["  key:", "    enabled: true"]`` for optional modules with extra config.
     """
     if module_id in MANDATORY_MODULES:
         return [f"  {yaml_key}:"]
-    return [f"  {yaml_key}:", "    enabled: true"]
+    if has_config:
+        return [f"  {yaml_key}:", "    enabled: true"]
+    return [f"  {yaml_key}: true"]
 
 
 def _get_module_enabled(cfg: dict, default: bool = True) -> bool:

--- a/test/python/mission_builder/test_config_migrator.py
+++ b/test/python/mission_builder/test_config_migrator.py
@@ -185,10 +185,10 @@ class TestYamlSnippet(unittest.TestCase):
             enable_lines = [ln for ln in uncommented if "enable:" in ln]
             self.assertEqual(enable_lines, [], f"{mandatory} must not have 'enable:' in yaml snippet")
 
-        # Non-mandatory enabled module must use enabled: true
+        # Non-mandatory enabled module must use shorthand `: true` (no extra config here)
         self.assertTrue(
-            any("enabled: true" in ln and not ln.lstrip().startswith("#") for ln in lines),
-            "At least one non-mandatory module must be emitted with 'enabled: true'",
+            any(": true" in ln and not ln.lstrip().startswith("#") for ln in lines),
+            "At least one non-mandatory module must be emitted with ': true'",
         )
 
 

--- a/test/python/mission_builder/test_v5_converter.py
+++ b/test/python/mission_builder/test_v5_converter.py
@@ -469,9 +469,9 @@ class TestV5ConverterIntegration(unittest.TestCase):
             V5Converter().convert(folder, backup=False)
             yaml_content = (folder / "mission.yaml").read_text()
             self.assertIn("modules:", yaml_content)
-            self.assertIn("mist: true", yaml_content)
-            self.assertIn("ctld: true", yaml_content)
-            self.assertIn("skynet: false", yaml_content)
+            self.assertIn("MIST: true", yaml_content)
+            self.assertIn("CTLD: true", yaml_content)
+            self.assertIn("SKYNET: false", yaml_content)
 
     def test_mission_yaml_community_scripts_all_false_when_no_community_folder(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -483,7 +483,7 @@ class TestV5ConverterIntegration(unittest.TestCase):
             # All community script IDs must appear with ": false" (no community folder → none detected)
             from mission_tools.mission_constants import get_community_script_files
             for script in get_community_script_files():
-                sid = script["id"]
+                sid = script["id"].upper()
                 self.assertIn(f"  {sid}: false", yaml_content)
                 self.assertNotIn(f"  {sid}: true", yaml_content)
     def test_mission_yaml_global_log_level_defaults_to_info(self) -> None:

--- a/test/python/veaf_libs/test_lua_config_generator.py
+++ b/test/python/veaf_libs/test_lua_config_generator.py
@@ -292,10 +292,10 @@ def test_mandatory_module_no_enable_in_yaml_template():
             ln.strip() == f"{mandatory}:" for ln in uncommented
         ), f"{mandatory} must be emitted as bare null 'key:'"
 
-    # Non-mandatory enabled module must use enabled: true (not enable:)
+    # Non-mandatory enabled module (no extra config) must use shorthand `: true`
     assert any(
-        ln.strip() == "enabled: true" and not ln.startswith("#") for ln in lines
-    ), "RADIO (non-mandatory) must produce an 'enabled: true' line"
+        ln.strip() == "RADIO: true" and not ln.startswith("#") for ln in lines
+    ), "RADIO (non-mandatory) must produce a 'RADIO: true' shorthand line"
 
 
 def test_non_mandatory_disabled_no_error(caplog):


### PR DESCRIPTION
## Summary
- Optional VEAF modules without extra config now use compact `MODULE: true` shorthand (was two-line block)
- Community script IDs in generated `mission.yaml` are now uppercase (`MIST`, `STTS`, `CTLD`…) consistent with VEAF module style
- Modules sorted by category in generated file: Infrastructure → Core → Features → Combat → External
- Parser (`_normalize_mission_yaml`) accepts uppercase or lowercase community IDs (case-insensitive)

## Test plan
- [ ] `poetry run pytest` — all green
- [ ] Run `convert-v5` on a real v5 mission folder; verify module section layout in generated `mission.yaml`
- [ ] Verify `veaf-tools build` still works on a mission using `MIST: true` (uppercase) in `modules:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Sort generated mission.yaml modules by category and simplify optional module syntax while standardizing and loosening case handling for community script IDs.

New Features:
- Support compact MODULE: true shorthand for optional modules without additional configuration in generated mission.yaml.

Enhancements:
- Group modules by cosmetic category when emitting the modules section in mission.yaml, with uncategorized modules appended afterward.
- Emit community script module IDs in mission.yaml in uppercase to match VEAF module style.
- Treat community script IDs in mission.yaml case-insensitively when normalizing configuration, allowing uppercase or lowercase forms.

Documentation:
- Document the new module ordering, shorthand syntax, and uppercase community script handling in the changelog.

Tests:
- Update and extend tests to cover new module shorthand syntax, category-based ordering, and uppercase community script IDs in mission.yaml output.