### PR TITLE
feat(era-autodetect): auto-detect mission era from .miz, manual override wins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Automatic mission-era detection**: when `mission.era` is not set in `mission.yaml`, `build` infers it (`WW2` / `COLD_WAR` / `MODERN`) from the base mission — a combined heuristic over the DCS mission **year** and a **WW2-era unit/aircraft-type** reference table (WW2 wins on the unit signal even at a modern default year). A manually-set `mission.era` always takes precedence (ERA-AUTODETECT-001/002)
 - `convert-v5`: **commented-out v5 elements are no longer silently dropped** — a combat zone, asset, QRA, shortcut, etc. that was disabled with `--` in `missionConfig.lua` is now re-emitted at the end of `mission.yaml` as a fully-commented **"Commented-out v5 elements"** block, so you can re-enable it by uncommenting. Generic across every extractor (a de-commented re-extraction is diffed against the active config; pattern-based extraction ignores prose) (CONVERT-FIDELITY-001)
 - `convert-v5`: the annotated report (`convert-v5-report.md`) now opens with an at-a-glance **Summary** — how many modules were migrated and how many items still need manual action (with the source line numbers) — so you see whether work remains without reading the full annotated config (CONVERT-FIDELITY-004)
 - `mission.silence_atc_on_all_airbases` (default `true` in the template): emits `veaf.silenceAtcOnAllAirbases()`; `convert-v5` detects an active call in `missionConfig.lua` and preserves it (CONVERT-FIDELITY-003)

--- a/backlog.md
+++ b/backlog.md
@@ -24,7 +24,7 @@
 | Lot SECREV — full-repo code review findings (lupa RCE, helicopter extraction data loss, zip hardening, Lua nil-derefs) | ✅ |
 | Lot TODO0609-MODULES-UNIFY — single `modules:` block as source of truth (QRA + community config nested), CTLD/CSAR extracted from v5 | ✅ |
 | Lot TODO0609-CONVERT-FIDELITY — convert-v5 report fidelity: comment full migrated blocks, emit commented-out v5 elements, silenceAtc key | ✅ |
-| Lot TODO0609-ERA-AUTODETECT — auto-detect mission era (incl. WW2) from `.miz` content, manual override wins | ⬜ |
+| Lot TODO0609-ERA-AUTODETECT — auto-detect mission era (incl. WW2) from `.miz` content, manual override wins | 🔄 |
 | Lot TODO0609-SPAWN-EXTERNALIZE — externalize spawn group / veafUnits / dcsUnits definitions from Lua to YAML (spike + impl) | ⬜ |
 | Lot TODO0609-DYNLOAD-CLARIFY — clarify `veafDynamicConfig.lua` vs `VeafDynamicLoader.lua`, find obsolete one (spike) | ⬜ |
 | Lot TODO0609-PRESETS-FIDELITY — iso-functional v5 presets conversion (fix) + presets data-structure/defaults analysis (spike) | ⬜ |

--- a/backlog.md
+++ b/backlog.md
@@ -24,7 +24,7 @@
 | Lot SECREV — full-repo code review findings (lupa RCE, helicopter extraction data loss, zip hardening, Lua nil-derefs) | ✅ |
 | Lot TODO0609-MODULES-UNIFY — single `modules:` block as source of truth (QRA + community config nested), CTLD/CSAR extracted from v5 | ✅ |
 | Lot TODO0609-CONVERT-FIDELITY — convert-v5 report fidelity: comment full migrated blocks, emit commented-out v5 elements, silenceAtc key | ✅ |
-| Lot TODO0609-ERA-AUTODETECT — auto-detect mission era (incl. WW2) from `.miz` content, manual override wins | 🔄 |
+| Lot TODO0609-ERA-AUTODETECT — auto-detect mission era (incl. WW2) from `.miz` content, manual override wins | ✅ |
 | Lot TODO0609-SPAWN-EXTERNALIZE — externalize spawn group / veafUnits / dcsUnits definitions from Lua to YAML (spike + impl) | ⬜ |
 | Lot TODO0609-DYNLOAD-CLARIFY — clarify `veafDynamicConfig.lua` vs `VeafDynamicLoader.lua`, find obsolete one (spike) | ⬜ |
 | Lot TODO0609-PRESETS-FIDELITY — iso-functional v5 presets conversion (fix) + presets data-structure/defaults analysis (spike) | ⬜ |
