### PR TITLE
fix(prerel-bugs): fix 5 pre-release findings (PREREL-001..005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- `config_migrator`: `_lua_extract_string()` no longer absorbs quoted strings from chained Lua setters after `:setBriefing(…)` — search is now bounded to the matching closing parenthesis (regression from PR #390)
+- `mission_builder_worker`: missing-files error now uses i18n keys (`builder.missing_files`, `builder.update_hint`) instead of hardcoded English; `spinner_context` for `dcs-bridge.lua` injection also uses `t("builder.inject_dcs_bridge")`; fatal error no longer calls `exit()` (raises via `logger.error` instead, giving a non-zero exit code)
+- `paths.py`: `resolve_path` now raises `FileNotFoundError` instead of calling `exit(-1)` when a required path does not exist — makes the function testable and avoids `SystemExit(0)` on error
+- `v5_converter`: removed dead `is None` branch inside `if mr.mission_export_path is not None:` (unreachable)
+
 ### Added
 - docs: documentation overhaul (bilingual FR/EN) — pilot guide rewritten (deduplicated, accessible, jargon explained, `_auth` standardized); mission.yaml example updated to the unified `modules:` block; mermaid diagrams added (F10 radio menu, build pipeline, v5→v6 migration flow); screenshot placeholders added under `doc/assets/img/`; created the missing French `veafInterpreter` page; fixed broken `GUIDE.fr.md` links
 - docs: French/English parity for the large reference docs — `LUA_API_REFERENCE.md` (all module sections brought to full depth: missing functions, parameters, and code examples translated), `TOOLS_REFERENCE.md` (troubleshooting, command reference, best practices, security, FAQ sections added), and `dcs-radio-specs.md` (header and critical-aircraft prose translated)

--- a/backlog.md
+++ b/backlog.md
@@ -16,7 +16,7 @@
 | Phase 0b — GitHub cleanup | ⬜ |
 | Lot 5 — RELEASE | ⬜ |
 | Lot FIX-I18N-CONVERT-V5 — Hardcoded English messages in convert-v5 | ✅ |
-| Lot PREREL-BUGS — pre-release code review findings (briefing over-capture, exit codes, i18n, error handling) | ⬜ |
+| Lot PREREL-BUGS — pre-release code review findings (briefing over-capture, exit codes, i18n, error handling) | ✅ |
 | Lot SECREV — full-repo code review findings (lupa RCE, helicopter extraction data loss, zip hardening, Lua nil-derefs) | ⬜ |
 
 ---
@@ -104,10 +104,10 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 
 | # | Ticket | Type | Status |
 |---|--------|------|--------|
-| PREREL-001 (B1) | **Regression** — `config_migrator.py` `_lua_extract_string()` over-collects quoted strings after `:setBriefing(`: a briefing absorbs following setter strings in the same call chain. Introduced by the multiline fix (PR #390), reproduced empirically. Fix: bound the search to the matching `)` of `:setBriefing(`. Add a regression test covering a chained `:setBriefing("..."):setX("...")` case. | fix | ⬜ |
-| PREREL-002 (B2) | `mission_builder_worker.py` (~L339): `exit()` returns code 0 after a fatal error, so a failed build is reported as success. Use a non-zero exit code / raise. | fix | ⬜ |
-| PREREL-003 (B3/B4) | Hardcoded English in `mission_builder_worker.py`: ~L333-338 missing-files message and ~L1168 `"Injecting dcs-bridge.lua"` spinner must use `t()`; add FR translations to `fr.json`. | fix | ⬜ |
-| PREREL-004 (I1) | `paths.py`: replace `exit(-1)` with a raised exception (utility code should not call `exit()`; makes it testable). | fix | ⬜ |
-| PREREL-005 (cosmetic) | `v5_converter.py` (~L885): remove the dead `is None` branch (never reached). Low priority. | chore | ⬜ |
+| PREREL-001 (B1) | **Regression** — `config_migrator.py` `_lua_extract_string()` over-collects quoted strings after `:setBriefing(`: a briefing absorbs following setter strings in the same call chain. Introduced by the multiline fix (PR #390), reproduced empirically. Fix: bound the search to the matching `)` of `:setBriefing(`. Add a regression test covering a chained `:setBriefing("..."):setX("...")` case. | fix | ✅ |
+| PREREL-002 (B2) | `mission_builder_worker.py` (~L339): `exit()` returns code 0 after a fatal error, so a failed build is reported as success. Use a non-zero exit code / raise. | fix | ✅ |
+| PREREL-003 (B3/B4) | Hardcoded English in `mission_builder_worker.py`: ~L333-338 missing-files message and ~L1168 `"Injecting dcs-bridge.lua"` spinner must use `t()`; add FR translations to `fr.json`. | fix | ✅ |
+| PREREL-004 (I1) | `paths.py`: replace `exit(-1)` with a raised exception (utility code should not call `exit()`; makes it testable). | fix | ✅ |
+| PREREL-005 (cosmetic) | `v5_converter.py` (~L885): remove the dead `is None` branch (never reached). Low priority. | chore | ✅ |
 
 ---

--- a/src/python/veaf-tools/mission_builder/config_migrator.py
+++ b/src/python/veaf-tools/mission_builder/config_migrator.py
@@ -102,11 +102,52 @@ _LUA_ESCAPES: list[tuple[str, str]] = [
 ]
 
 
+def _find_matching_paren(text: str, start: int) -> int:
+    """Return the index of the ``')'`` that closes the ``'('`` just before *start*.
+
+    Skips quoted string content so parentheses inside strings are not counted.
+    *start* is the index immediately after the opening ``'('``.
+    Returns ``len(text)`` when no matching ``')'`` is found.
+
+    Args:
+        text: Source text to scan.
+        start: Index of the first character inside the open parenthesis.
+
+    Returns:
+        Index of the matching closing parenthesis, or ``len(text)`` if not found.
+    """
+    depth = 1
+    i = start
+    while i < len(text) and depth > 0:
+        c = text[i]
+        if c in ('"', "'"):
+            quote = c
+            i += 1
+            while i < len(text):
+                if text[i] == "\\":
+                    i += 2
+                    continue
+                if text[i] == quote:
+                    break
+                i += 1
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return len(text)
+
+
 def _lua_extract_string(text: str, call_name: str) -> str | None:
     """Extract and decode a Lua method argument that may be a ``[[...]]`` long string or ``"..."``-concat.
 
     Handles Lua ``..`` string concatenation — e.g.:
     ``:setBriefing("line1\\n" .. "line2\\n")`` → ``"line1\\nline2\\n"`` with ``\\n`` → real newlines.
+
+    Only the argument of the matched call is inspected; chained setters after the closing
+    ``')'`` are not included.
 
     Args:
         text: The source text containing the method call.
@@ -119,12 +160,14 @@ def _lua_extract_string(text: str, call_name: str) -> str | None:
     if not m:
         return None
     arg_start = m.end()
+    arg_end = _find_matching_paren(text, arg_start)
+    arg_text = text[arg_start:arg_end]
     # Long string [[...]] — no escape decoding needed
-    ls = re.match(r"\s*\[\[(.*?)\]\]", text[arg_start:], re.DOTALL)
+    ls = re.match(r"\s*\[\[(.*?)\]\]", arg_text, re.DOTALL)
     if ls:
         return ls.group(1).strip()
-    # Collect all "..." fragments (handles .. concatenation across lines)
-    fragments = _LUA_QUOTED_STR_RE.findall(text[arg_start:])
+    # Collect all "..." fragments within the argument (handles .. concatenation)
+    fragments = _LUA_QUOTED_STR_RE.findall(arg_text)
     if not fragments:
         return None
     joined = "".join(fragments)

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -330,13 +330,9 @@ class MissionBuilderWorker(BaseWorker):
             if Path(file_pattern[0]).name not in collected_file_paths
         ]
 
-        message = f"Error: missing files from {scripts_folder}:\n"
-        for missing_file in sorted(missing_files):
-            message += f"  - {missing_file}\n"
-        message = message.rstrip("\n")
-        message += "\nTry updating the veaf-tools package using veaf-tools-updater.exe!"
-        logger.error(message=message, raise_exception=False)
-        exit()
+        files_str = ", ".join(sorted(missing_files))
+        message = t("builder.missing_files", folder=scripts_folder, files=files_str) + "\n" + t("builder.update_hint")
+        logger.error(message=message)
 
     def get_collected_mission_script_files(self) -> dict[str, bytes]:
         if self.collected_mission_script_files:
@@ -1165,7 +1161,7 @@ class MissionBuilderWorker(BaseWorker):
 
         # Optionally inject dcs-bridge.lua before all other triggers
         if self.dcs_bridge_enabled:
-            with spinner_context("Injecting dcs-bridge.lua", silent=silent):
+            with spinner_context(t("builder.inject_dcs_bridge"), silent=silent):
                 bridge_file = self.resolve_dcs_bridge_file()
                 self.inject_dcs_bridge_trigger(bridge_file)
 

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -893,7 +893,7 @@ class V5Converter:
             if mr.mission_era:
                 lines.append(f"  era: {mr.mission_era}")
             if mr.mission_export_path is not None:
-                ep_yaml = "null" if mr.mission_export_path is None else _yaml_str(str(mr.mission_export_path))
+                ep_yaml = _yaml_str(str(mr.mission_export_path))
                 lines.append(f"  export_path: {ep_yaml}")
             lines.append("")
 

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -487,6 +487,7 @@
   "builder.unknown_module_ids": "--log-modules: unknown module ID(s): {ids} - check spelling",
   "builder.unknown_community_script": "Unknown community script id {id} in 'community_scripts:'; ignoring.",
   "builder.dcs_bridge_downloading": "dcs_bridge: downloading dcs-bridge.lua from {url}",
+  "builder.inject_dcs_bridge": "Injecting dcs-bridge.lua",
   "builder.copied_from_defaults": "Copied required file '{file}' from default folder '{folder}'",
   "builder.mission_read_error": "An error occurred while reading the {path} file; is this a valid DCS mission?",
   "builder.veaf_config_generated": "Generated '{file}' from mission.yaml",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -487,6 +487,7 @@
   "builder.unknown_module_ids": "--log-modules : ID(s) de module inconnu(s) : {ids} — vérifiez l'orthographe",
   "builder.unknown_community_script": "ID de script communautaire inconnu {id} dans 'community_scripts:' ; ignoré.",
   "builder.dcs_bridge_downloading": "dcs_bridge : téléchargement de dcs-bridge.lua depuis {url}",
+  "builder.inject_dcs_bridge": "Injection de dcs-bridge.lua",
   "builder.copied_from_defaults": "Fichier requis '{file}' copié depuis le dossier par défaut '{folder}'",
   "builder.mission_read_error": "Erreur lors de la lecture du fichier {path} ; est-ce une mission DCS valide ?",
   "builder.veaf_config_generated": "'{file}' généré depuis mission.yaml",

--- a/src/python/veaf-tools/veaf_libs/paths.py
+++ b/src/python/veaf-tools/veaf_libs/paths.py
@@ -42,8 +42,7 @@ def resolve_path(
             result.mkdir(exist_ok=True)
 
     if should_exist and not result.exists():
-        logger.error(t("paths.path_not_found", path=result))
-        exit(-1)
+        logger.error(t("paths.path_not_found", path=result), exception_type=FileNotFoundError)
 
     return result
 

--- a/test/python/mission_builder/test_config_migrator.py
+++ b/test/python/mission_builder/test_config_migrator.py
@@ -821,6 +821,18 @@ class TestCombatZoneBriefingMultiline(unittest.TestCase):
         self.assertNotIn("\\n", zone["briefing"])
         self.assertIn("\n", zone["briefing"])
 
+    def test_chained_setter_not_absorbed(self) -> None:
+        """Regression PREREL-001: setBriefing must not absorb quoted strings from chained setters."""
+        zone = self._extract_zone(':setBriefing("The briefing"):setName("Zone Alpha")')
+        self.assertEqual(zone["briefing"], "The briefing")
+
+    def test_chained_setter_multiline_not_absorbed(self) -> None:
+        """Regression PREREL-001: multiline briefing with chained setter must stop at closing paren."""
+        zone = self._extract_zone(':setBriefing("Line one\\n" .. "Line two\\n"):setName("Zone Alpha")')
+        self.assertIn("Line one", zone["briefing"])
+        self.assertIn("Line two", zone["briefing"])
+        self.assertNotIn("Zone Alpha", zone["briefing"])
+
 
 class TestExtractAirwavesZones(unittest.TestCase):
     """_extract_airwaves_zones must parse AirWaveZone builder chains."""

--- a/test/python/veaf_libs/test_paths.py
+++ b/test/python/veaf_libs/test_paths.py
@@ -55,7 +55,7 @@ class TestResolvePath(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             missing = Path(tmpdir) / "does_not_exist.txt"
-            with self.assertRaises((typer.Abort, SystemExit)):
+            with self.assertRaises((typer.Abort, SystemExit, FileNotFoundError)):
                 resolve_path(path=str(missing), should_exist=True)
 
     def test_should_exist_passes_for_existing_path(self) -> None:


### PR DESCRIPTION
## Summary

- **PREREL-001** — `config_migrator._lua_extract_string()` bounded to the matching `)` via new `_find_matching_paren()` helper; chained setters after `:setBriefing(…)` no longer bleed into the extracted briefing. Two regression tests added.
- **PREREL-002** — Removed bare `exit()` call after `logger.error(raise_exception=False)` in `signal_missing_required_files_after_collection`; `logger.error` already raises `typer.Abort` (non-zero) by default — the `exit()` was giving exit code 0 on a fatal build error.
- **PREREL-003** — Replaced hardcoded English strings with `t("builder.missing_files")`, `t("builder.update_hint")` (pre-existing unused keys) and new `t("builder.inject_dcs_bridge")`; French translation added for the new key.
- **PREREL-004** — `paths.resolve_path` now raises `FileNotFoundError` via `logger.error(exception_type=FileNotFoundError)` instead of `exit(-1)`; makes the function testable; test updated to accept `FileNotFoundError`.
- **PREREL-005** — Removed dead `is None` ternary inside the already-guarded `if mr.mission_export_path is not None:` block in `v5_converter.py`.

## Test plan

- [x] `poetry run pytest test/python/ --no-cov` — 1065 passed, 1 skipped
- [x] `poetry run ruff check src/python/ --fix` — no errors
- [x] `poetry run mypy src/python/veaf-tools/` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Address multiple pre-release findings in mission builder tooling, tightening Lua briefing parsing, error handling, i18n, and minor cleanup.

Bug Fixes:
- Limit Lua briefing string extraction to the matched call so chained setters are no longer absorbed into the briefing text.
- Ensure missing required files during mission building raise a proper non-zero error via logger instead of exiting with code 0.
- Make path resolution raise FileNotFoundError via logger when a required path is missing instead of calling exit(-1).

Enhancements:
- Use existing and new i18n keys for missing-files messaging and the dcs-bridge injection spinner, adding the corresponding French translation.
- Remove a dead export-path None branch in the v5 converter for clearer mission YAML generation logic.

Documentation:
- Mark the PREREL-BUGS lot as completed in the backlog and document the fixes in the changelog.

Tests:
- Add regression tests ensuring chained Lua setters do not bleed into extracted briefings and update path resolution tests to expect FileNotFoundError as appropriate.

Chores:
- Mark all PREREL-001..005 tickets as done in the backlog tracking table.