### PR TITLE
chore(ci): migrate GitHub Actions off deprecated Node.js 20 (CI-NODE24)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # mike needs full history to manage the gh-pages branch correctly
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/lua-ci.yml
+++ b/.github/workflows/lua-ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Lua 5.1
         run: |
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Lua 5.1 + luacheck (via LuaRocks)
         run: |
@@ -62,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check formatting with StyLua
-        uses: JohnnyMorganz/stylua-action@v4
+        uses: JohnnyMorganz/stylua-action@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: "2.4.0"

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -17,9 +17,9 @@ jobs:
   python-quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -44,7 +44,7 @@ jobs:
         run: poetry run pytest
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: coverage-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -38,7 +38,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -17,9 +17,9 @@ jobs:
       contents: write   # needed to upload to GitHub Release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -38,14 +38,14 @@ jobs:
 
       - name: Upload SBOM as artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sbom-${{ github.ref_name }}
           path: sbom.cyclonedx.json
           retention-days: 90
 
       - name: Attach SBOM to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: sbom.cyclonedx.json

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -10,13 +10,13 @@ jobs:
     name: Gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full history needed for gitleaks to scan all commits on push
           fetch-depth: 0
 
       - name: Scan for secrets
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Changed
+- CI: migrated GitHub Actions off the deprecated Node.js 20 runtime ahead of the forced 2026-06-16 migration. Bumped `actions/checkout@v4`→`@v5`, `actions/setup-python@v5`→`@v6`, `actions/upload-artifact@v4`→`@v6` (first major running on `node24`), and the third-party actions `JohnnyMorganz/stylua-action@v4`→`@v5`, `softprops/action-gh-release@v2`→`@v3`, `gitleaks/gitleaks-action@v2`→`@v3`. `snok/install-poetry@v1` is a composite action with no Node runtime and was left unchanged
+
+---
+
 ## [6.4.0] — 2026-06-09
 
 ### Fixed

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 | Lot | Status |
 |-----|--------|
 | Phase 0b — GitHub cleanup | ⬜ |
-| Lot CI-NODE24 — Migrate GitHub Actions off deprecated Node.js 20 | ⬜ |
+| Lot CI-NODE24 — Migrate GitHub Actions off deprecated Node.js 20 | 🔄 |
 | Lot TUI-YAML-DEFAULTS — TUI defaults aware of an existing mission.yaml | ✅ |
 | Lot 5 — RELEASE | ⬜ |
 | Lot FIX-BUILD-BARE-NAME-PATH — `build` with a bare mission name produces a relative output path, breaking the weather step | ✅ |
@@ -93,10 +93,10 @@
 
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
-| CI-NODE24-001 | Bump `actions/checkout@v4` → `@v5` in all workflows | `.github/workflows/docs.yml`, `python-quality.yml`, `release.yml`, `lua-ci.yml` (×2), `sbom.yml`, `secret-scanning.yml` | chore | ⬜ |
-| CI-NODE24-002 | Bump `actions/setup-python@v5` → `@v6` in all workflows | `.github/workflows/docs.yml`, `python-quality.yml`, `release.yml`, `sbom.yml` | chore | ⬜ |
-| CI-NODE24-003 | Verify `actions/upload-artifact@v4` runs on Node.js 24 (bump if a newer major exists); audit any third-party actions for the same deprecation | `.github/workflows/python-quality.yml`, `sbom.yml`, all workflows | chore | ⬜ |
-| CI-NODE24-004 | Trigger each workflow (or wait for natural runs) and confirm the Node.js 20 deprecation annotation no longer appears | CI runs | chore | ⬜ |
+| CI-NODE24-001 | Bump `actions/checkout@v4` → `@v5` in all workflows | `.github/workflows/docs.yml`, `python-quality.yml`, `release.yml`, `lua-ci.yml` (×3), `sbom.yml`, `secret-scanning.yml` | chore | ✅ |
+| CI-NODE24-002 | Bump `actions/setup-python@v5` → `@v6` in all workflows | `.github/workflows/docs.yml`, `python-quality.yml`, `release.yml`, `sbom.yml` | chore | ✅ |
+| CI-NODE24-003 | Bump Node.js 20 actions to their first Node.js 24 major: `actions/upload-artifact@v4`→`@v6` (v5 still defaults to Node 20; v6 is `runs.using: node24`), `JohnnyMorganz/stylua-action@v4`→`@v5`, `softprops/action-gh-release@v2`→`@v3`, `gitleaks/gitleaks-action@v2`→`@v3`. `snok/install-poetry@v1` left as-is (composite action — no Node runtime, unaffected). | `.github/workflows/python-quality.yml`, `sbom.yml`, `lua-ci.yml`, `secret-scanning.yml` | chore | ✅ |
+| CI-NODE24-004 | Trigger each workflow (or wait for natural runs) and confirm the Node.js 20 deprecation annotation no longer appears | CI runs | chore | 🔄 |
 
 ---
 

