### PR TITLE
fix(convert-v5): extract full multiline Lua briefings with .. concatenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - `convert-v5`: generated `mission.yaml` now includes the YAML syntax quick-reference header (was only present in `generate-config` output)
 - `convert-v5`: all comment strings in generated `mission.yaml` are now localized via `t()` — French users see French comments
+- `convert-v5`: multi-line Lua briefings using `..` concatenation (e.g. `"line1\n" .. "line2\n"`) are now fully extracted; `\n` escape sequences are decoded to real newlines and emitted as YAML block scalars
 
 ### Changed
 - `weather` pipeline step now uses `versions.yaml` exclusively — `missions.yaml` is no longer recognised as an alias; rename any existing `src/missions.yaml` to `src/versions.yaml`

--- a/src/python/veaf-tools/mission_builder/config_migrator.py
+++ b/src/python/veaf-tools/mission_builder/config_migrator.py
@@ -87,6 +87,53 @@ class MigrationResult:
 
 
 # ---------------------------------------------------------------------------
+# Lua string helpers
+# ---------------------------------------------------------------------------
+
+#: Matches one double-quoted Lua string fragment (with escaped chars).
+_LUA_QUOTED_STR_RE = re.compile(r'"((?:[^"\\]|\\.)*)"', re.DOTALL)
+
+#: Lua escape sequences to decode in string values.
+_LUA_ESCAPES: list[tuple[str, str]] = [
+    ("\\n", "\n"),
+    ("\\t", "\t"),
+    ('\\"', '"'),
+    ("\\\\", "\\"),
+]
+
+
+def _lua_extract_string(text: str, call_name: str) -> str | None:
+    """Extract and decode a Lua method argument that may be a ``[[...]]`` long string or ``"..."``-concat.
+
+    Handles Lua ``..`` string concatenation — e.g.:
+    ``:setBriefing("line1\\n" .. "line2\\n")`` → ``"line1\\nline2\\n"`` with ``\\n`` → real newlines.
+
+    Args:
+        text: The source text containing the method call.
+        call_name: The method name to search for, e.g. ``"setBriefing"``.
+
+    Returns:
+        The decoded string value, or ``None`` if the call is not found.
+    """
+    m = re.search(rf":{re.escape(call_name)}\s*\(", text)
+    if not m:
+        return None
+    arg_start = m.end()
+    # Long string [[...]] — no escape decoding needed
+    ls = re.match(r"\s*\[\[(.*?)\]\]", text[arg_start:], re.DOTALL)
+    if ls:
+        return ls.group(1).strip()
+    # Collect all "..." fragments (handles .. concatenation across lines)
+    fragments = _LUA_QUOTED_STR_RE.findall(text[arg_start:])
+    if not fragments:
+        return None
+    joined = "".join(fragments)
+    for esc, char in _LUA_ESCAPES:
+        joined = joined.replace(esc, char)
+    return joined
+
+
+# ---------------------------------------------------------------------------
 # Migrator
 # ---------------------------------------------------------------------------
 
@@ -654,10 +701,9 @@ class ConfigMigrator:
         if m:
             cm["radio_menu_enabled"] = m.group(1) == "true"
 
-        # Briefing: [[...]] or [==[...]==] or "..."
-        m = re.search(r":setBriefing\s*\(\s*(?:\[\[([^\]]*(?:\][^\]])*)\]\]|\[=\[([^=]*)\]=\]|\"([^\"]*)\")", text)
-        if m:
-            briefing = m.group(1) or m.group(2) or m.group(3) or ""
+        # Briefing: handles [[...]], "..." and "..." .. "..." concatenation
+        briefing = _lua_extract_string(text, "setBriefing")
+        if briefing is not None:
             cm["briefing"] = briefing.strip()
 
         # Elements
@@ -1016,10 +1062,10 @@ class ConfigMigrator:
         if m:
             zone["friendly_name"] = m.group(1)
 
-        # Briefing: [[...]] or "..."
-        m = re.search(r':setBriefing\s*\(\s*(?:\[\[([^\]]*(?:\][^\]])*)\]\]|"([^"]*)")', chain_text)
-        if m:
-            zone["briefing"] = (m.group(1) or m.group(2) or "").strip()
+        # Briefing: handles [[...]], "..." and "..." .. "..." concatenation
+        briefing = _lua_extract_string(chain_text, "setBriefing")
+        if briefing is not None:
+            zone["briefing"] = briefing.strip()
 
         if re.search(r":disableUserActivation\s*\(\s*\)", chain_text):
             zone["user_activation_disabled"] = True
@@ -1056,9 +1102,10 @@ class ConfigMigrator:
         if m:
             op["friendly_name"] = m.group(1)
 
-        m = re.search(r':setBriefing\s*\(\s*(?:\[\[([^\]]*(?:\][^\]])*)\]\]|"([^"]*)")', chain_text)
-        if m:
-            op["briefing"] = (m.group(1) or m.group(2) or "").strip()
+        # Briefing: handles [[...]], "..." and "..." .. "..." concatenation
+        briefing = _lua_extract_string(chain_text, "setBriefing")
+        if briefing is not None:
+            op["briefing"] = briefing.strip()
 
         # addTaskingOrder(zoneVar, {deps}) — local var refs → extract as string names
         tasking_orders = []

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -103,6 +103,10 @@ def _yaml_str(value: str) -> str:
         return f'"{value}"'
     if _YAML_NEEDS_QUOTE_RE.search(value):
         return f'"{value}"'
