### PR TITLE
chore(release): prepare v6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [6.4.0] — 2026-06-09
 
 ### Fixed
 - `config_migrator`: `_lua_extract_string()` no longer absorbs quoted strings from chained Lua setters after `:setBriefing(…)` — search is now bounded to the matching closing parenthesis (regression from PR #390)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -59,7 +59,7 @@ d'activer ou désactiver individuellement les scripts Lua communautaires
 
 ### Affichage console épuré
 
-La sortie des outils en ligne de commande est désormais « décluttée » : les
+La sortie des outils en ligne de commande est désormais « épurée » : les
 messages de progression de faible importance défilent sur une seule ligne
 réécrite, tandis que les lignes techniques permanentes et les en-têtes d'étape
 restent affichés. Chaque étape du build se termine par une ligne de résultat
@@ -72,7 +72,7 @@ fichier de log complet reste inchangé.
 
 Tous les messages des outils (build, injecteurs de presets et waypoints,
 validateur de fréquences, convertisseur v5…) sont désormais traduits en
-français — plus aucun texte anglais en dur dans les logs en locale française.
+français — plus aucun texte anglais en dur dans les logs en français.
 
 ### Profil de coloration Klogg
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,39 +1,141 @@
-# VEAF Mission Creation Tools — v6.3.4
+# VEAF Mission Creation Tools — v6.4.0
 
-**Version de consolidation** — corrections, clarté des erreurs, et enrichissement de la documentation.
+**Version de consolidation** — unification de la configuration `mission.yaml`,
+internationalisation complète, refonte de la documentation et nombreuses
+corrections de la conversion v5→v6.
 
-Un grand merci à **Flogas** pour ses tests approfondis et ses retours précieux qui ont contribué à la qualité de cette version.
+Un grand merci à **Tripack** pour ses contributions et ses retours qui ont
+nourri la qualité de cette version.
+
+---
+
+## ⚠️ Migrations à effectuer
+
+### `versions.yaml` remplace `missions.yaml`
+
+L'étape *weather* du build utilise désormais **exclusivement** `src/versions.yaml`.
+Le nom `missions.yaml` n'est plus reconnu. **Renommez votre fichier
+`src/missions.yaml` en `src/versions.yaml`** avant de relancer un build.
+
+### Syntaxe `mission.yaml` unifiée
+
+Les sections `lua_modules:` et `community_scripts:` fusionnent dans un bloc
+**`modules:`** unique. Autres changements :
+
+- les modules obligatoires s'écrivent `MODULE:` (valeur nulle) au lieu de `MODULE: {}` ;
+- la clé `enable:` devient `enabled:` ;
+- les listes en bloc remplacent la notation `[...]` ;
+- un en-tête aide-mémoire de syntaxe YAML est ajouté aux fichiers générés.
+
+> Les anciennes clés restent acceptées avec un avertissement de dépréciation —
+> mais il est recommandé de migrer vers la nouvelle syntaxe.
 
 ---
 
 ## Nouveautés
 
-### Scripts Lua personnalisés dans `mission.yaml`
+### Validation des fréquences radio DCS
 
-Il est désormais possible de déclarer des scripts Lua personnalisés situés dans `src/scripts/` via la nouvelle section `custom_scripts` de `mission.yaml`. Chaque script peut désactiver la génération automatique du trigger de chargement DCS avec `generate_load_trigger: false`.
+L'injection des presets vérifie maintenant chaque fréquence contre les
+capacités matérielles réelles de l'avion **au moment du build**. Une fréquence
+invalide (par ex. 284 MHz sur un MiG-19P ou une Gazelle M) déclenche un
+avertissement *avant* que DCS ne la rejette au chargement de la mission.
+
+Une table de référence lisible des plages de fréquences valides pour les
+**85 avions pilotables de DCS** est fournie dans
+`doc/mission-maker/dcs-radio-specs.md`.
+
+### Injection automatique de `dcs-bridge.lua`
+
+Nouvelle section `dcs_bridge` dans `mission.yaml` : injecte `dcs-bridge.lua`
+comme premier trigger DO SCRIPT FILE de la mission. Si `lua_path` est absent,
+le fichier est téléchargé automatiquement depuis GitHub (`VEAF/VEAF-dcs-bridge`).
+
+### Activation fine des scripts communautaires
+
+La section `community_scripts:` (intégrée au nouveau bloc `modules:`) permet
+d'activer ou désactiver individuellement les scripts Lua communautaires
+(MIST, CTLD, CSAR…). En l'absence de cette section, tous les scripts restent actifs.
+
+### Affichage console épuré
+
+La sortie des outils en ligne de commande est désormais « décluttée » : les
+messages de progression de faible importance défilent sur une seule ligne
+réécrite, tandis que les lignes techniques permanentes et les en-têtes d'étape
+restent affichés. Chaque étape du build se termine par une ligne de résultat
+concise (« injected presets into 127 aircraft », « created 6 weather
+variants »…), si bien qu'un compteur à `0` signale immédiatement un problème de
+configuration. `--verbose` rétablit l'affichage classique ligne par ligne ; le
+fichier de log complet reste inchangé.
+
+### Internationalisation complète
+
+Tous les messages des outils (build, injecteurs de presets et waypoints,
+validateur de fréquences, convertisseur v5…) sont désormais traduits en
+français — plus aucun texte anglais en dur dans les logs en locale française.
+
+### Profil de coloration Klogg
+
+Un profil de mise en évidence des logs DCS est fourni dans
+`tools/klogg/veaf.conf` pour faciliter l'analyse des journaux.
 
 ---
 
-## Corrections
+## Conversion v5 → v6 (`convert-v5`)
 
-- **Erreurs YAML** : si `mission.yaml` contient une erreur de syntaxe, l'outil affiche maintenant un message clair indiquant le fichier, la ligne, la colonne et une explication en langage naturel — plus de crash Python cryptique.
-- **Modules obligatoires** : spécifier `enable: true/false` sur un module Lua obligatoire (`UNITS`, `TIME`, `CACHE`…) lève désormais une erreur explicite au lieu d'être silencieusement ignoré.
+De nombreuses améliorations de la conversion automatique des missions v5 :
+
+- **Résolution des dépendances** : activer un module (par ex. `CASMISSION`)
+  active automatiquement les modules requis (`GROUNDAI`, `SPAWN` et leurs
+  dépendances transitives). Le fichier généré reflète fidèlement ce qui
+  s'exécutera ; le rapport de conversion liste les modules auto-activés.
+- **Modules triés par catégorie** (Infrastructure → Core → Features → Combat →
+  External) ; les modules optionnels sans configuration utilisent le raccourci
+  `MODULE: true`.
+- **Presets radio par avion** extraits depuis `radioSettings` : les warbirds
+  (par ex. Bf-109K-4) sont assignés à `{coalition}_warbird`, les avions à VHF
+  primaire (I-16, Spitfire) à un nouveau preset `{coalition}_vhf_primary`.
+- **Briefings multi-lignes** en concaténation Lua (`"ligne1\n" .. "ligne2\n"`)
+  désormais entièrement extraits et convertis en blocs YAML lisibles.
+- **Commentaires localisés** : les utilisateurs francophones voient des
+  commentaires en français dans le `mission.yaml` généré.
+- `global_log_level` par défaut à `info` (au lieu de `debug`).
+- La commande accepte d'être appelée sans argument (répertoire courant par défaut).
+
+---
+
+## Corrections notables
+
+- **`presets inject`** : les clés `presets_assignments` acceptent désormais des
+  motifs regex (`A[-]10C.*`, `FW[-]190.*`) — correspondance exacte prioritaire,
+  puis motif, puis repli `all`. Les avertissements de fréquence sont regroupés
+  par type d'avion.
+- **`aircraft-groups inject` (mode `add`)** : les groupes dont le nom existe déjà
+  sont ignorés au lieu d'être dupliqués — évite un crash DCS sur les FA-18C/F-16C
+  privés de `datalinks` après une conversion v5→v6.
+- **Lua** : gardes nil-safe ajoutées dans `veafGrass`, `veafSpawnGround` et
+  `veafSpawnEffects` autour de `ctld.builtFOBS` / `logisticUnits` / `beaconCount`
+  — plus de crash quand CTLD n'est pas chargé.
+- **`veafRadio`** : l'absence du fichier de config SRS n'émet plus d'avertissement
+  (passé en `debug`).
+- **`veaf-tools-updater`** : URL de documentation corrigée lors de la première
+  installation.
 
 ---
 
 ## Documentation
 
-- **Nouvelle URL** : la documentation est maintenant publiée sur [veaf.github.io/documentation/](https://veaf.github.io/documentation/). Mettez à jour vos favoris.
-- **Français par défaut** : le français est désormais la langue principale de la documentation ; l'anglais reste disponible en langue secondaire.
-- **Nouvelle section** dans la référence `MISSION_YAML_REFERENCE` : explication des erreurs de syntaxe YAML et leurs causes courantes.
-- **Pages enrichies** : Skynet IADS Helper, QRA Manager, Combat Zone, Radio, Weather — contenus corrigés et complétés.
+- **Refonte bilingue (FR/EN)** : guide pilote réécrit (dédupliqué, accessible,
+  jargon expliqué) ; exemple `mission.yaml` mis à jour vers le bloc `modules:`
+  unifié ; diagrammes mermaid ajoutés (menu radio F10, pipeline de build,
+  migration v5→v6).
+- **Parité FR/EN** des grandes références : `LUA_API_REFERENCE`,
+  `TOOLS_REFERENCE` et `dcs-radio-specs`.
+- Page française `veafInterpreter` créée (corrige un lien de navigation cassé)
+  et liens brisés de `GUIDE.fr.md` réparés.
 
 ---
 
-## Retraits
-
-- La commande `convert` a été supprimée. Elle était non fonctionnelle sur les missions v6. Le flux `extract` suivi de `build` couvre entièrement son usage.
-
----
-
-*VEAF Mission Creation Tools est un projet communautaire open-source. Contributions et retours bienvenus sur [GitHub](https://github.com/VEAF/VEAF-Mission-Creation-Tools).*
+*VEAF Mission Creation Tools est un projet communautaire open-source.
+Contributions et retours bienvenus sur
+[GitHub](https://github.com/VEAF/VEAF-Mission-Creation-Tools).*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.3.12"
+version = "6.4.0"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"


### PR DESCRIPTION
## Release v6.4.0 — Consolidation

Prepares the **v6.4.0** release: closes the `[Unreleased]` changelog section, writes the validated `RELEASE_NOTES.md`, and bumps the version to `6.4.0`.

### Theme
Consolidation du code et de la documentation : unified `mission.yaml` configuration, full i18n (French), documentation overhaul, and many v5→v6 conversion fixes.

### ⚠️ Migrations for mission makers
- **`versions.yaml` replaces `missions.yaml`** — the weather build step no longer accepts `missions.yaml`; rename `src/missions.yaml` → `src/versions.yaml`.
- **Unified `mission.yaml` syntax** — `lua_modules:` + `community_scripts:` merged into a single `modules:` block; `enable:` → `enabled:`; `MODULE: {}` → `MODULE:`. Legacy keys still accepted with a deprecation warning.

### Files changed
- `RELEASE_NOTES.md` — validated v6.4.0 notes
- `CHANGELOG.md` — `[Unreleased]` → `[6.4.0] — 2026-06-09`
- `pyproject.toml` — version `6.3.12` → `6.4.0`

### Highlight
Merci à **Tripack** pour ses contributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the 6.4.0 release with updated release notes, changelog entry, and version metadata.

New Features:
- Document new mission configuration schema with unified mission.yaml modules block and versions.yaml replacing missions.yaml.
- Describe new DCS radio frequency validation at build time and provide a reference of supported ranges per aircraft.
- Introduce automatic dcs-bridge.lua injection via mission.yaml configuration and finer control over community Lua scripts.
- Describe console output decluttering, full French internationalisation of tooling messages, and a new Klogg log-highlighting profile.
- Detail enhancements to the v5→v6 mission converter, including module dependency resolution, radio preset extraction, improved briefing extraction, and defaults adjustments.

Bug Fixes:
- Record fixes to radio preset injection pattern matching and warning aggregation, aircraft group injection duplication, Lua nil-guard crashes when CTLD is absent, veafRadio log level for missing SRS config, and the documentation URL in the tools updater.

Build:
- Bump the project version from 6.3.12 to 6.4.0 in pyproject.toml.

Documentation:
- Replace and expand release notes with detailed migration guidance, new features, conversion improvements, and documentation changes for v6.4.0.
- Note the bilingual documentation overhaul and parity between French and English references, plus new and repaired documentation pages.
- Update the changelog to close the Unreleased section and record v6.4.0 with its key fix.