### PR TITLE
fix(build): anchor bare-name output mission in the mission folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- `build`: a bare mission name (not a `.miz` file) now produces an **absolute** output path anchored in the mission folder. Previously the path stayed relative, so the weather step looked for the mission under `<folder>/src/` and aborted with `Base mission not found`. This surfaced through the TUI, whose mission.yaml-aware default now pre-fills the real mission name (regression from lot TUI-YAML-DEFAULTS)
+
+---
+
 ## [6.4.0] — 2026-06-09
 
 ### Fixed

--- a/backlog.md
+++ b/backlog.md
@@ -17,10 +17,23 @@
 | Lot CI-NODE24 — Migrate GitHub Actions off deprecated Node.js 20 | ⬜ |
 | Lot TUI-YAML-DEFAULTS — TUI defaults aware of an existing mission.yaml | ✅ |
 | Lot 5 — RELEASE | ⬜ |
+| Lot FIX-BUILD-BARE-NAME-PATH — `build` with a bare mission name produces a relative output path, breaking the weather step | ✅ |
 | Lot FIX-EXTRACT-COMMUNITY-DICT — `extract` crashes with KeyError on community script dicts | ✅ |
 | Lot FIX-I18N-CONVERT-V5 — Hardcoded English messages in convert-v5 | ✅ |
 | Lot PREREL-BUGS — pre-release code review findings (briefing over-capture, exit codes, i18n, error handling) | ✅ |
 | Lot SECREV — full-repo code review findings (lupa RCE, helicopter extraction data loss, zip hardening, Lua nil-derefs) | ⬜ |
