### PR TITLE
feat(convert-fidelity): recover commented-out v5 elements as commented YAML (001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `convert-v5`: **commented-out v5 elements are no longer silently dropped** — a combat zone, asset, QRA, shortcut, etc. that was disabled with `--` in `missionConfig.lua` is now re-emitted at the end of `mission.yaml` as a fully-commented **"Commented-out v5 elements"** block, so you can re-enable it by uncommenting. Generic across every extractor (a de-commented re-extraction is diffed against the active config; pattern-based extraction ignores prose) (CONVERT-FIDELITY-001)
 - `convert-v5`: the annotated report (`convert-v5-report.md`) now opens with an at-a-glance **Summary** — how many modules were migrated and how many items still need manual action (with the source line numbers) — so you see whether work remains without reading the full annotated config (CONVERT-FIDELITY-004)
 - `mission.silence_atc_on_all_airbases` (default `true` in the template): emits `veaf.silenceAtcOnAllAirbases()`; `convert-v5` detects an active call in `missionConfig.lua` and preserves it (CONVERT-FIDELITY-003)
 

--- a/backlog.md
+++ b/backlog.md
@@ -23,7 +23,7 @@
 | Lot PREREL-BUGS — pre-release code review findings (briefing over-capture, exit codes, i18n, error handling) | ✅ |
 | Lot SECREV — full-repo code review findings (lupa RCE, helicopter extraction data loss, zip hardening, Lua nil-derefs) | ✅ |
 | Lot TODO0609-MODULES-UNIFY — single `modules:` block as source of truth (QRA + community config nested), CTLD/CSAR extracted from v5 | ✅ |
-| Lot TODO0609-CONVERT-FIDELITY — convert-v5 report fidelity: comment full migrated blocks, emit commented-out v5 elements, silenceAtc key | 🔄 |
+| Lot TODO0609-CONVERT-FIDELITY — convert-v5 report fidelity: comment full migrated blocks, emit commented-out v5 elements, silenceAtc key | ✅ |
 | Lot TODO0609-ERA-AUTODETECT — auto-detect mission era (incl. WW2) from `.miz` content, manual override wins | ⬜ |
 | Lot TODO0609-SPAWN-EXTERNALIZE — externalize spawn group / veafUnits / dcsUnits definitions from Lua to YAML (spike + impl) | ⬜ |
 | Lot TODO0609-DYNLOAD-CLARIFY — clarify `veafDynamicConfig.lua` vs `VeafDynamicLoader.lua`, find obsolete one (spike) | ⬜ |
@@ -221,12 +221,12 @@ was constrained to a working branch.
 
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
-| CONVERT-FIDELITY-001 | Re-parse commented-out v5 elements (any extractable module, e.g. a commented `combatZone_Abu_al_Duhur`) and re-emit them as **commented** YAML in `mission.yaml`, instead of silently dropping them. (todo item 4) | `mission_builder/config_migrator.py`, `mission_builder/v5_converter.py`, `test/python/` | feat | ⬜ |
+| CONVERT-FIDELITY-001 | Re-parse commented-out v5 elements (any extractable module, e.g. a commented `combatZone_Abu_al_Duhur`) and re-emit them as **commented** YAML in `mission.yaml`, instead of silently dropping them. (todo item 4) | `mission_builder/config_migrator.py`, `mission_builder/v5_converter.py`, `test/python/` | feat | ✅ |
 | CONVERT-FIDELITY-002 | In the annotated `missionConfig`, comment out the **entire** `if veafXxx then … end` init block of a migrated module (not only the `initialize()` line), so non-migrated code visually stands out. (todo item 9) | `mission_builder/config_migrator.py`, `test/python/` | feat | ✅ |
 | CONVERT-FIDELITY-003 | Add `mission.silence_atc_on_all_airbases` to the default `mission.yaml` (value `true`) and emit the corresponding Lua. At conversion, scan `missionConfig.lua` for an active `veaf.silenceAtcOnAllAirbases()` call → `true`, else `false`. (todo item 10) | `src/defaults/mission-folder/mission.yaml`, `veaf_libs/lua_config_generator.py`, `mission_builder/config_migrator.py`, `test/python/` | feat | ✅ |
 | CONVERT-FIDELITY-004 | Prepend a numeric summary header to `convert-v5-report.md` (e.g. "N modules migrated · M need manual action (lines …)") so the mission-maker sees at a glance whether work remains, without reading the full annotated config. Drives off the same data the annotation pass already computes. | `mission_builder/v5_converter.py`, `mission_builder/config_migrator.py`, `test/python/` | feat | ✅ |
 
-> **001 deferred to a follow-up PR**: 002/003/004 shipped together; 001 (re-parse *any* commented-out extractable element → commented YAML) is larger and under-specified ("which extractors?" + a reusable per-element commented-YAML emitter entangled with the section-by-section builder). Needs a tighter spec before implementation.
+> **001 done** (follow-up PR): a de-commented re-extraction of `missionConfig.lua` is diffed against the active `mission.yaml`; lines present only because of previously-commented elements are appended as a fully-commented "Commented-out v5 elements" block (generic — covers every extractor; pattern-based extraction filters prose). Covers all extractable types at once.
 
 ## Lot TODO0609-ERA-AUTODETECT — Automatic mission era detection
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.4.5"
+version = "6.4.6"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"
@@ -132,7 +132,7 @@ addopts = [
     "--cov=src/python/veaf-tools",
     "--cov-report=xml",
     "--cov-report=term-missing:skip-covered",
-    "--cov-fail-under=62",
+    "--cov-fail-under=63",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -18,6 +18,7 @@ DCS trigger conversion (v5 → v6) is handled automatically by
 
 from __future__ import annotations
 
+import difflib
 import re
 import shutil
 from collections.abc import Callable
@@ -191,6 +192,8 @@ class ConversionReport:
     """Relative paths of v5 files/folders backed up under ``backup_v5/``."""
     missionconfig_annotated_content: str = ""
     """Annotated missionConfig.lua content (with [v6 ...] comments) — embedded in report."""
+    missionconfig_source: str = ""
+    """Original (pre-migration) missionConfig.lua content — used to recover commented-out v5 elements."""
 
     # -----------------------------------------------------------------------
     # Report rendering
@@ -543,6 +546,34 @@ def _ctld_csar_settings(mr: object, upper: str) -> dict:
     return getattr(mr, attr, None) or {}
 
 
+_DECOMMENT_RE = re.compile(r"^(\s*)--+ ?(.*)$")
+
+
+def _decomment_lua(content: str) -> str:
+    """Strip the leading ``--`` from single-line comments to reveal v5 code.
+
+    Used to recover *commented-out* v5 elements (CONVERT-FIDELITY-001): a
+    re-extraction of the de-commented text surfaces any builder chains / tables
+    the mission-maker had disabled. ``-- [v6 …]`` migration markers are left
+    untouched (they are not original v5 elements). Prose comments are harmless —
+    the extraction is pattern-based, so non-code lines simply do not match.
+
+    Args:
+        content: The original missionConfig.lua content.
+
+    Returns:
+        The content with single-line comments un-commented.
+    """
+    out: list[str] = []
+    for line in content.splitlines():
+        if line.lstrip().startswith("-- [v6"):
+            out.append(line)
+            continue
+        match = _DECOMMENT_RE.match(line)
+        out.append(f"{match.group(1)}{match.group(2)}" if match else line)
+    return "\n".join(out)
+
+
 def _emit_qra_definitions(silence_all: bool | None, definitions: list[dict], indent: int) -> list[str]:
     """Emit the QRA ``silence_all`` + ``definitions`` block at the given indent.
 
@@ -848,6 +879,7 @@ class V5Converter:
         original_content = src.read_text(encoding="utf-8")
         result = self._migrator.migrate(original_content)
         report.migration_result = result
+        report.missionconfig_source = original_content
         annotated_content = result.new_content
 
         mission_folder = report.mission_folder
@@ -949,6 +981,7 @@ class V5Converter:
             return
 
         content = self._build_mission_yaml(report)
+        content = self._append_commented_v5_elements(report, content)
         dest.write_text(content, encoding="utf-8")
         report.mission_yaml_generated = True
         report.mission_yaml_path = dest
@@ -963,6 +996,52 @@ class V5Converter:
         report.actions.append(
             t("convert_v5.action.yaml_generated", enabled=enabled_count, total=all_count, pipeline=pipeline_note)
         )
+
+    def _append_commented_v5_elements(self, report: ConversionReport, active_yaml: str) -> str:
+        """Recover commented-out v5 elements and append them as commented YAML.
+
+        Re-extracts the de-commented ``missionConfig.lua`` and diffs the
+        resulting ``mission.yaml`` against the active one; any lines that exist
+        only because of previously-commented elements are appended under a
+        clearly-marked, fully-commented block so the mission-maker can re-enable
+        them by uncommenting (CONVERT-FIDELITY-001). Returns ``active_yaml``
+        unchanged when there is nothing to recover.
+
+        Args:
+            report: The conversion report (source + active migration result).
+            active_yaml: The mission.yaml built from the active configuration.
+
+        Returns:
+            ``active_yaml``, optionally followed by the commented-elements block.
+        """
+        source = report.missionconfig_source
+        active_mr = report.migration_result
+        if not source or active_mr is None:
+            return active_yaml
+
+        decommented = _decomment_lua(source)
+        if decommented == source:
+            return active_yaml
+
+        # Build the de-commented mission.yaml with the same report context.
+        saved_deps = list(report.auto_resolved_deps)
+        report.migration_result = self._migrator.migrate(decommented)
+        decommented_yaml = self._build_mission_yaml(report)
+        report.migration_result = active_mr
+        report.auto_resolved_deps = saved_deps
+
+        # Lines present only in the de-commented YAML are the recovered elements.
+        matcher = difflib.SequenceMatcher(a=active_yaml.splitlines(), b=decommented_yaml.splitlines())
+        recovered: list[str] = []
+        for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
+            if tag in ("insert", "replace"):
+                recovered.extend(line for line in decommented_yaml.splitlines()[j1:j2] if line.strip())
+        if not recovered:
+            return active_yaml
+
+        block = ["", t("converter.yaml.header.commented_elements")]
+        block += [f"# {line}" for line in recovered]
+        return active_yaml + "\n" + "\n".join(block) + "\n"
 
     def _build_mission_yaml(self, report: ConversionReport) -> str:
         """Produce the full mission.yaml content (with explanatory comments)."""

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -1031,11 +1031,16 @@ class V5Converter:
         report.auto_resolved_deps = saved_deps
 
         # Lines present only in the de-commented YAML are the recovered elements.
-        matcher = difflib.SequenceMatcher(a=active_yaml.splitlines(), b=decommented_yaml.splitlines())
+        # Only ``insert`` opcodes are taken: a ``replace`` could carry lines that
+        # are modifications of *active* config rather than purely recovered
+        # elements, which we must not mislabel as "commented-out".
+        active_lines = active_yaml.splitlines()
+        decommented_lines = decommented_yaml.splitlines()
+        matcher = difflib.SequenceMatcher(a=active_lines, b=decommented_lines)
         recovered: list[str] = []
         for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
-            if tag in ("insert", "replace"):
-                recovered.extend(line for line in decommented_yaml.splitlines()[j1:j2] if line.strip())
+            if tag == "insert":
+                recovered.extend(line for line in decommented_lines[j1:j2] if line.strip())
         if not recovered:
             return active_yaml
 

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -578,6 +578,7 @@
   "converter.yaml.loglevel.desc2": "# Values: error | warning | info | debug | trace",
   "converter.yaml.loglevel.desc3": "# Remove or set to 'info' before deploying to players.",
   "converter.yaml.header.identity": "# ── Mission identity ──────────────────────────────────────────────────────────",
+  "converter.yaml.header.commented_elements": "# ── Commented-out v5 elements (disabled in v5 — uncomment to re-enable) ──",
   "converter.yaml.header.security": "# ── Security ──────────────────────────────────────────────────────────────────",
   "converter.yaml.header.modules": "# ── Module configuration ─────────────────────────────────────────────────────",
   "converter.yaml.modules.desc1": "# Enable or disable VEAF modules and community scripts.",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -578,6 +578,7 @@
   "converter.yaml.loglevel.desc2": "# Valeurs : error | warning | info | debug | trace",
   "converter.yaml.loglevel.desc3": "# Retirez ou mettez 'info' avant de déployer pour les joueurs.",
   "converter.yaml.header.identity": "# ── Identité de la mission ────────────────────────────────────────────────────",
+  "converter.yaml.header.commented_elements": "# ── Éléments v5 commentés (désactivés en v5 — décommentez pour réactiver) ──",
   "converter.yaml.header.security": "# ── Sécurité ──────────────────────────────────────────────────────────────────",
   "converter.yaml.header.modules": "# ── Configuration des modules ────────────────────────────────────────────────",
   "converter.yaml.modules.desc1": "# Activer ou désactiver les modules VEAF et les scripts communautaires.",

--- a/test/python/mission_builder/test_convert_fidelity_commented_elements.py
+++ b/test/python/mission_builder/test_convert_fidelity_commented_elements.py
@@ -1,0 +1,74 @@
+"""CONVERT-FIDELITY-001 — recover commented-out v5 elements as commented YAML."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from mission_builder.v5_converter import V5Converter, _decomment_lua
+from veaf_libs.i18n import current_language, set_language
+
+
+class TestDecommentLua(unittest.TestCase):
+    def test_uncomments_single_line_comments(self) -> None:
+        out = _decomment_lua("-- foo = 1\n--   bar = 2\n")
+        self.assertEqual(out, "foo = 1\n  bar = 2")
+
+    def test_leaves_v6_markers_untouched(self) -> None:
+        out = _decomment_lua("-- [v6 migration] removed\nactive = 1\n")
+        self.assertIn("-- [v6 migration] removed", out)
+
+    def test_leaves_active_code_untouched(self) -> None:
+        self.assertEqual(_decomment_lua("active = 1\n"), "active = 1")
+
+
+class TestCommentedElementsRecovery(unittest.TestCase):
+    def setUp(self) -> None:
+        self._prev = current_language()
+        set_language("en")
+
+    def tearDown(self) -> None:
+        set_language(self._prev)
+
+    def _make_missionconfig(self, folder: Path, content: str) -> None:
+        scripts_dir = folder / "src" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "missionConfig.lua").write_text(content, encoding="utf-8")
+
+    def test_commented_combat_zone_recovered_as_commented_yaml(self) -> None:
+        mission_config = (
+            "-- if veafCombatZone then\n"
+            "--   veafCombatZone.AddZone(\n"
+            "--     VeafCombatZone:new()\n"
+            '--       :setMissionEditorZoneName("AbuZone")\n'
+            '--       :setFriendlyName("Abu")\n'
+            "--       :initialize()\n"
+            "--   )\n"
+            "-- end\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            self._make_missionconfig(folder, mission_config)
+            V5Converter().convert(folder, backup=False)
+            yaml_content = (folder / "mission.yaml").read_text()
+            # The recovered block header is present, and the zone appears commented.
+            self.assertIn("Commented-out v5 elements", yaml_content)
+            self.assertIn("AbuZone", yaml_content)
+            # The recovered zone line is itself commented out.
+            zone_line = next(line for line in yaml_content.splitlines() if "AbuZone" in line)
+            self.assertTrue(zone_line.lstrip().startswith("#"), zone_line)
+
+    def test_no_block_when_nothing_commented(self) -> None:
+        # Only active code → nothing to recover.
+        mission_config = "if veafSpawn then\n  veafSpawn.initialize()\nend\n"
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            self._make_missionconfig(folder, mission_config)
+            V5Converter().convert(folder, backup=False)
+            yaml_content = (folder / "mission.yaml").read_text()
+            self.assertNotIn("Commented-out v5 elements", yaml_content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## CONVERT-FIDELITY-001 — recover commented-out v5 elements

Follow-up to #409. Closes the last ticket of the CONVERT-FIDELITY lot.

### Problem
When a mission-maker disables a chunk of v5 config by commenting it out (e.g. `-- combatZone_Abu = …`), `convert-v5` silently dropped it — the element vanished from the converted `mission.yaml` and the maker lost any trace it existed.

### Fix
`convert-v5` now re-emits those elements at the end of `mission.yaml` as a fully-commented **"Commented-out v5 elements (disabled in v5 — uncomment to re-enable)"** block, so they stay disabled but visible and re-enableable.

**Mechanism (generic — covers every extractor at once):**
1. De-comment the original `missionConfig.lua` (`_decomment_lua`, leaving `-- [v6 …]` markers).
2. Re-run extraction on it → a `MigrationResult` that also contains the previously-commented elements.
3. Build the de-commented `mission.yaml` with the same report context, and `difflib`-diff it against the active one.
4. Append the inserted lines as a commented block.

It's **safe** because extraction is pattern-based: de-commented prose matches nothing, so only real extractable elements (combat zones, assets, QRA, shortcuts, sanctuary, …) ever surface. It's a purely **additive post-pass** — the existing extraction/build logic is untouched.

Example recovered block:
```yaml
# ── Commented-out v5 elements (disabled in v5 — uncomment to re-enable) ──
#   COMBATZONE:
#     enabled: true
#     combat_zones:
#     - type: zone
#       zone_name: AbuZone
#       friendly_name: Abu
```

### Quality
- New tests: `test_convert_fidelity_commented_elements` (de-comment helper + end-to-end recovery + "nothing commented → no block").
- Full suite green (coverage 64.89% ≥ gate, bumped 62 → 63), mypy clean, ruff + `ruff format --check` clean. Version 6.4.6.

### Manual test (🧑)
Per the agreed approach, eyeballing a real `convert-v5-report.md` / generated `mission.yaml` is a post-merge confirmation (pre-release, fix-forward).

https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw)_

## Summary by Sourcery

Recover commented-out v5 configuration elements in convert-v5 by re-emitting them as a commented YAML block at the end of mission.yaml, and mark the CONVERT-FIDELITY backlog lot as completed with a version bump.

New Features:
- Preserve previously commented-out v5 mission elements by appending them to mission.yaml as a fully commented "Commented-out v5 elements" block so they can be re-enabled later.

Enhancements:
- Store original missionConfig.lua content in the conversion report and add a de-commenting helper to support re-extraction of disabled v5 elements.

Build:
- Increase the project version to 6.4.6 and raise the test coverage threshold from 62 to 63.

Documentation:
- Update backlog and changelog entries to reflect completion of CONVERT-FIDELITY-001 and document the new commented-out elements behavior of convert-v5.

Tests:
- Add unit and integration tests covering Lua de-commenting and end-to-end recovery of commented-out v5 elements, including the no-op case when nothing is commented.