### PR TITLE
fix(convert-v5): pre-resolve module dependencies in generated mission.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `mission.yaml` (all generators): each section now includes a `# Doc:` link to the relevant chapter of the Mission Maker Guide; section headers and descriptions improved (security, external modules, mandatory modules explanation)
 
 ### Fixed
+- `convert-v5`: the generated `mission.yaml` now pre-resolves module dependencies — enabling a module such as `CASMISSION` automatically enables the modules it requires (`GROUNDAI`, `SPAWN`, and their transitive dependencies). The build no longer needs to auto-enable them with a warning, and the generated file accurately reflects what will run. The conversion report lists the auto-enabled modules.
 - docs: removed the obsolete `convert` command from the Mission Maker Guide command tables (FR + EN); corrected the false "CSAR not available via mission.yaml" note in the mission.yaml reference (CSAR is supported via `external_modules.csar`); updated the Debug Logging section to reflect the single `veaf-scripts.lua` loader and `global_log_level`/`logLevel` control; created the missing French `veafInterpreter` page (fixes a broken FR nav link); consolidated duplicate `[Unreleased]` changelog sections and translated the stray French entry
 - `veaf-tools-updater`: fixed the dead documentation URL shown on first install (`VEAF-Mission-Creation-Tools-v6/…` → `documentation/dev/…`)
 - `convert-v5`: generated `mission.yaml` now includes the YAML syntax quick-reference header (was only present in `generate-config` output)

--- a/backlog.md
+++ b/backlog.md
@@ -94,7 +94,7 @@
 | Lot DOC-OVERHAUL — Complete, detailed, bilingual, ELI5 documentation with diagrams + screenshots | ~12h | ✅ |
 | Lot PREREL-BUGS — pre-release code review findings (briefing over-capture, exit codes, i18n, error handling) | ~2h | ⬜ |
 | Lot UI-OUTPUT — Declutter CLI output (transient status line + chapter/technical tiers) | ~3h30 | ✅ |
-| Lot FIX-CONVERT-V5-DEPS — resolve module dependencies when generating mission.yaml | ~45 min | ⬜ |
+| Lot FIX-CONVERT-V5-DEPS — resolve module dependencies when generating mission.yaml | ~45 min | ✅ |
 | **Total** | **~212h** | |
 
 *Initial calibration factor: 1.15 — recalculate after each completed lot.*
@@ -111,9 +111,9 @@
 
 | # | Ticket | Files | Type | Effort | Status |
 |---|--------|-------|------|--------|--------|
-| CVDEP-001 | Expose the dependency graph / resolver from `lua_config_generator.py` so the converter can reuse it (avoid duplicating `_MODULE_DEPS`) | `veaf_libs/lua_config_generator.py` | refactor | 15 min | ⬜ |
-| CVDEP-002 | In `convert-v5` module generation, auto-enable required dependencies (transitively) and emit them explicitly in the generated `mission.yaml`; add a one-line note in the conversion report listing dependencies that were auto-added | `mission_builder/v5_converter.py`, `locales/*.json` | feat | 20 min | ⬜ |
-| CVDEP-003 | TDD: a v5 folder enabling `CASMISSION` produces a `mission.yaml` with `GROUNDAI` (and `SPAWN`) enabled; `build` no longer prints the dependency auto-enable warning for it | `test/python/` | test | 10 min | ⬜ |
+| CVDEP-001 | Expose the dependency graph / resolver from `lua_config_generator.py` so the converter can reuse it (avoid duplicating `_MODULE_DEPS`) — added pure `resolve_module_dependencies()` helper | `veaf_libs/lua_config_generator.py` | refactor | 15 min | ✅ |
+| CVDEP-002 | In `convert-v5` module generation, auto-enable required dependencies (transitively) and emit them explicitly in the generated `mission.yaml`; add a one-line note in the conversion report listing dependencies that were auto-added | `mission_builder/v5_converter.py`, `locales/*.json` | feat | 20 min | ✅ |
+| CVDEP-003 | TDD: a v5 folder enabling `CASMISSION` produces a `mission.yaml` with `GROUNDAI` (and `SPAWN`) enabled; `build` no longer prints the dependency auto-enable warning for it | `test/python/` | test | 10 min | ✅ |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.11"
+version = "6.3.12"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -933,9 +933,11 @@ class V5Converter:
         # the generated mission.yaml is self-consistent and the build no longer
         # needs to auto-enable them at config-generation time with a warning.
         auto_deps = resolve_module_dependencies(enabled_set)
