### PR TITLE
fix(extractor): handle community script dicts in extract_mission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- `mission_extractor`: `extract` no longer crashes with `KeyError: 1` — the script-file cleanup loop now accepts both the `(path, dest)` tuples returned by `get_veaf_script_files()`/`get_legacy_script_files()` and the dict descriptors returned by `get_community_script_files()` (regression from the COMM-001 refactor)
+
+---
+
 ## [6.4.0] — 2026-06-09
 
 ### Fixed

--- a/backlog.md
+++ b/backlog.md
@@ -17,9 +17,22 @@
 | Lot CI-NODE24 — Migrate GitHub Actions off deprecated Node.js 20 | ⬜ |
 | Lot TUI-YAML-DEFAULTS — TUI defaults aware of an existing mission.yaml | ⬜ |
 | Lot 5 — RELEASE | ⬜ |
+| Lot FIX-EXTRACT-COMMUNITY-DICT — `extract` crashes with KeyError on community script dicts | ✅ |
 | Lot FIX-I18N-CONVERT-V5 — Hardcoded English messages in convert-v5 | ✅ |
 | Lot PREREL-BUGS — pre-release code review findings (briefing over-capture, exit codes, i18n, error handling) | ✅ |
 | Lot SECREV — full-repo code review findings (lupa RCE, helicopter extraction data loss, zip hardening, Lua nil-derefs) | ⬜ |
+
+---
+
+## Lot FIX-EXTRACT-COMMUNITY-DICT — `extract` crashes with KeyError on community script dicts
+
+**Goal**: `veaf-tools extract` raised `KeyError: 1` because `extract_mission` still indexed every script-file entry as a `(path, dest)` tuple, while `get_community_script_files()` was refactored (lot COMM-001) to return dicts. Normalize the iteration so community dicts are handled by their `path`/`dest` keys.
+
+**Branch**: `fix/extract-community-dict` → PR → `develop-v6`
+
+| # | Ticket | Files | Type | Status |
+|---|--------|-------|------|--------|
+| FIX-EXTRACT-COMMUNITY-DICT-001 | Normalize the cleanup loop in `extract_mission` to accept both tuple (VEAF/legacy) and dict (community) script descriptors; add an end-to-end regression test extracting a `.miz` that bundles a community script. | `mission_extractor/mission_extractor_worker.py`, `test/python/mission_extractor/test_mission_extractor_worker.py` | fix | ✅ |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.4.0"
+version = "6.4.1"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/mission_extractor/mission_extractor_worker.py
+++ b/src/python/veaf-tools/mission_extractor/mission_extractor_worker.py
@@ -94,10 +94,10 @@ class MissionExtractorWorker(BaseWorker):
             temp_mission_file.unlink()
 
             # Remove the VEAF, community, and legacy VEAF
-            for file_in_mission in [
-                Path(f[1]) / Path(f[0]).name
-                for f in get_veaf_script_files() + get_community_script_files() + get_legacy_script_files()
-            ]:
+            # VEAF and legacy entries are (path, dest) tuples; community entries are dicts.
+            script_files: list[tuple[str, str]] = list(get_veaf_script_files()) + list(get_legacy_script_files())
+            script_files += [(s["path"], s["dest"]) for s in get_community_script_files()]
+            for file_in_mission in [Path(dest) / Path(path).name for path, dest in script_files]:
                 file_in_temp: Path = temp_dir / file_in_mission
                 rm_file_or_dir(file_in_temp)
 

--- a/test/python/mission_extractor/test_mission_extractor_worker.py
+++ b/test/python/mission_extractor/test_mission_extractor_worker.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
+
+MINIMAL_MISSION_LUA = b'mission = {\n  ["name"] = "TestMission",\n}\n'
+MINIMAL_OPTIONS_LUA = b"options = {\n}\n"
+MINIMAL_WAREHOUSES_LUA = b"warehouses = {\n}\n"
 
 
 class TestMissionExtractorWorkerInit(unittest.TestCase):
@@ -38,6 +43,41 @@ class TestMissionExtractorWorkerInit(unittest.TestCase):
             nonexistent_folder = folder / "no_such_folder"
             with self.assertRaises((FileNotFoundError, SystemExit)):
                 MissionExtractorWorker(mission_folder=nonexistent_folder, input_mission_path=miz)
+
+
+class TestMissionExtractorWorkerExtract(unittest.TestCase):
+    def test_extract_handles_community_script_dicts(self) -> None:
+        """Regression: get_community_script_files() returns dicts, not tuples.
+
+        extract_mission used to index entries as f[0]/f[1], raising KeyError on
+        the dict entries. It must iterate them by their 'path'/'dest' keys and
+        remove the bundled community scripts from the extracted mission.
+        """
+        from mission_extractor.mission_extractor_worker import MissionExtractorWorker
+        from mission_tools import get_community_script_files
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            folder = Path(tmpdir)
+            miz = folder / "test.miz"
+
+            community = get_community_script_files()
+            with zipfile.ZipFile(miz, "w") as zf:
+                zf.writestr("mission", MINIMAL_MISSION_LUA)
+                zf.writestr("options", MINIMAL_OPTIONS_LUA)
+                zf.writestr("warehouses", MINIMAL_WAREHOUSES_LUA)
+                zf.writestr("theatre", b"Caucasus")
+                zf.writestr("l10n/DEFAULT/dictionary", b"dictionary = {\n}\n")
+                zf.writestr("l10n/DEFAULT/mapResource", b"mapResource = {\n}\n")
+                # Bundle one community script so the cleanup loop has something to remove.
+                first = community[0]
+                bundled_name = Path(first["path"]).name
+                zf.writestr(f"{first['dest']}/{bundled_name}", b"-- community script\n")
+
+            worker = MissionExtractorWorker(mission_folder=folder, input_mission_path=miz)
+            worker.extract_mission()  # must not raise KeyError
+
+            extracted = folder / "src" / "mission" / first["dest"] / bundled_name
+            self.assertFalse(extracted.exists(), "community script should have been removed on extract")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`veaf-tools extract` crashed with `KeyError: 1`:

```
in extract_mission:98
KeyError: 1
```

The script-file cleanup loop in `extract_mission` still indexed every entry as a `(path, dest)` tuple via `f[1]`/`f[0]`. But `get_community_script_files()` was refactored (lot COMM-001) to return **dicts** (`{"id", "path", "dest"}`). Evaluating `Path(f[1])` on a dict raised `KeyError: 1`.

## Fix

Normalize the iteration so it accepts both shapes:
- `(path, dest)` tuples from `get_veaf_script_files()` / `get_legacy_script_files()`
- dict descriptors from `get_community_script_files()` (consumed by `path`/`dest`, matching how `mission_builder_worker` already reads them)

## Tests

Added an end-to-end regression test that builds a minimal `.miz` bundling a community script, runs `extract_mission`, and asserts no `KeyError` is raised and the bundled community script is removed from the extracted mission.

- ✅ `poetry run pytest` (full suite)
- ✅ `ruff check` / `mypy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix mission extraction to support community script descriptors returned as dictionaries and add regression coverage while preparing a patch release.

Bug Fixes:
- Prevent `extract_mission` from raising `KeyError` by normalizing script-file cleanup to handle both tuple and dict script descriptors.

Enhancements:
- Document the extraction crash regression and its resolution in the backlog and changelog.

Build:
- Bump project version from 6.4.0 to 6.4.1 for the patch release.

Tests:
- Add an end-to-end regression test that extracts a `.miz` containing a bundled community script and verifies it is removed without errors.