### PR TITLE
docs: complete bilingual (FR/EN) documentation overhaul (DOC-OVERHAUL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- docs: documentation overhaul (bilingual FR/EN) — pilot guide rewritten (deduplicated, accessible, jargon explained, `_auth` standardized); mission.yaml example updated to the unified `modules:` block; mermaid diagrams added (F10 radio menu, build pipeline, v5→v6 migration flow); screenshot placeholders added under `doc/assets/img/`; created the missing French `veafInterpreter` page; fixed broken `GUIDE.fr.md` links
 - `mission.yaml`: new `dcs_bridge` section to optionally inject `dcs-bridge.lua` as the first DO SCRIPT FILE trigger in the mission; `lua_path` is optional — when absent, the file is downloaded automatically from GitHub (`VEAF/VEAF-dcs-bridge`)
 - `community_scripts:` section in `mission.yaml`: individually enable/disable community Lua scripts (MIST, CTLD, CSAR, etc.) — absent section keeps all scripts active
 - `convert-v5`: generated `mission.yaml` now includes a `community_scripts:` section pre-populated from scripts detected in `published/src/scripts/community/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,52 +9,44 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
-- `convert-v5`: generated `mission.yaml` now includes the YAML syntax quick-reference header (was only present in `generate-config` output)
-- `convert-v5`: all comment strings in generated `mission.yaml` are now localized via `t()` — French users see French comments
-- `convert-v5`: multi-line Lua briefings using `..` concatenation (e.g. `"line1\n" .. "line2\n"`) are now fully extracted; `\n` escape sequences are decoded to real newlines and emitted as YAML block scalars
+### Added
+- `mission.yaml`: new `dcs_bridge` section to optionally inject `dcs-bridge.lua` as the first DO SCRIPT FILE trigger in the mission; `lua_path` is optional — when absent, the file is downloaded automatically from GitHub (`VEAF/VEAF-dcs-bridge`)
+- `community_scripts:` section in `mission.yaml`: individually enable/disable community Lua scripts (MIST, CTLD, CSAR, etc.) — absent section keeps all scripts active
+- `convert-v5`: generated `mission.yaml` now includes a `community_scripts:` section pre-populated from scripts detected in `published/src/scripts/community/`
+- `inject-presets`: DCS aircraft radio frequency validation — preset frequencies are now checked against each aircraft's hardware specs at build time; invalid frequencies (e.g. 284 MHz on a MiG-19P or Gazelle M) emit a warning before DCS rejects them at mission load
+- `doc/mission-maker/dcs-radio-specs.md`: human-readable reference table of valid radio frequency ranges for all 85 DCS player-flyable aircraft, sourced from [dcs-lua-datamine](https://github.com/Quaggles/dcs-lua-datamine)
+- `scripts/extract_dcs_radio_specs.py`: standalone utility to regenerate `dcs-radio-specs.yaml` and the reference doc after a DCS patch
+- Klogg highlight profile for DCS logs added to `tools/klogg/veaf.conf`; GUIDE.md and GUIDE.en.md updated to reference it
+- i18n coverage: all log messages in `mission_builder_worker.py`, `aircrafts_injector_worker.py`, and `waypoints_manager.py` now use `t()` — no more hardcoded English strings; matching French translations added to `fr.json`; tests verify all `t()` keys exist in `en.json` and that `fr.json` covers every `en.json` key
+- i18n: AST-based test (`TestI18nNoHardcodedStrings`) scans all Python source files for hardcoded English prose in `logger.*()`, `console.print()`, and `return` statements; `aircrafts_injector_worker.py` and `lua_config_generator.py` now fully i18n-clean; remaining files listed in `_TODO_EXEMPTIONS` for progressive cleanup
+- i18n: 90 additional hardcoded English strings replaced by `t()` calls across 24 source files (`mission_builder_worker.py`, `mission_extractor_worker.py`, `mission_constants.py`, `radio_frequency_validator.py`, `veaf-tools-updater.py`, `build_profiles.py`, `paths.py`, `tui.py`, all `veaf_tools/commands/*.py`, `waypoints_injector_worker.py`, `waypoints_manager.py`, `weather_injector/**/*.py`); `_TODO_EXEMPTIONS` emptied; Rich markup filter added to scanner `_has_prose`; all new keys added to `en.json` and `fr.json`
 
 ### Changed
 - `weather` pipeline step now uses `versions.yaml` exclusively — `missions.yaml` is no longer recognised as an alias; rename any existing `src/missions.yaml` to `src/versions.yaml`
 - `mission.yaml` syntax simplified: `lua_modules:` + `community_scripts:` merged into a single `modules:` block; mandatory modules use bare null syntax (`MODULE:` with no value) instead of `MODULE: {}`; `enable:` replaced by `enabled:`; block-style lists replace inline `[...]`; generated files include a YAML syntax quick-reference header; legacy keys still accepted with a deprecation warning
 - `convert-v5`: modules in generated `mission.yaml` are now sorted by category (Infrastructure → Core → Features → Combat → External); optional modules without extra config use `MODULE: true` shorthand instead of two-line block; community script IDs are emitted in uppercase (`MIST`, `STTS`, …); parser accepts uppercase or lowercase community IDs
-
-### Added
-- i18n coverage: all log messages in `mission_builder_worker.py`, `aircrafts_injector_worker.py`, and `waypoints_manager.py` now use `t()` — no more hardcoded English strings; matching French translations added to `fr.json`; tests verify all `t()` keys exist in `en.json` and that `fr.json` covers every `en.json` key
-- i18n: AST-based test (`TestI18nNoHardcodedStrings`) scans all Python source files for hardcoded English prose in `logger.*()`, `console.print()`, and `return` statements; `aircrafts_injector_worker.py` and `lua_config_generator.py` now fully i18n-clean; remaining files listed in `_TODO_EXEMPTIONS` for progressive cleanup
-- i18n: 90 additional hardcoded English strings replaced by `t()` calls across 24 source files (`mission_builder_worker.py`, `mission_extractor_worker.py`, `mission_constants.py`, `radio_frequency_validator.py`, `veaf-tools-updater.py`, `build_profiles.py`, `paths.py`, `tui.py`, all `veaf_tools/commands/*.py`, `waypoints_injector_worker.py`, `waypoints_manager.py`, `weather_injector/**/*.py`); `_TODO_EXEMPTIONS` emptied; Rich markup filter added to scanner `_has_prose`; all new keys added to `en.json` and `fr.json`
-- Klogg highlight profile for DCS logs added to `tools/klogg/veaf.conf`; GUIDE.md and GUIDE.en.md updated to reference it
-- `community_scripts:` section in `mission.yaml`: individually enable/disable community Lua scripts (MIST, CTLD, CSAR, etc.) — absent section keeps all scripts active
-- `convert-v5`: generated `mission.yaml` now includes a `community_scripts:` section pre-populated from scripts detected in `published/src/scripts/community/`
+- `mission.yaml` (all generators): each section now includes a `# Doc:` link to the relevant chapter of the Mission Maker Guide; section headers and descriptions improved (security, external modules, mandatory modules explanation)
 
 ### Fixed
+- docs: removed the obsolete `convert` command from the Mission Maker Guide command tables (FR + EN); corrected the false "CSAR not available via mission.yaml" note in the mission.yaml reference (CSAR is supported via `external_modules.csar`); updated the Debug Logging section to reflect the single `veaf-scripts.lua` loader and `global_log_level`/`logLevel` control; created the missing French `veafInterpreter` page (fixes a broken FR nav link); consolidated duplicate `[Unreleased]` changelog sections and translated the stray French entry
+- `veaf-tools-updater`: fixed the dead documentation URL shown on first install (`VEAF-Mission-Creation-Tools-v6/…` → `documentation/dev/…`)
+- `convert-v5`: generated `mission.yaml` now includes the YAML syntax quick-reference header (was only present in `generate-config` output)
+- `convert-v5`: all comment strings in generated `mission.yaml` are now localized via `t()` — French users see French comments
+- `convert-v5`: multi-line Lua briefings using `..` concatenation (e.g. `"line1\n" .. "line2\n"`) are now fully extracted; `\n` escape sequences are decoded to real newlines and emitted as YAML block scalars
 - `convert-v5`: `global_log_level` now defaults to `info` instead of `debug` when no log level is found in `missionConfig.lua`
 - `convert-v5`: command now accepts being called without arguments (uses current directory by default); `no_args_is_help=True` removed
+- `convert-v5`: all warning and manual-review messages are now fully translated via i18n — no more hardcoded English strings visible when running in French locale
 - `veafRadio`: SRS config file absence no longer emits a warning — downgraded to `debug` when the file does not exist on disk
 - `veafGrass`, `veafSpawnGround`, `veafSpawnEffects`: nil-safe guards added around `ctld.builtFOBS`, `ctld.logisticUnits`, `ctld.beaconCount` — prevent crashes when CTLD is not loaded or not yet initialized
 - `presets inject`: `presets_assignments` keys now support regex patterns (e.g. `A[-]10C.*`, `FW[-]190.*`) — exact match takes priority, then pattern, then `all` fallback
 - `convert-v5` presets: per-aircraft radio assignments are now extracted from `radioSettings` — warbird aircraft (e.g. Bf-109K-4) are auto-assigned to `{coalition}_warbird`, VHF-primary aircraft (e.g. I-16, Spitfire) get a new `{coalition}_vhf_primary` preset; hardcoded and typePattern entries emit explicit warnings listing the recommended preset
-- i18n : tous les messages des injectors (presets, waypoints) et du validateur de fréquences radio sont maintenant traduits en français — plus de messages en anglais dans le log de `veaf-tools build`
+- i18n: all injector messages (presets, waypoints) and the radio frequency validator are now translated to French — no more English messages in the `veaf-tools build` log
 - `presets inject`: radio frequency warnings are now deduplicated by aircraft type — instead of one warning block per group, a single block is emitted per unit type listing all affected groups in parentheses
 - `build`: bundle `presets_injector/data/dcs-radio-specs.yaml` into the PyInstaller executable — fixes `ModuleNotFoundError: No module named 'presets_injector.data'` at runtime
 - `aircraft-groups inject` (mode `add`): skip groups whose name already exists in the mission instead of creating duplicates — prevents DCS crash on FA-18C/F-16C units missing `datalinks` after a v5→v6 conversion
 - `convert-v5`, `generate-config`, `migrate-config`: mandatory Lua modules (UNITS, TIME, CACHE, EVENTS, MARKERS, COMMANDS) are now emitted as `{}` in `mission.yaml` instead of `enable: true`, which would cause a build error
 - `convert-v5`: `_BASE_ALWAYS_ON` now includes COMMANDS (previously missing) and is derived from the canonical `MANDATORY_MODULES` set
 - `mission.yaml` (all generators and the default template): fixed broken doc URL (`doc/MISSION_MAKER_GUIDE.md` → `doc/mission-maker/GUIDE.en.md`)
-
-### Fixed
-- `convert-v5`: all warning and manual-review messages are now fully translated via i18n — no more hardcoded English strings visible when running in French locale
-
-### Changed
-- `mission.yaml` (all generators): each section now includes a `# Doc:` link to the relevant chapter of the Mission Maker Guide; section headers and descriptions improved (security, external modules, mandatory modules explanation)
-
-### Added
-- `inject-presets`: DCS aircraft radio frequency validation — preset frequencies are now checked against each aircraft's hardware specs at build time; invalid frequencies (e.g. 284 MHz on a MiG-19P or Gazelle M) emit a warning before DCS rejects them at mission load
-- `doc/mission-maker/dcs-radio-specs.md`: human-readable reference table of valid radio frequency ranges for all 85 DCS player-flyable aircraft, sourced from [dcs-lua-datamine](https://github.com/Quaggles/dcs-lua-datamine)
-- `scripts/extract_dcs_radio_specs.py`: standalone utility to regenerate `dcs-radio-specs.yaml` and the reference doc after a DCS patch
-
-### Added
-- `mission.yaml`: new `dcs_bridge` section to optionally inject `dcs-bridge.lua` as the first DO SCRIPT FILE trigger in the mission; `lua_path` is optional — when absent, the file is downloaded automatically from GitHub (`VEAF/VEAF-dcs-bridge`)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - docs: documentation overhaul (bilingual FR/EN) — pilot guide rewritten (deduplicated, accessible, jargon explained, `_auth` standardized); mission.yaml example updated to the unified `modules:` block; mermaid diagrams added (F10 radio menu, build pipeline, v5→v6 migration flow); screenshot placeholders added under `doc/assets/img/`; created the missing French `veafInterpreter` page; fixed broken `GUIDE.fr.md` links
+- docs: French/English parity for the large reference docs — `LUA_API_REFERENCE.md` (all module sections brought to full depth: missing functions, parameters, and code examples translated), `TOOLS_REFERENCE.md` (troubleshooting, command reference, best practices, security, FAQ sections added), and `dcs-radio-specs.md` (header and critical-aircraft prose translated)
 - `mission.yaml`: new `dcs_bridge` section to optionally inject `dcs-bridge.lua` as the first DO SCRIPT FILE trigger in the mission; `lua_path` is optional — when absent, the file is downloaded automatically from GitHub (`VEAF/VEAF-dcs-bridge`)
 - `community_scripts:` section in `mission.yaml`: individually enable/disable community Lua scripts (MIST, CTLD, CSAR, etc.) — absent section keeps all scripts active
 - `convert-v5`: generated `mission.yaml` now includes a `community_scripts:` section pre-populated from scripts detected in `published/src/scripts/community/`

--- a/backlog.md
+++ b/backlog.md
@@ -495,9 +495,9 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 |---|--------|------|--------|--------|
 | DOC-001 | Create `veafInterpreter.md` (FR) — fixes broken FR nav. (`dcs-radio-specs` EN parity deferred to DOC-005: file is hand-maintained, not purely generated) | fix | 30 min | ✅ |
 | DOC-002 | Isolated content errors done: remove `convert`, CSAR note (FR+EN), dead updater URL, debug-logging section, CHANGELOG consolidation. (`enable:`→`enabled:` + `lua_modules:`→`modules:` across ~20 files folded into per-file DOC-005 passes) | fix | 45 min | ✅ |
-| DOC-003 | ELI5 rewrite pilot/README + pilot/GUIDE (FR+EN) + mermaid (F10 menu, marker flow) + screenshot placeholders | feat | 2h | ⬜ |
-| DOC-004 | ELI5 rewrite mission-maker/README + GUIDE intro (FR+EN) + mermaid (pipeline, mission.yaml, migration) + placeholders | feat | 2h | ⬜ |
-| DOC-005 | Bilingual reparity: bring FR to EN detail for LUA_API_REFERENCE, TOOLS_REFERENCE, script docs | feat | 5h | ⬜ |
+| DOC-003 | Pilot guide rewritten (FR+EN): deduplicated, accessible, `_auth` standardized, mermaid F10 menu, screenshot placeholders; READMEs reviewed (already clean) | feat | 2h | ✅ |
+| DOC-004 | Mission-maker GUIDE + MIGRATION_GUIDE (FR+EN): build-pipeline + v5→v6 mermaid diagrams, `modules:` block example, broken `GUIDE.fr.md` links fixed | feat | 2h | ✅ |
+| DOC-005 | Bilingual reparity + accessibility: LUA_API_REFERENCE (−1077 l.), TOOLS_REFERENCE (−346 l.), 20 script docs (`enable:`→`enabled:`, FR/EN parity), dcs-radio-specs FR, migration guide YAML examples | feat | 5h | ⬜ |
 | DOC-006 | Produce DCS screenshot capture list for the user | chore | 30 min | ⬜ |
 
 **Estimated total: ~12h**

--- a/backlog.md
+++ b/backlog.md
@@ -90,8 +90,9 @@
 | Lot FEAT-YAML-MODULE-UX — Module shorthand, uppercase community IDs, category sort | ~1h | ✅ |
 | Lot FIX-BRIEFING-MULTILINE — convert-v5 truncates multi-line Lua briefings | ~45 min | ✅ |
 | Lot FIX-I18N-HARDCODED — AST test + fix hardcoded strings in aircrafts_injector + lua_config_generator | ~1h | ✅ |
-| Lot FIX-I18N-DEBT — Fix remaining 107 hardcoded strings across 25 files, clear _TODO_EXEMPTIONS | ~4h | 🔄 |
-| **Total** | **~194h** | |
+| Lot FIX-I18N-DEBT — Fix remaining 107 hardcoded strings across 25 files, clear _TODO_EXEMPTIONS | ~4h | ✅ |
+| Lot DOC-OVERHAUL — Complete, detailed, bilingual, ELI5 documentation with diagrams + screenshots | ~12h | 🔄 |
+| **Total** | **~206h** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*
 
@@ -474,5 +475,31 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 | DEBT-006 | Fix `weather_injector/utils/lua_converter.py` (5 violations) | util + locales | fix | 10 min | ⬜ |
 | DEBT-007 | Fix remaining small files (≤3 violations each): mission_extractor, mission_tools, presets_injector, veaf-tools-updater, veaf_libs/*, veaf_tools/commands (7 files), waypoints_manager, weather_injector/* | various + locales | fix | 45 min | ⬜ |
 | DEBT-008 | Remove all 25 files from `_TODO_EXEMPTIONS` in test_i18n.py | test | 5 min | ⬜ |
+
+---
+
+## Lot DOC-OVERHAUL — Complete, detailed, bilingual, ELI5 documentation
+
+**Goal**: Make the documentation complete, detailed, accessible, fully bilingual (FR/EN parity), with ELI5 explanations for non-dev audiences (pilots, mission makers), mermaid diagrams, and screenshot placeholders. Blocks the next develop-v6 release.
+
+**Branch**: `feature/doc-overhaul` → PR → `develop-v6`
+
+**Audit findings** (verified):
+- FR systematically lags EN: LUA_API_REFERENCE −1077 lines, TOOLS_REFERENCE −346, pilot/GUIDE −103, veafAirWaves −131, veafCombatZone −103, others −20…−50
+- Missing files: `veafInterpreter.md` (no FR → nav L105 404), `dcs-radio-specs.en.md` (no EN)
+- Zero images/screenshots in 40 docs; mermaid only in developer docs
+- Pilot guide not truly ELI5 (unexplained jargon: Lua framework, AWACS, IADS)
+- Content errors: deprecated `enable:` examples, removed `convert` command listed, CSAR "not available" (false), dead URL in updater
+
+| # | Ticket | Type | Effort | Status |
+|---|--------|------|--------|--------|
+| DOC-001 | Create `veafInterpreter.md` (FR) — fixes broken FR nav. (`dcs-radio-specs` EN parity deferred to DOC-005: file is hand-maintained, not purely generated) | fix | 30 min | ✅ |
+| DOC-002 | Isolated content errors done: remove `convert`, CSAR note (FR+EN), dead updater URL, debug-logging section, CHANGELOG consolidation. (`enable:`→`enabled:` + `lua_modules:`→`modules:` across ~20 files folded into per-file DOC-005 passes) | fix | 45 min | ✅ |
+| DOC-003 | ELI5 rewrite pilot/README + pilot/GUIDE (FR+EN) + mermaid (F10 menu, marker flow) + screenshot placeholders | feat | 2h | ⬜ |
+| DOC-004 | ELI5 rewrite mission-maker/README + GUIDE intro (FR+EN) + mermaid (pipeline, mission.yaml, migration) + placeholders | feat | 2h | ⬜ |
+| DOC-005 | Bilingual reparity: bring FR to EN detail for LUA_API_REFERENCE, TOOLS_REFERENCE, script docs | feat | 5h | ⬜ |
+| DOC-006 | Produce DCS screenshot capture list for the user | chore | 30 min | ⬜ |
+
+**Estimated total: ~12h**
 
 ---

--- a/backlog.md
+++ b/backlog.md
@@ -500,8 +500,34 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 | DOC-005a | Mechanical syntax sweeps (`enable:`→`enabled:` ×62, `lua_modules:`→`modules:` ×56) + MISSION_YAML_REFERENCE unified `modules:` rewrite (FR+EN) | feat | 1h30 | ✅ |
 | DOC-005b | Script docs FR→EN parity: veafAirWaves, veafCombatZone, veafQraManager, veafShortcuts, veafWeather, veafRadio (all now delta ≤10) + broken `.fr.md` links fixed | feat | 2h30 | ✅ |
 | DOC-005c | Big references in-section depth parity: LUA_API_REFERENCE (~1050 l. across 5 API sections) + TOOLS_REFERENCE (~346 l.) + dcs-radio-specs FR prose | feat | 5h | ⬜ |
-| DOC-006 | Produce DCS screenshot capture list for the user | chore | 30 min | ⬜ |
+| DOC-006 | Produce DCS screenshot capture list for the user | chore | 30 min | ✅ |
 
 **Estimated total: ~12h**
+
+### DOC-005c handoff brief (cold-start ready)
+
+The remaining work is **in-section depth parity** — same headings in FR and EN, but the
+FR has shorter descriptions / fewer code examples. Approach: for each section, read the
+EN version, then expand the FR to match (translate the missing prose, tables, and code
+blocks). Code blocks/identifiers stay identical; only prose is translated.
+
+**Files and gaps (FR lines behind EN):**
+
+| File | Gap | Where the gap is |
+|------|-----|------------------|
+| `doc/LUA_API_REFERENCE.md` | ~1050 | Core Infrastructure (−190), Unit & Group Management (−388), Mission Systems (−284), Infrastructure & Services (−102), Communication & Control (−90). Other sections already at parity. |
+| `doc/TOOLS_REFERENCE.md` | ~346 | All sections present (translated headings); depth is thinner throughout the updater/publish/architecture sections. |
+| `doc/mission-maker/dcs-radio-specs.md` | prose only | The frequency table is language-neutral and fine; only the header prose + the hand-written "Critical aircraft" section need a FR pass. NOTE: this file is **hand-maintained** beyond what `veaf_build/radio_specs_updater.py` generates — do not regenerate, edit by hand. |
+
+**Conventions already established this lot (keep consistent):**
+- Tone: sober, vouvoiement, jargon explained at first use (no childish analogies).
+- YAML syntax in examples: unified `modules:` block, `enabled:` (never `enable:`), community scripts as uppercase IDs inside `modules:`.
+- Auth command is `_auth [PASSWORD]` (canonical `veafSecurity.Keyphrase`); never `-login`.
+- Cross-doc links use `*.md` (NOT `*.fr.md` / `*.en.md`) — mkdocs-static-i18n resolves the language. Several `.fr.md` links were already fixed; watch for more.
+- Screenshot placeholders live under `doc/assets/img/<area>/`.
+- Per-doc commits, verify parity with `wc -l` after each file.
+
+**After DOC-005c:** update CHANGELOG, open PR `feature/doc-overhaul` → `develop-v6`,
+then the user captures the screenshots listed in DOC-006 to drop into `doc/assets/img/`.
 
 ---

--- a/backlog.md
+++ b/backlog.md
@@ -497,7 +497,9 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 | DOC-002 | Isolated content errors done: remove `convert`, CSAR note (FR+EN), dead updater URL, debug-logging section, CHANGELOG consolidation. (`enable:`→`enabled:` + `lua_modules:`→`modules:` across ~20 files folded into per-file DOC-005 passes) | fix | 45 min | ✅ |
 | DOC-003 | Pilot guide rewritten (FR+EN): deduplicated, accessible, `_auth` standardized, mermaid F10 menu, screenshot placeholders; READMEs reviewed (already clean) | feat | 2h | ✅ |
 | DOC-004 | Mission-maker GUIDE + MIGRATION_GUIDE (FR+EN): build-pipeline + v5→v6 mermaid diagrams, `modules:` block example, broken `GUIDE.fr.md` links fixed | feat | 2h | ✅ |
-| DOC-005 | Bilingual reparity + accessibility: LUA_API_REFERENCE (−1077 l.), TOOLS_REFERENCE (−346 l.), 20 script docs (`enable:`→`enabled:`, FR/EN parity), dcs-radio-specs FR, migration guide YAML examples | feat | 5h | ⬜ |
+| DOC-005a | Mechanical syntax sweeps (`enable:`→`enabled:` ×62, `lua_modules:`→`modules:` ×56) + MISSION_YAML_REFERENCE unified `modules:` rewrite (FR+EN) | feat | 1h30 | ✅ |
+| DOC-005b | Script docs FR→EN parity: veafAirWaves, veafCombatZone, veafQraManager, veafShortcuts, veafWeather, veafRadio (all now delta ≤10) + broken `.fr.md` links fixed | feat | 2h30 | ✅ |
+| DOC-005c | Big references in-section depth parity: LUA_API_REFERENCE (~1050 l. across 5 API sections) + TOOLS_REFERENCE (~346 l.) + dcs-radio-specs FR prose | feat | 5h | ⬜ |
 | DOC-006 | Produce DCS screenshot capture list for the user | chore | 30 min | ⬜ |
 
 **Estimated total: ~12h**

--- a/backlog.md
+++ b/backlog.md
@@ -91,8 +91,9 @@
 | Lot FIX-BRIEFING-MULTILINE — convert-v5 truncates multi-line Lua briefings | ~45 min | ✅ |
 | Lot FIX-I18N-HARDCODED — AST test + fix hardcoded strings in aircrafts_injector + lua_config_generator | ~1h | ✅ |
 | Lot FIX-I18N-DEBT — Fix remaining 107 hardcoded strings across 25 files, clear _TODO_EXEMPTIONS | ~4h | ✅ |
-| Lot DOC-OVERHAUL — Complete, detailed, bilingual, ELI5 documentation with diagrams + screenshots | ~12h | 🔄 |
-| **Total** | **~206h** | |
+| Lot DOC-OVERHAUL — Complete, detailed, bilingual, ELI5 documentation with diagrams + screenshots | ~12h | ✅ |
+| Lot PREREL-BUGS — pre-release code review findings (briefing over-capture, exit codes, i18n, error handling) | ~2h | ⬜ |
+| **Total** | **~208h** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*
 
@@ -499,7 +500,7 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 | DOC-004 | Mission-maker GUIDE + MIGRATION_GUIDE (FR+EN): build-pipeline + v5→v6 mermaid diagrams, `modules:` block example, broken `GUIDE.fr.md` links fixed | feat | 2h | ✅ |
 | DOC-005a | Mechanical syntax sweeps (`enable:`→`enabled:` ×62, `lua_modules:`→`modules:` ×56) + MISSION_YAML_REFERENCE unified `modules:` rewrite (FR+EN) | feat | 1h30 | ✅ |
 | DOC-005b | Script docs FR→EN parity: veafAirWaves, veafCombatZone, veafQraManager, veafShortcuts, veafWeather, veafRadio (all now delta ≤10) + broken `.fr.md` links fixed | feat | 2h30 | ✅ |
-| DOC-005c | Big references in-section depth parity: LUA_API_REFERENCE (~1050 l. across 5 API sections) + TOOLS_REFERENCE (~346 l.) + dcs-radio-specs FR prose | feat | 5h | ⬜ |
+| DOC-005c | Big references in-section depth parity: LUA_API_REFERENCE (~1050 l. across 5 API sections) + TOOLS_REFERENCE (~346 l.) + dcs-radio-specs FR prose | feat | 5h | ✅ |
 | DOC-006 | Produce DCS screenshot capture list for the user | chore | 30 min | ✅ |
 
 **Estimated total: ~12h**
@@ -529,5 +530,23 @@ blocks). Code blocks/identifiers stay identical; only prose is translated.
 
 **After DOC-005c:** update CHANGELOG, open PR `feature/doc-overhaul` → `develop-v6`,
 then the user captures the screenshots listed in DOC-006 to drop into `doc/assets/img/`.
+
+---
+
+## Lot PREREL-BUGS — Pre-release code review findings
+
+**Goal**: Fix bugs found during a verified pre-release code review (unrelated to the documentation lot). These block the next `develop-v6` release. B1 is a functional regression and should be fixed first.
+
+**Branch**: `fix/prerel-bugs` → PR → `develop-v6` (Python changes; separate from the doc PR)
+
+| # | Ticket | Type | Effort | Status |
+|---|--------|------|--------|--------|
+| PREREL-001 (B1) | **Regression** — `config_migrator.py` `_lua_extract_string()` over-collects quoted strings after `:setBriefing(`: a briefing absorbs following setter strings in the same call chain. Introduced by the multiline fix (PR #390), reproduced empirically. Fix: bound the search to the matching `)` of `:setBriefing(`. Add a regression test covering a chained `:setBriefing("..."):setX("...")` case. | fix | 1h | ⬜ |
+| PREREL-002 (B2) | `mission_builder_worker.py` (~L339): `exit()` returns code 0 after a fatal error, so a failed build is reported as success. Use a non-zero exit code / raise. | fix | 20 min | ⬜ |
+| PREREL-003 (B3/B4) | Hardcoded English in `mission_builder_worker.py`: ~L333-338 missing-files message and ~L1168 `"Injecting dcs-bridge.lua"` spinner must use `t()`; add FR translations to `fr.json`. | fix | 20 min | ⬜ |
+| PREREL-004 (I1) | `paths.py`: replace `exit(-1)` with a raised exception (utility code should not call `exit()`; makes it testable). | fix | 15 min | ⬜ |
+| PREREL-005 (cosmetic) | `v5_converter.py` (~L885): remove the dead `is None` branch (never reached). Low priority. | chore | 10 min | ⬜ |
+
+**Estimated total: ~2h05**
 
 ---

--- a/doc/LUA_API_REFERENCE.md
+++ b/doc/LUA_API_REFERENCE.md
@@ -3395,6 +3395,11 @@ Initialise le module CAS.
 - `position` (vec3) — Position de l'aérodrome
 - `coalition` (coalition) — Propriétaire actuel
 - `runways` (table) — Tableau d'objets Runway
+- `fuelCapacity` (number) — Stockage de carburant
+- `ammoBlueMissile` (number) — Munitions missiles bleus
+- `ammoBlueGun` (number) — Munitions canons bleus
+- `ammoRedMissile` (number) — Munitions missiles rouges
+- `ammoRedGun` (number) — Munitions canons rouges
 
 **Méthodes :**
 ```lua
@@ -3439,6 +3444,25 @@ Obtient un aérodrome par nom.
 
 **Retourne :** `Airbase` — Objet Airbase ou nil
 
+**Exemple :**
+```lua
+local kutaisi = veafAirbases.getAirbaseByName("Kutaisi")
+if kutaisi then
+  veaf.logger:info("Kutaisi has %d runways", kutaisi:getRunwayCount())
+  veaf.logger:info("Position: %s", veaf.vecToString(kutaisi:getPosition()))
+end
+```
+
+##### `veafAirbases.getAirbaseFromDcsAirbase(dcsAirbase)`
+
+Convertit un aérodrome DCS en objet Airbase.
+
+**Paramètres :**
+
+- `dcsAirbase` (DCS Airbase) — Objet aérodrome DCS
+
+**Retourne :** `Airbase` — Objet aérodrome VEAF
+
 ##### `veafAirbases.getNearestAirbaseList(dcsUnit, iCount)`
 
 Obtient les aérodromes les plus proches d'une unité.
@@ -3450,6 +3474,15 @@ Obtient les aérodromes les plus proches d'une unité.
 
 **Retourne :** `table` — Tableau d'objets Airbase triés par distance
 
+**Exemple :**
+```lua
+local unit = Unit.getByName("Viper 1-1")
+local nearestBases = veafAirbases.getNearestAirbaseList(unit, 3)
+for i, airbase in ipairs(nearestBases) then
+  veaf.logger:info("%d. %s", i, airbase:getName())
+end
+```
+
 ##### `veafAirbases.getNearestAirbase(dcsUnit)`
 
 Obtient l'aérodrome le plus proche.
@@ -3459,6 +3492,14 @@ Obtient l'aérodrome le plus proche.
 - `dcsUnit` (DCS Unit) — Objet unité
 
 **Retourne :** `Airbase` — Aérodrome le plus proche
+
+**Exemple :**
+```lua
+local unit = Unit.getByName("Viper 1-1")
+local nearest = veafAirbases.getNearestAirbase(unit)
+veaf.outTextForUnit("Viper 1-1",
+  string.format("Nearest airbase: %s", nearest:getName()), 10)
+```
 
 ---
 
@@ -3485,6 +3526,25 @@ Démarre les opérations de recovery du porte-avions.
 - Tourne le porte-avions face au vent
 - Maintient la position pour la recovery
 - Rapporte la direction du vent et les infos ATC
+
+**Exemple :**
+```lua
+veafCarrierOperations.startCarrierOperations({
+  carrierGroupName = "CVN-73",
+  userUnitName = "Hornet 1-1"
+})
+```
+
+##### `veafCarrierOperations.continueCarrierOperations(groupName, userUnitName)`
+
+Poursuit les opérations du porte-avions.
+
+**Paramètres :**
+
+- `groupName` (string) — Nom du groupe porte-avions
+- `userUnitName` (string, optionnel) — Unité utilisateur
+
+**Retourne :** Rien
 
 ##### `veafCarrierOperations.stopCarrierOperations(parameters)`
 
@@ -3520,6 +3580,48 @@ Radio: 127.5 MHz AM
 TACAN: 73X (1205 MHz)
 ICLS: 13
 ```
+
+##### `veafCarrierOperations.atcForCarrierOperations(parameters)`
+
+Obtient l'ATC pour le porte-avions (avec sortie).
+
+**Paramètres :**
+
+- `parameters` (table) — `{carrierGroupName=string, userUnitName=string}`
+
+**Retourne :** Rien
+
+##### `veafCarrierOperations.listAvailableCarriers(forGroup)`
+
+Affiche les porte-avions disponibles.
+
+**Paramètres :**
+
+- `forGroup` (string, optionnel) — Nom du groupe recevant la liste
+
+**Retourne :** Rien
+
+##### `veafCarrierOperations.executeCommandFromRemote(parameters)`
+
+Exécute depuis l'API distante.
+
+**Paramètres :**
+
+- `parameters` (table) — Paramètres de commande distante
+
+**Retourne :** Rien
+
+##### `veafCarrierOperations.initializeCarrierGroups()`
+
+Initialise les groupes de porte-avions.
+
+**Retourne :** Rien
+
+##### `veafCarrierOperations.buildRadioMenu()`
+
+Construit le menu radio des porte-avions.
+
+**Retourne :** Rien
 
 ##### `veafCarrierOperations.initialize()`
 

--- a/doc/LUA_API_REFERENCE.md
+++ b/doc/LUA_API_REFERENCE.md
@@ -2862,11 +2862,28 @@ Initialise le module assets.
 **Version :** 2.2.1
 **Objectif :** Créer et gérer des missions de combat avec objectifs
 
+#### Constantes
+
+```lua
+veafCombatMission.SecondsBetweenWatchdogChecks = 30
+veafCombatMission.RadioMenuName = "MISSIONS"
+veafCombatMission.MinimumSpacingBetweenClones = 300  -- meters
+```
+
 #### Classes
 
 ##### VeafCombatMissionObjective
 
 Définition d'objectif de mission.
+
+**Champs :**
+
+- `name` (string) — Nom de l'objectif
+- `description` (string) — Texte de description
+- `message` (string) — Message de complétion
+- `parameters` (table) — Paramètres de l'objectif
+- `onStartupFunction` (function) — Appelée au démarrage de la mission
+- `onCheckFunction` (function) — Appelée périodiquement pour vérifier la complétion
 
 **États :**
 ```lua
@@ -2879,23 +2896,29 @@ VeafCombatMissionObjective.NOTHING = 0
 ```lua
 obj = VeafCombatMissionObjective:new()
 obj:setName(value)
+obj:getName()
 obj:setDescription(value)
+obj:getDescription()
 obj:setMessage(value)
+obj:getMessage()
 obj:setParameters(value)
+obj:getParameters()
 obj:setOnStartupFunction(value)
+obj:getOnStartupFunction()
 obj:setOnCheckFunction(value)
+obj:getOnCheckFunction()
 ```
 
 **Exemple :**
 ```lua
 local objective = VeafCombatMissionObjective:new()
-objective:setName("Détruire les blindés")
-objective:setDescription("Détruire tous les chars ennemis")
+objective:setName("Destroy Armor")
+objective:setDescription("Destroy all enemy tanks")
 objective:setOnStartupFunction(function(mission)
-  -- Spawner les chars ennemis
+  -- Spawn enemy tanks
 end)
 objective:setOnCheckFunction(function(mission)
-  -- Vérifier si les chars sont détruits
+  -- Check if tanks destroyed
   if allTanksDestroyed() then
     return VeafCombatMissionObjective.SUCCESS
   end
@@ -2907,17 +2930,60 @@ end)
 
 Définition complète d'une mission.
 
+**Champs :**
+
+- `name` (string) — Nom de la mission
+- `description` (string) — Description courte
+- `briefing` (string) — Texte de briefing complet
+- `secured` (boolean) — Nécessite une autorisation de sécurité
+- `radioMenuEnabled` (boolean) — Afficher dans le menu F10
+- `objectives` (table) — Tableau d'objectifs
+- `spawnPosition` (vec3) — Emplacement de spawn
+- `altitude` (number) — Altitude de spawn
+- `spawnZone` (string) — Nom de la zone de spawn
+- `spawnRadius` (number) — Dispersion de spawn
+- `activeSquads` (table) — Groupes spawnés
+- `skills` (table) — Niveaux de compétence de l'IA
+- `scales` (table) — Facteurs d'échelle de la mission
+
 **Méthodes :**
 ```lua
 mission = VeafCombatMission:new()
 mission:setName(value)
+mission:getName()
 mission:setDescription(value)
+mission:getDescription()
 mission:setBriefing(value)
+mission:getBriefing()
 mission:setSecured(value)
+mission:getSecured()
 mission:setRadioMenuEnabled(value)
+mission:getRadioMenuEnabled()
+mission:setObjectives(value)
+mission:getObjectives()
 mission:addObjective(objective)
+mission:setSpawnPosition(value)
+mission:getSpawnPosition()
+mission:setAltitude(value)
+mission:getAltitude()
 mission:setSpawnZone(value)
+mission:getSpawnZone()
 mission:setSpawnRadius(value)
+mission:getSpawnRadius()
+mission:getActiveSquads()
+```
+
+**Exemple :**
+```lua
+local mission = VeafCombatMission:new()
+mission:setName("Strike Alpha")
+mission:setDescription("Destroy enemy armor column")
+mission:setBriefing("Enemy armor advancing on friendly position. Destroy all tanks.")
+mission:setSpawnZone("SpawnZone1")
+mission:addObjective(destroyTanksObjective)
+mission:addObjective(rtbObjective)
+
+veafCombatMission.AddMission(mission)
 ```
 
 #### Fonctions
@@ -2947,6 +3013,17 @@ Ajoute des variantes de mission avec différents niveaux de compétence/échelle
 
 **Description :** Crée plusieurs variantes (ex : "Strike Alpha - Good - 1.0x")
 
+**Exemple :**
+```lua
+veafCombatMission.AddMissionsWithSkillAndScale(
+  baseMission,
+  false,
+  {"Average", "Good", "High", "Excellent"},
+  {0.5, 1.0, 1.5, 2.0}
+)
+-- Creates 16 mission variants (4 skills × 4 scales)
+```
+
 ##### `veafCombatMission.GetMission(name)`
 
 Obtient une mission par nom.
@@ -2956,6 +3033,16 @@ Obtient une mission par nom.
 - `name` (string) — Nom de la mission
 
 **Retourne :** `VeafCombatMission` — Objet mission ou nil
+
+##### `veafCombatMission.GetMissionNumber(number)`
+
+Obtient une mission par index.
+
+**Paramètres :**
+
+- `number` (number) — Index de la mission (à partir de 1)
+
+**Retourne :** `VeafCombatMission` — Objet mission
 
 ##### `veafCombatMission.ActivateMission(name, silent, unitName)`
 
@@ -2976,6 +3063,22 @@ Active une mission.
 - Démarre le timer watchdog
 - Affiche le briefing
 
+**Exemple :**
+```lua
+veafCombatMission.ActivateMission("Strike Alpha", false, "Viper 1-1")
+```
+
+##### `veafCombatMission.ActivateMissionNumber(number, silent)`
+
+Active une mission par index.
+
+**Paramètres :**
+
+- `number` (number) — Index de la mission
+- `silent` (boolean, optionnel) — Supprimer les messages
+
+**Retourne :** Rien
+
 ##### `veafCombatMission.DesactivateMission(name, silent, unitName)`
 
 Désactive une mission.
@@ -2994,6 +3097,30 @@ Désactive une mission.
 - Détruit les groupes spawnés
 - Réinitialise les objectifs
 
+##### `veafCombatMission.DesactivateMissionNumber(number, silent)`
+
+Désactive une mission par index.
+
+**Retourne :** Rien
+
+##### `veafCombatMission.GetInformationOnMission(parameters)`
+
+Obtient l'état d'une mission.
+
+**Paramètres :**
+
+- `parameters` (table) — `{name=string, unitName=string}`
+
+**Retourne :** `string` — Texte d'état de la mission
+
+**Exemple :**
+```lua
+local status = veafCombatMission.GetInformationOnMission({
+  name = "Strike Alpha",
+  unitName = "Viper 1-1"
+})
+```
+
 ##### `veafCombatMission.CompletionCheck(name)`
 
 Vérifie l'état de complétion d'une mission.
@@ -3003,6 +3130,79 @@ Vérifie l'état de complétion d'une mission.
 - `name` (string) — Nom de la mission
 
 **Retourne :** `number` — État : FAILED (-1), SUCCESS (1), NOTHING (0)
+
+**Description :** Appelle toutes les fonctions de vérification des objectifs et agrège les résultats.
+
+##### `veafCombatMission.addCapMission(missionName, missionDescription, missionBriefing, secured, radioMenuEnabled, skills, scales, spawnRadius)`
+
+Assistant de création de mission CAP.
+
+**Paramètres :**
+
+- `missionName` (string) — Nom de la mission
+- `missionDescription` (string) — Description
+- `missionBriefing` (string) — Briefing
+- `secured` (boolean) — Sécurité requise
+- `radioMenuEnabled` (boolean) — Afficher dans le menu
+- `skills` (table) — Niveaux de compétence
+- `scales` (table) — Facteurs d'échelle
+- `spawnRadius` (number) — Dispersion de spawn
+
+**Retourne :** `VeafCombatMission` — Objet mission
+
+**Description :** Assistant pour créer des missions CAP avec des objectifs standard.
+
+##### `veafCombatMission.listAvailableMissions(unitName)`
+
+Affiche la liste des missions au joueur.
+
+**Paramètres :**
+
+- `unitName` (string) — Unité recevant la liste
+
+**Retourne :** Rien
+
+##### `veafCombatMission.listActiveMissions()`
+
+Affiche les missions actives.
+
+**Retourne :** Rien
+
+##### `veafCombatMission.help(unitName)`
+
+Affiche le texte d'aide.
+
+**Paramètres :**
+
+- `unitName` (string) — Unité recevant l'aide
+
+**Retourne :** Rien
+
+##### `veafCombatMission.buildRadioMenu()`
+
+Construit le menu radio des missions.
+
+**Retourne :** Rien
+
+##### `veafCombatMission.executeCommandFromRemote(parameters)`
+
+Exécute une commande depuis l'API distante.
+
+**Paramètres :**
+
+- `parameters` (table) — Paramètres de commande distante
+
+**Retourne :** Rien
+
+##### `veafCombatMission.dumpMissionsList(export_path)`
+
+Exporte les missions vers un fichier.
+
+**Paramètres :**
+
+- `export_path` (string, optionnel) — Répertoire d'export
+
+**Retourne :** Rien
 
 ##### `veafCombatMission.initialize()`
 
@@ -3025,8 +3225,24 @@ veafCasMission.Keyphrase = "_cas"
 veafCasMission.SecondsBetweenWatchdogChecks = 15
 veafCasMission.SecondsBetweenSmokeRequests = 180
 veafCasMission.SecondsBetweenFlareRequests = 120
+veafCasMission.RedCasGroupName = "Red CAS Group"
+veafCasMission.BlueCasGroupName = "Blue CAS Group"
 veafCasMission.RadioMenuName = "CAS MISSION"
 ```
+
+#### Tables de types d'unités
+
+Les unités sont catégorisées par coalition, époque et niveau de défense :
+
+```lua
+TRANSPORT_TYPES[coalition][era][defense] = {unit_types}
+ARMOR_TYPES[coalition][era][defense] = {unit_types}
+DEFENSE_TYPES[coalition][era][defense] = {unit_types}
+```
+
+**Coalition :** `"blue"`, `"red"`
+**Époque :** `"cold"`, `"modern"`
+**Défense :** `0-5` (0=aucune, 5=lourde)
 
 #### Fonctions
 
@@ -3043,6 +3259,28 @@ Exécute une commande de mission CAS.
 - `bypassSecurity` (boolean, optionnel) — Ignorer la sécurité
 
 **Retourne :** `boolean` — Indicateur de succès
+
+##### `veafCasMission.markTextAnalysis(text)`
+
+Analyse le texte d'un marqueur CAS.
+
+**Paramètres :**
+
+- `text` (string) — Texte du marqueur
+
+**Retourne :** `table` — Options analysées
+
+**Options :**
+```lua
+{
+  size = 0-5,              -- Force size
+  defense = 0-5,           -- Defense level
+  armor = 0-5,             -- Armor level
+  spacing = number,        -- Unit spacing (meters)
+  disperseOnAttack = boolean,  -- Units disperse when attacked
+  side = coalition         -- Coalition
+}
+```
 
 ##### `veafCasMission.generateCasMission(spawnSpot, size, defense, armor, spacing, disperseOnAttack, side)`
 
@@ -3079,9 +3317,55 @@ Ajoute de la fumée sur la cible CAS actuelle.
 
 **Retourne :** Rien
 
+**Description :** Limité par le timer `SecondsBetweenSmokeRequests`.
+
 ##### `veafCasMission.flareCasTargetGroup()`
 
 Ajoute une fusée sur la cible CAS actuelle.
+
+**Retourne :** Rien
+
+##### `veafCasMission.smokeReset()`
+
+Réinitialise le timer des demandes de fumée.
+
+**Retourne :** Rien
+
+##### `veafCasMission.flareReset()`
+
+Réinitialise le timer des demandes de fusée.
+
+**Retourne :** Rien
+
+##### `veafCasMission.skipCasTarget()`
+
+Passe le groupe cible actuel (détruit sans score).
+
+**Retourne :** Rien
+
+##### `veafCasMission.reportTargetInformation(unitName)`
+
+Obtient les informations de la cible CAS.
+
+**Paramètres :**
+
+- `unitName` (string) — Unité recevant le rapport
+
+**Retourne :** Rien
+
+##### `veafCasMission.help(unitName)`
+
+Affiche le texte d'aide CAS.
+
+**Paramètres :**
+
+- `unitName` (string) — Unité recevant l'aide
+
+**Retourne :** Rien
+
+##### `veafCasMission.buildRadioMenu()`
+
+Construit le menu radio CAS.
 
 **Retourne :** Rien
 

--- a/doc/LUA_API_REFERENCE.md
+++ b/doc/LUA_API_REFERENCE.md
@@ -3993,6 +3993,16 @@ Trouve une unité par nom de type.
 
 **Retourne :** `table` — Définition d'unité ou nil
 
+**Exemple :**
+```lua
+local f16 = dcsUnits.findUnit("F-16C_50")
+if f16 then
+  veaf.logger:info("Display: %s", f16.displayName)
+  veaf.logger:info("Role: %s", f16.role)
+  veaf.logger:info("Year: %d", f16.year)
+end
+```
+
 ##### `dcsUnits.getUnitsByCategory(category)`
 
 Obtient toutes les unités d'une catégorie.
@@ -4002,6 +4012,14 @@ Obtient toutes les unités d'une catégorie.
 - `category` (string) — Nom de la catégorie
 
 **Retourne :** `table` — Tableau de définitions d'unités
+
+**Exemple :**
+```lua
+local aircraft = dcsUnits.getUnitsByCategory("Airplane")
+for _, unit in ipairs(aircraft) do
+  veaf.logger:info("%s (%s)", unit.displayName, unit.type)
+end
+```
 
 ##### `dcsUnits.getUnitsByCountry(country)`
 

--- a/doc/LUA_API_REFERENCE.md
+++ b/doc/LUA_API_REFERENCE.md
@@ -1938,6 +1938,80 @@ local pos = {x=1000, y=0, z=2000}
 veafSpawn.executeCommand(pos, "_spawn, name F-16C, group 2, hdg 270", coalition.side.BLUE)
 ```
 
+##### `veafSpawn.markTextAnalysis(text)`
+
+Analyse le texte d'un marqueur pour en extraire les paramètres de spawn.
+
+**Paramètres :**
+
+- `text` (string) — Texte du marqueur
+
+**Retourne :** `table` — Options analysées
+
+**Champs de la table retournée :**
+```lua
+{
+  name = string,           -- Unit/group name
+  unitName = string,       -- Specific unit name
+  groupName = string,      -- Override group name
+  alias = string,          -- Name alias
+  group = number,          -- Group count
+  country = string,        -- Country name
+  alt = number,            -- Altitude (feet)
+  altitude = number,       -- Altitude (feet)
+  hdg = number,            -- Heading (degrees)
+  heading = number,        -- Heading (degrees)
+  speed = number,          -- Speed (knots)
+  dist = number,           -- Distance
+  spacing = number,        -- Unit spacing (meters)
+  side = coalition,        -- Coalition
+  defense = number,        -- Defense level (0-5)
+  armor = number,          -- Armor level (0-5)
+  size = number,           -- Size (0-5)
+  shells = number,         -- Shell count
+  power = number,          -- Explosion power
+  radius = number,         -- Dispersion radius
+  color = string,          -- Smoke color
+  smoke = boolean,         -- Add smoke
+  type = string,           -- Type specification
+  skill = string,          -- Skill level
+  password = string,       -- Security password
+  silent = boolean,        -- Suppress messages
+
+  -- Specific spawn types
+  convoy = boolean,
+  dest = vec3,             -- Destination
+  patrol = boolean,
+  offroad = boolean,
+
+  -- Air units
+  cap = boolean,           -- CAP mission
+  capRadius = number,      -- CAP radius
+  afac = boolean,          -- AFAC unit
+  immortal = boolean,      -- Invulnerable
+
+  -- Effects
+  bomb = boolean,
+  smoke = boolean,
+  flare = boolean,
+  illumination = boolean,
+
+  -- FARP/FOB
+  farp = boolean,
+  fob = boolean,
+  farptype = string,
+  fobtype = string,
+
+  -- Advanced
+  code = number,           -- Laser/TACAN code
+  freq = number,           -- Frequency
+  mod = string,            -- Modulation
+  role = string,           -- Unit role
+  static = boolean,        -- Spawn as static
+  hidden = boolean         -- Hide from MFD
+}
+```
+
 #### Fonctions de spawn d'unités
 
 ##### `veafSpawn.spawnUnit(spawnPosition, radius, name, czName, country, alt, hdg, unitName, role, static, code, freq, mod, silent, hiddenOnMFD)`
@@ -1998,6 +2072,12 @@ Spawne un groupe prédéfini.
 
 **Retourne :** `table` — Info du groupe
 
+**Exemple :**
+```lua
+-- Spawner un peloton blindé depuis un template
+veafSpawn.spawnGroup(pos, 100, "Soviet Armor Platoon", nil, nil, nil, 180, 50)
+```
+
 #### Spawn de forces terrestres
 
 ##### `veafSpawn.spawnInfantryGroup(spawnSpot, radius, czName, country, side, heading, spacing, defense, armor, size, silent, hiddenOnMFD)`
@@ -2021,6 +2101,12 @@ Spawne un groupe d'infanterie avec paramètres.
 
 **Retourne :** `table` — Info du groupe
 
+**Exemple :**
+```lua
+-- Spawner une petite escouade d'infanterie
+veafSpawn.spawnInfantryGroup(pos, 50, nil, nil, coalition.side.RED, 0, 10, 0, 0, 1, false)
+```
+
 ##### `veafSpawn.spawnArmoredPlatoon(spawnSpot, radius, czName, country, side, heading, spacing, defense, armor, size, silent, hasDest, hiddenOnMFD)`
 
 Spawne un peloton blindé.
@@ -2029,6 +2115,12 @@ Spawne un peloton blindé.
 
 **Retourne :** `table` — Info du groupe
 
+**Exemple :**
+```lua
+-- Spawner un peloton de chars moyens
+veafSpawn.spawnArmoredPlatoon(pos, 100, nil, nil, coalition.side.BLUE, 90, 50, 2, 3, 3, false)
+```
+
 ##### `veafSpawn.spawnAirDefenseBattery(spawnSpot, radius, czName, country, side, heading, spacing, defense, silent, hasDest, hiddenOnMFD)`
 
 Spawne une batterie SAM/AAA.
@@ -2036,6 +2128,12 @@ Spawne une batterie SAM/AAA.
 **Paramètres :** Similaires au peloton blindé
 
 **Retourne :** `table` — Info du groupe
+
+**Exemple :**
+```lua
+-- Spawner une batterie SA-6
+veafSpawn.spawnAirDefenseBattery(pos, 200, nil, nil, coalition.side.RED, 0, 75, 4, false)
+```
 
 ##### `veafSpawn.spawnTransportCompany(spawnSpot, radius, czName, country, side, heading, spacing, defense, size, silent, hasDest, hiddenOnMFD)`
 
@@ -2085,6 +2183,32 @@ veafSpawn.spawnConvoy(start, "Convoy1", nil, 50, nil, coalition.side.RED,
   nil, 25, 40, false, false, dest, 2, 3, 2, false)
 ```
 
+##### Fonctions de contrôle des convois
+
+**`veafSpawn.stopClosestConvoy(unitName)`**
+
+Arrête le convoi le plus proche de l'unité.
+
+**`veafSpawn.moveClosestConvoy(unitName)`**
+
+Reprend le déplacement du convoi le plus proche.
+
+**`veafSpawn.markClosestConvoyWithSmoke(unitName)`**
+
+Marque le convoi le plus proche à la fumée.
+
+**`veafSpawn.markClosestConvoyRouteWithSmoke(unitName)`**
+
+Marque la route du convoi avec des marqueurs fumée.
+
+**`veafSpawn.infoOnAllConvoys(unitName)`**
+
+Affiche les informations de tous les convois actifs.
+
+**`veafSpawn.cleanupAllConvoys()`**
+
+Détruit tous les convois actifs.
+
 #### Spawn aérien
 
 ##### `veafSpawn.spawnCombatAirPatrol(spawnSpot, radius, name, country, altitude, altitudeDelta, hdg, distance, speed, capRadius, skill, silent, hiddenOnMFD)`
@@ -2115,6 +2239,14 @@ Spawne un vol CAP avec orbite de patrouille.
 - Crée une orbite racetrack à l'emplacement spécifié
 - Démarre un watchdog pour surveiller et engager les cibles
 
+**Exemple :**
+```lua
+-- Spawner une CAP de F-15C
+local pos = {x=0, y=0, z=0}
+veafSpawn.spawnCombatAirPatrol(pos, 100, "F-15C", nil, 25000, 2000,
+  90, 50000, 450, 20000, "Good", false)
+```
+
 ##### `veafSpawn.spawnAFAC(spawnSpot, name, country, altitude, speed, hdg, frequency, mod, code, immortal, silent, hiddenOnMFD)`
 
 Spawne un contrôleur aérien avancé en vol (AFAC).
@@ -2136,6 +2268,28 @@ Spawne un contrôleur aérien avancé en vol (AFAC).
 
 **Retourne :** `table` — Info AFAC
 
+**Exemple :**
+```lua
+-- Spawner un AFAC A-10C
+veafSpawn.spawnAFAC(pos, "A-10C", nil, 15000, 250, 0, 133.0, "AM", 1688, true, false)
+```
+
+##### `veafSpawn.startCapWatchdog(capGroupName, capCoalition, capZone, pTargetsList, pNumberOfTasksAddedByWatchdog)`
+
+Démarre le watchdog d'engagement de la CAP.
+
+**Paramètres :**
+
+- `capGroupName` (string) — Nom du groupe CAP
+- `capCoalition` (coalition) — Coalition
+- `capZone` (table) — Définition de la zone
+- `pTargetsList` (table, optionnel) — Cibles spécifiques
+- `pNumberOfTasksAddedByWatchdog` (number, optionnel) — Tâches maximum
+
+**Retourne :** Rien
+
+**Description :** Surveille la zone et missionne la CAP pour engager les appareils ennemis.
+
 #### Cargo et logistique
 
 ##### `veafSpawn.spawnCargo(spawnSpot, radius, cargoType, country, weightBias, cargoSmoke, unitName, silent, hiddenOnMFD)`
@@ -2155,6 +2309,18 @@ Spawne un cargo CTLD.
 - `hiddenOnMFD` (boolean, optionnel) — Masquer du MFD
 
 **Retourne :** `table` — Info du cargo
+
+**Exemple :**
+```lua
+-- Spawner des conteneurs de carburant
+veafSpawn.spawnCargo(pos, 10, "fuel", nil, 0.5, true, "Fuel-1", false)
+```
+
+##### `veafSpawn.spawnLogistic(spawnSpot, radius, country, silent, hiddenOnMFD)`
+
+Spawne une unité logistique CTLD.
+
+**Retourne :** `table` — Info de l'unité logistique
 
 #### FARP et FOB
 
@@ -2188,6 +2354,14 @@ veafSpawn.spawnFarp(pos, 100, "FARP Alpha", nil, nil, coalition.side.BLUE,
   0, 50, false, false, false, 71, 251.0, "AM")
 ```
 
+##### `veafSpawn.spawnFob(spawnSpot, radius, name, country, fobtype, side, hdg, spacing, silent, hiddenOnMFD)`
+
+Spawne une base d'opérations avancée (FOB).
+
+**Paramètres :** Similaires au FARP
+
+**Retourne :** `table` — Info du FOB
+
 #### Effets et marqueurs
 
 ##### `veafSpawn.spawnBomb(spawnSpot, radius, shells, power, altitude, altitudedelta, password)`
@@ -2206,6 +2380,12 @@ Crée un effet d'explosion.
 
 **Retourne :** Rien
 
+**Exemple :**
+```lua
+-- Créer 5 explosions de 500 kg
+veafSpawn.spawnBomb(pos, 50, 5, 500, 0, 0)
+```
+
 ##### `veafSpawn.spawnSmoke(spawnSpot, color, radius, shells)`
 
 Ajoute des marqueurs fumée.
@@ -2218,6 +2398,12 @@ Ajoute des marqueurs fumée.
 - `shells` (number) — Nombre de marqueurs fumée
 
 **Retourne :** Rien
+
+**Exemple :**
+```lua
+-- Marquer une position avec de la fumée rouge
+veafSpawn.spawnSmoke(pos, "Red", 0, 1)
+```
 
 ##### `veafSpawn.spawnSignalFlare(spawnSpot, radius, shells, color)`
 
@@ -2249,6 +2435,12 @@ Crée un patron d'illumination par fusées éclairantes.
 
 **Retourne :** Rien
 
+**Exemple :**
+```lua
+-- Créer une ligne d'illumination
+veafSpawn.spawnIlluminationFlare(pos, 0, 5, 1000000, 1000, 90, 500, 0)
+```
+
 #### Fonctions de dessin
 
 ##### `veafSpawn.drawCircle(point, name, radius, color, fillColor, lineType)`
@@ -2265,6 +2457,12 @@ Dessine un cercle sur la carte.
 - `lineType` (number, optionnel) — Type de ligne
 
 **Retourne :** Rien
+
+**Exemple :**
+```lua
+-- Dessiner un cercle rouge
+veafSpawn.drawCircle(pos, "Zone1", 5000, {1, 0, 0, 1}, {1, 0, 0, 0.3})
+```
 
 ##### `veafSpawn.drawSquare(point, name, side, color, fillColor, lineType)`
 
@@ -2326,6 +2524,12 @@ Téléporte un groupe à une position.
 
 **Retourne :** Rien
 
+**Exemple :**
+```lua
+-- Téléporter le groupe du joueur à une position
+veafSpawn.teleport(newPos, "Viper Flight", false)
+```
+
 #### Fonctions JTAC
 
 ##### `veafSpawn.JTACAutoLase(groupName, laserCode, radioData)`
@@ -2345,6 +2549,129 @@ Configure un JTAC en auto-désignation laser.
 veafSpawn.JTACAutoLase("JTAC-1", 1688, {freq=133.0, mod="AM"})
 ```
 
+##### `veafSpawn.convertLaserToFreq(laser)`
+
+Convertit un code laser en fréquence radio.
+
+**Paramètres :**
+
+- `laser` (number) — Code laser
+
+**Retourne :** `number` — Fréquence en MHz
+
+#### Fonctions Mission Master
+
+Mission Master fournit un contrôle de mission scriptable.
+
+##### `veafSpawn.missionMasterSetMessagingMode(silent, toGroupId)`
+
+Définit le mode de sortie des messages.
+
+**Paramètres :**
+
+- `silent` (boolean) — Mode silencieux
+- `toGroupId` (number, optionnel) — ID du groupe cible
+
+**Retourne :** Rien
+
+##### `veafSpawn.missionMasterOutText(message)`
+
+Affiche un message Mission Master.
+
+**Paramètres :**
+
+- `message` (string) — Texte du message
+
+**Retourne :** Rien
+
+##### `veafSpawn.missionMasterAddRunnable(name, code, parameters)`
+
+Ajoute une commande exécutable.
+
+**Paramètres :**
+
+- `name` (string) — Nom de la commande
+- `code` (string) — Code Lua à exécuter
+- `parameters` (table, optionnel) — Paramètres
+
+**Retourne :** Rien
+
+##### `veafSpawn.missionMasterRun(name)`
+
+Exécute une commande Mission Master.
+
+**Paramètres :**
+
+- `name` (string) — Nom de la commande
+
+**Retourne :** Rien
+
+##### `veafSpawn.missionMasterSetFlag(name, value)`
+
+Définit un flag Mission Master.
+
+**Paramètres :**
+
+- `name` (string) — Nom du flag
+- `value` (any) — Valeur du flag
+
+**Retourne :** Rien
+
+##### `veafSpawn.missionMasterGetFlag(name)`
+
+Récupère la valeur d'un flag.
+
+**Paramètres :**
+
+- `name` (string) — Nom du flag
+
+**Retourne :** `any` — Valeur du flag
+
+##### `veafSpawn.missionMasterAddValueToFlag(name, increment)`
+
+Modifie la valeur d'un flag.
+
+**Paramètres :**
+
+- `name` (string) — Nom du flag
+- `increment` (number) — Valeur à ajouter
+
+**Retourne :** Rien
+
+#### Fonctions utilitaires
+
+##### `veafSpawn.listAllCAP(unitName)`
+
+Affiche la liste de tous les vols CAP actifs.
+
+**Paramètres :**
+
+- `unitName` (string) — Nom de l'unité demandeuse
+
+**Retourne :** Rien
+
+##### `veafSpawn.dumpSpawnablePlanesList(export_path)`
+
+Exporte la liste des appareils spawnables vers un fichier.
+
+**Paramètres :**
+
+- `export_path` (string, optionnel) — Répertoire d'export
+
+**Retourne :** Rien
+
+##### `veafSpawn.buildRadioMenu()`
+
+Construit le menu radio de spawn.
+
+**Retourne :** Rien
+
+##### `veafSpawn.initialize()`
+
+Initialise le module de spawn.
+
+**Retourne :** Rien
+
 ---
 
 ### veafUnits.lua
@@ -2352,6 +2679,15 @@ veafSpawn.JTACAutoLase("JTAC-1", 1688, {freq=133.0, mod="AM"})
 **Module ID :** `UNITS`
 **Version :** 1.15.0
 **Objectif :** Définitions d'unités/groupes et utilitaires
+
+#### Constantes
+
+```lua
+veafUnits.DefaultCellWidth = 10        -- meters
+veafUnits.DefaultCellHeight = 10       -- meters
+veafUnits.DefaultPathfindingUnitType = "TZ-22_KrAZ"
+veafUnits.delayBeforePathfindingFix = 5  -- seconds
+```
 
 #### Fonctions
 
@@ -2364,6 +2700,14 @@ Trouve une unité DCS par nom de type (insensible à la casse).
 - `unitType` (string) — Type d'unité (ex : "F-16C", "M-1 Abrams")
 
 **Retourne :** `table` — Définition d'unité ou nil
+
+**Exemple :**
+```lua
+local f16 = veafUnits.findDcsUnit("F-16C_50")
+if f16 then
+  veaf.logger:info("Found: %s", f16.displayName)
+end
+```
 
 ##### `veafUnits.countInfantryAndVehicles(groupname)`
 
@@ -2428,6 +2772,11 @@ Respawne un groupe d'asset.
 - Respawne tous les groupes liés
 - Démarre le JTAC si configuré
 
+**Exemple :**
+```lua
+veafAssets.respawn("Tanker-1")
+```
+
 ##### `veafAssets.dispose(name)`
 
 Détruit un asset.
@@ -2437,6 +2786,11 @@ Détruit un asset.
 - `name` (string) — Nom de l'asset
 
 **Retourne :** Rien
+
+**Exemple :**
+```lua
+veafAssets.dispose("AWACS-1")
+```
 
 ##### `veafAssets.info(parameters)`
 
@@ -2448,6 +2802,12 @@ Obtient les informations d'un asset.
 
 **Retourne :** `string` — Texte d'info de l'asset
 
+**Exemple :**
+```lua
+local info = veafAssets.info({name="Tanker-1", unitName="Viper 1-1"})
+-- Displays tanker position, TACAN, frequency
+```
+
 ##### `veafAssets.get(assetName)`
 
 Obtient la définition d'un asset.
@@ -2458,11 +2818,39 @@ Obtient la définition d'un asset.
 
 **Retourne :** `table` — Définition de l'asset
 
+##### `veafAssets.help(unitName)`
+
+Affiche le texte d'aide.
+
+**Paramètres :**
+
+- `unitName` (string) — Unité destinataire de l'aide
+
+**Retourne :** Rien
+
+##### `veafAssets.buildRadioMenu()`
+
+Construit le menu radio des assets.
+
+**Retourne :** Rien
+
+##### `veafAssets.buildAssetsDatabase()`
+
+Construit les tables de recherche des assets.
+
+**Retourne :** Rien
+
 ##### `veafAssets.initialize()`
 
 Initialise le module assets.
 
 **Retourne :** Rien
+
+**Description :**
+
+- Construit la base de données des assets
+- Crée les menus radio
+- Doit être appelé après la définition des assets
 
 ---
 

--- a/doc/LUA_API_REFERENCE.md
+++ b/doc/LUA_API_REFERENCE.md
@@ -1255,6 +1255,29 @@ veafEventHandler.EVENTS = {
   [10] = "S_EVENT_BASE_CAPTURED",
   [11] = "S_EVENT_MISSION_START",
   [12] = "S_EVENT_MISSION_END",
+  [13] = "S_EVENT_TOOK_CONTROL",
+  [14] = "S_EVENT_REFUELING_STOP",
+  [15] = "S_EVENT_BIRTH",
+  [16] = "S_EVENT_HUMAN_FAILURE",
+  [17] = "S_EVENT_DETAILED_FAILURE",
+  [18] = "S_EVENT_ENGINE_STARTUP",
+  [19] = "S_EVENT_ENGINE_SHUTDOWN",
+  [20] = "S_EVENT_PLAYER_ENTER_UNIT",
+  [21] = "S_EVENT_PLAYER_LEAVE_UNIT",
+  [22] = "S_EVENT_PLAYER_COMMENT",
+  [23] = "S_EVENT_SHOOTING_START",
+  [24] = "S_EVENT_SHOOTING_END",
+  [25] = "S_EVENT_MARK_ADDED",
+  [26] = "S_EVENT_MARK_CHANGE",
+  [27] = "S_EVENT_MARK_REMOVED",
+  [28] = "S_EVENT_KILL",
+  [29] = "S_EVENT_SCORE",
+  [30] = "S_EVENT_UNIT_LOST",
+  [31] = "S_EVENT_LANDING_AFTER_EJECTION",
+  [32] = "S_EVENT_PARATROOPER_LENDING",
+  [33] = "S_EVENT_DISCARD_CHAIR_AFTER_EJECTION",
+  [34] = "S_EVENT_WEAPON_ADD",
+  [35] = "S_EVENT_TRIGGER_ZONE",
   -- ... jusqu'à l'événement 61
 }
 ```
@@ -1302,6 +1325,11 @@ veafEventHandler.addCallback("birthHandler",
     end
   end
 )
+
+-- Écouter par ID d'événement
+veafEventHandler.addCallback("shotHandler", {1, 23}, function(event)
+  -- Gère S_EVENT_SHOT et S_EVENT_SHOOTING_START
+end)
 ```
 
 ##### `veafEventHandler.completeUnit(unit)`
@@ -1340,6 +1368,26 @@ Obtient les informations d'unité à partir du nom.
 
 **Retourne :** `table` — Table d'info unité (même structure que completeUnit)
 
+**Exemple :**
+```lua
+local unitInfo = veafEventHandler.completeUnitFromName("Viper 1-1")
+if unitInfo then
+  veaf.logger:info("L'unité %s est à %.0f%% de vie",
+    unitInfo.unitName, unitInfo.unitLifePercent)
+end
+```
+
+##### `veafEventHandler.checkEventKnown(eventNameOrId, warnOnly)`
+
+Vérifie qu'un événement est reconnu par DCS.
+
+**Paramètres :**
+
+- `eventNameOrId` (string ou number) — Nom ou ID de l'événement
+- `warnOnly` (boolean, optionnel) — Émet seulement un avertissement, sans erreur
+
+**Retourne :** `boolean` — True si l'événement est connu
+
 ##### `veafEventHandler.setEventEnabled(eventNameOrId, enabled)`
 
 Active ou désactive le traitement d'un événement.
@@ -1367,6 +1415,18 @@ Vérifie si le traitement d'un événement est activé.
 - `eventNameOrId` (string ou number) — Événement à vérifier
 
 **Retourne :** `boolean` — True si activé
+
+##### `veafEventHandler.isEventDelayedCallback(eventNameOrId)`
+
+Vérifie si un événement utilise un callback différé.
+
+**Paramètres :**
+
+- `eventNameOrId` (string ou number) — Événement à vérifier
+
+**Retourne :** `boolean` — True si différé
+
+**Description :** Certains événements comme BIRTH nécessitent des callbacks différés pour laisser DCS initialiser complètement les objets.
 
 ##### `veafEventHandler.initialize()`
 
@@ -1414,7 +1474,18 @@ Les événements passés aux callbacks sont enrichis de champs supplémentaires 
     unitPilotName = string,       -- si humain
     unitPilotUcid = string,       -- si humain
     unitLifePercent = number
-  }
+  },
+
+  -- Info cible enrichie (si target existe)
+  target = {
+    -- même structure que initiator
+  },
+
+  -- Info arme (si une arme a tiré/touché)
+  weaponName = string,            -- Nom du type d'arme
+
+  -- Champs d'événement marqueur
+  comment = string                -- Texte du commentaire de marqueur
 }
 ```
 
@@ -1431,6 +1502,32 @@ Les événements passés aux callbacks sont enrichis de champs supplémentaires 
 - Les événements BIRTH se déclenchent avant que les unités soient complètement initialisées
 - Utiliser les callbacks différés pour BIRTH si vous accédez aux propriétés de l'unité
 - PLAYER_ENTER_UNIT se déclenche après le chargement complet du joueur
+
+**Exemple : handler d'événements complet :**
+```lua
+-- Suivre les kills des joueurs
+local playerKills = {}
+
+veafEventHandler.addCallback("killTracker", {"S_EVENT_KILL"}, function(event)
+  if event.initiator and event.initiator.unitPilotName then
+    -- Un joueur humain a réalisé un kill
+    local playerName = event.initiator.unitPilotName
+    playerKills[playerName] = (playerKills[playerName] or 0) + 1
+
+    local targetName = "unknown"
+    if event.target and event.target.unitName then
+      targetName = event.target.unitName
+    end
+
+    veaf.outTextForUnit(event.initiator.unitName,
+      string.format("Kill confirmed! Total: %d", playerKills[playerName]),
+      10, false)
+
+    veaf.logger:info("%s killed %s (total kills: %d)",
+      playerName, targetName, playerKills[playerName])
+  end
+end)
+```
 
 ---
 
@@ -1493,6 +1590,75 @@ Supprime un handler d'événement marqueur.
 - `id` (number) — ID du handler depuis registerEventHandler
 
 **Retourne :** `boolean` — True si désenregistré avec succès
+
+**Exemple :**
+```lua
+local handlerId = veafMarkers.registerEventHandler(veafMarkers.MarkerAdd, myHandler)
+-- Plus tard...
+veafMarkers.unregisterEventHandler(handlerId)
+```
+
+#### Structure d'événement marqueur
+
+Les événements marqueur reçus par les handlers contiennent :
+
+```lua
+{
+  id = number,              -- ID du marqueur
+  time = number,            -- Temps mission
+  initiator = DCS_Unit,     -- Unité ayant créé le marqueur (si applicable)
+  coalition = coalition,    -- Coalition (-1 pour toutes, 0=neutre, 1=bleu, 2=rouge)
+  groupID = number,         -- ID du groupe
+  text = string,            -- Texte du marqueur
+  pos = vec3                -- Position du marqueur
+}
+```
+
+#### Patrons d'utilisation
+
+**Patron commande :**
+
+Les modules enregistrent un handler auprès de `veafCommands`, qui route de façon centralisée toutes les commandes des marqueurs F10 :
+```lua
+-- Dans la fonction initialize() d'un module :
+veafCommands.registerCommandHandler(function(pos, event, bypass, fromMarker, groups, route)
+  local text = event.text or ""
+  if not text:lower():match("^_mycommand") then
+    return false  -- not our command
+  end
+  -- handle the command...
+  return true   -- consumed
+end, veafCommands.PRIORITY_SPAWN)
+```
+
+Tous les handlers sont appelés par ordre de priorité jusqu'à ce que l'un retourne `true`.
+Le dispatcher central (`veafCommands.dispatchMarker`) gère automatiquement la suppression du marqueur.
+
+**Patron sécurité :**
+
+Vérifiez la coalition avant d'exécuter :
+```lua
+veafMarkers.registerEventHandler(veafMarkers.MarkerAdd, function(pos, event)
+  -- Only allow blue coalition markers
+  if event.coalition == coalition.side.BLUE then
+    processCommand(pos, event.text)
+  else
+    veaf.logger:warn("Unauthorized marker from coalition %d", event.coalition)
+  end
+end)
+```
+
+**Patron nettoyage :**
+
+Supprimez les marqueurs après traitement :
+```lua
+veafMarkers.registerEventHandler(veafMarkers.MarkerChange, function(pos, event)
+  if processMarkerCommand(pos, event.text) then
+    -- Remove marker after successful processing
+    trigger.action.removeMark(event.id)
+  end
+end)
+```
 
 ---
 
@@ -1598,6 +1764,8 @@ Exécute une commande VEAF. Délègue à `veafCommands.execute()` — tous les h
 
 **Retourne :** `boolean` — True si la commande a été exécutée avec succès
 
+**Note :** le routage des commandes est géré par `veafCommands`. Les modules s'enregistrent via `veafCommands.registerCommandHandler()`.
+
 **Exemple :**
 ```lua
 local pos = {x=1000, y=50, z=2000}
@@ -1643,6 +1811,27 @@ Initialise le module interpréteur.
 - Appelé automatiquement lors de l'initialisation VEAF
 - Scanne les unités avec des commandes interpréteur dans les noms
 - Exécute les commandes après un délai
+
+#### Flux d'exécution des commandes
+
+```
+1. Command received (unit name or marker)
+   ↓
+2. veafInterpreter.interpret() extracts command
+   ↓
+3. Check veafShortcuts for shorthand
+   ↓
+4. Try module-specific handlers in order:
+   - veafSpawn (spawn commands)
+   - veafNamedPoints (named locations)
+   - veafCasMission (CAS missions)
+   - veafSecurity (security commands)
+   - veafMove (movement)
+   - veafRadio (radio/comms)
+   - veafRemote (remote API)
+   ↓
+5. Return success/failure
+```
 
 #### Patron d'utilisation des commandes dans les noms d'unités
 

--- a/doc/LUA_API_REFERENCE.md
+++ b/doc/LUA_API_REFERENCE.md
@@ -3683,6 +3683,13 @@ Ajoute une commande à un sous-menu.
 
 **Retourne :** Rien
 
+**Signature du callback :**
+```lua
+function callback(parameters)
+  -- parameters: value passed to addCommandToSubmenu
+end
+```
+
 **Exemple :**
 ```lua
 local menu = veafRadio.addSubMenu("Test")
@@ -3700,6 +3707,48 @@ Ajoute une commande protégée par la sécurité.
 **Retourne :** Rien
 
 **Description :** La commande n'apparaît que si l'utilisateur a l'habilitation de sécurité.
+
+##### `veafRadio.executeCommand(eventPos, eventText, eventCoalition, bypassSecurity)`
+
+Exécute une commande radio depuis un marqueur.
+
+**Paramètres :**
+
+- `eventPos` (vec3) — Position de la commande
+- `eventText` (string) — Texte de la commande
+- `eventCoalition` (coalition) — Coalition
+- `bypassSecurity` (boolean, optionnel) — Ignorer la vérification de sécurité
+
+**Retourne :** `boolean` — Indicateur de succès
+
+**Commandes supportées :**
+
+- `transmit` — Transmettre via SRS
+- `playmp3` — Jouer un MP3 via SRS
+
+##### `veafRadio.markTextAnalysis(text)`
+
+Analyse le texte d'un marqueur radio.
+
+**Paramètres :**
+
+- `text` (string) — Texte du marqueur
+
+**Retourne :** `table` — Options analysées
+
+**Options :**
+```lua
+{
+  transmit = boolean,      -- Transmit message
+  playmp3 = boolean,       -- Play MP3 file
+  message = string,        -- Message text
+  frequencies = table,     -- Array of frequencies (MHz)
+  modulations = table,     -- Array of "AM"/"FM"
+  name = string,           -- Transmission name
+  path = string,           -- MP3 file path
+  quiet = boolean          -- Suppress confirmation
+}
+```
 
 ##### `veafRadio.transmitMessage(message, frequencies, modulations, name, coalition, position, quiet)`
 
@@ -3741,6 +3790,19 @@ Joue un fichier MP3 via SRS.
 
 **Retourne :** Rien
 
+**Exemple :**
+```lua
+veafRadio.playToRadio(
+  "D:\\Sounds\\airraid.mp3",
+  {305.0},
+  {"AM"},
+  "Alert",
+  coalition.side.BLUE,
+  nil,
+  false
+)
+```
+
 ##### `veafRadio.refreshRadioMenu()`
 
 Reconstruit le menu radio (différé).
@@ -3748,6 +3810,34 @@ Reconstruit le menu radio (différé).
 **Retourne :** Rien
 
 **Description :** Planifie la reconstruction du menu après un délai pour éviter les conflits.
+
+##### `veafRadio.addPaginatedRadioElements(menu, buildFunction, elements, sortKey, sortField)`
+
+Ajoute des éléments paginés à un menu.
+
+**Paramètres :**
+
+- `menu` (menu) — Menu cible
+- `buildFunction` (function) — Fonction de construction de chaque élément
+- `elements` (table) — Tableau d'éléments
+- `sortKey` (string, optionnel) — Clé de tri
+- `sortField` (string, optionnel) — Champ de tri
+
+**Retourne :** Rien
+
+**Description :** Crée des pages de 10 éléments avec navigation suivant/précédent.
+
+##### `veafRadio.onBirthEvent(event)`
+
+Gère la naissance d'une unité (ajout au menu radio).
+
+**Paramètres :**
+
+- `event` (table) — Événement de naissance
+
+**Retourne :** Rien
+
+**Description :** Ajoute automatiquement les unités humaines au menu radio.
 
 ##### `veafRadio.initialize()`
 

--- a/doc/MISSION_YAML_REFERENCE.en.md
+++ b/doc/MISSION_YAML_REFERENCE.en.md
@@ -210,7 +210,14 @@ external_modules:
 | `enabled` | boolean | `false` | Enable CTLD integration |
 | *(any ctld property)* | any | — | Any `ctld.xxx` property (e.g. `hoverPickup: true`) |
 
-> CSAR configuration is not yet available via `mission.yaml` — configure it in `mission-script.lua` directly.
+#### `external_modules.csar` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable CSAR integration |
+| *(any csar property)* | any | — | Any `csar.xxx` property (e.g. `enableAllslots: true`, `csarPrefix: "MEDEVAC"`) |
+
+VEAF generates the `csar.xxx = value` assignments and the `csar.initialize()` call in `veaf-config.lua`. For complex settings such as `aircraftType` (a per-aircraft table), continue using the Lua callback pattern in `mission-script.lua`. See [CTLD and CSAR Integration](mission-maker/GUIDE.en.md#ctld-and-csar-integration).
 
 ---
 

--- a/doc/MISSION_YAML_REFERENCE.en.md
+++ b/doc/MISSION_YAML_REFERENCE.en.md
@@ -27,7 +27,7 @@ These files are **not** loaded at DCS runtime — they are consumed by `veaf-too
 
 `mission.yaml` itself configures **how VEAF Lua modules behave at DCS runtime**. It is translated at build time into `veaf-config.lua`, which is injected into the mission and executed when DCS loads the mission.
 
-Sections such as `lua_modules:`, `qra:`, `assets:`, and `shortcuts:` all describe runtime module behaviour.
+Sections such as `modules:`, `qra:`, `assets:`, and `shortcuts:` all describe runtime module behaviour.
 
 ```
 mission folder/
@@ -58,7 +58,7 @@ mission:
 security:
   disabled: true
 
-lua_modules:
+modules:
   RADIO:
     enabled: true
   ASSETS:
@@ -240,39 +240,67 @@ veaf_tools:
 
 ---
 
-### `lua_modules:`
+### `modules:`
 
-Enable, disable, or configure individual VEAF Lua modules. Modules not listed are enabled with their default settings.
+The unified `modules:` block enables, disables, or configures every VEAF Lua module **and** every community script in a single place. Modules not listed are enabled with their default settings.
 
-> **Infrastructure modules are always active.**
-> The modules `UNITS`, `TIME`, `CACHE`, `EVENTS`, `MARKERS`, and `COMMANDS` are mandatory and are always loaded regardless of configuration. The `enable` key must **not** be set for these modules — doing so is a build error. They can still appear under `lua_modules:` to configure other fields such as `logLevel`.
+> **Migration note.** `modules:` replaces the older `lua_modules:` + `community_scripts:` keys. The legacy keys still work but emit a deprecation warning at build time. `enabled:` replaces the old `enable:` key.
+
+Each entry can take **three forms**:
 
 ```yaml
-lua_modules:
-  # Infrastructure modules: always active — configure only, do not use 'enable'
-  UNITS:
-    logLevel: debug
-  # Optional modules: can be enabled or disabled
-  RADIO:
-    enabled: true
-    logLevel: info            # optional per-module log level override
-    init:
-      help_menus: true
+modules:
+  # 1. Shorthand — just enable an optional module with default settings:
+  RADIO: true
+
+  # 2. Block — enable and configure:
   SPAWN:
     enabled: true
+    logLevel: debug           # optional per-module log level override
+    init:
+      help_menus: true
+
+  # 3. Bare null — mandatory infrastructure module, configure only:
+  UNITS:
     logLevel: debug
 ```
 
-The `logLevel` field is available for every module. The `enable` field applies **only to optional modules** — it is a build error on Infrastructure modules. Additional `init:` or data fields are module-specific — see each module's documentation page.
+> **Infrastructure modules are always active.**
+> `UNITS`, `TIME`, `CACHE`, `EVENTS`, `MARKERS`, and `COMMANDS` are mandatory and always loaded. Do **not** set `enabled:` on them — it is a build error. They may still appear in `modules:` to configure other fields such as `logLevel`.
 
 **Common fields (all modules):**
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enable` | boolean | `true` | Enable or disable this module *(optional modules only — not allowed on Infrastructure modules)* |
+| `enabled` | boolean | `true` | Enable or disable this module *(optional modules only — not allowed on Infrastructure modules)* |
 | `logLevel` | string | *(global)* | Override log level for this module only |
 
-**Module IDs:**
+Additional `init:` or data fields are module-specific — see each module's documentation page.
+
+**Community scripts** are listed in the same block, using their uppercase IDs. When a script is absent from `modules:`, it keeps its default state (included). Set it to `false` to exclude it:
+
+```yaml
+modules:
+  CTLD: true
+  CSAR: true
+  SKYNET: false               # excluded from this mission
+```
+
+| Community ID | Script |
+|----|--------|
+| `MIST` | MIST (Mission Scripting Tools) |
+| `STTS` | DCS-SimpleTextToSpeech |
+| `WEATHERMARK` | WeatherMark |
+| `CTLD` | CTLD (Combat Transport & Logistics Dispatcher) |
+| `AIEN` | AIEN (AI Enhancement) |
+| `CSAR` | CSAR (Combat Search and Rescue) |
+| `HERCULES` | Hercules Cargo |
+| `SKYNET` | Skynet IADS |
+| `TUM` | The Universal Mission (TUM) |
+
+> An unknown identifier triggers a build warning and is ignored.
+
+**VEAF module IDs:**
 
 | ID | Module | Doc page |
 |----|--------|----------|
@@ -298,7 +326,7 @@ The `logLevel` field is available for every module. The `enable` field applies *
 
 ### `qra:`, `cap_missions:`, `combat_missions:`
 
-Top-level sections for QRA, CAP mission, and combat mission definitions. These require the corresponding modules enabled under `lua_modules:`.
+Top-level sections for QRA, CAP mission, and combat mission definitions. These require the corresponding modules enabled under `modules:`.
 
 See the respective module pages for full schema:
 - [`qra:`](mission-maker/scripts/veafQraManager.md#configuration-missionyaml) — Quick Reaction Alert definitions
@@ -306,36 +334,9 @@ See the respective module pages for full schema:
 
 ---
 
-### `community_scripts:`
+### `community_scripts:` *(legacy)*
 
-Allows enabling or disabling individual community Lua scripts (MIST, CTLD, CSAR, etc.) injected into the mission. When this section is absent, **all** community scripts are included.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `<id>.enabled` | `bool` | `true` | Enables (`true`) or disables (`false`) the script identified by `<id>` |
-
-**Available identifiers**
-
-| ID | Script |
-|----|--------|
-| `mist` | MIST (Mission Scripting Tools) |
-| `stts` | DCS-SimpleTextToSpeech |
-| `weathermark` | WeatherMark |
-| `ctld` | CTLD (Combat Transport & Logistics Dispatcher) |
-| `aien` | AIEN (AI Enhancement) |
-| `csar` | CSAR (Combat Search and Rescue) |
-| `hercules` | Hercules Cargo |
-| `skynet` | Skynet IADS |
-| `tum` | The Universal Mission (TUM) |
-
-```yaml
-community_scripts:
-  ctld:   { enabled: true }
-  csar:   { enabled: true }
-  skynet: { enabled: false }   # disabled for this mission
-```
-
-> An unknown identifier in this section triggers a build warning and is ignored.
+> **Deprecated.** Community scripts are now configured in the unified [`modules:`](#modules) block using their uppercase IDs (e.g. `CTLD: true`). The separate `community_scripts:` section still works but emits a deprecation warning. See [`modules:`](#modules) for the current syntax and the list of community IDs.
 
 ---
 
@@ -463,7 +464,7 @@ veaf-tools.exe build --profile SERVER
 | Section / Field | Description |
 |-----------------|-------------|
 | [`security:`](#security) | Enable/disable security, password hashes |
-| `lua_modules.SECURITY` | [veafSecurity](mission-maker/scripts/veafSecurity.md) |
+| `modules.SECURITY` | [veafSecurity](mission-maker/scripts/veafSecurity.md) |
 
 ### Combat
 
@@ -472,28 +473,28 @@ veaf-tools.exe build --profile SERVER
 | [`qra:`](#qra-cap_missions-combat_missions) | QRA definitions |
 | [`cap_missions:`](#qra-cap_missions-combat_missions) | CAP mission definitions |
 | [`combat_missions:`](#qra-cap_missions-combat_missions) | Combat mission definitions |
-| `lua_modules.COMBATZONE` | [veafCombatZone](mission-maker/scripts/veafCombatZone.md) |
-| `lua_modules.AIRWAVES` | [veafAirWaves](mission-maker/scripts/veafAirWaves.md) |
-| `lua_modules.CASMISSION` | [veafCasMission](mission-maker/scripts/veafCasMission.md) |
+| `modules.COMBATZONE` | [veafCombatZone](mission-maker/scripts/veafCombatZone.md) |
+| `modules.AIRWAVES` | [veafAirWaves](mission-maker/scripts/veafAirWaves.md) |
+| `modules.CASMISSION` | [veafCasMission](mission-maker/scripts/veafCasMission.md) |
 
 ### Air Defense
 
 | Section / Field | Description |
 |-----------------|-------------|
 | `external_modules.skynet` | Skynet IADS integration |
-| `lua_modules.SANCTUARY` | [veafSanctuary](mission-maker/scripts/veafSanctuary.md) |
-| `lua_modules.MISSILEGUARDIAN` | [veafMissileGuardian](mission-maker/scripts/veafMissileGuardian.md) |
-| `lua_modules.QRA` | [veafQraManager](mission-maker/scripts/veafQraManager.md) |
+| `modules.SANCTUARY` | [veafSanctuary](mission-maker/scripts/veafSanctuary.md) |
+| `modules.MISSILEGUARDIAN` | [veafMissileGuardian](mission-maker/scripts/veafMissileGuardian.md) |
+| `modules.QRA` | [veafQraManager](mission-maker/scripts/veafQraManager.md) |
 
 ### Assets & Support
 
 | Section / Field | Description |
 |-----------------|-------------|
-| `lua_modules.ASSETS` | [veafAssets](mission-maker/scripts/veafAssets.md) |
-| `lua_modules.CARRIER` | [veafCarrierOperations](mission-maker/scripts/veafCarrierOperations.md) |
-| `lua_modules.NAMEDPOINTS` | [veafNamedPoints](mission-maker/scripts/veafNamedPoints.md) |
-| `lua_modules.RADIO` | [veafRadio](mission-maker/scripts/veafRadio.md) |
-| `lua_modules.SHORTCUTS` | [veafShortcuts](mission-maker/scripts/veafShortcuts.md) |
+| `modules.ASSETS` | [veafAssets](mission-maker/scripts/veafAssets.md) |
+| `modules.CARRIER` | [veafCarrierOperations](mission-maker/scripts/veafCarrierOperations.md) |
+| `modules.NAMEDPOINTS` | [veafNamedPoints](mission-maker/scripts/veafNamedPoints.md) |
+| `modules.RADIO` | [veafRadio](mission-maker/scripts/veafRadio.md) |
+| `modules.SHORTCUTS` | [veafShortcuts](mission-maker/scripts/veafShortcuts.md) |
 
 ### Build Pipeline
 
@@ -516,15 +517,15 @@ veaf-tools.exe build --profile SERVER
 
 | Module | mission.yaml key | Doc page |
 |--------|-----------------|----------|
-| veafRadio | `lua_modules.RADIO` | [veafRadio](mission-maker/scripts/veafRadio.md#configuration-missionyaml) |
-| veafShortcuts | `lua_modules.SHORTCUTS` | [veafShortcuts](mission-maker/scripts/veafShortcuts.md#configuration-missionyaml) |
-| veafNamedPoints | `lua_modules.NAMEDPOINTS` | [veafNamedPoints](mission-maker/scripts/veafNamedPoints.md#configuration-missionyaml) |
-| veafCarrierOperations | `lua_modules.CARRIER` | [veafCarrierOperations](mission-maker/scripts/veafCarrierOperations.md#configuration-missionyaml) |
-| veafAssets | `lua_modules.ASSETS` | [veafAssets](mission-maker/scripts/veafAssets.md#configuration-missionyaml) |
-| veafSanctuary | `lua_modules.SANCTUARY` | [veafSanctuary](mission-maker/scripts/veafSanctuary.md#configuration-missionyaml) |
-| veafCombatZone | `lua_modules.COMBATZONE` | [veafCombatZone](mission-maker/scripts/veafCombatZone.md#configuration-missionyaml) |
-| veafAirWaves | `lua_modules.AIRWAVES` | [veafAirWaves](mission-maker/scripts/veafAirWaves.md#configuration-missionyaml) |
-| veafQraManager | `lua_modules.QRA` + `qra:` | [veafQraManager](mission-maker/scripts/veafQraManager.md#configuration-missionyaml) |
+| veafRadio | `modules.RADIO` | [veafRadio](mission-maker/scripts/veafRadio.md#configuration-missionyaml) |
+| veafShortcuts | `modules.SHORTCUTS` | [veafShortcuts](mission-maker/scripts/veafShortcuts.md#configuration-missionyaml) |
+| veafNamedPoints | `modules.NAMEDPOINTS` | [veafNamedPoints](mission-maker/scripts/veafNamedPoints.md#configuration-missionyaml) |
+| veafCarrierOperations | `modules.CARRIER` | [veafCarrierOperations](mission-maker/scripts/veafCarrierOperations.md#configuration-missionyaml) |
+| veafAssets | `modules.ASSETS` | [veafAssets](mission-maker/scripts/veafAssets.md#configuration-missionyaml) |
+| veafSanctuary | `modules.SANCTUARY` | [veafSanctuary](mission-maker/scripts/veafSanctuary.md#configuration-missionyaml) |
+| veafCombatZone | `modules.COMBATZONE` | [veafCombatZone](mission-maker/scripts/veafCombatZone.md#configuration-missionyaml) |
+| veafAirWaves | `modules.AIRWAVES` | [veafAirWaves](mission-maker/scripts/veafAirWaves.md#configuration-missionyaml) |
+| veafQraManager | `modules.QRA` + `qra:` | [veafQraManager](mission-maker/scripts/veafQraManager.md#configuration-missionyaml) |
 | veafCasMission | `cap_missions:` + `combat_missions:` | [veafCasMission](mission-maker/scripts/veafCasMission.md#configuration-missionyaml) |
 
 ---

--- a/doc/MISSION_YAML_REFERENCE.en.md
+++ b/doc/MISSION_YAML_REFERENCE.en.md
@@ -60,9 +60,9 @@ security:
 
 lua_modules:
   RADIO:
-    enable: true
+    enabled: true
   ASSETS:
-    enable: true
+    enabled: true
     assets:
       - sort: 1
         name: "Texaco"
@@ -254,12 +254,12 @@ lua_modules:
     logLevel: debug
   # Optional modules: can be enabled or disabled
   RADIO:
-    enable: true
+    enabled: true
     logLevel: info            # optional per-module log level override
     init:
       help_menus: true
   SPAWN:
-    enable: true
+    enabled: true
     logLevel: debug
 ```
 

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -405,7 +405,7 @@ build:
   scripts_path: C:/dev/VEAF-Mission-Creation-Tools
 ```
 
-> Voir la section [Mode développeur](developer/GUIDE.fr.md#mode-développeur) du Guide du développeur pour le workflow complet.
+> Voir la section [Mode développeur](developer/GUIDE.md#mode-développeur) du Guide du développeur pour le workflow complet.
 
 ---
 

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -210,7 +210,14 @@ external_modules:
 | `enabled` | booléen | `false` | Activer l'intégration CTLD |
 | *(toute propriété ctld)* | quelconque | — | Toute propriété `ctld.xxx` (ex: `hoverPickup: true`) |
 
-> La configuration CSAR n'est pas encore disponible via `mission.yaml` — configurez-la directement dans `mission-script.lua`.
+#### Champs de `external_modules.csar`
+
+| Champ | Type | Défaut | Description |
+|-------|------|--------|-------------|
+| `enabled` | booléen | `false` | Activer l'intégration CSAR |
+| *(toute propriété csar)* | quelconque | — | Toute propriété `csar.xxx` (ex: `enableAllslots: true`, `csarPrefix: "MEDEVAC"`) |
+
+VEAF génère les affectations `csar.xxx = value` et l'appel à `csar.initialize()` dans `veaf-config.lua`. Pour les réglages complexes comme `aircraftType` (table par appareil), continuez d'utiliser le motif de callback Lua dans `mission-script.lua`. Voir [Intégration CTLD et CSAR](mission-maker/GUIDE.md#ctld-and-csar-integration).
 
 ---
 

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -27,7 +27,7 @@ Ces fichiers **ne sont pas** chargés à l'exécution dans DCS — ils sont cons
 
 `mission.yaml` lui-même configure **le comportement des modules Lua VEAF lors de l'exécution dans DCS**. Il est traduit au moment du build en `veaf-config.lua`, injecté dans la mission et exécuté au chargement par DCS.
 
-Les sections `lua_modules:`, `qra:`, `assets:`, `shortcuts:` décrivent toutes le comportement des modules à l'exécution.
+Les sections `modules:`, `qra:`, `assets:`, `shortcuts:` décrivent toutes le comportement des modules à l'exécution.
 
 ```
 dossier mission/
@@ -58,7 +58,7 @@ mission:
 security:
   disabled: true
 
-lua_modules:
+modules:
   RADIO:
     enabled: true
   ASSETS:
@@ -240,39 +240,67 @@ veaf_tools:
 
 ---
 
-### `lua_modules:`
+### `modules:`
 
-Activer, désactiver ou configurer les modules Lua VEAF individuels. Les modules non listés sont activés avec leurs paramètres par défaut.
+Le bloc unifié `modules:` permet d'activer, de désactiver ou de configurer chaque module Lua VEAF **et** chaque script communautaire au même endroit. Les modules non listés sont activés avec leurs paramètres par défaut.
 
-> **Les modules d'infrastructure sont toujours actifs.**
-> Les modules `UNITS`, `TIME`, `CACHE`, `EVENTS`, `MARKERS` et `COMMANDS` sont obligatoires et toujours chargés, quelle que soit la configuration. La clé `enable` ne doit **pas** être utilisée sur ces modules — c'est une erreur de build. Ils peuvent toutefois apparaître dans `lua_modules:` pour configurer d'autres champs comme `logLevel`.
+> **Note de migration.** `modules:` remplace les anciennes clés `lua_modules:` + `community_scripts:`. Les clés héritées fonctionnent toujours mais émettent un avertissement de dépréciation au build. `enabled:` remplace l'ancienne clé `enable:`.
+
+Chaque entrée peut prendre **trois formes** :
 
 ```yaml
-lua_modules:
-  # Modules d'infrastructure : toujours actifs — configurer uniquement, ne pas utiliser 'enable'
-  UNITS:
-    logLevel: debug
-  # Modules optionnels : peuvent être activés ou désactivés
-  RADIO:
-    enabled: true
-    logLevel: info            # surcharge optionnelle du niveau de log par module
-    init:
-      help_menus: true
+modules:
+  # 1. Raccourci — activer un module optionnel avec ses réglages par défaut :
+  RADIO: true
+
+  # 2. Bloc — activer et configurer :
   SPAWN:
     enabled: true
+    logLevel: debug           # surcharge optionnelle du niveau de log par module
+    init:
+      help_menus: true
+
+  # 3. Null nu — module d'infrastructure obligatoire, configuration seule :
+  UNITS:
     logLevel: debug
 ```
 
-Le champ `logLevel` est disponible pour chaque module. Le champ `enable` s'applique **uniquement aux modules optionnels** — son utilisation sur les modules d'infrastructure est une erreur de build. Les champs supplémentaires `init:` ou de données sont spécifiques à chaque module — voir la page de documentation de chaque module.
+> **Les modules d'infrastructure sont toujours actifs.**
+> `UNITS`, `TIME`, `CACHE`, `EVENTS`, `MARKERS` et `COMMANDS` sont obligatoires et toujours chargés. Ne définissez **pas** `enabled:` dessus — c'est une erreur de build. Ils peuvent toutefois apparaître dans `modules:` pour configurer d'autres champs comme `logLevel`.
 
 **Champs communs (tous les modules) :**
 
 | Champ | Type | Défaut | Description |
 |-------|------|--------|-------------|
-| `enable` | booléen | `true` | Activer ou désactiver ce module *(modules optionnels uniquement — interdit sur les modules d'infrastructure)* |
+| `enabled` | booléen | `true` | Activer ou désactiver ce module *(modules optionnels uniquement — interdit sur les modules d'infrastructure)* |
 | `logLevel` | string | *(global)* | Surcharger le niveau de log pour ce module uniquement |
 
-**IDs de modules :**
+Les champs supplémentaires `init:` ou de données sont spécifiques à chaque module — voir la page de documentation de chaque module.
+
+**Les scripts communautaires** se déclarent dans le même bloc, via leurs IDs en majuscules. Lorsqu'un script est absent de `modules:`, il garde son état par défaut (inclus). Mettez-le à `false` pour l'exclure :
+
+```yaml
+modules:
+  CTLD: true
+  CSAR: true
+  SKYNET: false               # exclu de cette mission
+```
+
+| ID communautaire | Script |
+|----|--------|
+| `MIST` | MIST (Mission Scripting Tools) |
+| `STTS` | DCS-SimpleTextToSpeech |
+| `WEATHERMARK` | WeatherMark |
+| `CTLD` | CTLD (Combat Transport & Logistics Dispatcher) |
+| `AIEN` | AIEN (AI Enhancement) |
+| `CSAR` | CSAR (Combat Search and Rescue) |
+| `HERCULES` | Hercules Cargo |
+| `SKYNET` | Skynet IADS |
+| `TUM` | The Universal Mission (TUM) |
+
+> Un identifiant inconnu déclenche un avertissement au build et est ignoré.
+
+**IDs de modules VEAF :**
 
 | ID | Module | Page doc |
 |----|--------|----------|
@@ -298,7 +326,7 @@ Le champ `logLevel` est disponible pour chaque module. Le champ `enable` s'appli
 
 ### `qra:`, `cap_missions:`, `combat_missions:`
 
-Sections de premier niveau pour les définitions QRA, missions CAP et missions de combat. Ces sections nécessitent les modules correspondants activés dans `lua_modules:`.
+Sections de premier niveau pour les définitions QRA, missions CAP et missions de combat. Ces sections nécessitent les modules correspondants activés dans `modules:`.
 
 Voir les pages respectives pour le schéma complet :
 - [`qra:`](mission-maker/scripts/veafQraManager.md#configuration-missionyaml) — définitions Quick Reaction Alert
@@ -306,36 +334,9 @@ Voir les pages respectives pour le schéma complet :
 
 ---
 
-### `community_scripts:`
+### `community_scripts:` *(hérité)*
 
-Permet d'activer ou de désactiver individuellement les scripts Lua communautaires (MIST, CTLD, CSAR, etc.) injectés dans la mission. Lorsque cette section est absente, **tous** les scripts communautaires sont inclus.
-
-| Champ | Type | Défaut | Description |
-|-------|------|---------|-------------|
-| `<id>.enabled` | `bool` | `true` | Active (`true`) ou désactive (`false`) le script identifié par `<id>` |
-
-**Identifiants disponibles**
-
-| ID | Script |
-|----|--------|
-| `mist` | MIST (Mission Scripting Tools) |
-| `stts` | DCS-SimpleTextToSpeech |
-| `weathermark` | WeatherMark |
-| `ctld` | CTLD (Combat Transport & Logistics Dispatcher) |
-| `aien` | AIEN (AI Enhancement) |
-| `csar` | CSAR (Combat Search and Rescue) |
-| `hercules` | Hercules Cargo |
-| `skynet` | Skynet IADS |
-| `tum` | The Universal Mission (TUM) |
-
-```yaml
-community_scripts:
-  ctld:   { enabled: true }
-  csar:   { enabled: true }
-  skynet: { enabled: false }   # désactivé pour cette mission
-```
-
-> Un identifiant inconnu dans cette section déclenche un warning au build et est ignoré.
+> **Déprécié.** Les scripts communautaires se configurent désormais dans le bloc unifié [`modules:`](#modules) via leurs IDs en majuscules (ex. `CTLD: true`). La section séparée `community_scripts:` fonctionne toujours mais émet un avertissement de dépréciation. Voir [`modules:`](#modules) pour la syntaxe actuelle et la liste des IDs communautaires.
 
 ---
 
@@ -456,8 +457,8 @@ veaf-tools.exe build --profile SERVER
 | [`global_log_level`](#global_log_level) | Forcer un niveau de log sur tous les modules |
 | [`mission:`](#mission) | Nom, ère, chemin d'export |
 | [`security:`](#security) | Activer/désactiver la sécurité, hashes de mots de passe |
-| `lua_modules.RADIO` | [veafRadio](mission-maker/scripts/veafRadio.md) |
-| `lua_modules.ASSETS` | [veafAssets](mission-maker/scripts/veafAssets.md) |
+| `modules.RADIO` | [veafRadio](mission-maker/scripts/veafRadio.md) |
+| `modules.ASSETS` | [veafAssets](mission-maker/scripts/veafAssets.md) |
 | `pipeline.presets` | [schéma presets.yaml](PIPELINE_REFERENCE.md#étape-1--préréglages-radio-presetsyaml) |
 | `pipeline.waypoints` | [schéma waypoints.yaml](PIPELINE_REFERENCE.md#étape-2--points-de-cheminement-waypointsyaml) |
 
@@ -466,19 +467,19 @@ veaf-tools.exe build --profile SERVER
 | Section / Champ | Description |
 |-----------------|-------------|
 | [`settings:`](#settings) | Constantes mission → `veaf.config.XXX` |
-| `lua_modules.SHORTCUTS` | [veafShortcuts](mission-maker/scripts/veafShortcuts.md) |
-| `lua_modules.NAMEDPOINTS` | [veafNamedPoints](mission-maker/scripts/veafNamedPoints.md) |
-| `lua_modules.QRA` + [`qra:`](#qra-cap_missions-combat_missions) | [veafQraManager](mission-maker/scripts/veafQraManager.md) |
-| `lua_modules.COMBATZONE` | [veafCombatZone](mission-maker/scripts/veafCombatZone.md) |
-| `lua_modules.CARRIER` | [veafCarrierOperations](mission-maker/scripts/veafCarrierOperations.md) |
+| `modules.SHORTCUTS` | [veafShortcuts](mission-maker/scripts/veafShortcuts.md) |
+| `modules.NAMEDPOINTS` | [veafNamedPoints](mission-maker/scripts/veafNamedPoints.md) |
+| `modules.QRA` + [`qra:`](#qra-cap_missions-combat_missions) | [veafQraManager](mission-maker/scripts/veafQraManager.md) |
+| `modules.COMBATZONE` | [veafCombatZone](mission-maker/scripts/veafCombatZone.md) |
+| `modules.CARRIER` | [veafCarrierOperations](mission-maker/scripts/veafCarrierOperations.md) |
 
 ### Avancé — cas spécifiques
 
 | Section / Champ | Description |
 |-----------------|-------------|
-| `lua_modules.AIRWAVES` | [veafAirWaves](mission-maker/scripts/veafAirWaves.md) |
-| `lua_modules.SANCTUARY` | [veafSanctuary](mission-maker/scripts/veafSanctuary.md) |
-| `lua_modules.MISSILEGUARDIAN` | [veafMissileGuardian](mission-maker/scripts/veafMissileGuardian.md) |
+| `modules.AIRWAVES` | [veafAirWaves](mission-maker/scripts/veafAirWaves.md) |
+| `modules.SANCTUARY` | [veafSanctuary](mission-maker/scripts/veafSanctuary.md) |
+| `modules.MISSILEGUARDIAN` | [veafMissileGuardian](mission-maker/scripts/veafMissileGuardian.md) |
 | [`external_modules:`](#external_modules) | Skynet IADS, CTLD |
 | [`veaf_tools:`](#veaf_tools) | Contrainte de version |
 | `pipeline.aircraft_groups` | [schéma aircraft-templates.yaml](PIPELINE_REFERENCE.md#étape-3--groupes-daéronefs-aircraft-templatesyaml) |
@@ -495,15 +496,15 @@ veaf-tools.exe build --profile SERVER
 
 | Module | Clé mission.yaml | Page doc |
 |--------|-----------------|----------|
-| veafRadio | `lua_modules.RADIO` | [veafRadio](mission-maker/scripts/veafRadio.md#configuration-missionyaml) |
-| veafShortcuts | `lua_modules.SHORTCUTS` | [veafShortcuts](mission-maker/scripts/veafShortcuts.md#configuration-missionyaml) |
-| veafNamedPoints | `lua_modules.NAMEDPOINTS` | [veafNamedPoints](mission-maker/scripts/veafNamedPoints.md#configuration-missionyaml) |
-| veafCarrierOperations | `lua_modules.CARRIER` | [veafCarrierOperations](mission-maker/scripts/veafCarrierOperations.md#configuration-missionyaml) |
-| veafAssets | `lua_modules.ASSETS` | [veafAssets](mission-maker/scripts/veafAssets.md#configuration-missionyaml) |
-| veafSanctuary | `lua_modules.SANCTUARY` | [veafSanctuary](mission-maker/scripts/veafSanctuary.md#configuration-missionyaml) |
-| veafCombatZone | `lua_modules.COMBATZONE` | [veafCombatZone](mission-maker/scripts/veafCombatZone.md#configuration-missionyaml) |
-| veafAirWaves | `lua_modules.AIRWAVES` | [veafAirWaves](mission-maker/scripts/veafAirWaves.md#configuration-missionyaml) |
-| veafQraManager | `lua_modules.QRA` + `qra:` | [veafQraManager](mission-maker/scripts/veafQraManager.md#configuration-missionyaml) |
+| veafRadio | `modules.RADIO` | [veafRadio](mission-maker/scripts/veafRadio.md#configuration-missionyaml) |
+| veafShortcuts | `modules.SHORTCUTS` | [veafShortcuts](mission-maker/scripts/veafShortcuts.md#configuration-missionyaml) |
+| veafNamedPoints | `modules.NAMEDPOINTS` | [veafNamedPoints](mission-maker/scripts/veafNamedPoints.md#configuration-missionyaml) |
+| veafCarrierOperations | `modules.CARRIER` | [veafCarrierOperations](mission-maker/scripts/veafCarrierOperations.md#configuration-missionyaml) |
+| veafAssets | `modules.ASSETS` | [veafAssets](mission-maker/scripts/veafAssets.md#configuration-missionyaml) |
+| veafSanctuary | `modules.SANCTUARY` | [veafSanctuary](mission-maker/scripts/veafSanctuary.md#configuration-missionyaml) |
+| veafCombatZone | `modules.COMBATZONE` | [veafCombatZone](mission-maker/scripts/veafCombatZone.md#configuration-missionyaml) |
+| veafAirWaves | `modules.AIRWAVES` | [veafAirWaves](mission-maker/scripts/veafAirWaves.md#configuration-missionyaml) |
+| veafQraManager | `modules.QRA` + `qra:` | [veafQraManager](mission-maker/scripts/veafQraManager.md#configuration-missionyaml) |
 | veafCasMission | `cap_missions:` + `combat_missions:` | [veafCasMission](mission-maker/scripts/veafCasMission.md#configuration-missionyaml) |
 
 ---

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -60,9 +60,9 @@ security:
 
 lua_modules:
   RADIO:
-    enable: true
+    enabled: true
   ASSETS:
-    enable: true
+    enabled: true
     assets:
       - sort: 1
         name: "Texaco"
@@ -254,12 +254,12 @@ lua_modules:
     logLevel: debug
   # Modules optionnels : peuvent être activés ou désactivés
   RADIO:
-    enable: true
+    enabled: true
     logLevel: info            # surcharge optionnelle du niveau de log par module
     init:
       help_menus: true
   SPAWN:
-    enable: true
+    enabled: true
     logLevel: debug
 ```
 

--- a/doc/TOOLS_REFERENCE.md
+++ b/doc/TOOLS_REFERENCE.md
@@ -14,6 +14,7 @@
 1. [Pour les utilisateurs : Mise à jour](#pour-les-utilisateurs--mise-à-jour)
 2. [Pour les administrateurs : Publication](#pour-les-administrateurs--publication)
 3. [Architecture du système](#architecture-du-système)
+4. [Dépannage](#dépannage)
 
 ---
 
@@ -536,6 +537,350 @@ Tags Git :
 ├── published-latest ──► commit abc123def... (identique)
 └── published-v6.0.0 ──► commit xyz789uvw...
 ```
+
+---
+
+## Dépannage
+
+### Problème : « Tag not found on GitHub »
+
+**Cause :** le tag Git a été créé localement mais n'a pas été poussé sur GitHub.
+
+**Solution :**
+```bash
+# Check if tag exists locally
+git tag -l published-v6.0.1
+
+# If it exists, push it
+git push origin refs/tags/published-v6.0.1
+
+# If it doesn't exist, create it
+git tag -a published-v6.0.1 -m "Release 6.0.1"
+git push origin refs/tags/published-v6.0.1
+```
+
+### Problème : « Checksum mismatch » lors de la mise à jour
+
+**Cause :** corruption du fichier pendant le téléchargement (rare) ou problème réseau.
+
+**Solution :**
+```bash
+# Try again (usually fixes it)
+veaf-tools-updater.exe
+
+# If persists, check GitHub release:
+# https://github.com/VEAF/VEAF-Mission-Creation-Tools/releases
+```
+
+### Problème : « GitHub rate limit exceeded »
+
+**Cause :** trop d'appels à l'API en peu de temps.
+
+**Solution :**
+```bash
+# Option 1: Wait 1 hour (rate limit resets)
+
+# Option 2: Use Personal Access Token (better limits)
+veaf-tools-updater.exe --token ghp_xxxxxxxxxxxx
+
+# Get token from: https://github.com/settings/tokens
+# Scope: repo (full control)
+```
+
+### Problème : « Permission denied » lors de l'installation
+
+**Cause :** écriture impossible dans le dossier mission ou le répertoire courant.
+
+**Solution :**
+```bash
+# Run as Administrator (Windows)
+# Or specify a different directory as a positional argument:
+veaf-tools-updater.exe "C:\alternative\path"
+```
+
+### Problème : fichier introuvable lors de la publication
+
+**Cause :** `published.zip` n'existe pas ou le chemin est incorrect.
+
+**Solution :**
+```bash
+# Verify file exists
+dir published.zip
+
+# Use correct absolute path
+veaf-tools-updater.exe publish 6.0.1 "C:\full\path\to\published.zip" --token ghp_xxx
+
+# Create zip if missing
+# (select published/ folder, right-click → Send to → Compressed (zipped))
+```
+
+### Problème : « Failed to create GitHub release »
+
+**Cause :** généralement un problème de token ou de réseau.
+
+**Solution :**
+```bash
+# Check token:
+# 1. Verify veaf-tools-config.yaml exists and has correct token
+# 2. Go to https://github.com/settings/tokens
+# 3. Verify scope includes "repo"
+# 4. Create new token if old one expired
+# 5. Token must have write permissions
+
+# Update your config file and try again
+veaf-tools-updater.exe publish 6.0.1 ./published.zip --verbose
+```
+
+### Problème : « Not a git repository »
+
+**Cause :** la commande est lancée depuis le mauvais répertoire ou le dossier `.git` est absent.
+
+**Solution :**
+```bash
+# Publish command runs from repo root (has .git/)
+cd D:\dev\_VEAF\VEAF-Mission-Creation-Tools
+
+# Then run publish
+veaf-tools-updater.exe publish 6.0.1 ./published.zip --token ghp_xxx
+
+# Or specify repo path
+veaf-tools-updater.exe publish 6.0.1 ./published.zip \
+  --token ghp_xxx \
+  --repo-path "D:\dev\_VEAF\VEAF-Mission-Creation-Tools"
+```
+
+### Problème : « No release found for tag »
+
+**Cause :** le tag de version existe mais aucune Release GitHub n'a été créée pour lui.
+
+**Solution :**
+```bash
+# The publish command should create the release automatically
+
+# If it didn't:
+# 1. Visit https://github.com/VEAF/VEAF-Mission-Creation-Tools/releases
+# 2. Find the tag in "Releases" list
+# 3. Click "Edit" and re-publish
+
+# Or use publish again (it will detect existing tag)
+veaf-tools-updater.exe publish 6.0.1 ./published.zip --token ghp_xxx
+```
+
+### Obtenir plus d'aide
+
+Pour des informations de débogage détaillées :
+
+```bash
+# Show verbose output
+veaf-tools-updater.exe --verbose
+
+# Or for publish
+veaf-tools-updater.exe publish 6.0.1 ./published.zip --token ghp_xxx --verbose
+```
+
+Consultez le fichier `veaf-tools.log` dans le répertoire courant pour les journaux détaillés.
+
+---
+
+## Référence des commandes
+
+### Commande de mise à jour
+
+```bash
+veaf-tools-updater.exe [MISSION_FOLDER] [OPTIONS]
+
+Arguments:
+  MISSION_FOLDER                 Mission folder path (default: current directory)
+
+Options:
+  --tag TEXT                     Version tag to fetch (default: published-latest)
+  --token TEXT                   GitHub token (optional, overrides config file)
+  --force                        Ignore version check, install anyway
+  --no-verify-checksum           Skip checksum verification (not recommended)
+  --lang TEXT                    Force interface language (en, fr); overrides OS locale and ~/veafmct.yaml
+  --verbose                      Show detailed debug output
+  --pause                        Wait for user input before exiting
+  --help                         Show help message
+```
+
+**Note :** les réglages de `veaf-tools-config.yaml` sont utilisés automatiquement. Les options en ligne de commande priment sur les valeurs du fichier de configuration.
+
+**Exemples :**
+```bash
+veaf-tools-updater.exe
+veaf-tools-updater.exe --tag published-v6.0.0
+veaf-tools-updater.exe --token ghp_xxx --verbose
+veaf-tools-updater.exe --force
+```
+
+### Commande de publication
+
+```bash
+veaf-tools-updater.exe publish VERSION ZIP_FILE [OPTIONS]
+
+Required:
+  VERSION                        Version number (6.0.1 or v6.0.1)
+  ZIP_FILE                       Path to published.zip
+
+Options:
+  --token TEXT                   GitHub token (optional, overrides config file)
+  --repo-path TEXT               Repository path (default: current directory)
+  --release-notes TEXT           Release notes/changelog
+  --draft                        Create as draft (not visible to users)
+  --prerelease                   Mark as pre-release
+  --skip-tag                     Skip Git tag creation
+  --verbose                      Show detailed debug output
+  --pause                        Wait for user input before exiting
+  --help                         Show help message
+```
+
+**Note :** le token et les autres réglages de `veaf-tools-config.yaml` sont utilisés automatiquement. Les options en ligne de commande priment sur les valeurs du fichier de configuration.
+
+**Exemples :**
+```bash
+# With config file (recommended)
+veaf-tools-updater.exe publish 6.0.1 ./published.zip
+veaf-tools-updater.exe publish 6.0.1 ./published.zip --release-notes "Version 6.0.1 - Bug fixes"
+veaf-tools-updater.exe publish 6.0.1 ./published.zip --draft
+
+# Without config file (token required)
+veaf-tools-updater.exe publish 6.0.1 ./published.zip --token ghp_xxx
+veaf-tools-updater.exe publish 6.0.1 ./published.zip --token ghp_xxx --release-notes "..."
+```
+
+---
+
+## Bonnes pratiques
+
+### Pour les utilisateurs
+
+✅ **À faire :**
+- Lancez `veaf-tools update` régulièrement pour rester à jour
+- Laissez les checksums vérifier l'intégrité (n'utilisez pas `--no-verify-checksum`)
+- Utilisez `--help` en cas de doute sur une option
+
+❌ **À éviter :**
+- Ignorer la vérification de checksum
+- Modifier manuellement `veaf-tools-updater.exe` ou les scripts de build
+- Utiliser d'anciennes versions sans raison valable
+- Partager vos Personal Access Tokens (un token = un mot de passe)
+
+### Pour les administrateurs
+
+✅ **À faire :**
+- Stockez votre token dans `veaf-tools-config.yaml` (jamais dans git !)
+- Utilisez toujours la commande `publish` pour rester cohérent
+- Tenez les notes de version à jour
+- Testez avant de publier en production
+- Utilisez des tokens différents pour des machines différentes
+- Régénérez les tokens régulièrement
+- Conservez `veaf-tools-config.yaml` dans `.gitignore`
+
+❌ **À éviter :**
+- Committer `veaf-tools-config.yaml` dans git
+- Committer des Personal Access Tokens où que ce soit
+- Partager vos tokens avec d'autres personnes
+- Publier des versions non testées
+- Réutiliser un même token sur plusieurs machines
+- Sauter le processus de vérification
+
+---
+
+## Sécurité
+
+### Sûreté du token
+
+Votre Personal Access Token GitHub est comme un mot de passe :
+- ❌ Ne le committez jamais dans git (même dans des fichiers de configuration)
+- ❌ Ne le partagez jamais par e-mail ou message
+- ❌ Ne le collez jamais sur des forums publics
+- ❌ Ne poussez jamais `veaf-tools-config.yaml` dans git
+- ✅ Stockez-le dans `veaf-tools-config.yaml` (local uniquement)
+- ✅ Assurez-vous que `veaf-tools-config.yaml` figure dans `.gitignore`
+- ✅ Régénérez-le régulièrement (chaque mois)
+- ✅ Utilisez-le pour une tâche, puis révoquez-le (lorsque c'est possible)
+
+### Vérification par checksum
+
+Les checksums protègent les téléchargements :
+- ✅ Détectent la corruption réseau
+- ✅ Vérifient que les fichiers n'ont pas été modifiés
+- ✅ Préviennent les attaques de l'homme du milieu (man-in-the-middle)
+- ✅ Activés par défaut (gardez-les ainsi !)
+
+### HTTPS
+
+Toutes les communications avec GitHub utilisent le chiffrement TLS/SSL :
+- ✅ Les données en transit sont protégées
+- ✅ L'API GitHub impose HTTPS
+- ✅ Votre token est chiffré sur le réseau
+
+---
+
+## FAQ
+
+**Q : Puis-je revenir à une ancienne version ?**
+R : Oui ! `veaf-tools update --tag published-v6.0.0`
+
+**Q : Que faire si la publication échoue ?**
+R : Consultez la section Dépannage ci-dessus. La plupart des problèmes sont liés au réseau ou au token.
+
+**Q : Ai-je besoin du token pour mettre à jour ?**
+R : Non, le token ne sert qu'à publier. La mise à jour fonctionne sans lui (avec des limites de débit).
+
+**Q : À quelle fréquence dois-je publier de nouvelles versions ?**
+R : Aussi souvent que vous avez des changements. Les utilisateurs ne les verront que si vous le leur annoncez.
+
+**Q : Puis-je supprimer ou annuler une version publiée ?**
+R : Sur GitHub, oui. Mais les utilisateurs l'ont peut-être déjà téléchargée.
+
+**Q : Quelle est la différence entre `--draft` et `--prerelease` ?**
+R : Draft = caché, Prerelease = visible mais marqué comme « non final ».
+
+**Q : Puis-je publier sans créer de tag git ?**
+R : Oui, avec `--skip-tag`, mais ce n'est pas recommandé.
+
+**Q : Combien de temps les tokens durent-ils ?**
+R : Tant que vous ne les révoquez pas. Ils n'expirent pas automatiquement.
+
+**Q : Le checksum est-il obligatoire ?**
+R : Non (on peut l'ignorer avec `--no-verify-checksum`), mais il est fortement recommandé.
+
+---
+
+## Obtenir de l'aide
+
+Si vous rencontrez des problèmes :
+
+1. **Consultez la section Dépannage** ci-dessus
+2. **Lancez avec `--verbose`** pour voir la sortie détaillée
+3. **Vérifiez `veaf-tools.log`** dans le répertoire courant
+4. **Visitez la page des releases GitHub** pour confirmer que la release existe
+5. **Vérifiez votre connexion Internet** (la plupart des problèmes sont réseau)
+6. **Vérifiez les permissions du token** sur https://github.com/settings/tokens
+
+---
+
+## Historique des versions
+
+### Actuelle (6.0.1+)
+- ✅ Outil unifié de mise à jour / publication
+- ✅ Versionnement basé sur les tags Git
+- ✅ Vérification par checksum SHA256
+- ✅ Comparaison sémantique des versions
+- ✅ Publication entièrement automatisée
+
+### Précédente
+- Script de mise à jour basique
+- Versionnement basé sur les releases
+- Publication manuelle
+- Documentation limitée
+
+---
+
+**Bonnes publications !** 🚀
+
+Pour plus de détails techniques, consultez le code source ou le dépôt GitHub.
 
 ---
 

--- a/doc/TOOLS_REFERENCE.md
+++ b/doc/TOOLS_REFERENCE.md
@@ -549,4 +549,4 @@ Tags Git :
 4. Locale du système (registre Windows / locale système sur Linux–macOS)
 5. `en` (repli intégré)
 
-Langues supportées : anglais (`en`), français (`fr`). Voir [Configuration de la langue](mission-maker/GUIDE.fr.md#configuration-globale-utilisateur) pour les détails complets.
+Langues supportées : anglais (`en`), français (`fr`). Voir [Configuration de la langue](mission-maker/GUIDE.md#configuration-globale-utilisateur) pour les détails complets.

--- a/doc/assets/img/README.md
+++ b/doc/assets/img/README.md
@@ -1,0 +1,19 @@
+# Documentation images
+
+Screenshots and diagrams referenced from the documentation pages.
+
+## Layout
+
+| Folder | Used by |
+|--------|---------|
+| `pilot/` | Pilot Guide (`doc/pilot/`) |
+| `mission-maker/` | Mission Maker Guide (`doc/mission-maker/`) |
+| `tools/` | CLI / tooling docs |
+
+## Conventions
+
+- PNG, width ≥ 1280 px when possible.
+- File names are lower-case, hyphen-separated, and match the placeholder paths
+  already referenced in the Markdown (e.g. `pilot/f10-veaf-submenu.png`).
+- Until a screenshot is captured, its placeholder reference renders as a broken
+  image — this is expected during the documentation overhaul.

--- a/doc/developer/GUIDE.en.md
+++ b/doc/developer/GUIDE.en.md
@@ -271,7 +271,7 @@ global_log_level: debug
 For **per-module build-time** control, use the `lua_modules` section:
 
 ```yaml
-lua_modules:
+modules:
   SPAWN:
     logLevel: debug
   RADIO:

--- a/doc/developer/GUIDE.md
+++ b/doc/developer/GUIDE.md
@@ -270,7 +270,7 @@ global_log_level: debug
 Pour le contrôle **par module au moment du build**, utiliser la section `lua_modules` :
 
 ```yaml
-lua_modules:
+modules:
   SPAWN:
     logLevel: debug
   RADIO:

--- a/doc/mission-maker/GUIDE.en.md
+++ b/doc/mission-maker/GUIDE.en.md
@@ -265,7 +265,6 @@ security:
 | `extract-aircraft-groups` | Extracts aircraft groups from a mission |
 | `inject-waypoints` | Injects waypoints (bullseye, nav points) for human groups |
 | `extract-waypoints` | Extracts waypoints from a mission |
-| `convert` | Converts a vanilla mission to VEAF MCT format |
 | `convert-v5` | Migrates a v5 mission folder to v6 format |
 | `user-config` | Shows or edits the global user config (`~/veafmct.yaml`) |
 
@@ -545,22 +544,18 @@ When `dcs_bridge` is enabled, the trigger is inserted at **position 1**, before 
 
 ## Debug Logging
 
-All VEAF scripts write to the DCS log file (`Saved Games\DCS\Logs\dcs.log`). Three log levels are available, each with its own loader script:
-
-| Script | Level | Use |
-|--------|-------|-----|
-| `veaf-scripts.lua` | Normal (info + warnings) | Production missions |
-| `veaf-scripts-trace.lua` | Trace (all messages) | Deep debugging |
-| `veaf-scripts-trace-with-events.lua` | Trace + DCS events | Event handler debugging |
+All VEAF scripts write to the DCS log file (`Saved Games\DCS\Logs\dcs.log`). The build now produces a **single** `veaf-scripts.lua` loader; verbosity is controlled by log levels in `mission.yaml`, not by loading a different script file.
 
 ### Switching log levels
 
-Set `logLevel` per module in `mission.yaml`, then rebuild:
+Set a global default with `global_log_level`, or override it per module with `logLevel`, then rebuild:
 
 ```yaml
-lua_modules:
+global_log_level: info   # trace | debug | info | warning | error
+
+modules:
   SPAWN:
-    logLevel: debug   # trace | debug | info | warning | error
+    logLevel: debug   # overrides the global default for this module only
 ```
 
 `veaf-tools.exe build` regenerates `veaf-config.lua` from `mission.yaml`. For a quick change without rebuilding, edit `veaf-config.lua` directly — it is a generated file so your changes will be overwritten on the next build.

--- a/doc/mission-maker/GUIDE.en.md
+++ b/doc/mission-maker/GUIDE.en.md
@@ -185,6 +185,31 @@ If you have a custom `src/scripts/mission-script.lua`, it is also injected autom
 3. Injects fresh `DO SCRIPT FILE` triggers for all VEAF scripts + your custom scripts
 4. Writes the final `.miz`
 
+The full build then runs any optional pipeline steps whose configuration files are present (presets, waypoints, aircraft groups, weather):
+
+```mermaid
+flowchart TD
+    subgraph Inputs
+        YAML[mission.yaml]
+        SRC[src/mission + src/scripts]
+        LUA[VEAF Lua scripts]
+    end
+    YAML --> BUILD[veaf-tools build]
+    SRC --> BUILD
+    LUA --> BUILD
+    BUILD --> GEN[Generate veaf-config.lua from mission.yaml]
+    GEN --> TRIG[Inject DO SCRIPT FILE triggers]
+    TRIG --> PIPE{Optional pipeline steps}
+    PIPE -->|presets.yaml| P1[inject-presets]
+    PIPE -->|waypoints.yaml| P2[inject-waypoints]
+    PIPE -->|aircraft-templates.yaml| P3[inject-aircraft-groups]
+    PIPE -->|versions.yaml| P4[inject-weather]
+    P1 --> OUT[Final .miz ready to fly]
+    P2 --> OUT
+    P3 --> OUT
+    P4 --> OUT
+```
+
 ---
 
 ## Configuring Modules
@@ -202,19 +227,20 @@ For most missions, `mission.yaml` is sufficient. Use `mission-script.lua` only f
 mission:
   name: "My-Mission"
 
-lua_modules:
-  SECURITY:
-    enable: true
+modules:
+  SECURITY: true        # shorthand: just enable the module
   SPAWN:
-    logLevel: debug
+    logLevel: debug     # a module with extra config uses a block
   ASSETS:
-    enable: true
+    enabled: true
     assets:
       - sort: 1
         name: "T1-Arco-1"
         description: "Arco-1 (KC-135)"
         information: "Tacan 64Y\nU290.50 (20)"
 ```
+
+> The unified `modules:` block replaces the older `lua_modules:` + `community_scripts:` keys, and `enabled:` replaces `enable:`. The legacy keys still work but emit a deprecation warning. See the [mission.yaml Reference](../MISSION_YAML_REFERENCE.en.md) for the full syntax.
 
 ### mission-script.lua Example
 

--- a/doc/mission-maker/GUIDE.md
+++ b/doc/mission-maker/GUIDE.md
@@ -264,7 +264,6 @@ security:
 | `extract-aircraft-groups` | Extrait les groupes d'aéronefs d'une mission |
 | `inject-waypoints` | Injecte des waypoints (bullseye, points de navigation) pour les groupes humains |
 | `extract-waypoints` | Extrait les waypoints d'une mission |
-| `convert` | Convertit une mission vanilla au format VEAF MCT |
 | `convert-v5` | Migre un dossier mission v5 vers le format v6 |
 | `user-config` | Affiche ou modifie la configuration globale utilisateur (`~/veafmct.yaml`) |
 
@@ -544,22 +543,18 @@ Lorsque `dcs_bridge` est activé, le trigger est inséré en **position 1**, ava
 
 ## Journalisation de débogage
 
-Tous les scripts VEAF écrivent dans le journal DCS (`Saved Games\DCS\Logs\dcs.log`). Trois niveaux de journalisation sont disponibles, chacun avec son propre script de chargement :
-
-| Script | Niveau | Usage |
-|--------|--------|-------|
-| `veaf-scripts.lua` | Normal (info + avertissements) | Missions en production |
-| `veaf-scripts-trace.lua` | Trace (tous les messages) | Débogage approfondi |
-| `veaf-scripts-trace-with-events.lua` | Trace + événements DCS | Débogage des handlers d'événements |
+Tous les scripts VEAF écrivent dans le journal DCS (`Saved Games\DCS\Logs\dcs.log`). Le build produit désormais un **unique** chargeur `veaf-scripts.lua` ; la verbosité se contrôle via les niveaux de log dans `mission.yaml`, et non en chargeant un script différent.
 
 ### Changer le niveau de log
 
-Définissez `logLevel` par module dans `mission.yaml`, puis reconstruisez :
+Définissez un défaut global avec `global_log_level`, ou surchargez-le par module avec `logLevel`, puis reconstruisez :
 
 ```yaml
-lua_modules:
+global_log_level: info   # trace | debug | info | warning | error
+
+modules:
   SPAWN:
-    logLevel: debug   # trace | debug | info | warning | error
+    logLevel: debug   # surcharge le défaut global pour ce module uniquement
 ```
 
 `veaf-tools.exe build` régénère `veaf-config.lua` depuis `mission.yaml`. Pour un changement rapide sans reconstruire, éditez directement `veaf-config.lua` — c'est un fichier généré, donc vos modifications seront écrasées au prochain build.

--- a/doc/mission-maker/GUIDE.md
+++ b/doc/mission-maker/GUIDE.md
@@ -370,7 +370,7 @@ veaf-tools.exe build
 
 Les clés du profil **fusionnent en profondeur** sur la config de base : seules les clés que vous spécifiez sont surchargées, tout le reste reste tel que défini en haut de `mission.yaml`. Passer un nom de profil inconnu émet un avertissement et revient à la config de base.
 
-Voir [`profiles:` dans la référence YAML](../MISSION_YAML_REFERENCE.fr.md#profiles) pour la description complète.
+Voir [`profiles:` dans la référence YAML](../MISSION_YAML_REFERENCE.md#profiles) pour la description complète.
 
 ---
 

--- a/doc/mission-maker/GUIDE.md
+++ b/doc/mission-maker/GUIDE.md
@@ -184,6 +184,31 @@ Si vous avez un `src/scripts/mission-script.lua` personnalisé, il est aussi inj
 3. Injecte de nouveaux triggers `DO SCRIPT FILE` pour tous les scripts VEAF + vos scripts personnalisés
 4. Écrit le `.miz` final
 
+Le build complet exécute ensuite les étapes optionnelles du pipeline dont les fichiers de configuration sont présents (presets, waypoints, groupes d'aéronefs, météo) :
+
+```mermaid
+flowchart TD
+    subgraph Entrées
+        YAML[mission.yaml]
+        SRC[src/mission + src/scripts]
+        LUA[Scripts Lua VEAF]
+    end
+    YAML --> BUILD[veaf-tools build]
+    SRC --> BUILD
+    LUA --> BUILD
+    BUILD --> GEN[Génère veaf-config.lua depuis mission.yaml]
+    GEN --> TRIG[Injecte les triggers DO SCRIPT FILE]
+    TRIG --> PIPE{Étapes optionnelles du pipeline}
+    PIPE -->|presets.yaml| P1[inject-presets]
+    PIPE -->|waypoints.yaml| P2[inject-waypoints]
+    PIPE -->|aircraft-templates.yaml| P3[inject-aircraft-groups]
+    PIPE -->|versions.yaml| P4[inject-weather]
+    P1 --> OUT[.miz final prêt à voler]
+    P2 --> OUT
+    P3 --> OUT
+    P4 --> OUT
+```
+
 ---
 
 ## Configurer les modules
@@ -201,19 +226,20 @@ Pour la plupart des missions, `mission.yaml` suffit. N'utilisez `mission-script.
 mission:
   name: "My-Mission"
 
-lua_modules:
-  SECURITY:
-    enable: true
+modules:
+  SECURITY: true        # raccourci : activer simplement le module
   SPAWN:
-    logLevel: debug
+    logLevel: debug     # un module avec configuration utilise un bloc
   ASSETS:
-    enable: true
+    enabled: true
     assets:
       - sort: 1
         name: "T1-Arco-1"
         description: "Arco-1 (KC-135)"
         information: "Tacan 64Y\nU290.50 (20)"
 ```
+
+> Le bloc unifié `modules:` remplace les anciennes clés `lua_modules:` + `community_scripts:`, et `enabled:` remplace `enable:`. Les clés héritées fonctionnent toujours mais émettent un avertissement de dépréciation. Voir la [Référence mission.yaml](../MISSION_YAML_REFERENCE.md) pour la syntaxe complète.
 
 ### Exemple mission-script.lua
 

--- a/doc/mission-maker/MIGRATION_GUIDE.en.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.en.md
@@ -65,7 +65,7 @@ flowchart TD
 | **Module init pattern** | Bare `veafXxx.initialize()` calls | Auto-generated into `veaf-config.lua` by `veaf-tools build`; no manual `initialize()` calls needed |
 | **Config location** | Initialization scattered in DCS trigger scripts or a separate Lua file | `mission.yaml` generates `veaf-config.lua` at build time; optional custom Lua in `mission-script.lua` |
 | **Config migration** | Manual rewrite | `veaf-tools.exe convert-v5` — one command converts `missionConfig.lua`, pipeline files (presets, waypoints, weather, aircraft groups), and generates `mission.yaml` + `mission-script.lua`. Use `migrate-config` only to migrate `missionConfig.lua` alone. |
-| **Module log levels** | Set per-module by assigning `veafXxx.LogLevel` before init | `mission.yaml` → `lua_modules: → MODULE_ID: logLevel:` or `--log-modules` CLI flag |
+| **Module log levels** | Set per-module by assigning `veafXxx.LogLevel` before init | `mission.yaml` → `modules: → MODULE_ID: logLevel:` or `--log-modules` CLI flag |
 
 ### Step-by-step Migration
 
@@ -104,7 +104,7 @@ This single command handles everything in one pass:
 
 - **`missionConfig.lua` migration** — comments out `doFile()` calls that load VEAF scripts (the builder injects them automatically), wraps bare `veafXxx.initialize()` calls in `if veafXxx then … end` guards.
 - **Pipeline config conversion** — converts v5 config files (radio presets, waypoints, weather, aircraft groups) from Lua to v6 YAML format.
-- **`mission.yaml` generation** — creates `mission.yaml` with the correct `lua_modules:` and `pipeline:` sections.
+- **`mission.yaml` generation** — creates `mission.yaml` with the correct `modules:` and `pipeline:` sections.
 - **Conversion report** — saves `convert-v5-report.md` with all actions taken and any items requiring manual review.
 
 If your pipeline contains `realweather` weather versions, the tool will ask for the ICAO airport code to embed in the generated config. You can supply it upfront to avoid the interactive prompt:
@@ -207,17 +207,17 @@ Edit `mission.yaml` to enable the modules you want. By default, only the essenti
 ```yaml
 name: My Vanilla Mission
 
-lua_modules:
+modules:
   RADIO:
-    enable: true
+    enabled: true
   SPAWN:
-    enable: true
+    enabled: true
   # Uncomment to enable CAS missions:
   # CASMISSION:
-  #   enable: true
+  #   enabled: true
   # Uncomment to enable carrier ops:
   # CARRIER:
-  #   enable: true
+  #   enabled: true
 ```
 
 For custom Lua (advanced module calls, custom aliases, etc.), edit `src/scripts/mission-script.lua`.
@@ -299,7 +299,7 @@ veafShortcuts.AddAlias(
 )
 ```
 
-Module enable/disable is configured in `mission.yaml` → `lua_modules:` — not in this file. See the [YAML reference](../../MISSION_YAML_REFERENCE.md) for the full `mission.yaml` syntax.
+Module enable/disable is configured in `mission.yaml` → `modules:` — not in this file. See the [YAML reference](../../MISSION_YAML_REFERENCE.md) for the full `mission.yaml` syntax.
 
 ---
 
@@ -316,9 +316,9 @@ Alternatively, use `--migrate-from-v5` on the build to have the old triggers rem
 Confirm `RADIO` is enabled in `mission.yaml`:
 
 ```yaml
-lua_modules:
+modules:
   RADIO:
-    enable: true
+    enabled: true
 ```
 
 Rebuild with `veaf-tools.exe build` after any `mission.yaml` change.
@@ -328,9 +328,9 @@ Rebuild with `veaf-tools.exe build` after any `mission.yaml` change.
 Confirm `SPAWN` is enabled in `mission.yaml`:
 
 ```yaml
-lua_modules:
+modules:
   SPAWN:
-    enable: true
+    enabled: true
 ```
 
 Then check the DCS log (`Saved Games\DCS\Logs\dcs.log`) for VEAF errors — filter on `VEAF` or `ERROR`.

--- a/doc/mission-maker/MIGRATION_GUIDE.en.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.en.md
@@ -8,6 +8,15 @@ This guide covers two scenarios:
 
 In both cases the end result is a **VEAF MCT v6 mission folder** that you manage with `veaf-tools.exe`.
 
+```mermaid
+flowchart TD
+    V5[VEAF MCT v5 mission] -->|veaf-tools convert-v5| FOLDER[v6 mission folder]
+    VAN[Vanilla DCS .miz] -->|veaf-tools extract| FOLDER
+    FOLDER --> CFG[Edit mission.yaml]
+    CFG --> BUILD[veaf-tools build]
+    BUILD --> MIZ[v6 .miz ready to fly]
+```
+
 ---
 
 ## Before You Start
@@ -51,7 +60,7 @@ In both cases the end result is a **VEAF MCT v6 mission folder** that you manage
 | **Auto-inject pipeline** | Each inject command (`inject-presets`, `inject-waypoints`, etc.) had to be added manually to `build.cmd` | `veaf-tools build` auto-detects and runs each step when the matching file is present in `src/` |
 | **Tool updates** | NPM (`npm install`) — scripts distributed as a versioned package | `veaf-tools-updater.exe` — downloads and verifies the latest release in one command |
 | **Build-time config** | No build-time config file | `mission.yaml` — controls log levels, module enable/disable, pipeline step overrides |
-| **Module enable/disable** | Edit `missionConfig.lua` (or simply omit the `initialize()` call) | `mission.yaml` → `lua_modules:` section; generates `veaf-config.lua` automatically |
+| **Module enable/disable** | Edit `missionConfig.lua` (or simply omit the `initialize()` call) | `mission.yaml` → `modules:` block; generates `veaf-config.lua` automatically |
 | **Module configuration** | Direct assignment: `veafSpawn.SpawnKeyphrase = "_spawn"` in `missionConfig.lua` | Same direct assignment still works in `mission-script.lua`; or `veaf.setConfig("MODULE_ID", "key", value)` for config-driven overrides |
 | **Module init pattern** | Bare `veafXxx.initialize()` calls | Auto-generated into `veaf-config.lua` by `veaf-tools build`; no manual `initialize()` calls needed |
 | **Config location** | Initialization scattered in DCS trigger scripts or a separate Lua file | `mission.yaml` generates `veaf-config.lua` at build time; optional custom Lua in `mission-script.lua` |

--- a/doc/mission-maker/MIGRATION_GUIDE.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.md
@@ -7,6 +7,15 @@ Ce guide couvre deux scénarios :
 
 Dans les deux cas, le résultat final est un **dossier de mission VEAF MCT v6** que vous gérez avec `veaf-tools.exe`.
 
+```mermaid
+flowchart TD
+    V5[Mission VEAF MCT v5] -->|veaf-tools convert-v5| FOLDER[Dossier de mission v6]
+    VAN[Mission DCS vanilla .miz] -->|veaf-tools extract| FOLDER
+    FOLDER --> CFG[Éditer mission.yaml]
+    CFG --> BUILD[veaf-tools build]
+    BUILD --> MIZ[.miz v6 prêt à voler]
+```
+
 ---
 
 ## Avant de commencer
@@ -50,7 +59,7 @@ Dans les deux cas, le résultat final est un **dossier de mission VEAF MCT v6** 
 | **Pipeline d'auto-injection** | Chaque commande d'injection devait être ajoutée manuellement à `build.cmd` | `veaf-tools build` auto-détecte et exécute chaque étape quand le fichier correspondant est présent dans `src/` |
 | **Mises à jour des outils** | NPM (`npm install`) — scripts distribués sous forme de package versionné | `veaf-tools-updater.exe` — télécharge et vérifie la dernière release en une commande |
 | **Config au moment du build** | Pas de fichier de config au moment du build | `mission.yaml` — contrôle les niveaux de log, l'activation/désactivation des modules, les surcharges d'étapes du pipeline |
-| **Activation/désactivation de modules** | Éditer `missionConfig.lua` (ou simplement omettre l'appel à `initialize()`) | Section `lua_modules:` dans `mission.yaml` ; génère `veaf-config.lua` automatiquement |
+| **Activation/désactivation de modules** | Éditer `missionConfig.lua` (ou simplement omettre l'appel à `initialize()`) | Bloc `modules:` dans `mission.yaml` ; génère `veaf-config.lua` automatiquement |
 | **Configuration de modules** | Affectation directe : `veafSpawn.SpawnKeyphrase = "_spawn"` dans `missionConfig.lua` | La même affectation directe fonctionne toujours dans `mission-script.lua` ; ou `veaf.setConfig("MODULE_ID", "key", value)` pour les surcharges pilotées par config |
 | **Pattern d'init des modules** | Appels nus `veafXxx.initialize()` | Auto-généré dans `veaf-config.lua` par `veaf-tools build` ; aucun appel `initialize()` manuel nécessaire |
 | **Emplacement de la config** | Initialisation dispersée dans des scripts de trigger DCS ou un fichier Lua séparé | `mission.yaml` génère `veaf-config.lua` au moment du build ; code Lua personnalisé optionnel dans `mission-script.lua` |

--- a/doc/mission-maker/MIGRATION_GUIDE.md
+++ b/doc/mission-maker/MIGRATION_GUIDE.md
@@ -64,7 +64,7 @@ flowchart TD
 | **Pattern d'init des modules** | Appels nus `veafXxx.initialize()` | Auto-généré dans `veaf-config.lua` par `veaf-tools build` ; aucun appel `initialize()` manuel nécessaire |
 | **Emplacement de la config** | Initialisation dispersée dans des scripts de trigger DCS ou un fichier Lua séparé | `mission.yaml` génère `veaf-config.lua` au moment du build ; code Lua personnalisé optionnel dans `mission-script.lua` |
 | **Migration de la config** | Réécriture manuelle | `veaf-tools.exe convert-v5` — une seule commande migre `missionConfig.lua`, convertit les fichiers pipeline (préréglages, waypoints, météo, groupes d'aéronefs) et génère `mission.yaml` + `mission-script.lua`. Utilisez `migrate-config` uniquement pour migrer `missionConfig.lua` seul. |
-| **Niveaux de log des modules** | Définis par module en assignant `veafXxx.LogLevel` avant l'init | Section `lua_modules: → MODULE_ID: logLevel:` dans `mission.yaml` ou option CLI `--log-modules` |
+| **Niveaux de log des modules** | Définis par module en assignant `veafXxx.LogLevel` avant l'init | Section `modules: → MODULE_ID: logLevel:` dans `mission.yaml` ou option CLI `--log-modules` |
 
 ### Migration étape par étape
 
@@ -103,7 +103,7 @@ Cette commande unique gère tout en une seule passe :
 
 - **Migration de `missionConfig.lua`** — commente les appels `doFile()` qui chargent les scripts VEAF (le builder les injecte automatiquement), enveloppe les appels nus `veafXxx.initialize()` dans des gardes `if veafXxx then … end`.
 - **Conversion des configs pipeline** — convertit les fichiers de config v5 (préréglages radio, waypoints, météo, groupes d'aéronefs) du format Lua vers le YAML v6.
-- **Génération de `mission.yaml`** — crée `mission.yaml` avec les sections `lua_modules:` et `pipeline:` correctes.
+- **Génération de `mission.yaml`** — crée `mission.yaml` avec les sections `modules:` et `pipeline:` correctes.
 - **Rapport de conversion** — sauvegarde `convert-v5-report.md` avec toutes les actions effectuées et les éléments nécessitant une révision manuelle.
 
 Si votre pipeline contient des versions météo `realweather`, l'outil demandera le code ICAO de l'aéroport à intégrer dans la config générée. Vous pouvez le fournir directement pour éviter le prompt interactif :
@@ -206,17 +206,17 @@ Puis copiez votre `.miz` sous `mission.miz` et exécutez :
 ```yaml
 name: Ma Mission Vanilla
 
-lua_modules:
+modules:
   RADIO:
-    enable: true
+    enabled: true
   SPAWN:
-    enable: true
+    enabled: true
   # Décommenter pour activer les missions CAS :
   # CASMISSION:
-  #   enable: true
+  #   enabled: true
   # Décommenter pour activer les opérations carrier :
   # CARRIER:
-  #   enable: true
+  #   enabled: true
 ```
 
 Pour du Lua personnalisé (appels de modules avancés, aliases, etc.), éditez `src/scripts/mission-script.lua`.
@@ -298,7 +298,7 @@ veafShortcuts.AddAlias(
 )
 ```
 
-L'activation/désactivation des modules se configure dans `mission.yaml` → `lua_modules:` — pas dans ce fichier. Consultez la [référence YAML](../../MISSION_YAML_REFERENCE.md) pour la syntaxe complète de `mission.yaml`.
+L'activation/désactivation des modules se configure dans `mission.yaml` → `modules:` — pas dans ce fichier. Consultez la [référence YAML](../../MISSION_YAML_REFERENCE.md) pour la syntaxe complète de `mission.yaml`.
 
 ---
 
@@ -315,9 +315,9 @@ Alternativement, utilisez `--migrate-from-v5` sur le build pour que les anciens 
 Vérifiez que `RADIO` est activé dans `mission.yaml` :
 
 ```yaml
-lua_modules:
+modules:
   RADIO:
-    enable: true
+    enabled: true
 ```
 
 Reconstruisez avec `veaf-tools.exe build` après toute modification de `mission.yaml`.
@@ -327,9 +327,9 @@ Reconstruisez avec `veaf-tools.exe build` après toute modification de `mission.
 Vérifiez que `SPAWN` est activé dans `mission.yaml` :
 
 ```yaml
-lua_modules:
+modules:
   SPAWN:
-    enable: true
+    enabled: true
 ```
 
 Ensuite, consultez le journal DCS (`Saved Games\DCS\Logs\dcs.log`) pour les erreurs VEAF — filtrez sur `VEAF` ou `ERROR`.

--- a/doc/mission-maker/README.md
+++ b/doc/mission-maker/README.md
@@ -17,7 +17,7 @@ Intégrez le framework Lua VEAF dans vos missions DCS World pour offrir à vos j
 
 Ceci télécharge `veaf-tools.exe` et les scripts Lua VEAF dans votre répertoire de travail.
 
-> **Langue :** Les messages s'affichent dans la langue du système automatiquement (anglais ou français). Pour changer la langue : `veaf-tools.exe user-config --set lang=fr`. Voir [Configuration de la langue](GUIDE.fr.md#configuration-globale-utilisateur).
+> **Langue :** Les messages s'affichent dans la langue du système automatiquement (anglais ou français). Pour changer la langue : `veaf-tools.exe user-config --set lang=fr`. Voir [Configuration de la langue](GUIDE.md#configuration-globale-utilisateur).
 
 ### 2. Créer une mission dans l'éditeur DCS
 

--- a/doc/mission-maker/dcs-radio-specs.md
+++ b/doc/mission-maker/dcs-radio-specs.md
@@ -1,39 +1,40 @@
-# DCS Radio Frequency Specifications
+# Spécifications des fréquences radio DCS
 
-Reference table of valid radio frequency ranges for all DCS player-flyable aircraft.
-Used by `inject-presets` to validate that frequencies defined in `presets.yaml` are
-compatible with the target aircraft's radio hardware.
+Table de référence des plages de fréquences radio valides pour tous les appareils DCS pilotables
+par les joueurs. Utilisée par `inject-presets` pour vérifier que les fréquences définies dans
+`presets.yaml` sont compatibles avec le matériel radio de l'appareil cible.
 
-> **Source**: [dcs-lua-datamine](https://github.com/Quaggles/dcs-lua-datamine)  
-> Re-generate with `poetry run update-radio-specs` after a DCS patch.
+> **Source** : [dcs-lua-datamine](https://github.com/Quaggles/dcs-lua-datamine)  
+> Régénérez avec `poetry run update-radio-specs` après un patch DCS.
 
 ---
 
-## Critical aircraft (`dcs_rejects_on_load`)
+## Appareils critiques (`dcs_rejects_on_load`)
 
-Some aircraft raise a hard DCS error when the mission loads if any preset frequency is outside
-their valid radio range. These are flagged `dcs_rejects_on_load: true` in `dcs-radio-specs.yaml`
-and always emit a `WARNING` during `veaf-tools build`.
+Certains appareils provoquent une erreur DCS bloquante au chargement de la mission si une fréquence
+de preset se trouve hors de leur plage radio valide. Ils sont marqués `dcs_rejects_on_load: true`
+dans `dcs-radio-specs.yaml` et émettent toujours un `WARNING` pendant `veaf-tools build`.
 
-Currently known critical aircraft:
+Appareils critiques actuellement connus :
 
-| Aircraft | DCS ID | Valid range |
-|----------|--------|-------------|
+| Appareil | ID DCS | Plage valide |
+|----------|--------|--------------|
 | MiG-19P | `MiG-19P` | 100–150 MHz |
-| Gazelle SA342M | `SA342M` | 30–87.975 MHz (FM only) |
+| Gazelle SA342M | `SA342M` | 30–87.975 MHz (FM uniquement) |
 
-For other aircraft, DCS stores the frequencies silently without crashing. Issues are still
-reported in the automatic `presets-validation-report.md` generated after each build.
+Pour les autres appareils, DCS enregistre les fréquences silencieusement sans planter. Les
+problèmes restent signalés dans le `presets-validation-report.md` généré automatiquement après
+chaque build.
 
-If you discover another aircraft that causes DCS to reject the mission, add
-`dcs_rejects_on_load: true` to its entry in `src/python/veaf-tools/presets_injector/data/dcs-radio-specs.yaml`
-and open a pull request.
+Si vous découvrez un autre appareil qui pousse DCS à rejeter la mission, ajoutez
+`dcs_rejects_on_load: true` à son entrée dans
+`src/python/veaf-tools/presets_injector/data/dcs-radio-specs.yaml` et ouvrez une pull request.
 
 ---
 
-## Fixed-wing aircraft
+## Avions
 
-| Aircraft | DCS ID | Radio | Min (MHz) | Max (MHz) | Modulation |
+| Appareil | ID DCS | Radio | Min (MHz) | Max (MHz) | Modulation |
 |----------|--------|-------|----------:|----------:|------------|
 | **TurboFan** | `A-10C` | VHF AM: ARC-186 | 116.000 | 151.975 | AM / FM |
 |  |  | UHF AM: ARC-164 | 225.000 | 399.975 | AM / FM |
@@ -214,9 +215,9 @@ and open a pull request.
 |  |  | BC-1206 | 100.000 | 200.000 | AM / FM |
 | **Radial** | `Yak-52` | ARK-15M | 0.100 | 1.795 | AM / FM |
 
-## Helicopters
+## Hélicoptères
 
-| Aircraft | DCS ID | Radio | Min (MHz) | Max (MHz) | Modulation |
+| Appareil | ID DCS | Radio | Min (MHz) | Max (MHz) | Modulation |
 |----------|--------|-------|----------:|----------:|------------|
 | **TurboShaft** | `AH-64D_BLK_II` | ARC-186 | 108.000 | 151.975 | AM / FM |
 |  |  | ARC-164 | 225.000 | 399.975 | AM / FM |

--- a/doc/mission-maker/scripts/veafAirWaves.en.md
+++ b/doc/mission-maker/scripts/veafAirWaves.en.md
@@ -38,9 +38,9 @@ local defenseZone = AirWaveZone:new()
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   AIRWAVES:
-    enable: true          # default: true
+    enabled: true          # default: true
     logLevel: info        # optional log level override
     airwave_zones:
       - name: "BVR Zone"                  # REQUIRED — internal identifier
@@ -118,9 +118,9 @@ lua_modules:
 ### Minimal example
 
 ```yaml
-lua_modules:
+modules:
   AIRWAVES:
-    enable: true
+    enabled: true
     airwave_zones:
       - name: "BVR Arena"
         start: true

--- a/doc/mission-maker/scripts/veafAirWaves.md
+++ b/doc/mission-maker/scripts/veafAirWaves.md
@@ -35,9 +35,9 @@ local defenseZone = AirWaveZone:new()
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   AIRWAVES:
-    enable: true          # défaut : true
+    enabled: true          # défaut : true
     logLevel: info        # surcharge optionnelle du niveau de log
     airwave_zones:
       - name: "Zone BVR"                  # REQUIS — identifiant interne
@@ -115,9 +115,9 @@ lua_modules:
 ### Exemple minimal
 
 ```yaml
-lua_modules:
+modules:
   AIRWAVES:
-    enable: true
+    enabled: true
     airwave_zones:
       - name: "Arène BVR"
         start: true

--- a/doc/mission-maker/scripts/veafAirWaves.md
+++ b/doc/mission-maker/scripts/veafAirWaves.md
@@ -165,22 +165,88 @@ modules:
 
 ---
 
-## Vagues
+## Définition d'une vague
 
-Chaque vague est une liste de noms de groupes DCS. Tous les groupes d'une vague apparaissent simultanément. La vague suivante se déclenche quand tous les groupes de la vague courante sont détruits.
+`addWave(...)` accepte plusieurs formes — de la plus simple à la plus puissante :
 
 ```lua
-:addWave({ "BanditsA", "BanditsB" })   -- vague 1 : deux groupes apparaissent en même temps
-:addWave({ "BanditsC" })               -- vague 2 : un groupe
-:addWave({ "BanditsD", "BanditsE", "BanditsF" })  -- vague 3
+-- Un seul nom de groupe
+:addWave("Bandits Alpha")
+
+-- Plusieurs noms de groupes d'un coup
+:addWave("Bandits Alpha", "Bandits Bravo")
+
+-- Une table de noms de groupes
+:addWave({ "Bandits Alpha", "Bandits Bravo", "Bandits Charlie" })
+
+-- Une table de paramètres avec contrôle complet
+:addWave({
+  groups  = { "Fighter 1", "Fighter 2", "Fighter 3", "Fighter 4", "Fighter 5" },
+  number  = "1-3",   -- choisir entre 1 et 3 de ces groupes au hasard
+  bias    = 2,        -- démarrer le tirage aléatoire au 3e groupe (index 2+1)
+  delay   = 30,       -- attendre 30 s avant la vague suivante une fois celle-ci nettoyée
+})
 ```
+
+### `number` — contrôler combien de groupes apparaissent
+
+`number` définit combien de groupes de la liste apparaissent réellement. Valeurs possibles :
+- un entier : `number = 2` fait toujours apparaître exactement 2 groupes ;
+- une plage sous forme de chaîne : `number = "2-4"` fait apparaître 2, 3 ou 4 groupes au hasard.
+
+Si `number` dépasse la longueur de la liste, un même groupe peut être tiré plusieurs fois — utile pour faire apparaître plusieurs exemplaires de la même menace.
+
+### `bias` — pencher vers les variantes plus difficiles
+
+`bias` décale l'index de départ du tirage aléatoire vers la fin de la liste. Un `bias` de 0 (défaut) tire uniformément dans toute la liste. Un `bias` de 3 sur une liste de 6 groupes rend les 3 premières entrées moins susceptibles d'être choisies.
+
+Le motif typique consiste à ordonner les groupes du plus facile au plus difficile — en début de campagne, `bias` reste à 0, puis vous l'augmentez au fil du temps pour rendre l'opposition progressivement plus dangereuse :
+
+```lua
+-- Un pool de vagues ordonné par difficulté. Ajustez bias= dynamiquement dans des callbacks.
+:addWave({
+  groups = {
+    "Su-25 Flight",       -- 1 : facile
+    "Su-25T Flight",      -- 2 : moyen
+    "Su-27 Flight",       -- 3 : difficile
+    "Su-30SM Flight",     -- 4 : très difficile
+  },
+  number = "1-2",
+  bias   = 0,   -- démarrer facile ; monter à 2 plus tard dans la mission
+})
+```
+
+### `delay` — vagues simultanées
+
+Lorsque `delay` est **négatif**, la vague suivante apparaît immédiatement après celle-ci — sans attendre sa destruction. Cela permet d'envoyer plusieurs paquets de menaces en même temps :
+
+```lua
+:addWave({ groups = { "Fighter Escort" }, delay = -1 })  -- décolle en même temps que...
+:addWave({ groups = { "Strike Package" } })              -- ...cette vague
+```
+
+### Commandes VEAF comme groupes
+
+Au lieu d'un nom de groupe DCS, vous pouvez utiliser n'importe quelle commande de spawn VEAF (la même syntaxe qu'un marqueur de la carte F10). La commande est exécutée à la position d'apparition, ajustable avec un préfixe `[latDelta,lonDelta]` (en mètres, relatif au centre de la zone) :
+
+```lua
+:addWave({
+  groups = {
+    "[0,5000]-spawn su-27, country russia",           -- 5 km au nord du centre de la zone
+    "[-3000,0]-spawn su-25, alt 100, country russia", -- 3 km au sud, basse altitude
+  }
+})
+```
+
+Cela permet de monter facilement des menaces étagées venant de directions différentes, sans pré-placer de groupes dans l'éditeur de mission DCS.
 
 ---
 
-## Exemple
+## Exemples
+
+### Zone d'interception basique à trois vagues
 
 ```lua
--- Zone nécessitant 2 joueurs humains avec 3 vagues
 AirWaveZone:new()
   :setName("Intercept-West")
   :setZoneName("ZONE-WEST-INTERCEPT")
@@ -193,6 +259,66 @@ AirWaveZone:new()
   :setOnCompleted(function()
     trigger.action.setUserFlag("WEST_CLEAR", true)
   end)
+  :initialize()
+```
+
+### Vagues aléatoires à difficulté croissante
+
+```lua
+AirWaveZone:new()
+  :setName("Intercept-East")
+  :setZoneName("ZONE-EAST-INTERCEPT")
+  :setDescription("Axe de menace est — difficulté progressive")
+  -- Vague 1 : tirer 1 ou 2 chasseurs légers dans un pool
+  :addWave({
+    groups = { "MiG-21 Flight", "MiG-23 Flight", "MiG-29 Flight", "Su-27 Flight" },
+    number = "1-2",
+    bias   = 0,
+    delay  = 120,   -- 2 minutes de répit avant la vague 2
+  })
+  -- Vague 2 : chasseurs moyens, pool un peu plus difficile
+  :addWave({
+    groups = { "MiG-29 Flight", "Su-27 Flight", "Su-30SM Flight" },
+    number = 2,
+    bias   = 1,
+    delay  = 60,
+  })
+  -- Vague 3 : escorte lourde + attaque au sol simultanée (delay négatif)
+  :addWave({ groups = { "Su-27 Escort" }, delay = -1 })
+  :addWave({ groups = { "Su-24M Strike" } })
+  :setMinimumPlayersForWave(2)
+  :setDrawZone(true)
+  :initialize()
+```
+
+### Réutiliser une zone modèle par copie profonde
+
+Quand plusieurs secteurs partagent la même structure de vagues, définissez une zone modèle et clonez-la. Utilisez `:resetWaves()` pour vider les vagues du modèle avant d'ajouter celles propres au secteur :
+
+```lua
+-- Définir un modèle partagé (PAS encore initialisé)
+local zoneTemplate = AirWaveZone:new()
+  :setMinimumPlayersForWave(1)
+  :setDrawZone(true)
+  :addWave({ "MiG-29 Wave 1" })
+  :addWave({ "Su-27 Wave 2" })
+
+-- Cloner et personnaliser pour chaque secteur
+local zoneNorth = mist.utils.deepCopy(zoneTemplate)
+zoneNorth
+  :setName("AW-North")
+  :setZoneName("ZONE-AW-NORTH")
+  :setDescription("Secteur nord")
+  :initialize()
+
+local zoneSouth = mist.utils.deepCopy(zoneTemplate)
+zoneSouth
+  :setName("AW-South")
+  :setZoneName("ZONE-AW-SOUTH")
+  :setDescription("Secteur sud")
+  :resetWaves()                          -- vider les vagues du modèle
+  :addWave({ "Su-25T Wave 1" })          -- ajouter les vagues propres au secteur
+  :addWave({ "Su-24M Wave 2", "Su-24M Wave 2b" })
   :initialize()
 ```
 

--- a/doc/mission-maker/scripts/veafAssets.en.md
+++ b/doc/mission-maker/scripts/veafAssets.en.md
@@ -31,9 +31,9 @@ Must be called after defining `veafAssets.Assets`.
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   ASSETS:
-    enable: true          # default: true
+    enabled: true          # default: true
     logLevel: info        # optional log level override
     assets:               # list of persistent assets to manage
       - sort: 1                         # sort order in F10 menu (lower = first)
@@ -65,9 +65,9 @@ lua_modules:
 ### Minimal example
 
 ```yaml
-lua_modules:
+modules:
   ASSETS:
-    enable: true
+    enabled: true
     assets:
       - sort: 1
         name: "Texaco"

--- a/doc/mission-maker/scripts/veafAssets.md
+++ b/doc/mission-maker/scripts/veafAssets.md
@@ -30,9 +30,9 @@ Doit être appelé après avoir défini `veafAssets.Assets`.
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   ASSETS:
-    enable: true          # défaut : true
+    enabled: true          # défaut : true
     logLevel: info        # surcharge optionnelle du niveau de log
     assets:               # liste des ressources persistantes à gérer
       - sort: 1                         # ordre de tri dans le menu F10 (plus petit = premier)
@@ -64,9 +64,9 @@ lua_modules:
 ### Exemple minimal
 
 ```yaml
-lua_modules:
+modules:
   ASSETS:
-    enable: true
+    enabled: true
     assets:
       - sort: 1
         name: "Texaco"

--- a/doc/mission-maker/scripts/veafCarrierOperations.en.md
+++ b/doc/mission-maker/scripts/veafCarrierOperations.en.md
@@ -43,9 +43,9 @@ Or let `veafAssets` handle registration automatically when a carrier asset has `
 Carrier operations are enabled via the `CARRIER` module ID. Carrier definitions are typically declared through the `ASSETS` module (see [veafAssets — Configuration](veafAssets.md#configuration-missionyaml)).
 
 ```yaml
-lua_modules:
+modules:
   CARRIER:
-    enable: true          # default: true
+    enabled: true          # default: true
     logLevel: info        # optional log level override
     init:
       include_carrier_operations_radio: true  # add carrier menu to F10 (default: true)
@@ -60,9 +60,9 @@ lua_modules:
 ### Minimal example
 
 ```yaml
-lua_modules:
+modules:
   CARRIER:
-    enable: true
+    enabled: true
 ```
 
 ---

--- a/doc/mission-maker/scripts/veafCarrierOperations.md
+++ b/doc/mission-maker/scripts/veafCarrierOperations.md
@@ -42,9 +42,9 @@ Ou laisser `veafAssets` gérer l'enregistrement automatiquement quand une ressou
 Les opérations de porte-avions sont activées via l'ID de module `CARRIER`. Les définitions de porte-avions sont généralement déclarées via le module `ASSETS` (voir [veafAssets — Configuration](veafAssets.md#configuration-missionyaml)).
 
 ```yaml
-lua_modules:
+modules:
   CARRIER:
-    enable: true          # défaut : true
+    enabled: true          # défaut : true
     logLevel: info        # surcharge optionnelle du niveau de log
     init:
       include_carrier_operations_radio: true  # ajouter le menu carrier au F10 (défaut : true)
@@ -59,9 +59,9 @@ lua_modules:
 ### Exemple minimal
 
 ```yaml
-lua_modules:
+modules:
   CARRIER:
-    enable: true
+    enabled: true
 ```
 
 ---

--- a/doc/mission-maker/scripts/veafCasMission.en.md
+++ b/doc/mission-maker/scripts/veafCasMission.en.md
@@ -35,12 +35,12 @@ veafCasMission.start()
 `veafCasMission` itself has no YAML-configurable fields. However, **CAP missions** and **Combat missions** (managed by the `COMBATMISSION` module) are declared in top-level `mission.yaml` sections.
 
 ```yaml
-lua_modules:
+modules:
   CASMISSION:
-    enable: true          # default: true
+    enabled: true          # default: true
     logLevel: info        # optional log level override
   COMBATMISSION:
-    enable: true          # required for cap_missions: and combat_missions:
+    enabled: true          # required for cap_missions: and combat_missions:
 
 # ── CAP missions ──────────────────────────────────────────────────────────
 cap_missions:
@@ -94,9 +94,9 @@ combat_missions:
 ### Minimal example
 
 ```yaml
-lua_modules:
+modules:
   COMBATMISSION:
-    enable: true
+    enabled: true
 
 cap_missions:
   - group_name: "CAP-Alpha"

--- a/doc/mission-maker/scripts/veafCasMission.md
+++ b/doc/mission-maker/scripts/veafCasMission.md
@@ -34,12 +34,12 @@ veafCasMission.start()
 `veafCasMission` lui-même n'a pas de champs configurables en YAML. Cependant, les **missions CAP** et les **missions de combat** (gérées par le module `COMBATMISSION`) sont déclarées dans des sections de premier niveau de `mission.yaml`.
 
 ```yaml
-lua_modules:
+modules:
   CASMISSION:
-    enable: true          # défaut : true
+    enabled: true          # défaut : true
     logLevel: info        # surcharge optionnelle du niveau de log
   COMBATMISSION:
-    enable: true          # requis pour cap_missions: et combat_missions:
+    enabled: true          # requis pour cap_missions: et combat_missions:
 
 # ── Missions CAP ──────────────────────────────────────────────────────────────
 cap_missions:
@@ -93,9 +93,9 @@ combat_missions:
 ### Exemple minimal
 
 ```yaml
-lua_modules:
+modules:
   COMBATMISSION:
-    enable: true
+    enabled: true
 
 cap_missions:
   - group_name: "CAP-Alpha"

--- a/doc/mission-maker/scripts/veafCombatZone.en.md
+++ b/doc/mission-maker/scripts/veafCombatZone.en.md
@@ -32,9 +32,9 @@ Individual zones are created and initialised separately (see below).
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   COMBATZONE:
-    enable: true          # default: true
+    enabled: true          # default: true
     logLevel: info        # optional log level override
     combat_zone_settings: # optional global overrides
       event_message_combatzonecomplete: "Zone objective complete!"  # null = suppress
@@ -98,9 +98,9 @@ lua_modules:
 ### Minimal example
 
 ```yaml
-lua_modules:
+modules:
   COMBATZONE:
-    enable: true
+    enabled: true
     combat_zones:
       - type: zone
         zone_name: "CZ-Alpha"

--- a/doc/mission-maker/scripts/veafCombatZone.md
+++ b/doc/mission-maker/scripts/veafCombatZone.md
@@ -31,9 +31,9 @@ Les zones individuelles sont créées et initialisées séparément (voir ci-des
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   COMBATZONE:
-    enable: true          # défaut : true
+    enabled: true          # défaut : true
     logLevel: info        # surcharge optionnelle du niveau de log
     combat_zone_settings: # surcharges globales optionnelles
       event_message_combatzonecomplete: "Objectif de zone atteint !"  # null = supprimer
@@ -97,9 +97,9 @@ lua_modules:
 ### Exemple minimal
 
 ```yaml
-lua_modules:
+modules:
   COMBATZONE:
-    enable: true
+    enabled: true
     combat_zones:
       - type: zone
         zone_name: "CZ-Alpha"

--- a/doc/mission-maker/scripts/veafCombatZone.md
+++ b/doc/mission-maker/scripts/veafCombatZone.md
@@ -120,6 +120,70 @@ modules:
 
 ---
 
+## Fonctionnement
+
+Placez toutes les unités qui doivent apparaître dans la zone directement dans l'éditeur de mission DCS, à l'intérieur de la trigger zone. Au démarrage de la mission, VEAF les retire toutes — la zone est vide. Quand un joueur active la zone via le menu F10, toutes les unités réapparaissent à des positions aléatoires dans le rayon de la zone. Quand toutes les unités ennemies sont détruites, la zone est marquée comme terminée (un callback optionnel se déclenche, les zones chaînées optionnelles s'activent).
+
+Cette approche vous donne une conception entièrement visuelle dans l'éditeur tout en gardant la zone inactive au démarrage de la mission.
+
+### Mise en place dans l'éditeur de mission DCS
+
+1. **Créez une trigger zone** — définissez la zone de combat. Nommez-la, par exemple `ZONE-ALPHA`.
+2. **Placez des groupes d'unités** à l'intérieur de la zone. Mettez-les dans n'importe quelle coalition — VEAF gère leur cycle de vie.
+3. **Utilisez les tags de nom d'unité** (voir ci-dessous) pour personnaliser le comportement d'apparition par groupe.
+4. **Enregistrez la zone** dans `mission-script.lua` :
+
+```lua
+VeafCombatZone:new()
+  :setName("Alpha")
+  :setZoneName("ZONE-ALPHA")
+  :setDescription("Strike Alpha — Colonne blindée")
+  :initialize()
+```
+
+`veafCombatZone.initialize()` doit d'abord être appelé au niveau du module.
+
+---
+
+## Tags de nom d'unité
+
+Les noms d'unités et de groupes dans l'éditeur de mission DCS peuvent porter des tags spéciaux qui contrôlent la façon dont VEAF les traite à l'activation de la zone. Les tags sont intégrés dans le nom et n'affectent pas DCS lui-même.
+
+| Tag | Exemple | Description |
+|-----|---------|-------------|
+| `#spawnradius=N` | `#spawnradius=200` | Rayon de dispersion en mètres autour du centre de la zone pour ce groupe |
+| `#spawnchance=N` | `#spawnchance=50` | Probabilité en pourcentage (0–100) que ce groupe apparaisse réellement |
+| `#spawncount=N` | `#spawncount=3` | Nombre d'exemplaires à faire apparaître (peut être >1 pour des unités répétées) |
+| `#spawngroup="name"` | `#spawngroup="SAM"` | Remplace le nom du groupe d'apparition (utile pour cibler un modèle nommé) |
+| `#spawndelay=N` | `#spawndelay=120` | Délai en secondes avant l'apparition de ce groupe après l'activation de la zone |
+| `#command="cmd"` | `#command="-spawn sa-11"` | Exécute une commande VEAF au lieu de faire apparaître ce groupe ; l'unité sert de déclencheur et est détruite |
+
+### Exemple pratique — embuscade MANPADS
+
+Vous voulez quatre positions de MANPADS dans une zone, mais seules deux devraient réellement être occupées. Placez quatre unités d'infanterie factices nommées :
+
+```
+ALPHA-MANPAD-1 #spawnchance=50
+ALPHA-MANPAD-2 #spawnchance=50
+ALPHA-MANPAD-3 #spawnchance=50
+ALPHA-MANPAD-4 #spawnchance=50
+```
+
+Chaque position a 50 % de chances d'apparaître — statistiquement, environ deux seront actives à chaque déclenchement de la zone.
+
+### `#command` — apparition via la syntaxe de marqueur VEAF
+
+Le tag `#command` transforme une unité en déclencheur à usage unique. À l'activation de la zone, VEAF exécute la commande à la position de l'unité et détruit l'unité. C'est l'équivalent du dépôt d'un marqueur de carte à cet endroit.
+
+```
+SPAWN-SA11 #command="-spawn sa-11, side red"
+CONVOY-TRIGGER #command="-convoy from ZONE-ALPHA to ZONE-BRAVO"
+```
+
+Cela permet de monter des apparitions complexes (batterie SA-11, convois avec routes IA) sans aucun code Lua.
+
+---
+
 ## Définir une zone
 
 ```lua
@@ -209,6 +273,50 @@ VeafCombatOperation:new()
   :setBriefing("Détruire les deux colonnes blindées avant qu'elles atteignent Senaki.")
   :initialize()
 ```
+
+`VeafCombatOperation` étend `VeafCombatZone` — toutes les méthodes du builder ci-dessus s'appliquent, et l'opération elle-même apparaît dans le menu radio comme une seule entrée activable.
+
+---
+
+## Chaînage de zones
+
+Une zone peut activer automatiquement une ou plusieurs zones suivantes lorsqu'elle est terminée. Cela permet de construire des progressions de campagne dynamiques sans scripting manuel :
+
+```lua
+VeafCombatZone:new()
+  :setName("Strike Alpha")
+  :setZoneName("ZONE-ALPHA")
+  :addChainedCombatZone("Strike Bravo")     -- se déclenche quand Alpha est terminée
+  :addChainedCombatZone("Strike Charlie")   -- l'une est choisie au hasard
+  :setChainedCombatZonesDelay(60)           -- attendre 60 s avant le chaînage
+  :initialize()
+```
+
+Quand plusieurs zones chaînées sont définies, **une seule est tirée au hasard** — utile pour des scénarios à embranchements ou pour éviter la prévisibilité.
+
+| Méthode | Description |
+|---------|-------------|
+| `:addChainedCombatZone(name)` | Ajouter une zone à déclencher après la complétion |
+| `:setChainedCombatZonesDelay(s)` | Secondes à attendre avant le chaînage (défaut : 0) |
+
+---
+
+## Mode entraînement
+
+Mettre une zone en mode entraînement change deux choses :
+
+- **Pas de sécurité** : n'importe quel joueur peut activer ou désactiver la zone via le menu radio (normalement l'activation de la zone est journalisée et peut être restreinte par `/secu login`).
+- **État détaillé** : le message d'info de la zone liste les unités restantes et leurs positions approximatives (via fumée ou relèvements), donnant aux pilotes une vue claire de ce qu'il reste.
+
+```lua
+VeafCombatZone:new()
+  :setName("Training-A")
+  :setZoneName("ZONE-TRAINING-A")
+  :setTraining(true)
+  :initialize()
+```
+
+Le mode entraînement est idéal pour des scénarios d'entraînement BFM / CAS où les pilotes ont besoin de connaître les positions des unités.
 
 ---
 

--- a/doc/mission-maker/scripts/veafInterpreter.md
+++ b/doc/mission-maker/scripts/veafInterpreter.md
@@ -1,0 +1,130 @@
+# veafInterpreter — Commandes embarquées dans les unités
+
+
+**ID du module :** `INTERPRETER` | **Version :** 1.6.x | **Fichier :** `veafInterpreter.lua`
+
+---
+
+## Objectif
+
+L'interpréteur VEAF permet d'embarquer des commandes VEAF directement dans le nom des unités ou objets statiques de l'éditeur de mission DCS, sans écrire la moindre ligne de Lua. Au démarrage de la mission, l'interpréteur parcourt toutes les unités, détecte les commandes embarquées, les exécute, puis supprime l'unité déclencheuse.
+
+Résultat : toute votre configuration d'apparition (spawn) vit dans l'éditeur DCS sous forme d'unités nommées — pas de scripts, pas de triggers, pas de magie.
+
+---
+
+## Fonctionnement
+
+1. Placez une unité (ou un objet statique) dans l'éditeur de mission DCS, n'importe où sur la carte.
+2. Nommez-la avec la balise `#veafInterpreter["command"]` — où `command` est n'importe quelle commande de marqueur VEAF.
+3. Une seconde après le démarrage de la mission, l'interpréteur parcourt toutes les unités de la base de données de la mission.
+4. Pour chaque unité portant une balise valide, il exécute la commande à la position de cette unité, puis **détruit l'unité** (et son groupe).
+
+La position de l'unité devient la position de la commande — parfait pour des configurations de JTAC, des points de passage de convois, ou des emplacements de batteries SAM que vous voulez positionner visuellement dans l'éditeur.
+
+Si l'unité hôte appartient à un groupe doté de **points de passage**, ces points de passage sont transmis aux groupes générés. Les convois et patrouilles générés ainsi suivront la route que vous avez tracée dans l'éditeur.
+
+---
+
+## Convention de nommage des unités
+
+```
+#veafInterpreter["<command>"]
+```
+
+La balise peut apparaître n'importe où dans le nom de l'unité. Le texte avant et après est ignoré — ce qui est utile pour rendre les noms d'unités uniques quand DCS l'exige :
+
+```
+#veafInterpreter["-spawn sa-11, side red"] #001
+#veafInterpreter["-spawn sa-11, side red"] #002
+```
+
+Les deux unités portent la même commande mais ont des noms différents.
+
+---
+
+## Syntaxe des commandes
+
+La commande à l'intérieur de la balise utilise la même syntaxe que les marqueurs de la carte F10 — le préfixe `-` suivi d'une commande VEAF et de ses options :
+
+```
+-spawn sa-11, side red
+-jtac, laserCode 1688
+-convoy from ZONE-A to ZONE-B
+-arty, rounds 10
+```
+
+Toutes les commandes comprises par le système de marqueurs VEAF fonctionnent ici. Voir la [référence des commandes VEAF](../../LUA_API_REFERENCE.md) pour la liste complète.
+
+---
+
+## Exemples
+
+### JTAC à une position fixe
+
+Placez une unité d'infanterie factice nommée :
+```
+#veafInterpreter["-jtac, laserCode 1688, smoke red"]
+```
+
+Au démarrage de la mission, l'interpréteur crée un JTAC à cette position avec le code laser 1688 et déclenche une fumée rouge. L'infanterie factice disparaît.
+
+### Batterie SA-11
+
+```
+#veafInterpreter["-spawn sa-11, side red, defense 2, size 2"]
+```
+
+Une batterie SA-11 complète apparaît à la position de l'unité dans l'éditeur. Ajustez `defense` et `size` selon vos besoins.
+
+### Convoi suivant une route tracée dans l'éditeur
+
+1. Dans l'éditeur DCS, créez un groupe terrestre et tracez des **points de passage** de A vers B.
+2. Nommez le groupe (ou une unité du groupe) :
+   ```
+   #veafInterpreter["-convoy, defense 1, size 8, patrol"]
+   ```
+3. Au démarrage de la mission, l'interpréteur crée un convoi à la position du groupe, suivant la route tracée. Le groupe d'origine est détruit.
+
+### Plusieurs sites SAM avec des noms uniques
+
+```
+#veafInterpreter["-spawn sa-10, side red"] NORTH-01
+#veafInterpreter["-spawn sa-10, side red"] NORTH-02
+#veafInterpreter["-spawn sa-6, side red"]  SOUTH-01
+```
+
+### Artillerie en position défensive
+
+```
+#veafInterpreter["-arty, rounds 20, defense 2"]
+```
+
+---
+
+## Configuration
+
+L'interpréteur ne nécessite aucune configuration par mission. Le seul réglage est le délai de démarrage :
+
+```lua
+-- À changer avant l'appel à initialize() (défaut : 1 seconde)
+veafInterpreter.DelayForStartup = 3
+```
+
+Augmentez cette valeur si votre mission charge de nombreux scripts en parallèle et que l'interpréteur se déclenche avant que les autres modules ne soient prêts.
+
+---
+
+## Astuces
+
+- Utilisez un type d'unité visuellement représentatif pour bien voir les positions d'apparition dans l'éditeur (par exemple un soldat pour un JTAC, un type de radar SAM pour un élément d'IADS).
+- L'activation différée (*late-activation*) n'est pas requise pour les unités portant des balises d'interpréteur — VEAF les détruira de toute façon, mais l'activation différée évite qu'elles n'apparaissent brièvement en jeu.
+- L'interpréteur effectue un balayage unique. Il ne se relance pas pendant la mission.
+
+---
+
+## Voir aussi
+
+- [veafSpawn](veafSpawn.md) — commandes d'apparition manuelles
+- [veafCombatZone](veafCombatZone.md) — zones activables (la balise `#command` dans les noms d'unités utilise le même mécanisme)
+- [Référence de l'API Lua](../../LUA_API_REFERENCE.md) — API complète de `veafInterpreter`

--- a/doc/mission-maker/scripts/veafNamedPoints.en.md
+++ b/doc/mission-maker/scripts/veafNamedPoints.en.md
@@ -29,9 +29,9 @@ veafNamedPoints.initialize()
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   NAMEDPOINTS:
-    enable: true          # default: true
+    enabled: true          # default: true
     logLevel: info        # optional log level override
     custom_points:        # pre-defined named points
       - name: "Battle Area Alpha"    # point name (referenced in commands)
@@ -56,9 +56,9 @@ lua_modules:
 ### Minimal example
 
 ```yaml
-lua_modules:
+modules:
   NAMEDPOINTS:
-    enable: true
+    enabled: true
     custom_points:
       - name: "BULLSEYE"
         lat: "41.100000"

--- a/doc/mission-maker/scripts/veafNamedPoints.md
+++ b/doc/mission-maker/scripts/veafNamedPoints.md
@@ -28,9 +28,9 @@ veafNamedPoints.initialize()
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   NAMEDPOINTS:
-    enable: true          # défaut : true
+    enabled: true          # défaut : true
     logLevel: info        # surcharge optionnelle du niveau de log
     custom_points:        # points nommés prédéfinis
       - name: "Zone de Combat Alpha"  # nom du point (référencé dans les commandes)
@@ -55,9 +55,9 @@ lua_modules:
 ### Exemple minimal
 
 ```yaml
-lua_modules:
+modules:
   NAMEDPOINTS:
-    enable: true
+    enabled: true
     custom_points:
       - name: "BULLSEYE"
         lat: "41.100000"

--- a/doc/mission-maker/scripts/veafQraManager.en.md
+++ b/doc/mission-maker/scripts/veafQraManager.en.md
@@ -49,12 +49,12 @@ local myQra = VeafQRA:new()
 
 ## Configuration (`mission.yaml`)
 
-QRA definitions live in the **top-level `qra:` section** (not under `lua_modules:`). The `QRA` module must be enabled in `lua_modules:`.
+QRA definitions live in the **top-level `qra:` section** (not under `modules:`). The `QRA` module must be enabled in `modules:`.
 
 ```yaml
-lua_modules:
+modules:
   QRA:
-    enable: true          # default: true
+    enabled: true          # default: true
     logLevel: info        # optional log level override
 
 qra:
@@ -109,9 +109,9 @@ qra:
 ### Minimal example
 
 ```yaml
-lua_modules:
+modules:
   QRA:
-    enable: true
+    enabled: true
 
 qra:
   definitions:

--- a/doc/mission-maker/scripts/veafQraManager.md
+++ b/doc/mission-maker/scripts/veafQraManager.md
@@ -222,15 +222,64 @@ Par défaut, la QRA dispose d'un nombre illimité d'aéronefs. Utiliser ces mét
 
 ---
 
-## Machine à états QRA
+## Fonctionnement
+
+Une zone QRA surveille un volume d'espace aérien défini par une trigger zone DCS. Dès qu'un aéronef hostile y pénètre, la QRA décolle — à condition d'être prête. Quand la QRA est abattue, la zone entre en état de réarmement ; elle redevient active une fois les ennemis partis et le minuteur de réarmement expiré.
+
+### Machine à états
 
 ```
-PRÊTE ──(intrus entre)──> ACTIVE ──(QRA détruite)──> MORTE
-  ^                                                       |
-  └──────(tous les intrus partis + délai de réarmement)──┘
+STOP ──start()──► READY ──(intrus entre)──► ACTIVE ──(QRA détruite)──► DEAD
+  ▲                 ▲                                                      │
+  │                 └──────────(tous les intrus partis + délai réarm.)─────┘
+  │                                                     │
+  └──────────────────────────stop()────────────────────►┘
 ```
 
-États supplémentaires : `WILLREARM`, `OUT` (plus de groupes), `NOAIRBASE` (base aérienne détruite), `STOP` (désactivée manuellement).
+États complets :
+
+| État | Signification |
+|------|---------------|
+| `STOP` | Inactive — `stop()` a été appelé ou la QRA n'a jamais démarré |
+| `READY` | Armée et en surveillance d'intrus |
+| `READY_WAITINGFORMORE` | QRA décollée ; des intrus supplémentaires ont déclenché le déploiement de groupes additionnels |
+| `ACTIVE` | La QRA est en vol et en interception |
+| `DEAD` | La QRA a été détruite ; en attente des conditions de réarmement |
+| `WILLREARM` | Le minuteur de réarmement est en cours |
+| `OUT` | Plus d'aéronefs disponibles (stock épuisé) |
+| `NOAIRBASE` | La base aérienne liée a été détruite — la QRA se met en retrait |
+
+### Mise en place dans l'éditeur de mission DCS
+
+1. **Créez une trigger zone** — dessinez l'espace aérien à protéger. Donnez-lui un nom mémorable, par exemple `ZONE-QRA-NORTH`.
+2. **Placez le groupe QRA** — créez le groupe d'aéronefs qui décollera. Mettez-le en **Activation différée** (*Late Activation*) pour qu'il n'apparaisse pas au démarrage (VEAF gère l'activation). Donnez au groupe un nom distinctif, par exemple `MiG-29 QRA North`.
+3. **Reliez le tout dans `mission-script.lua`** (ou via `mission.yaml` → `qra:` pour l'approche YAML recommandée) :
+
+```lua
+VeafQRA:new()
+  :setName("QRA-North")
+  :setTriggerZone("ZONE-QRA-NORTH")
+  :setCoalition(coalition.side.RED)
+  :addGroup("MiG-29 QRA North")
+  :start()
+```
+
+C'est tout — aucune condition de trigger, aucune fonction planifiée. VEAF gère la détection, le décollage et le réarmement automatiquement.
+
+### Chaîne logistique
+
+Par défaut, une QRA dispose d'aéronefs en nombre illimité. Le système de logistique permet de modéliser un stock d'aérodrome fini avec ravitaillement optionnel — utile pour les missions persistantes de longue durée :
+
+| Paramètre | Rôle |
+|-----------|------|
+| `setQRAcount(n)` | Nombre total de groupes disponibles (sert de stock courant) |
+| `setQRAmaxCount(n)` | Plafond strict de groupes actifs simultanément |
+| `setQRAresupplyDelay(s)` | Secondes à attendre avant le démarrage d'un ravitaillement |
+| `setQRAminCountforResupply(n)` | Niveau de stock qui déclenche un ravitaillement |
+| `setQRAmaxResupplyCount(n)` | Nombre maximum de cycles de ravitaillement (`-1` = illimité) |
+| `setResupplyAmount(n)` | Groupes ajoutés par cycle de ravitaillement (défaut `1`) |
+
+Voyez cela comme un entrepôt : `QRAcount` est ce qui est en rayon, `resupplyDelay` le délai de livraison du camion, et `minCountforResupply` le point de recommande.
 
 ---
 

--- a/doc/mission-maker/scripts/veafQraManager.md
+++ b/doc/mission-maker/scripts/veafQraManager.md
@@ -48,12 +48,12 @@ local myQra = VeafQRA:new()
 
 ## Configuration (`mission.yaml`)
 
-Les définitions QRA vivent dans la **section de premier niveau `qra:`** (pas sous `lua_modules:`). Le module `QRA` doit être activé dans `lua_modules:`.
+Les définitions QRA vivent dans la **section de premier niveau `qra:`** (pas sous `modules:`). Le module `QRA` doit être activé dans `modules:`.
 
 ```yaml
-lua_modules:
+modules:
   QRA:
-    enable: true          # défaut : true
+    enabled: true          # défaut : true
     logLevel: info        # surcharge optionnelle du niveau de log
 
 qra:
@@ -108,9 +108,9 @@ qra:
 ### Exemple minimal
 
 ```yaml
-lua_modules:
+modules:
   QRA:
-    enable: true
+    enabled: true
 
 qra:
   definitions:

--- a/doc/mission-maker/scripts/veafRadio.en.md
+++ b/doc/mission-maker/scripts/veafRadio.en.md
@@ -39,9 +39,9 @@ This rebuilds the entire F10 tree. It is safe to call multiple times — it debo
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   RADIO:
-    enable: true          # default: true
+    enabled: true          # default: true
     logLevel: info        # optional log level override
     init:
       help_menus: true    # show built-in "Help" entries in radio menus (default: true)
@@ -56,9 +56,9 @@ lua_modules:
 ### Minimal example
 
 ```yaml
-lua_modules:
+modules:
   RADIO:
-    enable: true
+    enabled: true
 ```
 
 ---

--- a/doc/mission-maker/scripts/veafRadio.md
+++ b/doc/mission-maker/scripts/veafRadio.md
@@ -39,9 +39,9 @@ Cela reconstruit l'intégralité de l'arbre F10. L'appel est idempotent — il g
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   RADIO:
-    enable: true          # défaut : true
+    enabled: true          # défaut : true
     logLevel: info        # surcharge optionnelle du niveau de log
     init:
       help_menus: true    # afficher les entrées "Aide" intégrées dans les menus radio (défaut : true)
@@ -56,9 +56,9 @@ lua_modules:
 ### Exemple minimal
 
 ```yaml
-lua_modules:
+modules:
   RADIO:
-    enable: true
+    enabled: true
 ```
 
 ---

--- a/doc/mission-maker/scripts/veafRadio.md
+++ b/doc/mission-maker/scripts/veafRadio.md
@@ -154,6 +154,23 @@ veafRadio.addSecuredCommandToSubmenu(
 veafRadio.refreshRadioMenu()
 ```
 
+### Menus paginés
+
+Quand un sous-menu compte plus d'environ 9 entrées (limite DCS), utilisez les helpers paginés :
+
+```lua
+veafRadio.addPaginatedRadioMenu(
+  "All Zones",          -- titre du menu
+  parentMenu,           -- nœud du menu parent
+  veafRadio.addCommandToSubmenu,
+  myZonesList,          -- table d'éléments
+  "name",               -- attribut utilisé comme titre d'entrée
+  "sortKey"             -- attribut utilisé pour le tri (optionnel)
+)
+```
+
+Des pages de 10 sont créées automatiquement avec un sous-menu « Page suivante ».
+
 ---
 
 ## Exemples pratiques de fonctions de callback
@@ -223,6 +240,20 @@ veafRadio.createUserMenu(
             veafRadio.command("Décrémenter 127", veafSpawn.missionMasterDecrementFlagValue,   127)
         )
     )
+)
+```
+
+### Commande par groupe (ForGroup)
+
+Une entrée « Demander un appui aérien » qui apparaît une fois par patrouille connectée, en passant automatiquement le nom d'unité de ce groupe :
+
+```lua
+veafRadio.addCommandToSubmenu(
+  "Request CAS",
+  supportMenu,
+  myCasDispatch,      -- reçoit { originalParams, unitName } à l'exécution
+  {},
+  veafRadio.USAGE_ForGroup
 )
 ```
 

--- a/doc/mission-maker/scripts/veafSanctuary.en.md
+++ b/doc/mission-maker/scripts/veafSanctuary.en.md
@@ -39,9 +39,9 @@ VeafSanctuary:new()
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   SANCTUARY:
-    enable: true          # default: true
+    enabled: true          # default: true
     logLevel: info        # optional log level override
     sanctuary_zones:      # list of protected zones
       - name: "Carrier Zone"            # internal identifier
@@ -71,9 +71,9 @@ lua_modules:
 ### Minimal example
 
 ```yaml
-lua_modules:
+modules:
   SANCTUARY:
-    enable: true
+    enabled: true
     sanctuary_zones:
       - name: "Carrier Protection"
         polygon_units:

--- a/doc/mission-maker/scripts/veafSanctuary.md
+++ b/doc/mission-maker/scripts/veafSanctuary.md
@@ -38,9 +38,9 @@ VeafSanctuary:new()
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   SANCTUARY:
-    enable: true          # défaut : true
+    enabled: true          # défaut : true
     logLevel: info        # surcharge optionnelle du niveau de log
     sanctuary_zones:      # liste des zones protégées
       - name: "Zone Carrier"            # identifiant interne
@@ -70,9 +70,9 @@ lua_modules:
 ### Exemple minimal
 
 ```yaml
-lua_modules:
+modules:
   SANCTUARY:
-    enable: true
+    enabled: true
     sanctuary_zones:
       - name: "Protection Porte-Avions"
         polygon_units:

--- a/doc/mission-maker/scripts/veafShortcuts.en.md
+++ b/doc/mission-maker/scripts/veafShortcuts.en.md
@@ -33,9 +33,9 @@ This automatically registers the default alias list.
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   SHORTCUTS:
-    enable: true          # default: true
+    enabled: true          # default: true
     logLevel: info        # optional log level override
     shortcuts:            # custom alias definitions
       - name: "smoke"                 # alias name (used as -smoke in markers)
@@ -57,9 +57,9 @@ lua_modules:
 ### Minimal example
 
 ```yaml
-lua_modules:
+modules:
   SHORTCUTS:
-    enable: true
+    enabled: true
     shortcuts:
       - name: "cas"
         description: "Request CAS"

--- a/doc/mission-maker/scripts/veafShortcuts.en.md
+++ b/doc/mission-maker/scripts/veafShortcuts.en.md
@@ -89,16 +89,7 @@ veafShortcuts.AddAlias(
 
 ## Default Aliases Reference
 
-See the **[Aliases Reference](../../ALIASES.md)** for the complete list of all built-in aliases.
-
----
-
-## See also
-
-- [Aliases Reference](../../ALIASES.md) — full list of all built-in aliases
-- [veafSpawn](veafSpawn.md) — the underlying spawn engine
-- [veafSecurity](veafSecurity.md) — permission system
-
+The most common built-in aliases are grouped below. See the **[Aliases Reference](../../ALIASES.md)** for the complete list of all built-in aliases.
 
 ### Air Missions
 

--- a/doc/mission-maker/scripts/veafShortcuts.md
+++ b/doc/mission-maker/scripts/veafShortcuts.md
@@ -89,7 +89,40 @@ veafShortcuts.AddAlias(
 
 ## Référence des aliases par défaut
 
-Voir la **[Référence des Alias](../../ALIASES.fr.md)** pour la liste complète de tous les alias intégrés.
+Les aliases intégrés les plus courants sont regroupés ci-dessous. Voir la **[Référence des Alias](../../ALIASES.md)** pour la liste complète de tous les alias intégrés.
+
+### Missions aériennes
+
+| Alias | Description |
+|-------|-------------|
+| `-cap` | CAP dynamique (nécessite le nom de l'appareil) |
+| `-airstart` | Démarrer une mission de combat (nécessite un nom) |
+| `-airstop` | Arrêter une mission de combat (nécessite un nom) |
+| `-zonestart` | Activer une zone de combat (nécessite un nom) |
+| `-zonestop` | Désactiver une zone de combat (nécessite un nom) |
+
+### Radio
+
+| Alias | Description |
+|-------|-------------|
+| `-send` | Envoyer un message radio (nécessite `"MESSAGE"`) |
+| `-play` | Jouer un fichier son (nécessite `"NOMFICHIER"`) |
+
+### Mission Master
+
+| Alias | Description |
+|-------|-------------|
+| `-flag` | Lire la valeur d'un flag (nécessite un nom) |
+| `-flagon` | Mettre un flag à ON (nécessite un nom) |
+| `-flagoff` | Mettre un flag à OFF (nécessite un nom) |
+| `-run` | Exécuter un runnable (nécessite un nom) |
+
+### Commandes utilitaires
+
+| Alias | Description |
+|-------|-------------|
+| `-destroy` | Détruire toute unité dans un rayon de 100 m du marqueur |
+| `-ai_set` | Définir le handler IA d'un groupe terrestre |
 
 ---
 
@@ -101,7 +134,7 @@ La plupart des aliases respectent le système de sécurité (`veafSecurity`). Ce
 
 ## Voir aussi
 
-- [Référence des Alias](../../ALIASES.fr.md) — liste complète de tous les alias intégrés
+- [Référence des Alias](../../ALIASES.md) — liste complète de tous les alias intégrés
 - [veafSpawn](veafSpawn.md) — le moteur de spawn sous-jacent
 - [veafSecurity](veafSecurity.md) — système de permissions
 

--- a/doc/mission-maker/scripts/veafShortcuts.md
+++ b/doc/mission-maker/scripts/veafShortcuts.md
@@ -33,9 +33,9 @@ Cela enregistre automatiquement la liste d'aliases par défaut.
 ## Configuration (`mission.yaml`)
 
 ```yaml
-lua_modules:
+modules:
   SHORTCUTS:
-    enable: true          # défaut : true
+    enabled: true          # défaut : true
     logLevel: info        # surcharge optionnelle du niveau de log
     shortcuts:            # définitions d'aliases personnalisés
       - name: "smoke"                 # nom de l'alias (tapé en -smoke dans les marqueurs)
@@ -57,9 +57,9 @@ lua_modules:
 ### Exemple minimal
 
 ```yaml
-lua_modules:
+modules:
   SHORTCUTS:
-    enable: true
+    enabled: true
     shortcuts:
       - name: "cas"
         description: "Demander CAS"

--- a/doc/mission-maker/scripts/veafWeather.md
+++ b/doc/mission-maker/scripts/veafWeather.md
@@ -117,15 +117,26 @@ veafWeather.FOG_ANIMATED_30M_NO:activate()       -- dissipation en 30 minutes
 veafWeather.FOG_ANIMATED_5M_HEAVY:activate()     -- brouillard épais en 5 minutes
 ```
 
+### Activer un objet brouillard directement
+
+```lua
+veafWeather.setAndActivateFog(veafWeather.FOG_STATIC_MEDIUM)
+```
+
+C'est équivalent à appeler `:activate()` sur la constante. Tout brouillard actif précédemment est d'abord annulé.
+
 ### Déclencher un changement de brouillard depuis un trigger
 
 ```lua
+-- Sur un trigger DCS « Début phase de nuit », activer un brouillard épais
 mist.scheduleFunction(function()
     veafWeather.FOG_ANIMATED_15M_HEAVY:activate()
 end, {}, timer.getTime() + 0)
 ```
 
-### Commandes chat (hook serveur VEAF)
+---
+
+## Commandes chat / à distance
 
 | Commande | Effet |
 |----------|-------|

--- a/doc/pilot/GUIDE.en.md
+++ b/doc/pilot/GUIDE.en.md
@@ -1,7 +1,6 @@
 # Pilot Guide — VEAF Mission Creation Tools
 
-
-This guide is for players flying missions that use the VEAF script framework. No technical knowledge required.
+This guide is for players flying missions that use the VEAF framework. No technical knowledge is required: everything is done in-game, with the mouse and keyboard.
 
 ---
 
@@ -9,84 +8,88 @@ This guide is for players flying missions that use the VEAF script framework. No
 
 1. [What is VEAF MCT?](#what-is-veaf-mct)
 2. [Recognising a VEAF Mission](#recognising-a-veaf-mission)
-3. [F10 Radio Menu](#f10-radio-menu)
+3. [The F10 Radio Menu](#the-f10-radio-menu)
 4. [Marker Commands](#marker-commands)
-5. [Assets — Tankers, AWACS, Carriers](#assets)
-6. [Missions and Combat Zones](#missions-and-combat-zones)
+5. [Assets: Tankers, AWACS, Carriers](#assets)
+6. [Combat Zones and Missions](#combat-zones-and-missions)
 7. [CAS Training](#cas-training)
 8. [Security and Permissions](#security-and-permissions)
-9. [Tips by Aircraft Role](#tips-by-aircraft-role)
-10. [FAQ](#faq)
+9. [Tips for Your Aircraft](#tips-for-your-aircraft)
+10. [Frequently Asked Questions (FAQ)](#frequently-asked-questions-faq)
 11. [Community and Support](#community-and-support)
 
 ---
 
 ## What is VEAF MCT?
 
-VEAF Mission Creation Tools is a Lua script framework that makes DCS World missions dynamic and interactive. Instead of a static scenario, you can:
+VEAF Mission Creation Tools (VEAF MCT) makes DCS World missions alive and interactive. In a regular mission, everything is fixed in advance. With VEAF MCT, you can act while flying:
 
-- Spawn enemy units on demand via map markers or radio menu
-- Create CAS training zones with configurable difficulty
-- Activate predefined combat missions
-- Manage shared assets (tankers, AWACS, carriers) via F10 menu
-- Interact with the environment in real time
+- spawn enemy units on demand;
+- request a tanker, an AWACS or a carrier;
+- launch a Close Air Support (CAS) training session at the difficulty level of your choice;
+- activate combat missions prepared by the mission maker.
+
+These capabilities come from small programs — called **scripts** — that the mission maker has added. **You have nothing to install**: everything is already included in the mission. You give orders in two ways: through the **radio menu** (F10 key) or by **placing a marker** on the map.
 
 ---
 
 ## Recognising a VEAF Mission
 
-When a mission uses VEAF scripts you will see:
+Three signs tell you a mission uses VEAF:
 
-- Startup messages in the lower-right corner listing loaded VEAF modules
-- A **VEAF** submenu under **F10 → Other**
-- Map markers showing tanker tracks, AWACS orbits or combat zone positions
+1. **Startup messages** appear in the lower-right corner of the screen at launch, listing the loaded VEAF modules.
+2. **A "VEAF" submenu** appears under **F10 → Other**.
+3. **Map markers** show tanker tracks, AWACS orbits or combat zone positions.
+
+![VEAF startup messages in the lower-right corner](../assets/img/pilot/startup-messages.png)
 
 ---
 
-## F10 Radio Menu
+## The F10 Radio Menu
 
-All VEAF MCT features are accessible via **F10 → Other → VEAF**.
+All VEAF MCT features are available from **F10 → Other → VEAF**. (The radio menu is the list that opens with the F10 key; "Other" groups the commands added by the mission.)
 
-### Typical Menu Structure
-
-```
-F10 → Other → VEAF
-├── Assets
-│   ├── Tankers
-│   │   └── [Tanker name] → Info / Respawn
-│   ├── AWACS
-│   │   └── [AWACS name] → Info / Respawn
-│   └── Carriers
-│       └── [Carrier name] → Info / Start Recovery / Stop Recovery
-├── CAS Mission
-│   ├── Generate
-│   ├── Smoke
-│   ├── Flare
-│   ├── Skip
-│   ├── Info
-│   └── Cleanup
-├── Combat Zones
-│   └── [Zone name] → Activate / Deactivate / Info / Smoke / Flare
-├── Missions
-│   └── [Mission name] → Activate / Deactivate / Info
-└── Help
+```mermaid
+graph TD
+    F10[F10 Radio Menu] --> Other[Other] --> VEAF[VEAF]
+    VEAF --> Res[Assets]
+    VEAF --> CAS[CAS Mission]
+    VEAF --> CZ[Combat Zones]
+    VEAF --> Miss[Missions]
+    VEAF --> Help[Help]
+    Res --> Tank[Tankers]
+    Res --> AWACS[AWACS]
+    Res --> Carrier[Carriers]
 ```
 
-The exact structure depends on what the mission maker has enabled.
+![VEAF submenu in the F10 radio menu](../assets/img/pilot/f10-veaf-submenu.png)
+
+The exact contents depend on what the mission maker has enabled: some missions will not have every entry.
 
 ---
 
 ## Marker Commands
 
-Place a marker on the F10 map (right-click → Add marker), type a command in the text field, then confirm. VEAF MCT intercepts the marker, executes the command, and removes the marker.
+In addition to the radio menu, you can give orders by writing a **command in a marker** on the F10 map.
 
-> On multiplayer servers some commands require a password. See [Security](#security-and-permissions).
+**How to do it:**
 
-### Aliases (Shortcuts) — The Preferred Way
+1. Open the map (F10).
+2. Right-click → **Add marker**.
+3. Type the command in the marker's text field.
+4. Confirm.
 
-Aliases start with `-` and are the easiest way to spawn units. They are predefined by the mission maker and map to full spawn commands behind the scenes.
+VEAF detects the marker, runs the command at the marker's location, then removes it automatically.
 
-#### Common air-defense aliases
+![Typing a command into an F10 map marker](../assets/img/pilot/map-marker-add.png)
+
+> On multiplayer servers, some commands require a password. See [Security and Permissions](#security-and-permissions).
+
+### Aliases: the simplest method
+
+An **alias** is a shortcut prepared by the mission maker. It starts with a hyphen `-` and triggers a full command behind the scenes. It is the easiest way to spawn units: you only need to know the shortcut's name.
+
+**Common air-defence aliases:**
 
 | Alias | What spawns |
 |-------|-------------|
@@ -97,11 +100,11 @@ Aliases start with `-` and are the easiest way to spawn units. They are predefin
 | `-sa15` | SA-15 Gauntlet (Tor) vehicle |
 | `-sa22` | SA-22 Greyhound (Pantsir-S1) vehicle |
 | `-shilka` | ZSU-23-4 Shilka AAA |
-| `-manpads` | MANPAD squad |
+| `-manpads` | MANPADS squad (man-portable surface-to-air missiles) |
 | `-samLR` | Random long-range SAM battery |
 | `-samSR` | Random short-range SAM battery |
 
-#### Common vehicle/ship aliases
+**Common vehicle and ship aliases:**
 
 | Alias | What spawns |
 |-------|-------------|
@@ -112,22 +115,15 @@ Aliases start with `-` and are the easiest way to spawn units. They are predefin
 | `-mlrs` | MLRS rocket battery |
 | `-attack_convoy_red` | Red attack convoy |
 
-#### Utility aliases
+![Units spawned by an alias command, shown on the map](../assets/img/pilot/marker-units-spawned.png)
 
-| Alias | What it does |
-|-------|--------------|
-| `-point Name` | Names a map point |
-| `-destroy` | Destroys units within 100 m |
-| `-login PASSWORD` | Authenticates for restricted commands |
-| `-logout` | Locks the system again |
-
-> **Tip:** Mission makers can define custom aliases. Ask your server admin for the full list.
+> **Tip:** each mission can define its own aliases. Ask your server administrator for the full list.
 
 ### Raw Commands (Advanced)
 
-For anything not covered by an alias, you can use the full VEAF command syntax directly. These commands start with `_`.
+For anything not covered by an alias, you can write a full VEAF command directly. These commands start with an underscore `_`.
 
-#### Spawn a unit: `_spawn unit`
+**Spawn a unit — `_spawn unit`:**
 
 ```
 _spawn unit, name F-16C
@@ -144,24 +140,24 @@ Common options:
 | `hdg [DEG]` | Initial heading in degrees | `hdg 270` |
 | `alt [FT]` | Altitude in feet (aircraft) | `alt 15000` |
 | `speed [KT]` | Speed in knots | `speed 450` |
-| `side [blue/red]` | Coalition override | `side red` |
+| `side [blue/red]` | Force the coalition | `side red` |
 
-#### Spawn a predefined group: `_spawn group`
+**Spawn a predefined group — `_spawn group`:**
 
 ```
 _spawn group, name CAP-2
 _spawn group, name RED-SAM-SITE, hdg 180
 ```
 
-Groups must be defined in the mission's configuration by the mission maker.
+Groups must have been defined in the mission's configuration by the mission maker.
 
-#### Spawn a CAP patrol: `_spawn cap`
+**Spawn a combat air patrol (CAP) — `_spawn cap`:**
 
 ```
 _spawn cap, name Su-27, alt 25000, capradius 20000
 ```
 
-#### Spawn smoke / flares / explosions
+**Smoke, flares, explosions:**
 
 ```
 _spawn smoke, color red
@@ -169,289 +165,181 @@ _spawn flare, power 1000000, shells 5
 _spawn bomb, power 500, shells 3
 ```
 
-### CAS Command
-
-```
-_cas
-_cas, size 3, defense 2, armor 3
-```
-
-**Options:**
-- `size [0-5]` — size of the enemy force
-- `defense [0-5]` — air defense level
-- `armor [0-5]` — armor level
-- `side [blue/red]` — coalition override
-
-### Security Authentication
-
-```
--login [PASSWORD]
-```
-
-Grants temporary elevated permissions. Required on some servers before using advanced spawn commands. Use `-logout` to lock again.
-
 ---
 
 ## Assets
 
+**Assets** are the mission's shared support aircraft and vessels: tankers, AWACS and carriers. You find them under **F10 → VEAF → Assets**.
+
+![Tankers and AWACS submenus](../assets/img/pilot/tanker-awacs-menu.png)
+
 ### Tankers
 
-Find tanker information via **F10 → VEAF → Assets → Tankers → [Name] → Info**.
+**F10 → VEAF → Assets → Tankers → [Name] → Info**
 
-Displayed: position, TACAN channel, radio frequency, type.
+Shows: position, TACAN channel (navigation beacon), radio frequency and refuelling type.
 
-If the tanker has been destroyed, use **Respawn** to bring it back (if the mission maker has allowed it).
+If the tanker has been destroyed, the **Respawn** option brings it back (if the mission maker has allowed it).
 
 ### AWACS
 
-Find AWACS via **F10 → VEAF → Assets → AWACS → [Name] → Info**.
+**F10 → VEAF → Assets → AWACS → [Name] → Info**
 
-Displayed: callsign, frequency, position.
+Shows: callsign, frequency and position.
 
 ### Carriers
 
 | Action | Menu path |
 |--------|-----------|
 | Get info (BRC, TACAN, ICLS, radio) | Assets → Carriers → [Name] → Info |
-| Turn carrier into wind for recovery | Assets → Carriers → [Name] → Start Recovery |
+| Turn the carrier into the wind for recovery | Assets → Carriers → [Name] → Start Recovery |
 | Resume normal navigation | Assets → Carriers → [Name] → Stop Recovery |
 
-Operations automatically time out after 45 minutes.
+![Carrier recovery submenu](../assets/img/pilot/carrier-recovery-menu.png)
+
+**Recovery procedure:**
+
+1. **Request recovery** 10–15 minutes before your approach (*Start Recovery*). The carrier turns into the wind to provide about 30 knots of relative wind over the deck.
+2. **Check the info** (*Info*):
+   - **BRC** (*Base Recovery Course*): the deck heading for recovery;
+   - **TACAN channel** (e.g. 73X): for navigation to the carrier;
+   - **ICLS channel** (e.g. 13): for glideslope guidance (F/A-18C, F-14);
+   - **ATC frequency**.
+3. **Approach and land** following TACAN, then ICLS.
+4. **After landing**, choose *Stop Recovery* to return the carrier to its route.
+
+> Recovery times out automatically after 45 minutes.
 
 ---
 
-## Missions and Combat Zones
+## Combat Zones and Missions
 
 ### Combat Zones
 
-Pre-built areas the mission maker has defined. You activate them on demand.
+A **combat zone** is an area prepared by the mission maker that you activate on demand. On activation, enemy units spawn; once all are destroyed, the zone is complete and can be replayed.
 
 | Action | Menu path |
 |--------|-----------|
 | List available zones | Combat Zones |
 | Activate a zone | Combat Zones → [Zone] → Activate |
-| Get zone status | Combat Zones → [Zone] → Info |
-| Mark zone with smoke | Combat Zones → [Zone] → Smoke |
-| Deactivate / cleanup | Combat Zones → [Zone] → Deactivate |
+| Check zone status | Combat Zones → [Zone] → Info |
+| Mark the zone with smoke | Combat Zones → [Zone] → Smoke |
+| Deactivate / clean up | Combat Zones → [Zone] → Deactivate |
 
-When a zone is activated, enemy units spawn. When all enemies are destroyed, the zone completes and can be replayed.
+### Missions
 
----
-
-## CAS Training
-
-Generate procedural CAS targets via **F10 → VEAF → CAS Mission**.
-
-| Action | Menu |
-|--------|------|
-| Create a new target zone | CAS Mission → Generate |
-| Mark with smoke | CAS Mission → Smoke |
-| Mark with flares | CAS Mission → Flare |
-| Skip current target | CAS Mission → Skip |
-| Get target info | CAS Mission → Info |
-| Remove all units | CAS Mission → Cleanup |
-
-Smoke/flare has a 3-minute cooldown between uses.
-
-### Difficulty Levels
-
-| Level | Size | Defense | Armour | Description |
-|-------|------|---------|--------|-------------|
-| 0 | Very small | None | Infantry | Beginner |
-| 1 | Small | Light | Light vehicles | Easy |
-| 2 | Medium | Moderate | APCs | Intermediate |
-| 3 | Medium-Large | Medium AA | IFVs + light tanks | Advanced |
-| 4 | Large | Heavy AA | Medium tanks | Difficult |
-| 5 | Very large | SAM | Heavy tanks | Expert |
-
-Set difficulty via marker: `_cas, size 3, defense 2, armor 3`
-
----
-
-## Carrier Operations
-
-### Recovery Procedure
-
-1. **Request recovery** (10–15 min before approach):
-   F10 → VEAF → Assets → Carriers → [Name] → Start Recovery
-
-2. **Check info**:
-   F10 → VEAF → Assets → Carriers → [Name] → Info
-   - BRC (Base Recovery Course)
-   - TACAN channel (e.g. 73X)
-   - ICLS channel (e.g. 13)
-   - ATC frequency
-
-3. **Approach and land** using TACAN for navigation and ICLS for glideslope (F/A-18C, F-14).
-
-4. **After landing**:
-   F10 → VEAF → Assets → Carriers → [Name] → Stop Recovery
-
-Recovery automatically times out after 45 minutes. The carrier turns into the wind to provide ~30 kt relative wind over deck.
-
----
-
-## Security and Permissions
-
-On multiplayer servers, some commands are restricted. Authenticate with:
-
-```
-_auth [PASSWORD]
-```
-
-Ask the server administrator for the password. Authentication persists for your session.
-
-Permission levels:
-
-| Level | Typical access |
-|-------|----------------|
-| Guest | View info, basic spawning (if allowed) |
-| Authenticated | Full spawn commands, CAS, missions |
-| Admin | Server management commands |
-
----
-
-## FAQ
-
-**Q: How do I know if a mission uses VEAF?**
-A: Press F10 — if you see a "VEAF" submenu under "Other", it's a VEAF mission.
-
-**Q: My marker commands don't work?**
-A: Check syntax (starts with `_`), check you're authenticated on multiplayer, and verify the server allows marker commands.
-
-**Q: What unit names can I use with `_spawn unit`?**
-A: Use standard DCS type names: `F-16C`, `Su-27`, `T-80`, `SA-6`, `M1 Abrams`, etc.
-
-**Q: Spawned units disappear?**
-A: DCS AI units can be cleaned up if you fly too far away. Stay within ~40–50 NM.
-
-**Q: How to reset a CAS mission?**
-A: F10 → CAS Mission → Cleanup, then Generate again.
-
-**Q: Can I spawn friendly units?**
-A: Yes — add `side blue` to your spawn command.
-
----
-
-## Community and Support
-
-- **VEAF Discord**: [veaf.org/discord](https://www.veaf.org/discord) — #support channel for help
-- **GitHub**: [github.com/VEAF/VEAF-Mission-Creation-Tools](https://github.com/VEAF/VEAF-Mission-Creation-Tools)
-- **Website**: [veaf.org](https://www.veaf.org)
-
-### Scripted Missions
-
-More complex scenarios with objectives and tracking.
+**Missions** are more elaborate scenarios, with objectives and progress tracking.
 
 | Action | Menu path |
 |--------|-----------|
 | List missions | Missions |
 | Activate | Missions → [Mission] → Activate |
-| Read status / objectives | Missions → [Mission] → Info |
+| Read status and objectives | Missions → [Mission] → Info |
 | Abort | Missions → [Mission] → Deactivate |
 
 ---
 
 ## CAS Training
 
-The CAS generator creates a target area with configurable threat packages.
+The **CAS** generator (*Close Air Support*) creates a zone of ground targets with an adjustable threat level. Ideal for practising attacks on enemy positions.
 
 **Workflow:**
 
-1. **Generate** — F10 → CAS Mission → Generate (optionally with parameters via marker `_cas, size 3, defense 2`)
-2. **Mark the zone** — F10 → CAS Mission → Smoke or Flare (3-minute cooldown between marks)
-3. **Get info** — F10 → CAS Mission → Info (position, unit composition, status)
-4. **Engage** — Attack the marked targets
-5. **Advance** — Zone auto-advances when all units are destroyed, or use **Skip**
-6. **Cleanup** — F10 → CAS Mission → Cleanup removes all remaining units
+1. **Generate** — F10 → VEAF → CAS Mission → Generate (with optional parameters via marker, see below).
+2. **Mark the zone** — Smoke or Flare (3-minute cooldown between marks).
+3. **Get info** — position, unit composition, status.
+4. **Engage** — attack the marked targets.
+5. **Advance** — the zone moves to the next one automatically when all units are destroyed, or use **Skip**.
+6. **Clean up** — *Cleanup* removes all remaining units.
 
-**Difficulty guide:**
+![Smoke marking a CAS target](../assets/img/pilot/cas-smoke.png)
 
-| Level | Typical composition | For |
-|-------|---------------------|-----|
+**Set the difficulty** via marker: `_cas, size 3, defense 2, armor 3`
+
+| Level | Typical composition | For whom |
+|-------|---------------------|----------|
 | 0 | Infantry, jeeps, no AA | Beginners |
 | 1 | Light vehicles, MANPADS | Easy |
-| 2 | APCs, light AAA | Intermediate |
-| 3 | IFVs, medium AAA + SHORAD | Advanced |
-| 4 | MBTs, ZSU + SA-9 | Difficult |
-| 5 | Heavy armor, SAMS | Expert |
+| 2 | Armoured personnel carriers (APC), light AA | Intermediate |
+| 3 | Infantry fighting vehicles (IFV), medium AA + SHORAD | Advanced |
+| 4 | Main battle tanks (MBT), ZSU + SA-9 | Difficult |
+| 5 | Heavy armour, SAMs | Expert |
+
+Options for the `_cas` command: `size [0-5]` (force size), `defense [0-5]` (AA level), `armor [0-5]` (armour), `side [blue/red]` (coalition).
 
 ---
 
 ## Security and Permissions
 
-On multiplayer servers the mission maker may restrict certain commands:
+On multiplayer servers, the mission maker may restrict certain commands according to your permission level:
 
-| Level | Who can use |
-|-------|-------------|
-| Public | All players — asset info, combat zone activation, smoke/flare |
+| Level | Who can use it |
+|-------|----------------|
+| Public | All players — asset info, zone activation, smoke/flare |
 | Pilots | Non-spectator players |
 | Admin | Server administrators |
 
-To authenticate as admin:
+To authenticate, place a marker containing:
 
 ```
 _auth [PASSWORD]
 ```
 
-After authentication you have elevated rights for the configured duration (default: 10 minutes). The password is set by the mission maker or server admin.
+The password is set by the mission maker or server administrator. Authentication stays valid for a configured duration (10 minutes by default), after which your rights return automatically to the public level.
 
 ---
 
-## Tips by Aircraft Role
+## Tips for Your Aircraft
 
 ### Fighters (F-16C, F/A-18C, F-15C, Su-27…)
 
-- Use AWACS for threat vectors before engaging
-- Spawn an enemy CAP with `-cap Su-27` for a realistic intercept scenario
-- Activate a predefined intercept mission via the F10 menu
+- Use the AWACS for threat vectors before engaging.
+- Spawn an enemy CAP with `_spawn cap, name Su-27` for a realistic intercept scenario.
+- Activate a predefined intercept mission from the F10 menu.
 
-### Attack Aircraft (A-10C, Su-25, F/A-18C…)
+### Attack aircraft (A-10C, Su-25, F/A-18C…)
 
-- Start CAS training at difficulty 1–2
-- Use **Smoke** to mark the target before attacking
-- Increase difficulty gradually (level 3+ has SEAD-worthy threats)
+- Start CAS training at difficulty 1 or 2.
+- Use **Smoke** to mark the target before attacking.
+- Increase difficulty gradually (level 3 and up: SEAD-worthy threats).
 
 ### Helicopters (AH-64D, Ka-50, Mi-24…)
 
-- Keep difficulty at 0–2 (minimal AA)
-- Use `_spawn unit, name BTR-80, group 5` for dispersed APC targets
-- Exploit terrain masking to approach below AA radar
+- Keep difficulty between 0 and 2 (minimal AA).
+- Use `_spawn unit, name BTR-80, group 5` for dispersed APC targets.
+- Use terrain masking to approach below AA radar coverage.
 
 ### Transports (C-130, Mi-8, UH-1H…)
 
-- Spawn a FARP as a destination: `-farp FARP Alpha`
-- Use CTLD integration (if enabled) for troop/cargo missions
+- Spawn a FARP as a destination: `-farp FARP Alpha`.
+- Use CTLD integration (if enabled) for troop and cargo missions.
 
 ---
 
-## FAQ
+## Frequently Asked Questions (FAQ)
 
-**Q: How do I know a mission uses VEAF?**
-Look for the VEAF submenu under F10 → Other at mission start.
+**How do I know if a mission uses VEAF?**
+Press F10: if a "VEAF" submenu appears under "Other", it is a VEAF mission.
 
-**Q: Why don't my markers work?**
-Check the command syntax. On some servers you may need to authenticate first with `_auth [PASSWORD]`.
+**My marker commands don't work. Why?**
+Check the syntax (raw commands start with `_`, aliases with `-`). In multiplayer you may need to authenticate first with `_auth [PASSWORD]`. Also check that the server allows marker commands.
 
-**Q: What DCS unit type names can I use?**
-Standard DCS names: `F-16C`, `Su-27`, `T-80`, `M1 Abrams`, `SA-6`, etc. They are case-sensitive.
+**What unit names can I use with `_spawn unit`?**
+Standard DCS type names: `F-16C`, `Su-27`, `T-80`, `M1 Abrams`, `SA-6`, etc. Note that they are case-sensitive.
 
-**Q: Spawned units disappeared?**
-Some missions enforce a range limit (~40–50 NM). Normal behaviour.
+**The units I spawned disappeared. Is that normal?**
+Yes — some missions enforce a range limit (about 40–50 NM): AI is cleaned up if you fly too far away.
 
-**Q: How do I reset a CAS session?**
+**How do I reset a CAS session?**
 F10 → CAS Mission → Cleanup, then Generate again.
 
-**Q: Can I spawn friendly units?**
-Yes, add `side blue` to any spawn command.
+**Can I spawn friendly units?**
+Yes: add `side blue` to your command.
 
 ---
 
 ## Community and Support
 
-- [VEAF Discord](https://www.veaf.org/discord) — real-time help, `#support` channel
-- [VEAF Website](https://www.veaf.org)
-- [GitHub](https://github.com/VEAF/VEAF-Mission-Creation-Tools)
-
----
-
+- **VEAF Discord**: [veaf.org/discord](https://www.veaf.org/discord) — `#support` channel for real-time help.
+- **Website**: [veaf.org](https://www.veaf.org)
+- **GitHub**: [github.com/VEAF/VEAF-Mission-Creation-Tools](https://github.com/VEAF/VEAF-Mission-Creation-Tools)

--- a/doc/pilot/GUIDE.md
+++ b/doc/pilot/GUIDE.md
@@ -1,6 +1,6 @@
 # Guide du pilote — VEAF Mission Creation Tools
 
-Ce guide s'adresse aux joueurs qui volent dans des missions utilisant le framework de scripts VEAF. Aucune connaissance technique n'est requise.
+Ce guide s'adresse aux joueurs qui volent dans des missions utilisant le framework VEAF. Aucune connaissance technique n'est nécessaire : tout se fait en jeu, à la souris et au clavier.
 
 ---
 
@@ -8,84 +8,88 @@ Ce guide s'adresse aux joueurs qui volent dans des missions utilisant le framewo
 
 1. [Qu'est-ce que VEAF MCT ?](#quest-ce-que-veaf-mct)
 2. [Reconnaître une mission VEAF](#reconnaître-une-mission-veaf)
-3. [Menu radio F10](#menu-radio-f10)
-4. [Commandes de marqueur](#commandes-de-marqueur)
-5. [Ressources — Ravitailleurs, AWACS, Porte-avions](#ressources)
-6. [Missions et zones de combat](#missions-et-zones-de-combat)
+3. [Le menu radio F10](#le-menu-radio-f10)
+4. [Les commandes par marqueur](#les-commandes-par-marqueur)
+5. [Ressources : ravitailleurs, AWACS, porte-avions](#ressources)
+6. [Zones et missions de combat](#zones-et-missions-de-combat)
 7. [Entraînement CAS](#entraînement-cas)
 8. [Sécurité et permissions](#sécurité-et-permissions)
-9. [Conseils par rôle d'appareil](#conseils-par-rôle-dappareil)
-10. [FAQ](#faq)
+9. [Conseils selon votre appareil](#conseils-selon-votre-appareil)
+10. [Questions fréquentes (FAQ)](#questions-fréquentes-faq)
 11. [Communauté et support](#communauté-et-support)
 
 ---
 
-## Qu'est-ce que VEAF MCT
+## Qu'est-ce que VEAF MCT ?
 
-VEAF Mission Creation Tools est un framework de scripts Lua qui rend les missions DCS World dynamiques et interactives. Au lieu d'un scénario statique, il est possible de :
+VEAF Mission Creation Tools (VEAF MCT) rend les missions DCS World vivantes et interactives. Dans une mission classique, tout est figé à l'avance. Avec VEAF MCT, vous pouvez agir pendant le vol :
 
-- Faire apparaître des unités ennemies à la demande via des marqueurs sur la carte ou le menu radio
-- Créer des zones d'entraînement CAS avec un niveau de difficulté configurable
-- Activer des missions de combat prédéfinies
-- Gérer des ressources partagées (ravitailleurs, AWACS, porte-avions) via le menu F10
-- Interagir avec l'environnement en temps réel
+- faire apparaître des unités ennemies à la demande ;
+- demander un avion ravitailleur, un AWACS ou un porte-avions ;
+- déclencher un entraînement d'appui aérien rapproché (CAS) au niveau de difficulté de votre choix ;
+- activer des missions de combat préparées par le créateur de la mission.
+
+Ces possibilités viennent de petits programmes — appelés **scripts** — que le créateur de la mission a ajoutés. **Vous n'avez rien à installer** : tout est déjà inclus dans la mission. Vous donnez vos ordres de deux façons : par le **menu radio** (touche F10) ou en **plaçant un marqueur** sur la carte.
 
 ---
 
 ## Reconnaître une mission VEAF
 
-Quand une mission utilise les scripts VEAF, il est possible d'observer :
+Trois signes indiquent qu'une mission utilise VEAF :
 
-- Des messages de démarrage dans le coin inférieur droit listant les modules VEAF chargés
-- Un sous-menu **VEAF** sous **F10 → Autre**
-- Des marqueurs sur la carte indiquant les trajectoires des ravitailleurs, les orbites AWACS ou les positions des zones de combat
+1. **Des messages de démarrage** s'affichent dans le coin inférieur droit de l'écran au lancement, listant les modules VEAF chargés.
+2. **Un sous-menu « VEAF »** apparaît dans **F10 → Autre**.
+3. **Des marqueurs** sur la carte indiquent les trajectoires des ravitailleurs, les orbites des AWACS ou la position des zones de combat.
 
----
-
-## Menu radio F10
-
-Toutes les fonctionnalités VEAF MCT sont accessibles via **F10 → Autre → VEAF**.
-
-### Structure typique du menu
-
-```
-F10 → Autre → VEAF
-├── Ressources
-│   ├── Ravitailleurs
-│   │   └── [Nom du ravitailleur] → Infos / Réapparition
-│   ├── AWACS
-│   │   └── [Nom de l'AWACS] → Infos / Réapparition
-│   └── Porte-avions
-│       └── [Nom du porte-avions] → Infos / Commencer récupération / Arrêter récupération
-├── Mission CAS
-│   ├── Générer
-│   ├── Fumée
-│   ├── Fusée éclairante
-│   ├── Passer
-│   ├── Infos
-│   └── Nettoyer
-├── Zones de combat
-│   └── [Nom de la zone] → Activer / Désactiver / Infos / Fumée / Fusée éclairante
-├── Missions
-│   └── [Nom de la mission] → Activer / Désactiver / Infos
-└── Aide
-```
-
-La structure exacte dépend de ce que le créateur de mission a activé.
+![Messages de démarrage VEAF dans le coin inférieur droit](../assets/img/pilot/startup-messages.png)
 
 ---
 
-## Commandes de marqueur
+## Le menu radio F10
 
-Placer un marqueur sur la carte F10 (clic droit → Ajouter marqueur), saisir une commande dans le champ texte, puis confirmer. VEAF MCT intercepte le marqueur, exécute la commande et supprime le marqueur.
+Toutes les fonctions de VEAF MCT sont accessibles depuis **F10 → Autre → VEAF**. (Le menu radio est la liste qui s'ouvre avec la touche F10 ; « Autre » y regroupe les commandes ajoutées par la mission.)
 
-> Sur les serveurs multijoueurs, certaines commandes nécessitent un mot de passe. Voir [Sécurité](#sécurité-et-permissions).
+```mermaid
+graph TD
+    F10[Menu radio F10] --> Autre[Autre] --> VEAF[VEAF]
+    VEAF --> Res[Ressources]
+    VEAF --> CAS[Mission CAS]
+    VEAF --> CZ[Zones de combat]
+    VEAF --> Miss[Missions]
+    VEAF --> Aide[Aide]
+    Res --> Tank[Ravitailleurs]
+    Res --> AWACS[AWACS]
+    Res --> Carrier[Porte-avions]
+```
 
-### Aliases (raccourcis) — La méthode recommandée
+![Sous-menu VEAF dans le menu radio F10](../assets/img/pilot/f10-veaf-submenu.png)
 
-Les aliases commencent par `-` et sont le moyen le plus simple de faire apparaître des unités. Ils sont prédéfinis par le créateur de mission et correspondent à des commandes complètes en arrière-plan.
+Le contenu exact dépend de ce que le créateur de la mission a activé : certaines missions n'auront pas toutes ces entrées.
 
-#### Aliases de défense aérienne courants
+---
+
+## Les commandes par marqueur
+
+En plus du menu radio, vous pouvez donner des ordres en écrivant une **commande dans un marqueur** sur la carte F10.
+
+**Comment faire :**
+
+1. Ouvrez la carte (F10).
+2. Clic droit → **Ajouter un marqueur**.
+3. Tapez la commande dans le champ de texte du marqueur.
+4. Validez.
+
+VEAF détecte le marqueur, exécute la commande à l'emplacement du marqueur, puis le supprime automatiquement.
+
+![Saisie d'une commande dans un marqueur de la carte F10](../assets/img/pilot/map-marker-add.png)
+
+> Sur les serveurs multijoueurs, certaines commandes demandent un mot de passe. Voir [Sécurité et permissions](#sécurité-et-permissions).
+
+### Les alias : la méthode la plus simple
+
+Un **alias** est un raccourci préparé par le créateur de la mission. Il commence par un tiret `-` et déclenche une commande complète en arrière-plan. C'est la façon la plus simple de faire apparaître des unités : il suffit de connaître le nom du raccourci.
+
+**Alias de défense aérienne courants :**
 
 | Alias | Ce qui apparaît |
 |-------|-----------------|
@@ -95,38 +99,31 @@ Les aliases commencent par `-` et sont le moyen le plus simple de faire apparaî
 | `-sa11` | Batterie SA-11 Gadfly (9K37 Buk) |
 | `-sa15` | Véhicule SA-15 Gauntlet (Tor) |
 | `-sa22` | Véhicule SA-22 Greyhound (Pantsir-S1) |
-| `-shilka` | AAA ZSU-23-4 Shilka |
-| `-manpads` | Escouade MANPAD |
+| `-shilka` | DCA ZSU-23-4 Shilka |
+| `-manpads` | Équipe de MANPADS (missiles sol-air portables) |
 | `-samLR` | Batterie SAM longue portée aléatoire |
 | `-samSR` | Batterie SAM courte portée aléatoire |
 
-#### Aliases de véhicules/navires courants
+**Alias de véhicules et navires courants :**
 
 | Alias | Ce qui apparaît |
 |-------|-----------------|
 | `-burke` | Destroyer USS Arleigh Burke IIa |
 | `-ticonderoga` | Croiseur Ticonderoga |
-| `-mortar` | Équipe de mortiers |
+| `-mortar` | Équipe de mortier |
 | `-arty` | Batterie d'artillerie M-109 |
-| `-mlrs` | Batterie de roquettes MLRS |
+| `-mlrs` | Batterie de lance-roquettes MLRS |
 | `-attack_convoy_red` | Convoi d'attaque rouge |
 
-#### Aliases utilitaires
+![Unités apparues après une commande alias, vues sur la carte](../assets/img/pilot/marker-units-spawned.png)
 
-| Alias | Ce que ça fait |
-|-------|----------------|
-| `-point Nom` | Nomme un point sur la carte |
-| `-destroy` | Détruit les unités dans un rayon de 100 m |
-| `-login MOT_DE_PASSE` | S'authentifie pour les commandes restreintes |
-| `-logout` | Verrouille le système |
+> **Astuce :** chaque mission peut définir ses propres alias. Demandez la liste complète à l'administrateur de votre serveur.
 
-> **Astuce :** Les créateurs de missions peuvent définir des aliases personnalisés. Demandez à l'administrateur de votre serveur la liste complète.
+### Les commandes brutes (avancé)
 
-### Commandes brutes (avancé)
+Pour tout ce qui n'est pas couvert par un alias, vous pouvez écrire directement une commande VEAF complète. Ces commandes commencent par un tiret bas `_`.
 
-Pour tout ce qui n'est pas couvert par un alias, vous pouvez utiliser la syntaxe complète des commandes VEAF. Ces commandes commencent par `_`.
-
-#### Faire apparaître une unité : `_spawn unit`
+**Faire apparaître une unité — `_spawn unit` :**
 
 ```
 _spawn unit, name F-16C
@@ -143,24 +140,24 @@ Options courantes :
 | `hdg [DEG]` | Cap initial en degrés | `hdg 270` |
 | `alt [FT]` | Altitude en pieds (aéronefs) | `alt 15000` |
 | `speed [KT]` | Vitesse en nœuds | `speed 450` |
-| `side [blue/red]` | Coalition imposée | `side red` |
+| `side [blue/red]` | Forcer la coalition | `side red` |
 
-#### Faire apparaître un groupe prédéfini : `_spawn group`
+**Faire apparaître un groupe prédéfini — `_spawn group` :**
 
 ```
 _spawn group, name CAP-2
 _spawn group, name RED-SAM-SITE, hdg 180
 ```
 
-Les groupes doivent être définis dans la configuration de la mission par le créateur.
+Les groupes doivent avoir été définis dans la configuration de la mission par son créateur.
 
-#### Faire apparaître une patrouille CAP : `_spawn cap`
+**Faire apparaître une patrouille de chasse (CAP) — `_spawn cap` :**
 
 ```
 _spawn cap, name Su-27, alt 25000, capradius 20000
 ```
 
-#### Fumée / fusées éclairantes / explosions
+**Fumée, fusées éclairantes, explosions :**
 
 ```
 _spawn smoke, color red
@@ -168,187 +165,181 @@ _spawn flare, power 1000000, shells 5
 _spawn bomb, power 500, shells 3
 ```
 
-### Commande CAS
-
-```
-_cas
-_cas, size 3, defense 2, armor 3
-```
-
-**Options :**
-- `size [0-5]` — taille de la force ennemie
-- `defense [0-5]` — niveau de défense aérienne
-- `armor [0-5]` — niveau de blindage
-- `side [blue/red]` — coalition
-
-### Authentification de sécurité
-
-```
--login [MOT_DE_PASSE]
-```
-
-Accorde des permissions élevées temporaires. Requis sur certains serveurs avant d'utiliser les commandes de spawn avancées. Utilisez `-logout` pour verrouiller à nouveau.
-
 ---
 
 ## Ressources
 
+Les **ressources** sont les appareils de soutien partagés de la mission : ravitailleurs, AWACS et porte-avions. Vous les retrouvez sous **F10 → VEAF → Ressources**.
+
+![Sous-menus Ravitailleurs et AWACS](../assets/img/pilot/tanker-awacs-menu.png)
+
 ### Ravitailleurs
 
-Les informations du ravitailleur sont accessibles via **F10 → VEAF → Ressources → Ravitailleurs → [Nom] → Infos**.
+**F10 → VEAF → Ressources → Ravitailleurs → [Nom] → Infos**
 
-Affichées : position, canal TACAN, fréquence radio, type.
+Affiche : position, canal TACAN (balise de navigation), fréquence radio et type de ravitaillement.
 
-Si le ravitailleur a été détruit, utiliser **Réapparition** pour le faire revenir (si le créateur de mission l'a autorisé).
+Si le ravitailleur a été détruit, l'option **Réapparition** le ramène (si le créateur de la mission l'a autorisée).
 
 ### AWACS
 
-Accéder à l'AWACS via **F10 → VEAF → Ressources → AWACS → [Nom] → Infos**.
+**F10 → VEAF → Ressources → AWACS → [Nom] → Infos**
 
-Affiché : indicatif, fréquence, position.
+Affiche : indicatif radio (*callsign*), fréquence et position.
 
 ### Porte-avions
 
-| Action | Chemin du menu |
-|--------|----------------|
+| Action | Chemin dans le menu |
+|--------|---------------------|
 | Obtenir les infos (BRC, TACAN, ICLS, radio) | Ressources → Porte-avions → [Nom] → Infos |
-| Mettre le porte-avions face au vent pour la récupération | Ressources → Porte-avions → [Nom] → Commencer récupération |
+| Mettre le porte-avions face au vent pour l'appontage | Ressources → Porte-avions → [Nom] → Commencer récupération |
 | Reprendre la navigation normale | Ressources → Porte-avions → [Nom] → Arrêter récupération |
 
-Les opérations expirent automatiquement après 45 minutes.
+![Sous-menu de récupération du porte-avions](../assets/img/pilot/carrier-recovery-menu.png)
+
+**Procédure d'appontage :**
+
+1. **Demandez la récupération** 10 à 15 minutes avant l'approche (*Commencer récupération*). Le porte-avions se place face au vent pour offrir environ 30 nœuds de vent relatif sur le pont.
+2. **Consultez les infos** (*Infos*) :
+   - **BRC** (*Base Recovery Course*) : le cap du pont pour l'appontage ;
+   - **canal TACAN** (ex. 73X) : pour la navigation jusqu'au porte-avions ;
+   - **canal ICLS** (ex. 13) : pour le guidage sur le plan de descente (F/A-18C, F-14) ;
+   - **fréquence ATC**.
+3. **Approchez et appontez** en suivant le TACAN puis l'ICLS.
+4. **Après l'appontage**, choisissez *Arrêter récupération* pour rendre sa route au porte-avions.
+
+> La récupération s'arrête automatiquement au bout de 45 minutes.
 
 ---
 
-## Missions et zones de combat
+## Zones et missions de combat
 
 ### Zones de combat
 
-Zones prédéfinies par le créateur de mission, activables à la demande.
+Une **zone de combat** est une zone préparée par le créateur de la mission, que vous activez à la demande. À l'activation, des unités ennemies apparaissent ; une fois toutes détruites, la zone est terminée et peut être rejouée.
 
-| Action | Chemin du menu |
-|--------|----------------|
+| Action | Chemin dans le menu |
+|--------|---------------------|
 | Lister les zones disponibles | Zones de combat |
 | Activer une zone | Zones de combat → [Zone] → Activer |
-| Consulter le statut de la zone | Zones de combat → [Zone] → Infos |
-| Marquer la zone avec de la fumée | Zones de combat → [Zone] → Fumée |
+| Voir l'état de la zone | Zones de combat → [Zone] → Infos |
+| Marquer la zone à la fumée | Zones de combat → [Zone] → Fumée |
 | Désactiver / nettoyer | Zones de combat → [Zone] → Désactiver |
 
-Quand une zone est activée, des unités ennemies apparaissent. Quand tous les ennemis sont détruits, la zone se complète et peut être rejouée.
+### Missions
 
-### Missions scriptées
+Les **missions** sont des scénarios plus élaborés, avec objectifs et suivi de progression.
 
-Scénarios plus complexes avec objectifs et suivi.
-
-| Action | Chemin du menu |
-|--------|----------------|
+| Action | Chemin dans le menu |
+|--------|---------------------|
 | Lister les missions | Missions |
 | Activer | Missions → [Mission] → Activer |
-| Lire le statut / les objectifs | Missions → [Mission] → Infos |
+| Lire l'état et les objectifs | Missions → [Mission] → Infos |
 | Abandonner | Missions → [Mission] → Désactiver |
 
 ---
 
 ## Entraînement CAS
 
-Le générateur CAS crée une zone cible avec des packages de menaces configurables.
+Le générateur **CAS** (*Close Air Support*, appui aérien rapproché) crée une zone de cibles au sol avec un niveau de menace réglable. Idéal pour s'entraîner au pilonnage de positions ennemies.
 
-**Procédure :**
+**Déroulement :**
 
-1. **Générer** — F10 → Mission CAS → Générer (optionnellement avec des paramètres via marqueur `_cas, size 3, defense 2`)
-2. **Marquer la zone** — F10 → Mission CAS → Fumée ou Fusée éclairante (délai de 3 minutes entre les marques)
-3. **Obtenir les infos** — F10 → Mission CAS → Infos (position, composition en unités, statut)
-4. **Engager** — Attaquer les cibles marquées
-5. **Avancer** — La zone passe automatiquement à la suivante quand toutes les unités sont détruites, ou utiliser **Passer**
-6. **Nettoyer** — F10 → Mission CAS → Nettoyer supprime toutes les unités restantes
+1. **Générer** — F10 → VEAF → Mission CAS → Générer (avec des paramètres optionnels via marqueur, voir plus bas).
+2. **Marquer la zone** — Fumée ou Fusée éclairante (3 minutes de délai entre deux marquages).
+3. **Obtenir les infos** — position, composition des unités, état.
+4. **Engager** — attaquez les cibles marquées.
+5. **Avancer** — la zone passe automatiquement à la suivante quand toutes les unités sont détruites, ou utilisez **Passer**.
+6. **Nettoyer** — *Nettoyer* supprime toutes les unités restantes.
 
-**Guide de difficulté :**
+![Fumée marquant une cible CAS](../assets/img/pilot/cas-smoke.png)
 
-| Niveau | Composition typique | Pour |
-|--------|---------------------|------|
-| 0 | Infanterie, jeeps, sans AA | Débutants |
+**Régler la difficulté** par marqueur : `_cas, size 3, defense 2, armor 3`
+
+| Niveau | Composition typique | Pour qui |
+|--------|---------------------|----------|
+| 0 | Infanterie, jeeps, pas de DCA | Débutants |
 | 1 | Véhicules légers, MANPADS | Facile |
-| 2 | APC, AAA légère | Intermédiaire |
-| 3 | IFV, AAA moyenne + SHORAD | Avancé |
-| 4 | Chars lourds, ZSU + SA-9 | Difficile |
+| 2 | Transports de troupes (APC), DCA légère | Intermédiaire |
+| 3 | Véhicules de combat d'infanterie (IFV), DCA moyenne + SHORAD | Avancé |
+| 4 | Chars de combat (MBT), ZSU + SA-9 | Difficile |
 | 5 | Blindés lourds, SAM | Expert |
+
+Options de la commande `_cas` : `size [0-5]` (taille de la force), `defense [0-5]` (niveau de DCA), `armor [0-5]` (blindage), `side [blue/red]` (coalition).
 
 ---
 
 ## Sécurité et permissions
 
-Sur les serveurs multijoueurs, le créateur de mission peut restreindre certaines commandes :
+Sur les serveurs multijoueurs, le créateur de la mission peut restreindre certaines commandes selon votre niveau de permission :
 
-| Niveau | Qui peut utiliser |
-|--------|------------------|
-| Public | Tous les joueurs — infos ressources, activation zones de combat, fumée/fusée |
-| Pilotes | Joueurs non spectateurs |
-| Admin | Administrateurs serveur |
+| Niveau | Qui peut l'utiliser |
+|--------|---------------------|
+| Public | Tous les joueurs — infos des ressources, activation des zones, fumée/fusée |
+| Pilotes | Joueurs non-spectateurs |
+| Admin | Administrateurs du serveur |
 
-Pour s'authentifier en tant qu'admin :
+Pour vous authentifier, placez un marqueur contenant :
 
 ```
 _auth [MOT_DE_PASSE]
 ```
 
-Après authentification, les droits élevés sont valables pendant la durée configurée (par défaut : 10 minutes). Le mot de passe est défini par le créateur de mission ou l'admin serveur.
+Le mot de passe est défini par le créateur de la mission ou l'administrateur du serveur. L'authentification reste valide pendant une durée configurée (10 minutes par défaut), puis vos droits reviennent automatiquement au niveau public.
 
 ---
 
-## Conseils par rôle d'appareil
+## Conseils selon votre appareil
 
 ### Chasseurs (F-16C, F/A-18C, F-15C, Su-27…)
 
-- Utiliser l'AWACS pour obtenir des vecteurs de menace avant d'engager
-- Faire apparaître une CAP ennemie avec `-cap Su-27` pour un scénario d'interception réaliste
-- Activer une mission d'interception prédéfinie via le menu F10
+- Utilisez l'AWACS pour obtenir les axes de menace avant d'engager.
+- Faites apparaître une CAP ennemie avec `_spawn cap, name Su-27` pour un scénario d'interception réaliste.
+- Activez une mission d'interception prédéfinie depuis le menu F10.
 
 ### Avions d'attaque (A-10C, Su-25, F/A-18C…)
 
-- Commencer l'entraînement CAS au niveau de difficulté 1–2
-- Utiliser **Fumée** pour marquer la cible avant d'attaquer
-- Augmenter progressivement la difficulté (le niveau 3+ contient des menaces nécessitant du SEAD)
+- Commencez l'entraînement CAS en difficulté 1 ou 2.
+- Utilisez **Fumée** pour marquer la cible avant l'attaque.
+- Montez la difficulté progressivement (niveau 3 et plus : menaces dignes d'une mission SEAD).
 
 ### Hélicoptères (AH-64D, Ka-50, Mi-24…)
 
-- Maintenir la difficulté à 0–2 (AA minimale)
-- Utiliser `_spawn unit, name BTR-80, group 5` pour des cibles APC dispersées
-- Exploiter le masquage de terrain pour approcher sous le radar AA
+- Gardez une difficulté de 0 à 2 (DCA minimale).
+- Utilisez `_spawn unit, name BTR-80, group 5` pour des cibles APC dispersées.
+- Profitez du relief pour approcher sous la couverture radar de la DCA.
 
 ### Transports (C-130, Mi-8, UH-1H…)
 
-- Faire apparaître un FARP comme destination : `-farp FARP Alpha`
-- Utiliser l'intégration CTLD (si activée) pour des missions de transport de troupes/cargo
+- Faites apparaître un FARP comme destination : `-farp FARP Alpha`.
+- Utilisez l'intégration CTLD (si elle est activée) pour les missions de troupes et de cargaison.
 
 ---
 
-## FAQ
+## Questions fréquentes (FAQ)
 
-**Q : Comment savoir si une mission utilise VEAF ?**
-Chercher le sous-menu VEAF sous F10 → Autre au démarrage de la mission.
+**Comment savoir si une mission utilise VEAF ?**
+Appuyez sur F10 : si un sous-menu « VEAF » apparaît sous « Autre », c'est une mission VEAF.
 
-**Q : Pourquoi mes marqueurs ne fonctionnent-ils pas ?**
-Vérifier la syntaxe de la commande. Sur certains serveurs, il faut d'abord s'authentifier avec `_auth [MOT_DE_PASSE]`.
+**Mes commandes par marqueur ne fonctionnent pas. Pourquoi ?**
+Vérifiez la syntaxe (les commandes brutes commencent par `_`, les alias par `-`). En multijoueur, vous devez peut-être vous authentifier d'abord avec `_auth [MOT_DE_PASSE]`. Vérifiez aussi que le serveur autorise les commandes par marqueur.
 
-**Q : Quels noms de types d'unités DCS puis-je utiliser ?**
-Les noms DCS standard : `F-16C`, `Su-27`, `T-80`, `M1 Abrams`, `SA-6`, etc. Ils sont sensibles à la casse.
+**Quels noms d'unités puis-je utiliser avec `_spawn unit` ?**
+Les noms de types standard de DCS : `F-16C`, `Su-27`, `T-80`, `M1 Abrams`, `SA-6`, etc. Attention, ils sont sensibles à la casse (majuscules/minuscules).
 
-**Q : Les unités apparues ont disparu ?**
-Certaines missions imposent une limite de portée (~40–50 NM). C'est un comportement normal.
+**Les unités que j'ai fait apparaître ont disparu. Est-ce normal ?**
+Oui, certaines missions imposent une limite de distance (environ 40 à 50 NM) : l'IA est nettoyée si vous vous éloignez trop.
 
-**Q : Comment réinitialiser une session CAS ?**
+**Comment réinitialiser un entraînement CAS ?**
 F10 → Mission CAS → Nettoyer, puis Générer à nouveau.
 
-**Q : Peut-on faire apparaître des unités amies ?**
-Oui, ajouter `side blue` à n'importe quelle commande de spawn.
+**Puis-je faire apparaître des unités amies ?**
+Oui : ajoutez `side blue` à votre commande.
 
 ---
 
 ## Communauté et support
 
-- [Discord VEAF](https://www.veaf.org/discord) — aide en temps réel, canal `#support`
-- [Site VEAF](https://www.veaf.org)
-- [GitHub](https://github.com/VEAF/VEAF-Mission-Creation-Tools)
-
----
-
-*Voir aussi : [Guide du créateur de mission](../mission-maker/GUIDE.md) pour la référence complète du créateur.*
+- **Discord VEAF** : [veaf.org/discord](https://www.veaf.org/discord) — canal `#support` pour obtenir de l'aide en temps réel.
+- **Site web** : [veaf.org](https://www.veaf.org)
+- **GitHub** : [github.com/VEAF/VEAF-Mission-Creation-Tools](https://github.com/VEAF/VEAF-Mission-Creation-Tools)

--- a/src/python/veaf-tools/veaf-tools-updater.py
+++ b/src/python/veaf-tools/veaf-tools-updater.py
@@ -488,7 +488,7 @@ exit /b 0
         console.print(
             t(
                 "updater.lang_tip",
-                url="https://veaf.github.io/VEAF-Mission-Creation-Tools-v6/mission-maker/GUIDE/#global-user-configuration",
+                url="https://veaf.github.io/documentation/dev/mission-maker/GUIDE/#global-user-configuration",
             )
         )
 

--- a/src/python/veaf-tools/veaf_libs/progress.py
+++ b/src/python/veaf-tools/veaf_libs/progress.py
@@ -65,8 +65,8 @@ def spinner_context(
             if show_done:
                 final_done_message = control.done_message or done_message
                 if not final_done_message:
-                    final_done_message = (
-                        t("progress.done", msg=message.removesuffix("...")[0].lower() + message.removesuffix("...")[1:])
+                    final_done_message = t(
+                        "progress.done", msg=message.removesuffix("...")[0].lower() + message.removesuffix("...")[1:]
                     )
                     if logger:
                         logger.info(message, no_console=True)
@@ -134,8 +134,8 @@ def progress_context(
         finally:
             if show_done:
                 if not done_message:
-                    done_message = (
-                        t("progress.done", msg=message.removesuffix("...")[0].lower() + message.removesuffix("...")[1:])
+                    done_message = t(
+                        "progress.done", msg=message.removesuffix("...")[0].lower() + message.removesuffix("...")[1:]
                     )
 
                 styled_done = Text(done_message, style=done_color)


### PR DESCRIPTION
@
## Lot DOC-OVERHAUL

Brings the documentation to full FR/EN parity, fixes content errors, and adds diagrams + screenshot placeholders. Blocks the next `develop-v6` release.

### Highlights
- **Pilot guide** rewritten (FR+EN): deduplicated, accessible, jargon explained, `_auth` standardized, mermaid F10 menu, screenshot placeholders.
- **Mission-maker GUIDE + MIGRATION_GUIDE** (FR+EN): build-pipeline + v5→v6 mermaid diagrams, unified `modules:` block example, broken `GUIDE.fr.md` links fixed.
- **Syntax sweeps**: `enable:`→`enabled:`, `lua_modules:`→`modules:` across ~20 files; `MISSION_YAML_REFERENCE` rewritten around the unified `modules:` block.
- **Script docs FR→EN parity**: veafAirWaves, veafCombatZone, veafQraManager, veafShortcuts, veafWeather, veafRadio.
- **Large reference docs FR→EN parity (DOC-005c)**:
  - `LUA_API_REFERENCE.md` (+~1050 lines): every module section brought to full depth — missing functions, parameters, and code examples translated across Core Infrastructure, Unit & Group Management, Mission Systems, Infrastructure & Services, Communication & Control, Data & Database. Heading structure now identical between FR and EN (327 = 327).
  - `TOOLS_REFERENCE.md` (+~346 lines): added Troubleshooting, Command Reference, Best Practices, Security, FAQ, Getting Help, Version History sections.
  - `dcs-radio-specs.md`: header + critical-aircraft prose translated to FR (hand-maintained file, frequency tables left language-neutral).
- **Content fixes**: removed obsolete `convert` command from command tables, corrected false "CSAR not available" note, fixed dead updater URL, created the missing French `veafInterpreter` page.

### Notes
- Code blocks and identifiers are kept identical across languages; only prose is translated.
- Cross-doc links use plain `*.md` (mkdocs-static-i18n resolves the language).
- Screenshot placeholders reference `doc/assets/img/<area>/`; the actual captures (DOC-006 list) are a follow-up by the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@