+        # Always assign (even when empty) so a report reused across calls never
+        # keeps stale auto-resolved dependencies.
+        report.auto_resolved_deps = auto_deps
         if auto_deps:
             enabled_set.update(auto_deps)
-            report.auto_resolved_deps = auto_deps
         all_mods = get_modules()
 
         # Modules explicitly enabled (from missionConfig.lua or always-on base set)

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -29,7 +29,13 @@ from typing import Any
 import yaml  # type: ignore[import-untyped]
 from mission_tools.mission_constants import get_community_script_files
 from veaf_libs.i18n import t
-from veaf_libs.lua_config_generator import MANDATORY_MODULES, MODULE_CATEGORIES, yaml_module_entry, yaml_syntax_header
+from veaf_libs.lua_config_generator import (
+    MANDATORY_MODULES,
+    MODULE_CATEGORIES,
+    resolve_module_dependencies,
+    yaml_module_entry,
+    yaml_syntax_header,
+)
 from veaf_libs.lua_module_scanner import get_modules
 
 from mission_builder.config_migrator import ConfigMigrator, MigrationResult
@@ -171,6 +177,8 @@ class ConversionReport:
     mission_yaml_generated: bool = False
     mission_yaml_path: Path | None = None
     mission_yaml_skipped_reason: str = ""
+    auto_resolved_deps: list[str] = field(default_factory=list)
+    """Module IDs auto-enabled to satisfy dependencies (e.g. CASMISSION → GROUNDAI)."""
 
     # ── Summary lists ──────────────────────────────────────────────────────
     actions: list[str] = field(default_factory=list)
@@ -322,6 +330,8 @@ class ConversionReport:
                 f"- `global_log_level: debug` \u2014 {t('report.mission_yaml.log_level_warn')}",
                 f"- `lua_modules:` \u2014 {t('report.mission_yaml.modules_count', enabled=enabled_count, disabled=disabled_count)}",
             ]
+            if self.auto_resolved_deps:
+                lines.append(f"- {t('report.mission_yaml.deps_resolved', list=', '.join(self.auto_resolved_deps))}")
             if self.pipeline_files:
                 ready = [pf for pf in self.pipeline_files if not pf.needs_conversion]
                 needs_conv = [pf for pf in self.pipeline_files if pf.needs_conversion]
@@ -919,6 +929,13 @@ class V5Converter:
 
         enabled_modules = mr.enabled_modules if mr else []
         enabled_set = set(enabled_modules) | _BASE_ALWAYS_ON
+        # Pre-resolve module dependencies (e.g. CASMISSION → GROUNDAI, SPAWN) so
+        # the generated mission.yaml is self-consistent and the build no longer
+        # needs to auto-enable them at config-generation time with a warning.
+        auto_deps = resolve_module_dependencies(enabled_set)
+        if auto_deps:
+            enabled_set.update(auto_deps)
+            report.auto_resolved_deps = auto_deps
         all_mods = get_modules()
 
         # Modules explicitly enabled (from missionConfig.lua or always-on base set)

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -245,6 +245,7 @@
   "convert_v5.report.unknown_reason": "Unknown reason.",
   "report.mission_yaml.created_with": "Created with:",
   "report.mission_yaml.modules_count": "{enabled} module(s) enabled, {disabled} disabled",
+  "report.mission_yaml.deps_resolved": "auto-enabled to satisfy dependencies: {list}",
   "cmd.user_config.help": "Show and manage the global user configuration (~/veafmct.yaml).",
   "cmd.user_config.opt.set": "Set a configuration key (format: key=value, e.g. lang=fr).",
   "cmd.user_config.opt.unset": "Remove a configuration key.",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -110,6 +110,7 @@
   "report.mission_yaml.not_generated": "Non généré",
   "report.mission_yaml.created_with": "Le fichier a été créé avec :",
   "report.mission_yaml.modules_count": "{enabled} module(s) activé(s), {disabled} désactivé(s)",