+    if "\n" in value:
+        # Double-quoted scalar with escaped newlines — safe for inline use.
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+        return f'"{escaped}"'
     return value
 
 
@@ -1048,7 +1052,13 @@ class V5Converter:
             for cap in mr.cap_missions_extracted:
                 lines.append(f"  - group_name: {_yaml_str(cap.get('group_name', ''))}")
                 lines.append(f"    menu_name: {_yaml_str(cap.get('menu_name', ''))}")
-                lines.append(f"    briefing: {_yaml_str(cap.get('briefing', ''))}")
+                b = cap.get("briefing", "")
+                if b and "\n" in b:
+                    lines.append("    briefing: |")
+                    for bl in b.strip().splitlines():
+                        lines.append(f"      {bl}")
+                else:
+                    lines.append(f"    briefing: {_yaml_str(b)}")
                 lines.append(f"    default: {'true' if cap.get('default') else 'false'}")
                 lines.append(f"    activated: {'true' if cap.get('activated', True) else 'false'}")
             lines.append("")

--- a/test/python/mission_builder/test_config_migrator.py
+++ b/test/python/mission_builder/test_config_migrator.py
@@ -783,6 +783,45 @@ class TestExtractCombatZones(unittest.TestCase):
         self.assertEqual(new_content, content)
 
 
+class TestCombatZoneBriefingMultiline(unittest.TestCase):
+    """setBriefing with Lua .. concatenation must produce a complete multiline string."""
+
+    def setUp(self) -> None:
+        self.m = ConfigMigrator()
+
+    def _extract_zone(self, briefing_call: str) -> dict:
+        content = (
+            "veafCombatZone.AddZone(\n"
+            "    VeafCombatZone:new()\n"
+            '        :setMissionEditorZoneName("testZone")\n'
+            f"        {briefing_call}\n"
+            "        :initialize()\n"
+            ")\n"
+        )
+        result = MigrationResult(new_content="")
+        self.m._extract_combat_zones(content, result)
+        return result.combat_zones_extracted[0]
+
+    def test_single_fragment_newline_decoded(self) -> None:
+        zone = self._extract_zone(':setBriefing("Hello\\nWorld")')
+        self.assertIn("\n", zone["briefing"])
+        self.assertIn("Hello", zone["briefing"])
+        self.assertIn("World", zone["briefing"])
+
+    def test_two_fragments_joined(self) -> None:
+        zone = self._extract_zone(':setBriefing("Line one\\n" ..\n            "Line two\\n")')
+        briefing = zone["briefing"]
+        self.assertIn("Line one", briefing)
+        self.assertIn("Line two", briefing)
+        self.assertNotIn("..", briefing)
+
+    def test_multiline_newlines_are_real(self) -> None:
+        """Decoded \\n must be a real newline char, not literal backslash-n."""
+        zone = self._extract_zone(':setBriefing("Part1\\nPart2")')
+        self.assertNotIn("\\n", zone["briefing"])
+        self.assertIn("\n", zone["briefing"])
+
+
 class TestExtractAirwavesZones(unittest.TestCase):
     """_extract_airwaves_zones must parse AirWaveZone builder chains."""
 


### PR DESCRIPTION
## Summary
- `setBriefing("line1\n" .. "line2\n")` previously captured only the first fragment — everything after `..` was silently dropped
- New `_lua_extract_string()` helper joins all `"..."` fragments in a Lua `..` concatenation and decodes `\n`/`\t` escape sequences to real characters
- Applied to all 3 `setBriefing` extraction sites: CombatMission, CombatZone, CombatOperation
- `_yaml_str()` now handles strings with real newlines (emits double-quoted YAML scalar with `\n` escape)
- CAP mission briefing uses YAML block scalar (`|`) when multiline, consistent with combat missions

## Test plan
- [ ] `poetry run pytest` — all green
- [ ] Re-run `convert-v5` on a mission with multi-line briefings (e.g. `Training-Syrie`); verify `briefing:` in `mission.yaml` contains both lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle multiline Lua briefings with string concatenation correctly during v5 mission conversion and emit them safely in mission.yaml.

New Features:
- Support extraction of Lua setBriefing arguments composed of multiple double-quoted fragments concatenated with .., including escape decoding for newlines and tabs.

Bug Fixes:
- Fix loss of briefing text after the first fragment when converting missions that use Lua .. string concatenation for setBriefing.
- Ensure decoded \n sequences in Lua briefings become real newlines in the extracted mission data rather than remaining as literal escape sequences.

Enhancements:
- Centralize Lua string extraction and decoding into a reusable helper used by combat missions, zones, and operations.
- Emit strings containing real newlines as safely escaped double-quoted YAML scalars, and use YAML block scalars for multiline CAP mission briefings for consistency with combat missions.
- Add tests covering multiline and concatenated Lua briefings to guard against regressions.

Documentation:
- Document the fix for multiline Lua briefings and their YAML emission in the changelog.