+
+---
+
+## Lot FIX-BUILD-BARE-NAME-PATH — `build` with a bare mission name produces a relative output path
+
+**Goal**: Running `build` with a bare mission name (instead of a `.miz` file or the default `mission.miz`) left the output mission as a path *relative to the current directory*. The weather step resolves a relative mission path against `versions.yaml`'s parent (`<folder>/src`), so it looked for `<folder>/src/<name>.miz` and aborted with `Base mission not found`. The bug surfaced through the TUI because the mission.yaml-aware default (lot TUI-YAML-DEFAULTS) now pre-fills the real mission name, taking this code path instead of the `== DEFAULT_MISSION_FILE` branch that anchored the path in the mission folder.
+
+**Branch**: `fix/build-bare-name-path` → PR → `develop-v6`
+
+| # | Ticket | Files | Type | Status |
+|---|--------|-------|------|--------|
+| FIX-BUILD-BARE-NAME-PATH-001 | Extract output-mission resolution into a testable `_resolve_output_mission` helper that anchors a bare-name `.miz` in the mission folder (absolute) and sanitizes the name, unifying the explicit-name and default+`mission.yaml` paths. Add unit tests covering: default+no yaml, default+yaml name, explicit bare name (regression), explicit `.miz`, unsafe-character sanitization. | `veaf_tools/commands/build.py`, `test/python/` | fix | ✅ |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.4.0"
+version = "6.4.1"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/veaf_tools/commands/build.py
+++ b/src/python/veaf-tools/veaf_tools/commands/build.py
@@ -27,6 +27,57 @@ from veaf_tools.app import (
 from veaf_tools.helpers import _update_build_config_in_yaml
 
 
+def _resolve_output_mission(
+    mission_name_or_file: str | None,
+    p_mission_folder: Path,
+    default_mission_file: str,
+) -> tuple[Path, str]:
+    """Resolve the output ``.miz`` path and its base name for a build.
+
+    - An explicit ``*.miz`` argument is used as-is (absolute, or relative to the
+      current directory).
+    - A bare mission name yields ``<sanitized-name>_<date>.miz`` anchored in
+      *p_mission_folder* (absolute). When the argument is the default and a
+      ``mission.yaml`` is present, its ``mission.name`` field supplies the name.
+
+    Anchoring a bare-name output in the mission folder keeps the path absolute so
+    every pipeline step (build, presets, weather, …) agrees on its location.
+
+    Args:
+        mission_name_or_file: The CLI argument (mission name, ``.miz`` file, or
+            the default sentinel).
+        p_mission_folder: The resolved mission folder.
+        default_mission_file: The sentinel default value (e.g. ``mission.miz``).
+
+    Returns:
+        A tuple of (output mission path, mission base name).
+    """
+    name_source: str = mission_name_or_file or default_mission_file
+
+    # When the default is used, prefer the mission.yaml name if available.
+    if name_source == default_mission_file:
+        mission_yaml_path = p_mission_folder / "mission.yaml"
+        if mission_yaml_path.exists():
+            validate_yaml_file(mission_yaml_path)
+            with mission_yaml_path.open("r", encoding="utf-8") as fh:
+                peek_yaml: dict = yaml.safe_load(fh) or {}
+            if yaml_name := (peek_yaml.get("mission") or {}).get("name"):
+                name_source = str(yaml_name)
+
+    # An explicit .miz file is used directly; a bare name becomes
+    # "<name>_<date>.miz" inside the mission folder.
+    if name_source.lower().endswith(".miz"):
+        p_output_mission = resolve_path(path=name_source)
+        return p_output_mission, p_output_mission.stem
+
+    safe_name = re.sub(r'[\\/:*?"<>|\x00-\x1f]', "_", name_source).strip(" .")
+    if not safe_name:
+        logger.warning(t("cmd.build.invalid_mission_name", name=repr(name_source)))
+        safe_name = "mission"
+    p_output_mission = p_mission_folder / f"{safe_name}_{datetime.now().strftime('%Y%m%d')}.miz"
+    return p_output_mission, safe_name
+
+
 @app.command(help=t("cmd.build.help"))
 def build(
     readme: bool = typer.Option(False, help=README_HELP),
@@ -80,25 +131,12 @@ def build(
     if not p_mission_folder.exists():
         logger.error(t("cmd.build.folder_not_found", path=p_mission_folder), exception_type=FileNotFoundError)
 
-    # Resolve output mission — peek mission.yaml for name only
-    p_output_mission = resolve_path(path=mission_name_or_file)
-    if p_output_mission.suffix.lower() != ".miz":
-        p_output_mission = Path(f"{mission_name_or_file}_{datetime.now().strftime('%Y%m%d')}.miz")
-    mission_base_name: str = p_output_mission.stem
+    # Resolve the output mission path and base name (mission.yaml-aware).
+    p_output_mission, mission_base_name = _resolve_output_mission(
+        mission_name_or_file, p_mission_folder, DEFAULT_MISSION_FILE
+    )
 
     mission_yaml_path = p_mission_folder / "mission.yaml"
-    if mission_name_or_file == DEFAULT_MISSION_FILE and mission_yaml_path.exists():
-        validate_yaml_file(mission_yaml_path)
-        with mission_yaml_path.open("r", encoding="utf-8") as fh:
-            _peek_yaml: dict = yaml.safe_load(fh) or {}
-        _yaml_mission_name: str | None = (_peek_yaml.get("mission") or {}).get("name")
-        if _yaml_mission_name:
-            _safe_name = re.sub(r'[\\/:*?"<>|\x00-\x1f]', "_", _yaml_mission_name).strip(" .")
-            if not _safe_name:
-                logger.warning(t("cmd.build.invalid_mission_name", name=repr(_yaml_mission_name)))
-                _safe_name = "mission"
-            p_output_mission = p_mission_folder / f"{_safe_name}_{datetime.now().strftime('%Y%m%d')}.miz"
-            mission_base_name = _safe_name
 
     # Build the mission
     logger.step(t("pipeline.console.build"))

--- a/test/python/veaf_tools/test_build_pipeline.py
+++ b/test/python/veaf_tools/test_build_pipeline.py
@@ -83,5 +83,58 @@ class TestAircraftOrphanWarning(unittest.TestCase):
         self.assertEqual(warnings, [])
 
 
+class TestResolveOutputMission(unittest.TestCase):
+    """Output-mission resolution — FIX-BUILD-BARE-NAME-PATH-001."""
+
+    DEFAULT = "mission.miz"
+
+    def _resolve(self, name: str | None, folder: Path) -> tuple[Path, str]:
+        from veaf_tools.commands.build import _resolve_output_mission
+
+        return _resolve_output_mission(name, folder, self.DEFAULT)
+
+    def test_default_without_yaml_uses_static_name(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            path, base = self._resolve(self.DEFAULT, Path(td))
+        self.assertEqual(path.name, "mission.miz")
+        self.assertEqual(base, "mission")
+
+    def test_default_with_yaml_derives_name_anchored_in_folder(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            (folder / "mission.yaml").write_text("mission:\n  name: Training-Syrie\n", encoding="utf-8")
+            with patch("veaf_tools.commands.build.validate_yaml_file"):
+                path, base = self._resolve(self.DEFAULT, folder)
+        self.assertEqual(base, "Training-Syrie")
+        self.assertTrue(path.is_absolute())
+        self.assertEqual(path.parent, folder)
+        self.assertTrue(path.name.startswith("Training-Syrie_"))
+        self.assertTrue(path.name.endswith(".miz"))
+
+    def test_bare_name_is_anchored_in_folder(self) -> None:
+        """Regression: a bare name must yield an absolute path inside the folder."""
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            path, base = self._resolve("Training-Syrie", folder)
+        self.assertEqual(base, "Training-Syrie")
+        self.assertTrue(path.is_absolute())
+        self.assertEqual(path.parent, folder)
+        self.assertTrue(path.name.startswith("Training-Syrie_"))
+        self.assertTrue(path.name.endswith(".miz"))
+
+    def test_explicit_miz_file_keeps_suffix_and_stem(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            path, base = self._resolve("custom.miz", Path(td))
+        self.assertEqual(path.name, "custom.miz")
+        self.assertEqual(base, "custom")
+
+    def test_unsafe_characters_are_sanitized(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            path, base = self._resolve('Vol:Aller/Retour', folder)
+        self.assertEqual(base, "Vol_Aller_Retour")
+        self.assertEqual(path.parent, folder)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Building via the **TUI** aborts at the weather step:

```
Pipeline : variantes météo (versions.yaml)
Échec de la création de la version 'dawn-scattered' : Base mission not found: D:\...\Training-Syrie\src\Training-Syrie_20260609.miz
Aborted.
```

The same `veaf-tools build` (no args) on the command line works fine.

## Root cause

`build` resolved the output mission like this:

```python
p_output_mission = resolve_path(path=mission_name_or_file)
if p_output_mission.suffix.lower() != ".miz":
    p_output_mission = Path(f"{mission_name_or_file}_{date}.miz")  # ← RELATIVE
```

A bare name (not a `.miz`) produced a **relative** path. The mission-folder anchoring only happened inside the `mission_name_or_file == DEFAULT_MISSION_FILE` branch. The weather worker resolves a relative mission path against `versions.yaml`'s parent:

```python
base_mission_path = self.mission_file if self.mission_file.is_absolute() else self.config_file.parent / self.mission_file
```

→ `<folder>/src/<name>.miz`, which doesn't exist → `Base mission not found`.

The bug surfaced through the TUI because lot **TUI-YAML-DEFAULTS** now pre-fills the mission-name prompt with the real `mission.name` (`Training-Syrie`), so the argument is a bare name instead of the default `mission.miz` — taking the un-anchored path. It is a latent bug that also affects `veaf-tools build <bare-name>` on the CLI.

## Fix

Extract output-mission resolution into a testable `_resolve_output_mission` helper that:
- anchors a bare-name `.miz` in the **mission folder** (absolute), so every pipeline step agrees on the location;
- sanitizes the name (mirroring the previous mission.yaml branch);
- unifies the explicit-name and default+`mission.yaml` code paths.

Behaviour preserved: default + no yaml → `mission.miz`; default + yaml → `<mission.name>_<date>.miz` in folder; explicit `.miz` → used as-is.

## Tests

`TestResolveOutputMission`:
- default + no yaml → static `mission.miz`
- default + yaml name → absolute, anchored in folder
- **explicit bare name → absolute, anchored in folder (regression)**
- explicit `.miz` → suffix/stem preserved
- unsafe characters sanitized

- ✅ `poetry run pytest` (full suite, 61.8% coverage)
- ✅ `ruff check` / `ruff format --check` / `mypy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure `build` consistently resolves the output mission path and name when given a bare mission identifier, preventing pipeline steps from failing due to relative paths.

Bug Fixes:
- Fix `build` so a bare mission name produces an absolute `.miz` path anchored in the mission folder, avoiding weather-step failures that previously looked in the wrong directory.

Enhancements:
- Centralize output-mission path and name resolution in a reusable helper that unifies behavior between default missions, `mission.yaml`-named missions, and explicit `.miz` files.

Build:
- Bump project version from 6.4.0 to 6.4.1 to release the path-resolution fix.

Documentation:
- Document the bare-name `build` path fix in the backlog and changelog, including its impact on the TUI and weather step.

Tests:
- Add unit tests covering output-mission resolution for default missions, `mission.yaml`-named missions, bare mission names, explicit `.miz` files, and unsafe-character sanitization.