### PR TITLE
feat(tui): derive mission-name prompt default from mission.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- TUI wizard: when a `mission.yaml` is present in the working directory, the mission-name prompts (`build`, `extract`, `inject-presets`, …) now propose its `mission.name` field as the default instead of the static `mission.miz`. Resolution precedence is: last saved preference > value derived from `mission.yaml` > static fallback
+
 ### Fixed
 - `mission_extractor`: `extract` no longer crashes with `KeyError: 1` — the script-file cleanup loop now accepts both the `(path, dest)` tuples returned by `get_veaf_script_files()`/`get_legacy_script_files()` and the dict descriptors returned by `get_community_script_files()` (regression from the COMM-001 refactor)
 

--- a/backlog.md
+++ b/backlog.md
@@ -15,7 +15,7 @@
 |-----|--------|
 | Phase 0b — GitHub cleanup | ⬜ |
 | Lot CI-NODE24 — Migrate GitHub Actions off deprecated Node.js 20 | ⬜ |
-| Lot TUI-YAML-DEFAULTS — TUI defaults aware of an existing mission.yaml | ⬜ |
+| Lot TUI-YAML-DEFAULTS — TUI defaults aware of an existing mission.yaml | ✅ |
 | Lot 5 — RELEASE | ⬜ |
 | Lot FIX-EXTRACT-COMMUNITY-DICT — `extract` crashes with KeyError on community script dicts | ✅ |
 | Lot FIX-I18N-CONVERT-V5 — Hardcoded English messages in convert-v5 | ✅ |
@@ -82,11 +82,13 @@
 
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
-| TUI-YAML-DEFAULTS-001 | When a `mission.yaml` exists in the working directory, the TUI derives the default for the `mission_name_or_file` prompt from its `mission.name` field instead of the static `mission.miz`. The `mission:` block already exists in the schema (`mission.name` → `veaf.config.MISSION_NAME`, emitted by `convert-v5` and read by `lua_config_generator`); reuse it as the source of truth. | `veaf_libs/tui.py`, `test/python/` | feat | ⬜ |
-| TUI-YAML-DEFAULTS-002 | Establish the default-resolution precedence and make it explicit: last saved preference > value derived from `mission.yaml` (`mission.name`) > static fallback (decide whether a saved preference should override a detected `mission.yaml` or the reverse). Cover with unit tests. | `veaf_libs/tui.py`, `veaf_libs/preferences.py`, `test/python/` | feat | ⬜ |
-| TUI-YAML-DEFAULTS-003 | Extend the `mission.yaml`-aware defaults to the other relevant prompts where it makes sense (e.g. `mission_folder`, `mission.export_path`, presets/template file paths) once the mechanism from -001/-002 is in place. | `veaf_libs/tui.py`, `test/python/` | feat | ⬜ |
+| TUI-YAML-DEFAULTS-001 | When a `mission.yaml` exists in the working directory, the TUI derives the default for the `mission_name_or_file` prompt from its `mission.name` field instead of the static `mission.miz`. The `mission:` block already exists in the schema (`mission.name` → `veaf.config.MISSION_NAME`, emitted by `convert-v5` and read by `lua_config_generator`); reuse it as the source of truth. | `veaf_libs/tui.py`, `test/python/` | feat | ✅ |
+| TUI-YAML-DEFAULTS-002 | Establish the default-resolution precedence and make it explicit: last saved preference > value derived from `mission.yaml` (`mission.name`) > static fallback (decide whether a saved preference should override a detected `mission.yaml` or the reverse). Cover with unit tests. | `veaf_libs/tui.py`, `veaf_libs/preferences.py`, `test/python/` | feat | ✅ |
+| TUI-YAML-DEFAULTS-003 | Extend the `mission.yaml`-aware defaults to the other relevant prompts where it makes sense (e.g. `mission_folder`, `mission.export_path`, presets/template file paths) once the mechanism from -001/-002 is in place. | `veaf_libs/tui.py`, `test/python/` | feat | ✅ |
 
 > Note: the `mission:` identity block already exists in the `mission.yaml` schema (`name`, `era`, `export_path`, `language`). `mission.name` (e.g. `Training-Syrie`) is the runtime mission name; it is the natural source for the mission-name prompt default. No new schema key is required.