+  "report.mission_yaml.deps_resolved": "activé(s) automatiquement pour satisfaire les dépendances : {list}",
   "report.mission_yaml.log_level_warn": "changez en `info` ou supprimez avant le déploiement en production",
   "report.mission_yaml.pipeline_none": "aucun fichier v6 détecté",
   "report.mission_yaml.pipeline_v5_warn": "Étapes avec fichiers v5 (à convertir) : {steps}",

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -246,6 +246,35 @@ _MODULE_DEPS: dict[str, list[str]] = {
 }
 
 
+def resolve_module_dependencies(enabled_ids: set[str]) -> list[str]:
+    """Return module IDs required (transitively) by *enabled_ids* but absent from it.
+
+    Walks the :data:`_MODULE_DEPS` graph so that, for example, enabling
+    ``CASMISSION`` pulls in ``GROUNDAI`` and ``SPAWN`` (and their own
+    dependencies). Pure and side-effect free — unlike :func:`_resolve_deps`,
+    it neither mutates input nor logs — so callers such as ``convert-v5`` can
+    pre-resolve dependencies when generating ``mission.yaml``.
+
+    Args:
+        enabled_ids: The module IDs that are explicitly enabled.
+
+    Returns:
+        Sorted list of additional module IDs that must be enabled to satisfy
+        every declared dependency. Never contains an ID already in
+        *enabled_ids*.
+    """
+    enabled = set(enabled_ids)
+    added: set[str] = set()
+    queue: list[str] = list(enabled)
+    while queue:
+        mod_id = queue.pop()
+        for dep in _MODULE_DEPS.get(mod_id, []):
+            if dep not in enabled and dep not in added:
+                added.add(dep)
+                queue.append(dep)
+    return sorted(added)
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------