--- a/backlog.md
+++ b/backlog.md
@@ -98,6 +98,10 @@
 | CI-NODE24-003 | Bump Node.js 20 actions to their first Node.js 24 major: `actions/upload-artifact@v4`→`@v6` (v5 still defaults to Node 20; v6 is `runs.using: node24`), `JohnnyMorganz/stylua-action@v4`→`@v5`, `softprops/action-gh-release@v2`→`@v3`, `gitleaks/gitleaks-action@v2`→`@v3`. `snok/install-poetry@v1` left as-is (composite action — no Node runtime, unaffected). | `.github/workflows/python-quality.yml`, `sbom.yml`, `lua-ci.yml`, `secret-scanning.yml` | chore | ✅ |
 | CI-NODE24-004 | Trigger each workflow (or wait for natural runs) and confirm the Node.js 20 deprecation annotation no longer appears | CI runs | chore | 🔄 |
 
+**Behavioral-change review (third-party major bumps)**: each cross-major bump was checked against its upstream release notes and confirmed to be a **runtime-only** Node 20→24 migration for our usage — no new defaults or flags affect these workflows: `stylua-action@v5` (Node 24 only; same `version`/`args` inputs), `action-gh-release@v3` (Node 24 only; v2 stays on Node 20), `gitleaks-action@v3` (Node 24 only; same `GITLEAKS_*` env contract). `upload-artifact@v6` keeps the v4 single-immutable-artifact-per-name semantics our steps already rely on (the v7 non-zipped-artifact change is opt-in and not adopted here).
+
+> **SHA pinning** (Sourcery suggestion): not done. The repo consistently uses floating major-version tags for every action; switching to commit-SHA pinning is a repo-wide supply-chain-hardening convention change, out of scope for this Node-runtime maintenance lot. Tracked as a possible future lot if the team wants it.
+
 ---
 
 ## Lot TUI-YAML-DEFAULTS — TUI defaults aware of an existing mission.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.4.0"
+version = "6.4.1"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"


### PR DESCRIPTION
## Lot CI-NODE24 — Migrate GitHub Actions off deprecated Node.js 20

GitHub forces Node.js 20 actions to run on Node.js 24 starting **2026-06-16**, and removes the Node.js 20 runtime from runners on **2026-09-16**. This bumps every affected action to the first major that ships a Node.js 24 runtime, so the workflows keep working without the deprecation annotation.

### First-party actions (CI-NODE24-001 / -002)
| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v5** |
| `actions/setup-python` | v5 | **v6** |
| `actions/upload-artifact` | v4 | **v6** |

> `upload-artifact` v5 still defaults to Node 20; **v6** is the first major with `runs.using: node24` (requires runner ≥ 2.327.1, satisfied by GitHub-hosted runners).

### Third-party actions audit (CI-NODE24-003)
| Action | From | To | Why |
|---|---|---|---|
| `JohnnyMorganz/stylua-action` | v4 | **v5** | v5 → Node 24 |
| `softprops/action-gh-release` | v2 | **v3** | v3 → Node 24 (v2 stays on Node 20) |
| `gitleaks/gitleaks-action` | v2 | **v3** | v3 → Node 24 (v2 stays on Node 20) |
| `snok/install-poetry` | v1 | **unchanged** | composite action — no Node runtime, unaffected |

The three third-party bumps cross a major version. They were verified as runtime-only Node 20 → 24 migrations on the upstream release notes, but flagging them here since a major bump is a judgment call worth a glance.

### Files touched
`.github/workflows/{checkout,…}`: `docs.yml`, `python-quality.yml`, `release.yml`, `lua-ci.yml` (×3 checkout), `sbom.yml`, `secret-scanning.yml`.

### Not done in this PR
- **CI-NODE24-004** (confirm the Node.js 20 deprecation annotation no longer appears) — verified by this PR's own CI runs; will mark ✅ once the runs are green.

### Housekeeping
- `backlog.md`: CI-NODE24 → 🔄 (001–003 ✅, 004 pending CI)
- `CHANGELOG.md`: `[Unreleased]` entry added
- `pyproject.toml`: 6.4.0 → 6.4.1 (PATCH bump per `CLAUDE.md` §9.5)

https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw)_

## Summary by Sourcery

Migrate CI GitHub Actions workflows to use Node.js 24–compatible action versions and record the change as a patch release.

Build:
- Update GitHub Actions workflows to use Node.js 24–compatible versions of first-party actions (`actions/checkout` v5, `actions/setup-python` v6, `actions/upload-artifact` v6).
- Upgrade third-party GitHub Actions (`JohnnyMorganz/stylua-action`, `softprops/action-gh-release`, `gitleaks/gitleaks-action`) to their Node.js 24–based major versions while leaving composite actions unaffected.
- Mark CI-NODE24 migration subtasks 001–003 as complete and 004 as in progress in the internal backlog.

Documentation:
- Add an unreleased changelog entry describing the CI GitHub Actions migration and associated action version bumps.

Chores:
- Bump project version from 6.4.0 to 6.4.1 to reflect the CI maintenance changes.