### PR TITLE
chore(backlog): close Phase 0b — mark triaged issues closed

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -125,7 +125,9 @@
 ## Phase 0b — GitHub cleanup
 
 Close issues identified during triage. **Verify each one before closing.**
-Direct commits on `develop-v6` (no feature branch needed — no code change).
+Originally planned as direct commits on `develop-v6` (no code change), but the
+backlog status update was delivered through PR #405 because the closing session
+was constrained to a working branch.
 
 | # | Ticket | Type | Status |
 |---|--------|------|--------|

--- a/backlog.md
+++ b/backlog.md
@@ -13,7 +13,7 @@
 
 | Lot | Status |
 |-----|--------|
-| Phase 0b — GitHub cleanup | ⬜ |
+| Phase 0b — GitHub cleanup | ✅ |
 | Lot CI-NODE24 — Migrate GitHub Actions off deprecated Node.js 20 | 🔄 |
 | Lot TUI-YAML-DEFAULTS — TUI defaults aware of an existing mission.yaml | ✅ |
 | Lot 5 — RELEASE | ⬜ |
@@ -129,8 +129,8 @@ Direct commits on `develop-v6` (no feature branch needed — no code change).
 
 | # | Ticket | Type | Status |
 |---|--------|------|--------|
-| CLOSE-001 | Close WONTFIX issues: #55, #146, #147, #180, #193, #246 | chore | ⬜ |
-| CLOSE-002 | Close STALE issues: #9, #19, #41, #167 | chore | ⬜ |
+| CLOSE-001 | Close WONTFIX issues: #55, #146, #147, #180, #193, #246 | chore | ✅ |
+| CLOSE-002 | Close STALE issues: #9, #19, #41, #167 | chore | ✅ |
 
 <details>
 <summary>Issues to close</summary>


### PR DESCRIPTION
## Phase 0b — GitHub cleanup

Closed the issues identified during the v6 triage and marked the lot done in `backlog.md`. Each issue was closed with a short French closing comment explaining the reason.

### Closed — WONTFIX (CLOSE-001)
| # | Reason | State reason |
|---|---|---|
| #55 | Already implemented → `veafCombatZone` | completed |
| #146 | External project (CTLD/Ciribob) | not planned |
| #147 | External project (CTLD/Ciribob) | not planned |
| #180 | Both tasks already ✅ in the issue | completed |
| #193 | Requires upstream CTLD PR, out of scope | not planned |
| #246 | CTLD external bug, out of scope | not planned |

### Closed — STALE (CLOSE-002)
| # | Reason | State reason |
|---|---|---|
| #9 | 2018, inactive since 2021, too vague | not planned |
| #19 | 2020, informal idea, no spec | not planned |
| #41 | 2021, vague, no activity | not planned |
| #167 | 2023 tech spike, no follow-up | not planned |

> The backlog described Phase 0b as "direct commits on `develop-v6`", but this session is constrained to its working branch, so the doc-only status update goes through this PR instead.

https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw)_

## Summary by Sourcery

Chores:
- Update backlog status for Phase 0b and its CLOSE-001/CLOSE-002 cleanup tasks to done.