+
+> Resolution: precedence is **last saved preference > `mission.yaml` (`mission.name`) > static fallback** — a saved value the user explicitly typed last run wins over the detected file. Implemented as two pure helpers in `veaf_libs/tui.py` (`_mission_yaml_defaults`, `_resolve_prompt_default`) wired into `run_wizard`. For -003, `mission.name` is the only `mission.yaml` field that maps to an existing prompt (the other prompts — `mission_folder`, presets/template paths — have no `mission.yaml` source); the mechanism is generic (keyed by prompt name) so future fields are a one-line addition.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.4.1"
+version = "6.4.2"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/veaf_libs/tui.py
+++ b/src/python/veaf-tools/veaf_libs/tui.py
@@ -11,6 +11,7 @@ wizard can pre-fill fields on the next run.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from veaf_libs.i18n import t
@@ -163,6 +164,78 @@ COMMANDS: list[CommandSpec] = [
 
 _COMMAND_MAP: dict[str, CommandSpec] = {cmd.cli_name: cmd for cmd in COMMANDS}
 
+# Prompt keys that should default to the ``mission.name`` field of a detected
+# ``mission.yaml``.  Both the ``build``/``extract`` positional and the
+# ``inject-presets`` variant share the same mission identity.
+_MISSION_NAME_PROMPT_KEYS: tuple[str, ...] = ("mission_name_or_file", "input_mission_name_or_file")
+
+# ---------------------------------------------------------------------------
+# mission.yaml-aware defaults
+# ---------------------------------------------------------------------------
+
+
+def _mission_yaml_defaults(folder: Path | None = None) -> dict[str, str]:
+    """Derive prompt defaults from a ``mission.yaml`` in *folder*.
+
+    Reads the ``mission.name`` field and maps it to the mission-name prompts so
+    the wizard proposes the real mission name instead of the static
+    ``mission.miz`` fallback.
+
+    Args:
+        folder: Directory to look in. Defaults to the current working directory.
+
+    Returns:
+        Mapping of prompt key to derived default value. Empty when no
+        ``mission.yaml`` is present, it carries no ``mission.name``, or it
+        cannot be parsed.
+    """
+    folder = folder or Path.cwd()
+    mission_yaml_path = folder / "mission.yaml"
+    if not mission_yaml_path.exists():
+        return {}
+
+    try:
+        import yaml  # noqa: PLC0415
+
+        with mission_yaml_path.open("r", encoding="utf-8") as fh:
+            data: dict = yaml.safe_load(fh) or {}
+    except Exception:
+        # mission.yaml-aware defaults are a convenience — never break the wizard.
+        return {}
+
+    defaults: dict[str, str] = {}
+    mission_name = (data.get("mission") or {}).get("name")
+    if mission_name:
+        for key in _MISSION_NAME_PROMPT_KEYS:
+            defaults[key] = str(mission_name)
+    return defaults
+
+
+def _resolve_prompt_default(
+    prompt: ArgPrompt, last_args: dict[str, Any], yaml_defaults: dict[str, str]
+) -> str:
+    """Resolve the default value offered for *prompt*.
+
+    Precedence: last saved preference > value derived from ``mission.yaml`` >
+    the prompt's static fallback.
+
+    Args:
+        prompt: The prompt being resolved.
+        last_args: Saved argument values for the selected command.
+        yaml_defaults: Defaults derived from a detected ``mission.yaml``.
+
+    Returns:
+        The default string to pre-fill in the prompt.
+    """
+    saved = last_args.get(prompt.key)
+    if saved:
+        return str(saved)
+    yaml_value = yaml_defaults.get(prompt.key)
+    if yaml_value:
+        return str(yaml_value)
+    return prompt.default
+
+
 # ---------------------------------------------------------------------------
 # Wizard entry point
 # ---------------------------------------------------------------------------
@@ -211,24 +284,25 @@ def run_wizard() -> list[str]:
 
         # ── Step 2: prompt for arguments ────────────────────────────────────
         last_args = get_last_args(selected)
+        yaml_defaults = _mission_yaml_defaults()
         collected: dict[str, Any] = {}
 
         for prompt in spec.prompts:
-            saved = last_args.get(prompt.key, prompt.default)
             # Show the CLI flag/name with color prefix for options
             if prompt.is_option:
                 display_label = f"{prompt.cli_flag}  {prompt.label}"
             else:
                 display_label = prompt.label
             if prompt.is_flag:
+                # Flags are booleans — only the saved preference is relevant.
                 value: Any = inquirer.confirm(  # type: ignore[attr-defined]
                     message=display_label,
-                    default=bool(saved),
+                    default=bool(last_args.get(prompt.key, prompt.default)),
                 ).execute()
             else:
                 value = inquirer.text(  # type: ignore[attr-defined]
                     message=display_label,
-                    default=str(saved) if saved else prompt.default,
+                    default=_resolve_prompt_default(prompt, last_args, yaml_defaults),
                 ).execute()
             collected[prompt.key] = value
 

--- a/src/python/veaf-tools/veaf_libs/tui.py
+++ b/src/python/veaf-tools/veaf_libs/tui.py
@@ -211,9 +211,7 @@ def _mission_yaml_defaults(folder: Path | None = None) -> dict[str, str]:
     return defaults
 
 
-def _resolve_prompt_default(
-    prompt: ArgPrompt, last_args: dict[str, Any], yaml_defaults: dict[str, str]
-) -> str:
+def _resolve_prompt_default(prompt: ArgPrompt, last_args: dict[str, Any], yaml_defaults: dict[str, str]) -> str:
     """Resolve the default value offered for *prompt*.
 
     Precedence: last saved preference > value derived from ``mission.yaml`` >

--- a/test/python/veaf_libs/test_tui.py
+++ b/test/python/veaf_libs/test_tui.py
@@ -1,10 +1,19 @@
 """Tests for veaf_libs.tui."""
 
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from veaf_libs.tui import _COMMAND_MAP, COMMANDS, ArgPrompt, CommandSpec, run_wizard
+from veaf_libs.tui import (
+    _COMMAND_MAP,
+    COMMANDS,
+    ArgPrompt,
+    CommandSpec,
+    _mission_yaml_defaults,
+    _resolve_prompt_default,
+    run_wizard,
+)
 
 
 class TestArgPrompt:
@@ -53,6 +62,62 @@ class TestCommandMap:
         assert name in _COMMAND_MAP
 
 
+class TestMissionYamlDefaults:
+    def test_returns_empty_when_no_mission_yaml(self, tmp_path: Path) -> None:
+        assert _mission_yaml_defaults(tmp_path) == {}
+
+    def test_derives_mission_name_for_name_prompts(self, tmp_path: Path) -> None:
+        (tmp_path / "mission.yaml").write_text(
+            "mission:\n  name: Operation-Thunder\n", encoding="utf-8"
+        )
+        defaults = _mission_yaml_defaults(tmp_path)
+        assert defaults["mission_name_or_file"] == "Operation-Thunder"
+        assert defaults["input_mission_name_or_file"] == "Operation-Thunder"
+
+    def test_empty_when_mission_block_has_no_name(self, tmp_path: Path) -> None:
+        (tmp_path / "mission.yaml").write_text("mission:\n  era: MODERN\n", encoding="utf-8")
+        assert _mission_yaml_defaults(tmp_path) == {}
+
+    def test_returns_empty_on_malformed_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / "mission.yaml").write_text("mission: [unclosed\n", encoding="utf-8")
+        assert _mission_yaml_defaults(tmp_path) == {}
+
+
+class TestResolvePromptDefault:
+    def _prompt(self) -> ArgPrompt:
+        return ArgPrompt("mission_name_or_file", "Mission", default="mission.miz", is_option=False)
+
+    def test_saved_preference_wins_over_yaml(self) -> None:
+        prompt = self._prompt()
+        result = _resolve_prompt_default(
+            prompt,
+            last_args={"mission_name_or_file": "saved.miz"},
+            yaml_defaults={"mission_name_or_file": "FromYaml"},
+        )
+        assert result == "saved.miz"
+
+    def test_yaml_used_when_no_saved_preference(self) -> None:
+        prompt = self._prompt()
+        result = _resolve_prompt_default(
+            prompt, last_args={}, yaml_defaults={"mission_name_or_file": "FromYaml"}
+        )
+        assert result == "FromYaml"
+
+    def test_static_default_when_no_saved_no_yaml(self) -> None:
+        prompt = self._prompt()
+        result = _resolve_prompt_default(prompt, last_args={}, yaml_defaults={})
+        assert result == "mission.miz"
+
+    def test_empty_saved_preference_falls_through_to_yaml(self) -> None:
+        prompt = self._prompt()
+        result = _resolve_prompt_default(
+            prompt,
+            last_args={"mission_name_or_file": ""},
+            yaml_defaults={"mission_name_or_file": "FromYaml"},
+        )
+        assert result == "FromYaml"
+
+
 class TestRunWizard:
     def test_returns_empty_list_when_not_tty(self) -> None:
         # run_wizard() checks isatty() itself — must return [] immediately
@@ -95,6 +160,31 @@ class TestRunWizard:
         assert "mission.miz" in result
         assert "." in result
         assert "--scripts-variant" not in result
+
+    def test_yaml_default_prefills_mission_name_prompt(self) -> None:
+        """With no saved arg, the mission.yaml name is offered as the prompt default."""
+        captured: dict[str, str] = {}
+
+        mock_select_instance = type("S", (), {"execute": lambda self: "extract"})()
+
+        def _fake_text(message: str, default: str):  # type: ignore[no-untyped-def]
+            captured.setdefault("first_default", default)
+            return type("T", (), {"execute": lambda self: default})()
+
+        with patch.object(sys.stdout, "isatty", return_value=True):
+            with patch("veaf_libs.preferences.get_last_command", return_value="extract"):
+                with patch("veaf_libs.preferences.get_last_args", return_value={}):
+                    with patch("veaf_libs.preferences.save_invocation"):
+                        with patch(
+                            "veaf_libs.tui._mission_yaml_defaults",
+                            return_value={"mission_name_or_file": "Op-Thunder"},
+                        ):
+                            with patch("InquirerPy.inquirer.select", return_value=mock_select_instance):
+                                with patch("InquirerPy.inquirer.text", side_effect=_fake_text):
+                                    result = run_wizard()
+
+        assert captured["first_default"] == "Op-Thunder"
+        assert "Op-Thunder" in result
 
     def test_about_command_returns_no_extra_args(self) -> None:
         """'about' has no prompts — result is just ['about']."""


### PR DESCRIPTION
## Lot TUI-YAML-DEFAULTS — TUI defaults aware of an existing `mission.yaml`

When the wizard launches in a folder containing a `mission.yaml`, it now proposes that mission's real name (`mission.name`) as the default for the mission-name prompts, instead of the static `mission.miz`.

### Resolution precedence (TUI-YAML-DEFAULTS-002)
Made explicit and documented:

1. **last saved preference** (what the user typed last run) — wins
2. **value derived from `mission.yaml`** (`mission.name`)
3. **static fallback** (`mission.miz`, …)

A value the user explicitly typed before wins over a detected file; otherwise the file-aware default kicks in.

### Implementation
- Two pure helpers in `veaf_libs/tui.py`:
  - `_mission_yaml_defaults(folder)` — reads `mission.name` from a detected `mission.yaml`, maps it to the mission-name prompt keys; returns `{}` on absence / missing name / parse error (never breaks the wizard)
  - `_resolve_prompt_default(prompt, last_args, yaml_defaults)` — applies the precedence above
- Wired into `run_wizard`; flags keep their boolean saved-preference behaviour.

### Scope of -003
`mission.name` is the only `mission.yaml` field that maps to an existing prompt — `mission_folder` and the presets/template paths have no `mission.yaml` source. The mechanism is generic (keyed by prompt name), so adding a future field is a one-line change.

## Tests
- `TestMissionYamlDefaults` — presence/absence, missing name, malformed YAML
- `TestResolvePromptDefault` — full precedence matrix (saved > yaml > static, empty-saved fall-through)
- `TestRunWizard::test_yaml_default_prefills_mission_name_prompt` — end-to-end wiring

- ✅ `poetry run pytest` (full suite, 60% coverage)
- ✅ `ruff check` / `mypy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the TUI wizard to derive mission name prompt defaults from an existing mission.yaml while preserving user-saved preferences as highest precedence.

New Features:
- Make the TUI wizard read mission.name from a mission.yaml in the working directory and use it as the default for mission-name prompts when no saved preference exists.

Enhancements:
- Introduce helpers to compute mission.yaml-aware prompt defaults and to resolve defaults with explicit precedence over static fallbacks, and wire them into the wizard flow.

Build:
- Bump veaf-tools package version from 6.4.1 to 6.4.2 to reflect the new TUI behavior.

Documentation:
- Document the new mission.yaml-aware default behavior in the backlog and changelog, including the precedence order of saved preferences, YAML-derived values, and static fallbacks.

Tests:
- Add unit and integration tests covering mission.yaml default extraction, default resolution precedence, and end-to-end wizard behavior with YAML-derived mission names.