--- a/test/python/mission_builder/test_v5_converter.py
+++ b/test/python/mission_builder/test_v5_converter.py
@@ -561,3 +561,44 @@ class TestMigrateConfigBackupNoBak(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# V5Converter._build_mission_yaml() — module dependency pre-resolution
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMissionYamlDependencyResolution(unittest.TestCase):
+    """convert-v5 must pre-resolve module dependencies in the generated mission.yaml."""
+
+    def _build(self, enabled_modules: list[str]) -> tuple[str, ConversionReport]:
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            mr = MigrationResult(new_content="", enabled_modules=enabled_modules)
+            report = ConversionReport(mission_folder=folder, version="test", migration_result=mr)
+            yaml = V5Converter(version="test")._build_mission_yaml(report)
+            return yaml, report
+
+    def test_casmission_pulls_in_groundai_and_spawn(self) -> None:
+        yaml, report = self._build(["CASMISSION"])
+        self.assertIn("CASMISSION", yaml)
+        self.assertIn("GROUNDAI", yaml)
+        self.assertIn("SPAWN", yaml)
+        # Dependencies recorded so the conversion report can mention them
+        self.assertIn("GROUNDAI", report.auto_resolved_deps)
+        self.assertIn("SPAWN", report.auto_resolved_deps)
+
+    def test_no_deps_recorded_when_none_needed(self) -> None:
+        # RADIO has no dependencies; the always-on base set is self-consistent.
+        _, report = self._build(["RADIO"])
+        self.assertEqual(report.auto_resolved_deps, [])
+
+    def test_report_mentions_resolved_dependencies(self) -> None:
+        _, report = self._build(["CASMISSION"])
+        report.mission_yaml_generated = True
+        report.mission_yaml_path = report.mission_folder / "mission.yaml"
+        markdown = report.to_markdown()
+        note = t("report.mission_yaml.deps_resolved", list=", ".join(report.auto_resolved_deps))
+        self.assertIn(note, markdown)
+        # The auto-resolved module names appear in the rendered report
+        self.assertIn("GROUNDAI", markdown)

--- a/test/python/veaf_libs/test_lua_config_generator.py
+++ b/test/python/veaf_libs/test_lua_config_generator.py
@@ -11,6 +11,7 @@ from veaf_libs.lua_config_generator import (
     _resolve_deps,
     generate_config_lua,
     generate_mission_yaml_template,
+    resolve_module_dependencies,
 )
 
 _LONG_STRING_RE = re.compile(r"^\[=*\[")
@@ -363,3 +364,31 @@ def test_explicitly_disabled_module_skips_dep_check():
     result = _resolve_deps(effective)
     # UNITS should NOT be auto-added since SPAWN is disabled
     assert "UNITS" not in result
+
+
+# ---------------------------------------------------------------------------
+# resolve_module_dependencies() — pure transitive dependency resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_module_dependencies_transitive():
+    """CASMISSION must pull in its full transitive dependency closure."""
+    added = resolve_module_dependencies({"CASMISSION"})
+    # CASMISSION -> SPAWN, GROUNDAI; SPAWN -> UNITS; GROUNDAI -> COMMANDS; COMMANDS -> MARKERS
+    for dep in ("SPAWN", "GROUNDAI", "COMMANDS", "MARKERS", "UNITS"):
+        assert dep in added, f"{dep} should be auto-resolved"
+    assert "CASMISSION" not in added  # never returns the input itself
+
+
+def test_resolve_module_dependencies_skips_already_enabled():
+    """Dependencies already in the enabled set are not returned again."""
+    added = resolve_module_dependencies({"CASMISSION", "GROUNDAI", "SPAWN"})
+    assert "GROUNDAI" not in added
+    assert "SPAWN" not in added
+    assert "COMMANDS" in added  # transitive deps still pulled in
+
+
+def test_resolve_module_dependencies_leaf_and_empty():
+    """A module with no dependencies (or an empty set) resolves to nothing."""
+    assert resolve_module_dependencies({"MARKERS"}) == []
+    assert resolve_module_dependencies(set()) == []


### PR DESCRIPTION
## Problem

`convert-v5` generated `mission.yaml` without resolving module dependencies. A later `veaf-tools build` then had to auto-enable missing dependencies at config-generation time and print a warning, e.g.:

> Module 'CASMISSION' requires 'GROUNDAI' which is not configured — auto-enabling 'GROUNDAI'

Since the converter had just produced the file, it should emit a self-consistent `mission.yaml` in the first place.

## Fix

- **`lua_config_generator.py`**: new pure helper `resolve_module_dependencies(enabled_ids)` that walks the existing `_MODULE_DEPS` graph **transitively** (no logging, no mutation). The converter reuses this single source of truth instead of duplicating the graph.
- **`v5_converter._build_mission_yaml`**: pre-resolves dependencies and emits the required modules explicitly as enabled (e.g. `CASMISSION` → `GROUNDAI`, `SPAWN`, and their transitive deps). The auto-enabled modules are recorded on the `ConversionReport` and listed in the conversion report.

The build-time `_resolve_deps` safety net still runs, but now finds the dependencies already present, so no warning is emitted and the generated file accurately reflects what will run.

## Tests
- `resolve_module_dependencies`: transitive closure, skips already-enabled modules, empty for leaf/empty input.
- `_build_mission_yaml`: enabling `CASMISSION` yields `GROUNDAI` + `SPAWN` in the YAML and records them; no deps recorded when none needed; the report mentions the resolved modules.
- Full suite green; `ruff check` / `ruff format --check` / `mypy` clean on `src/python`.

## Backlog
- Closes lot `FIX-CONVERT-V5-DEPS` (tickets `CVDEP-001..003`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pre-resolve module dependencies when generating mission.yaml so convert-v5 outputs a self-consistent configuration and surfaces auto-enabled modules in the conversion report.

Bug Fixes:
- Ensure convert-v5-generated mission.yaml auto-enables required module dependencies (e.g. CASMISSION → GROUNDAI, SPAWN, and transitive deps) so builds no longer emit dependency auto-enable warnings.

Enhancements:
- Introduce a pure resolve_module_dependencies helper in lua_config_generator to expose transitive dependency resolution without side effects.
- Extend ConversionReport to record and display auto-resolved module dependencies in the mission.yaml section of the report.

Tests:
- Add unit tests for resolve_module_dependencies covering transitive closure, already-enabled modules, and leaf/empty inputs.
- Add integration-style tests for V5Converter._build_mission_yaml to verify dependency auto-enabling, reporting, and absence of deps when not needed.

Chores:
- Mark FIX-CONVERT-V5-DEPS backlog lot and related CVDEP tickets as completed, bump project version to 6.3.12, and update the changelog with the new convert-v5 behavior.