@@ -238,8 +238,8 @@ was constrained to a working branch.
 
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
-| ERA-AUTODETECT-001 | Detection helper combining the DCS mission year and a WW2 unit/aircraft-type reference list to infer the era; document the priority rule. Unit tests over fixtures (WW2 by year, WW2 by units, modern, ambiguous). | `mission_builder/`, `test/python/` | feat | ⬜ |
-| ERA-AUTODETECT-002 | Wire the helper into conversion/build: use detected era only when `mission.yaml` `era` is absent; manual value always wins. Maintain the WW2-era types reference table. | `mission_builder/config_migrator.py` / `mission_builder/mission_builder_worker.py`, `test/python/` | feat | ⬜ |
+| ERA-AUTODETECT-001 | Detection helper combining the DCS mission year and a WW2 unit/aircraft-type reference list to infer the era; document the priority rule. Unit tests over fixtures (WW2 by year, WW2 by units, modern, ambiguous). | `mission_builder/`, `test/python/` | feat | ✅ |
+| ERA-AUTODETECT-002 | Wire the helper into conversion/build: use detected era only when `mission.yaml` `era` is absent; manual value always wins. Maintain the WW2-era types reference table. | `mission_builder/config_migrator.py` / `mission_builder/mission_builder_worker.py`, `test/python/` | feat | ✅ |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.4.6"
+version = "6.4.7"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"
@@ -132,7 +132,7 @@ addopts = [
     "--cov=src/python/veaf-tools",
     "--cov-report=xml",
     "--cov-report=term-missing:skip-covered",
-    "--cov-fail-under=63",
+    "--cov-fail-under=64",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/python/veaf-tools/mission_builder/era_detector.py
+++ b/src/python/veaf-tools/mission_builder/era_detector.py
@@ -1,0 +1,150 @@
+"""Automatic mission-era detection (ERA-AUTODETECT).
+
+Infers the VEAF era (``WW2`` / ``COLD_WAR`` / ``MODERN``) from a parsed ``.miz``
+mission, using a **combined heuristic**: the DCS mission year *and* the presence
+of WW2-era unit/aircraft types.
+
+Priority rule (a manual ``mission.yaml`` ``era`` always wins — that is enforced
+by the caller, not here):
+
+1. **WW2** when any WW2-era unit/aircraft type is present, **or** the mission
+   year is 1945 or earlier (the unit signal is the strongest indicator and wins
+   even if the year was left at a modern default).
+2. Otherwise, year-based: **COLD_WAR** up to 1991, **MODERN** from 1992 on.
+3. When neither a year nor WW2 units are available, default to **MODERN**.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+#: Era identifiers — must match ``veaf.ERA`` in ``veaf.lua``.
+ERA_WW2 = "WW2"
+ERA_COLD_WAR = "COLD_WAR"
+ERA_MODERN = "MODERN"
+
+#: Inclusive upper year bounds for each era.
+_WW2_MAX_YEAR = 1945
+_COLD_WAR_MAX_YEAR = 1991
+
+#: WW2-era DCS unit/aircraft type ids (reference table — maintained here).
+#: Aircraft are the strongest signal; iconic ground units and flak are included.
+WW2_UNIT_TYPES: frozenset[str] = frozenset(
+    {
+        # ── Aircraft ──
+        "SpitfireLFMkIX",
+        "SpitfireLFMkIXCW",
+        "P-51D",
+        "P-51D-30-NA",
+        "TF-51D",
+        "P-47D-30",
+        "P-47D-30bl1",
+        "P-47D-40",
+        "Bf-109K-4",
+        "FW-190D9",
+        "FW-190A8",
+        "MosquitoFBMkVI",
+        "A-20G",
+        "B-17G",
+        "Ju-88A4",
+        "I-16",
+        # ── Tanks / armour ──
+        "Tiger_I",
+        "Tiger_II",
+        "Pz_IV_H",
+        "Stug_III",
+        "Stug_IV",
+        "SturmpanzerIV",
+        "Sd_Kfz_251",
+        "Sd_Kfz_184",
+        "Elefant_SdKfz_184",
+        "M4_Sherman",
+        "M2A1_halftrack",
+        "M8_Greyhound",
+        "M30_CC",
+        "Churchill_VII",
+        "Cromwell_IV",
+        "Daimler_AC",
+        # ── Trucks / cars ──
+        "Sd_Kfz_2",
+        "Sd_Kfz_7",
+        "Kubelwagen_82",
+        "Horch_901_typ_40_kfz_21",
+        "Blitz_36-6700A",
+        "Bedford_MWD",
+        "CCKW_353",
+        # ── AAA / flak ──
+        "Flak18",
+        "Flak30",
+        "Flak36",
+        "Flak37",
+        "Flak38",
+        "Flak41",
+        "KDO_Mod40",
+        "Maschinensatz_33",
+        "Bofors40",
+    }
+)
+
+
+def _iter_unit_types(mission_content: dict) -> Iterator[str]:
+    """Yield every unit ``type`` string found in the mission.
+
+    Tolerates both list- and dict-shaped DCS tables (``country``/``group``/
+    ``units`` are usually 1-based and decode to lists).
+
+    Args:
+        mission_content: The parsed ``mission`` table from the ``.miz``.
+
+    Yields:
+        Each unit's ``type`` id.
+    """
+
+    def _values(node: object) -> Iterator:
+        if isinstance(node, dict):
+            yield from node.values()
+        elif isinstance(node, list):
+            yield from node
+
+    coalition = mission_content.get("coalition")
+    if not isinstance(coalition, dict):
+        return
+    for side in coalition.values():
+        if not isinstance(side, dict):
+            continue
+        for country in _values(side.get("country")):
+            if not isinstance(country, dict):
+                continue
+            for category in ("plane", "helicopter", "vehicle", "ship", "static"):
+                cat = country.get(category)
+                if not isinstance(cat, dict):
+                    continue
+                for group in _values(cat.get("group")):
+                    if not isinstance(group, dict):
+                        continue
+                    for unit in _values(group.get("units")):
+                        if isinstance(unit, dict) and (unit_type := unit.get("type")):
+                            yield unit_type
+
+
+def detect_era(mission_content: dict) -> str:
+    """Infer the mission era from its content (see module docstring for the rule).
+
+    Args:
+        mission_content: The parsed ``mission`` table from the ``.miz``.
+
+    Returns:
+        One of ``"WW2"``, ``"COLD_WAR"`` or ``"MODERN"``.
+    """
+    has_ww2_units = any(unit_type in WW2_UNIT_TYPES for unit_type in _iter_unit_types(mission_content))
+
+    year = None
+    date = mission_content.get("date")
+    if isinstance(date, dict) and isinstance(date.get("Year"), int):
+        year = date["Year"]
+
+    if has_ww2_units or (year is not None and year <= _WW2_MAX_YEAR):
+        return ERA_WW2
+    if year is not None:
+        return ERA_COLD_WAR if year <= _COLD_WAR_MAX_YEAR else ERA_MODERN
+    return ERA_MODERN

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -1189,7 +1189,8 @@ class MissionBuilderWorker(BaseWorker):
             return None
         try:
             content = luadata.unserialize(mission_file.read_text(encoding="utf-8"), keep_as_dict=["trig", "trigrules"])
-        except Exception:  # noqa: BLE001 - era detection must never break the build
+        except Exception as exc:  # noqa: BLE001 - era detection must never break the build
+            logger.debug(f"era auto-detect: could not parse base mission {mission_file}: {exc}")
             return None
         if not isinstance(content, dict):
             return None

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -10,6 +10,7 @@ import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import luadata  # type: ignore[import-untyped]
 import yaml
 from mission_tools import (
     DEFAULT_SCRIPTS_LOCATION,
@@ -32,6 +33,8 @@ from veaf_libs.lua_module_scanner import get_modules
 from veaf_libs.paths import resolve_path
 from veaf_libs.progress import spinner_context
 from veaf_libs.yaml_validator import validate_modules_semantics, validate_yaml_file
+
+from mission_builder.era_detector import detect_era
 
 _DCS_BRIDGE_DOWNLOAD_URL = (
     "https://raw.githubusercontent.com/VEAF/VEAF-dcs-bridge/refs/heads/develop/src/lua/dcs-bridge.lua"
@@ -1170,6 +1173,28 @@ class MissionBuilderWorker(BaseWorker):
         write_miz(mission=self.dcs_mission, miz_file_path=self.output_mission, additional_files=additional_files)
         logger.debug("Writing mission file done")
 
+    def _detect_era_from_base(self) -> str | None:
+        """Auto-detect the mission era from the base mission's units and date.
+
+        Reads the unpacked DCS ``mission`` table from ``src/mission/`` (available
+        before the output ``.miz`` is built) and runs the era heuristic. Used only
+        when ``mission.yaml`` does not set ``mission.era`` — a manual value always
+        wins (ERA-AUTODETECT-002).
+
+        Returns:
+            The detected era, or ``None`` when the base mission cannot be read.
+        """
+        mission_file = self.mission_folder / "src" / "mission" / "mission"
+        if not mission_file.exists():
+            return None
+        try:
+            content = luadata.unserialize(mission_file.read_text(encoding="utf-8"), keep_as_dict=["trig", "trigrules"])
+        except Exception:  # noqa: BLE001 - era detection must never break the build
+            return None
+        if not isinstance(content, dict):
+            return None
+        return detect_era(content)
+
     def write_config_lua(self) -> None:
         """Write veaf-config.lua from mission_yaml (or legacy lua_modules / global_log_level)."""
         # Build a YAML dict to pass to the generator
@@ -1186,6 +1211,15 @@ class MissionBuilderWorker(BaseWorker):
                 yaml_dict["global_log_level"] = self.global_log_level
             if self.lua_modules:
                 yaml_dict["lua_modules"] = self.lua_modules
+
+        # ERA-AUTODETECT-002: fill in the era only when the user did not set it.
+        mission_cfg = dict(yaml_dict.get("mission") or {})
+        if not mission_cfg.get("era"):
+            detected_era = self._detect_era_from_base()
+            if detected_era:
+                mission_cfg["era"] = detected_era
+                yaml_dict["mission"] = mission_cfg
+                logger.info(t("builder.era_detected", era=detected_era))
 
         if not yaml_dict:
             return

--- a/src/python/veaf-tools/veaf_libs/locales/en.json
+++ b/src/python/veaf-tools/veaf_libs/locales/en.json
@@ -503,6 +503,7 @@
   "builder.copied_from_defaults": "Copied required file '{file}' from default folder '{folder}'",
   "builder.mission_read_error": "An error occurred while reading the {path} file; is this a valid DCS mission?",
   "builder.veaf_config_generated": "Generated '{file}' from mission.yaml",
+  "builder.era_detected": "Auto-detected mission era: {era} (set mission.era in mission.yaml to override)",
   "aircraft_injector.validating_yaml": "Validating YAML file {path}",
   "aircraft_injector.yaml_valid": "YAML validation successful",
   "aircraft_injector.yaml_invalid": "YAML validation failed",

--- a/src/python/veaf-tools/veaf_libs/locales/fr.json
+++ b/src/python/veaf-tools/veaf_libs/locales/fr.json
@@ -503,6 +503,7 @@
   "builder.copied_from_defaults": "Fichier requis '{file}' copié depuis le dossier par défaut '{folder}'",
   "builder.mission_read_error": "Erreur lors de la lecture du fichier {path} ; est-ce une mission DCS valide ?",
   "builder.veaf_config_generated": "'{file}' généré depuis mission.yaml",
+  "builder.era_detected": "Ère de mission auto-détectée : {era} (définissez mission.era dans mission.yaml pour forcer)",
   "aircraft_injector.validating_yaml": "Validation du fichier YAML {path}",
   "aircraft_injector.yaml_valid": "Validation YAML réussie",
   "aircraft_injector.yaml_invalid": "Validation YAML échouée",

--- a/test/python/mission_builder/test_era_autodetect_wiring.py
+++ b/test/python/mission_builder/test_era_autodetect_wiring.py
@@ -1,0 +1,72 @@
+"""ERA-AUTODETECT-002 — wire era detection into the build (manual value wins)."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from mission_builder.mission_builder_worker import MissionBuilderWorker
+
+_BASE_MISSION_WW2 = (
+    "mission = {\n"
+    '  ["date"] = { ["Year"] = 2011, ["Month"] = 6, ["Day"] = 1 },\n'
+    '  ["coalition"] = {\n'
+    '    ["blue"] = {\n'
+    '      ["country"] = {\n'
+    "        [1] = {\n"
+    '          ["name"] = "USA",\n'
+    '          ["plane"] = { ["group"] = { [1] = { ["units"] = { [1] = { ["type"] = "SpitfireLFMkIX" } } } } },\n'
+    "        },\n"
+    "      },\n"
+    "    },\n"
+    "  },\n"
+    "}\n"
+)
+
+
+class TestEraAutodetectWiring(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.folder = Path(self._tmp.name)
+        (self.folder / "src" / "mission").mkdir(parents=True)
+        (self.folder / "src" / "mission" / "mission").write_text(_BASE_MISSION_WW2, encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _worker(self, yaml_content: str) -> MissionBuilderWorker:
+        (self.folder / "mission.yaml").write_text(yaml_content, encoding="utf-8")
+        return MissionBuilderWorker(
+            mission_folder=self.folder,
+            output_mission=self.folder / "out.miz",
+            dynamic_mode=None,
+        )
+
+    def _generated_config(self) -> str:
+        return (self.folder / "src" / "scripts" / "veaf-config.lua").read_text(encoding="utf-8")
+
+    def test_detect_era_from_base_returns_ww2(self) -> None:
+        worker = self._worker("mission:\n  name: Test\n")
+        self.assertEqual(worker._detect_era_from_base(), "WW2")
+
+    def test_era_injected_when_absent(self) -> None:
+        worker = self._worker("mission:\n  name: Test\n")
+        worker.write_config_lua()
+        self.assertIn("veaf.config.era = veaf.ERA.WW2", self._generated_config())
+
+    def test_manual_era_wins_over_detection(self) -> None:
+        worker = self._worker("mission:\n  name: Test\n  era: MODERN\n")
+        worker.write_config_lua()
+        config = self._generated_config()
+        self.assertIn("veaf.config.era = veaf.ERA.MODERN", config)
+        self.assertNotIn("veaf.ERA.WW2", config)
+
+    def test_no_base_mission_no_era(self) -> None:
+        (self.folder / "src" / "mission" / "mission").unlink()
+        worker = self._worker("mission:\n  name: Test\n")
+        self.assertIsNone(worker._detect_era_from_base())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/mission_builder/test_era_detector.py
+++ b/test/python/mission_builder/test_era_detector.py
@@ -1,0 +1,62 @@
+"""ERA-AUTODETECT-001 — mission-era detection helper."""
+
+from __future__ import annotations
+
+from mission_builder.era_detector import ERA_COLD_WAR, ERA_MODERN, ERA_WW2, detect_era
+
+
+def _mission(year: int | None = None, unit_type: str | None = None) -> dict:
+    content: dict = {}
+    if year is not None:
+        content["date"] = {"Day": 1, "Month": 6, "Year": year}
+    if unit_type is not None:
+        content["coalition"] = {
+            "blue": {"country": [{"name": "USA", "plane": {"group": [{"units": [{"type": unit_type}]}]}}]}
+        }
+    return content
+
+
+class TestDetectEra:
+    def test_ww2_by_year(self) -> None:
+        assert detect_era(_mission(year=1944)) == ERA_WW2
+
+    def test_ww2_boundary_year_1945(self) -> None:
+        assert detect_era(_mission(year=1945)) == ERA_WW2
+
+    def test_ww2_by_unit_type_overrides_modern_year(self) -> None:
+        # A WW2 aircraft present even with a modern default year → WW2.
+        assert detect_era(_mission(year=2011, unit_type="SpitfireLFMkIX")) == ERA_WW2
+
+    def test_ww2_by_ground_unit(self) -> None:
+        assert detect_era(_mission(year=2000, unit_type="Tiger_II")) == ERA_WW2
+
+    def test_cold_war_year(self) -> None:
+        assert detect_era(_mission(year=1975)) == ERA_COLD_WAR
+
+    def test_cold_war_boundary_1991(self) -> None:
+        assert detect_era(_mission(year=1991)) == ERA_COLD_WAR
+
+    def test_modern_year(self) -> None:
+        assert detect_era(_mission(year=2011)) == ERA_MODERN
+
+    def test_modern_boundary_1992(self) -> None:
+        assert detect_era(_mission(year=1992)) == ERA_MODERN
+
+    def test_modern_aircraft_does_not_trigger_ww2(self) -> None:
+        assert detect_era(_mission(year=2011, unit_type="F-16C_50")) == ERA_MODERN
+
+    def test_default_modern_when_no_year_no_units(self) -> None:
+        assert detect_era({}) == ERA_MODERN
+
+    def test_dict_shaped_tables_supported(self) -> None:
+        # DCS 1-based tables sometimes decode to dicts — must still scan.
+        content = {
+            "date": {"Year": 2011},
+            "coalition": {
+                "blue": {"country": {1: {"plane": {"group": {1: {"units": {1: {"type": "P-51D"}}}}}}}}
+            },
+        }
+        assert detect_era(content) == ERA_WW2
+
+    def test_malformed_content_does_not_crash(self) -> None:
+        assert detect_era({"coalition": "nonsense", "date": "bad"}) == ERA_MODERN

--- a/test/python/mission_builder/test_era_detector.py
+++ b/test/python/mission_builder/test_era_detector.py
@@ -60,3 +60,8 @@ class TestDetectEra:
 
     def test_malformed_content_does_not_crash(self) -> None:
         assert detect_era({"coalition": "nonsense", "date": "bad"}) == ERA_MODERN
+
+    def test_non_integer_year_defaults_to_modern(self) -> None:
+        # Locks in the isinstance(..., int) guard: a string/None year is ignored.
+        assert detect_era({"date": {"Year": "2011"}}) == ERA_MODERN
+        assert detect_era({"date": {"Year": None}}) == ERA_MODERN


### PR DESCRIPTION
## Lot TODO0609-ERA-AUTODETECT — automatic mission-era detection

When `mission.yaml` doesn't set `mission.era`, `build` now infers it from the base mission instead of silently defaulting to MODERN. A **manually-set `mission.era` always wins**.

### 001 — detection helper (`mission_builder/era_detector.py`)
`detect_era(mission_content)` uses a **combined heuristic**:
- **WW2** when any WW2-era unit/aircraft type is present (a curated reference table — Spitfire, Bf‑109, P‑51, Tiger, Flak…), **or** the mission year ≤ 1945. The unit signal wins even at a modern default year.
- otherwise year-based: **COLD_WAR** up to 1991, **MODERN** from 1992.
- **MODERN** when there's no year and no WW2 units.

Tolerates list- and dict-shaped DCS tables. 12 unit tests (WW2 by year / by unit / boundary years / modern / ambiguous / malformed).

### 002 — wired into the build
`write_config_lua` reads the unpacked base mission (`src/mission/mission`, available before the output `.miz` is built) via the **safe pure-Python `unserialize`** (post-SECREV, no code execution) and fills `mission.era` only when the user left it unset. Localized info line so the mission-maker knows detection happened and how to override. 4 wiring tests (detected→WW2, injected when absent, **manual MODERN wins over WW2 units**, no base → no era).

### Quality
- Full suite green (coverage 65.24%, gate bumped 63 → 64), **mypy clean** (incl. `mission_builder_worker`), ruff + `ruff format --check` clean. Version 6.4.7.

### Manual test (🧑)
None gated upstream (decision already frozen in the backlog). A real-mission build is a nice post-merge sanity check but not required.

https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw)_

## Summary by Sourcery

Auto-detect the mission era from the base DCS mission when not specified in mission.yaml, and bump tooling metadata accordingly.

New Features:
- Introduce an era detection helper that infers WW2, COLD_WAR or MODERN from mission year and WW2 unit types.
- Populate mission.era during build based on the detected era only when it is not explicitly set in mission.yaml, logging the result.

Enhancements:
- Mark the ERA-AUTODETECT backlog items as completed and document the feature in the changelog.
- Increase the project version and raise the test coverage threshold.

Tests:
- Add unit tests for the era detection heuristic and its wiring into the mission build pipeline.