### PR TITLE
docs(quality): document the quality ratchet policy (QUALITY-GATE-002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- `CLAUDE.md` §3: documented the **Quality Ratchet Policy** — every lot that substantially edits a mypy-excluded worker must drop its `ignore_errors` entry (and fix the surfaced type errors), and every lot that adds tests must bump `--cov-fail-under` to stay within ~2 points of actual coverage. The exclusions list and the coverage gate are now an explicitly erode-only debt
 - CI: migrated GitHub Actions off the deprecated Node.js 20 runtime ahead of the forced 2026-06-16 migration. Bumped `actions/checkout@v4`→`@v5`, `actions/setup-python@v5`→`@v6`, `actions/upload-artifact@v4`→`@v6` (first major running on `node24`), and the third-party actions `JohnnyMorganz/stylua-action@v4`→`@v5`, `softprops/action-gh-release@v2`→`@v3`, `gitleaks/gitleaks-action@v2`→`@v3`. `snok/install-poetry@v1` is a composite action with no Node runtime and was left unchanged
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
-- `CLAUDE.md` §3: documented the **Quality Ratchet Policy** — every lot that substantially edits a mypy-excluded worker must drop its `ignore_errors` entry (and fix the surfaced type errors), and every lot that adds tests must bump `--cov-fail-under` to stay within ~2 points of actual coverage. The exclusions list and the coverage gate are now an explicitly erode-only debt
+- `CLAUDE.md` §3: documented the **Quality Ratchet Policy** — every lot that substantially edits a mypy-excluded worker must drop its `ignore_errors` entry (and fix the surfaced type errors), and every lot that adds tests must bump `--cov-fail-under` to stay within ~2 points of actual coverage. The exclusions list and the coverage gate are now explicitly erode-only forms of debt
 - CI: migrated GitHub Actions off the deprecated Node.js 20 runtime ahead of the forced 2026-06-16 migration. Bumped `actions/checkout@v4`→`@v5`, `actions/setup-python@v5`→`@v6`, `actions/upload-artifact@v4`→`@v6` (first major running on `node24`), and the third-party actions `JohnnyMorganz/stylua-action@v4`→`@v5`, `softprops/action-gh-release@v2`→`@v3`, `gitleaks/gitleaks-action@v2`→`@v3`. `snok/install-poetry@v1` is a composite action with no Node runtime and was left unchanged
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@
 The mypy `ignore_errors` overrides in `pyproject.toml` (the excluded workers list) and the `--cov-fail-under` coverage gate are **technical debt to erode, never to grow**. They are eroded lot-by-lot, not in a single big-bang:
 
 - **mypy exclusions**: any lot that *substantially* edits a worker still listed under `ignore_errors` MUST drop that worker's entry as part of its Definition of Done, and fix the surfaced type errors. Never add a new entry to the excluded list.
+  - *Substantially* = touching the worker's logic: adding or changing a function, method, branch, or signature. A purely mechanical edit (a string/i18n change, an import reorder, a comment) does **not** trigger the obligation.
 - **Coverage gate**: any lot that adds tests MUST bump `--cov-fail-under` so the gate never sits more than **~2 points below** actual measured coverage. The number only ever goes up.
 
 These are enforcement obligations on **every** lot, not a separate clean-up task — the dedicated `QUALITY-GATE` lot only mops up whatever workers no other lot has reopened.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,15 @@
 - **Static Typing**: Type annotations are mandatory for all functions with explicit return syntax `-> ReturnType`. Use modern unions like `Type | None`.
 - **Docstrings**: Write comprehensive docstrings strictly following the Google format (with `Args:`, `Returns:`, `Raises:` sections).
 
+### Quality Ratchet Policy (mypy exclusions + coverage gate)
+
+The mypy `ignore_errors` overrides in `pyproject.toml` (the excluded workers list) and the `--cov-fail-under` coverage gate are **technical debt to erode, never to grow**. They are eroded lot-by-lot, not in a single big-bang:
+
+- **mypy exclusions**: any lot that *substantially* edits a worker still listed under `ignore_errors` MUST drop that worker's entry as part of its Definition of Done, and fix the surfaced type errors. Never add a new entry to the excluded list.
+- **Coverage gate**: any lot that adds tests MUST bump `--cov-fail-under` so the gate never sits more than **~2 points below** actual measured coverage. The number only ever goes up.
+
+These are enforcement obligations on **every** lot, not a separate clean-up task — the dedicated `QUALITY-GATE` lot only mops up whatever workers no other lot has reopened.
+
 ---
 
 ## 4. TDD and Behavioral Coverage Rule

--- a/backlog.md
+++ b/backlog.md
@@ -33,7 +33,7 @@
 | Lot TODO0609-AIRCRAFT-INJECT — split aircraft-group injection into spawnable-aircraft vs dynamic-slot-template steps, flag/prefix sort | ⬜ |
 | Lot TODO0609-DEFAULTS-AUDIT — audit `defaults/mission-folder` for genuinely-unused leftover files | ⬜ |
 | Lot UXPILOT-FEEDBACK — surface command errors to pilots (global pcall guard + unified feedback + unknown-parameter hints) | ⬜ |
-| Lot QUALITY-GATE — erode mypy `ignore_errors` and ratchet the coverage gate, one worker per lot | ⬜ |
+| Lot QUALITY-GATE — erode mypy `ignore_errors` and ratchet the coverage gate, one worker per lot | 🔄 |
 | Lot SPAWN-REFACTOR — characterize `veafSpawnParser` with tests, then de-duplicate the spawn subsystem | ⬜ |
 
 ---
@@ -363,7 +363,7 @@ was constrained to a working branch.
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
 | QUALITY-001 | Remove `ignore_errors` for the simplest still-excluded workers (start with `presets_injector_worker`, `waypoints_injector_worker`), fix the surfaced type errors, leave the rest. | `pyproject.toml`, touched workers, `test/python/` | chore | ⬜ |
-| QUALITY-002 | Document the ratchet policy in `CLAUDE.md` §3: every lot that substantially touches an excluded worker drops its `ignore_errors` entry as part of its Definition of Done; every lot that adds tests bumps `--cov-fail-under` so the gate never sits more than ~2 pts below actual coverage. | `CLAUDE.md`, `pyproject.toml` | chore | ⬜ |
+| QUALITY-002 | Document the ratchet policy in `CLAUDE.md` §3: every lot that substantially touches an excluded worker drops its `ignore_errors` entry as part of its Definition of Done; every lot that adds tests bumps `--cov-fail-under` so the gate never sits more than ~2 pts below actual coverage. | `CLAUDE.md`, `pyproject.toml` | chore | ✅ |
 
 > Cross-cutting reminder: the worker-reopening lots (MODULES-UNIFY, AIRCRAFT-INJECT, CONVERT-FIDELITY, SECREV) should each drop the touched worker's mypy exclusion as part of their own work, so this lot only mops up the remainder.
 

--- a/backlog.md
+++ b/backlog.md
@@ -365,7 +365,7 @@ was constrained to a working branch.
 | QUALITY-001 | Remove `ignore_errors` for the simplest still-excluded workers (start with `presets_injector_worker`, `waypoints_injector_worker`), fix the surfaced type errors, leave the rest. | `pyproject.toml`, touched workers, `test/python/` | chore | ⬜ |
 | QUALITY-002 | Document the ratchet policy in `CLAUDE.md` §3: every lot that substantially touches an excluded worker drops its `ignore_errors` entry as part of its Definition of Done; every lot that adds tests bumps `--cov-fail-under` so the gate never sits more than ~2 pts below actual coverage. | `CLAUDE.md`, `pyproject.toml` | chore | ✅ |
 
-> Cross-cutting reminder: the worker-reopening lots (MODULES-UNIFY, AIRCRAFT-INJECT, CONVERT-FIDELITY, SECREV) should each drop the touched worker's mypy exclusion as part of their own work, so this lot only mops up the remainder.
+> Cross-cutting reminder: the worker-reopening lots (MODULES-UNIFY, AIRCRAFT-INJECT, CONVERT-FIDELITY, SECREV) should each drop the touched worker's mypy exclusion as part of their own work, so this lot only mops up the remainder. **`CLAUDE.md` §3 (Quality Ratchet Policy) is the single source of truth** for this rule; the notes here and in `ROADMAP.md` §2 are summaries.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.4.1"
+version = "6.4.2"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"


### PR DESCRIPTION
## Lot QUALITY-GATE — ticket QUALITY-GATE-002 (ratchet policy)

Writes the **Quality Ratchet Policy** into `CLAUDE.md` §3, as the kick-off of the QUALITY-GATE lot — the convention must exist before any worker is touched (roadmap step #3).

### What the policy says
The mypy `ignore_errors` overrides (`pyproject.toml`) and the `--cov-fail-under` coverage gate are **erode-only technical debt**:
- **mypy exclusions** — any lot that *substantially* edits a still-excluded worker MUST drop that worker's `ignore_errors` entry as part of its Definition of Done and fix the surfaced errors. Never add a new entry.
- **Coverage gate** — any lot that adds tests MUST bump `--cov-fail-under` to stay within ~2 points of actual measured coverage. The number only goes up.
- These are obligations on **every** lot; the dedicated `QUALITY-GATE` lot only mops up workers no other lot has reopened.

This matches the cross-cutting reminders already in the backlog and `ROADMAP.md` §2.

### Files
- `CLAUDE.md` — new "Quality Ratchet Policy" subsection under §3
- `backlog.md` — QUALITY-GATE-002 → ✅, lot → 🔄 (QUALITY-001 code mop-up still open)
- `CHANGELOG.md` — `[Unreleased]` entry
- `pyproject.toml` — 6.4.1 → 6.4.2 (PATCH bump per `CLAUDE.md` §9.5)

> Doc/policy only — no Python or Lua code touched, so no test or coverage change in this PR. QUALITY-GATE-001 (actually removing exclusions for `presets_*`/`waypoints_*` and bumping the gate) remains a separate, continuous effort.

https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw)_

## Summary by Sourcery

Document the project’s quality ratchet policy for mypy exclusions and coverage thresholds and record its completion and release metadata.

Build:
- Bump the veaf-tools package version from 6.4.1 to 6.4.2.

Documentation:
- Add a Quality Ratchet Policy section to CLAUDE.md defining mypy ignore_errors removals and coverage gate increases as erode-only technical debt.
- Update backlog.md to mark QUALITY-GATE lot QUALITY-002 as completed and reflect the ongoing QUALITY-GATE lot status.
- Note the new Quality Ratchet Policy in the Unreleased section of the changelog.