### PR TITLE
docs(presets-fidelity): spike analysis (ADR 0003) + Tripack regression fixture

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -27,7 +27,7 @@
 | Lot TODO0609-ERA-AUTODETECT — auto-detect mission era (incl. WW2) from `.miz` content, manual override wins | ✅ |
 | Lot TODO0609-SPAWN-EXTERNALIZE — externalize spawn group / veafUnits / dcsUnits definitions from Lua to YAML (spike + impl) | ⬜ |
 | Lot TODO0609-DYNLOAD-CLARIFY — clarify `veafDynamicConfig.lua` vs `VeafDynamicLoader.lua`, find obsolete one (spike) | ⬜ |
-| Lot TODO0609-PRESETS-FIDELITY — iso-functional v5 presets conversion (fix) + presets data-structure/defaults analysis (spike) | ⬜ |
+| Lot TODO0609-PRESETS-FIDELITY — iso-functional v5 presets conversion (fix) + presets data-structure/defaults analysis (spike) | 🔄 |
 | Lot TODO0609-TRIGGERS-VERIFY — verify DCS trigger migration behaviour for custom scripts (with Flogas) | ⬜ |
 | Lot TODO0609-TUI-FOLDER-HINT — clarify the TUI mission-folder default (`.`) | ⬜ |
 | Lot TODO0609-AIRCRAFT-INJECT — split aircraft-group injection into spawnable-aircraft vs dynamic-slot-template steps, flag/prefix sort | ⬜ |
@@ -279,7 +279,7 @@ was constrained to a working branch.
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
 | PRESETS-FIDELITY-001 (13a) | Make `convert-v5` produce a `presets.yaml` iso-functional with the v5 mission's presets — preserve per-module channel mappings/offsets (Mi-24 ch0→20, AJS-37, …). Regression tests against real v5 preset fixtures. | `mission_builder/v5_pipeline_converters.py`, `presets_injector/`, `test/python/` | fix | ⬜ |
-| PRESETS-FIDELITY-002 (13b, spike) | Analyse the v6 `presets.yaml` data structure vs the v5 presets structure; decide whether to redesign it; propose a default `presets.yaml` that accounts for DCS module quirks. Deliverable: reco + tickets. | `presets_injector/`, `src/defaults/mission-folder/src/presets.yaml` | spike | ⬜ |
+| PRESETS-FIDELITY-002 (13b, spike) | Analyse the v6 `presets.yaml` data structure vs the v5 presets structure; decide whether to redesign it; propose a default `presets.yaml` that accounts for DCS module quirks. Deliverable: reco + tickets. | `presets_injector/`, `src/defaults/mission-folder/src/presets.yaml` | spike | ✅ |
 
 ---
 

--- a/docs/adr/0003-presets-fidelity.md
+++ b/docs/adr/0003-presets-fidelity.md
@@ -1,0 +1,67 @@
+---
+status: accepted
+---
+
+# Iso-functional radio-presets conversion (v5 → v6)
+
+The v5 `radioSettings.lua` encodes, per aircraft, an explicit per-radio channel
+table (`["Radio"][N]["channels"][index] = frequency`) that DCS writes verbatim
+into each unit's `Radio` table. Some aircraft use **bespoke** tables that the
+`convert-v5` presets converter silently flattened to a standard preset (or
+skipped), losing real configuration. This note (PRESETS-FIDELITY spike, item
+13b) documents the gap and the chosen fix (item 13a).
+
+## The two reference quirks (from a real Tripack mission)
+
+- **Mi-24P** — a **channel rotation**: slot `[1]` (DCS *channel 0*) holds preset
+  **#20**, then channels 1–19 hold presets 1–19 (`{[1]=RADIO1_20, [2]=RADIO1_01,
+  …, [20]=RADIO1_19}`). It also has a **second radio** (FM, `RADIO3_*`).
+- **AJS37** — a **leading dummy** (`[1]=0`, "channel 100"), then 20 UHF + 19 VHF
+  preset references, then **7 hardcoded special frequencies** (FR22/FR24), plus a
+  per-channel **`modulations`** table (AM/FM selection).
+
+The previous converter classified each aircraft only by *which preset table its
+radio 1 referenced* (`uhf`/`vhf`/`fm`/`warbird`) and assigned a standard preset.
+For these two aircraft that drops the rotation, the offset, the extra radio, the
+hardcoded specials and the modulations.
+
+## v6 representability
+
+The v6 model already supports everything needed — no schema redesign required:
+
+- `RadioDefinition.to_dict()` emits an explicit `channels: {number: freq}` map,
+  so arbitrary channel→frequency mappings (rotations, offsets, hardcoded freqs)
+  are representable.
+- A `PresetDefinition` maps **several** radio slots, covering multi-radio
+  aircraft (Mi-24 UHF + FM).
+- The injector writes `unit["Radio"] = preset.to_dict()`, the **same shape** DCS
+  expects, so reproducing the v5 table verbatim is **iso-functional by
+  construction** (the v6 channel `number` is the v5 table index — no 0-indexed
+  vs displayed ambiguity).
+- **Gap:** the per-channel `mod` (modulation) field exists in the model but was
+  commented out of `to_dict()`. The fix re-enables it so the AJS37 AM/FM
+  selection round-trips.
+
+## Decision
+
+When an aircraft's v5 `["Radio"]` table is **non-standard** (any radio whose
+channel list is not a plain 1:1 of a standard preset table — i.e. it reorders,
+offsets, mixes hardcoded frequencies, carries modulations, or adds extra
+radios), `convert-v5` emits a **dedicated per-aircraft preset** that reproduces
+the exact channel→frequency map (resolving `radioPresets*["##TOKEN##"]`
+references to their frequencies, keeping hardcoded literals) plus the
+modulations, and assigns the aircraft to it. Standard aircraft keep the existing
+lightweight assignment to a shared preset.
+
+Decisions (2026-06-10, with David): include modulations now; merge on green CI
+with the real Tripack `radioSettings.lua` as a regression fixture, then verify
+the channels in-game post-merge (pre-release, fix-forward).
+
+## Consequences
+
+- Bespoke aircraft (Mi-24, AJS37, …) keep their exact radio layout after
+  conversion instead of being flattened or skipped.
+- Per-aircraft presets make `presets.yaml` larger for missions that use many
+  bespoke layouts — acceptable, and only for the aircraft that need it.
+- Channel correctness is ultimately a DCS-runtime property; the regression
+  fixture locks the *conversion* output, the in-game test confirms the *result*.

--- a/test/python/mission_builder/fixtures/tripack_radioSettings.lua
+++ b/test/python/mission_builder/fixtures/tripack_radioSettings.lua
@@ -1,0 +1,5122 @@
+---@diagnostic disable: lowercase-global
+-- DEFINE THE PRESETS (CRYSTALLISATION) HERE AND REFER TO IT LATER IN THE FILE
+-- THIS IS THE MAIN TABLE OF PRESETS. 
+-- E.G. [1]  = radioPresets["##RADIO1_01##"],
+--
+-- THIS SHOULD BE THE ONLY PART OF THIS FILE YOU'LL NEED TO CHANGE IF YOU ONLY CHANGE THE FREQUENCIES
+-- TO ADD OR CHANGE AIRCRAFT AND COALITION TEMPLATES, SEE FURTHER BELOW
+radioPresetsBlue =
+{
+    -- radio 1 : left radio, red radio, UHF radio - channel frequency (Default range is 225MHz to 390MHz)
+    ["##RADIO1_01##"] = 284.000,-- TACTICAL UNIFORM
+    ["##RADIO1_02##"] = 250.550,-- Bassel / 98X
+    ["##RADIO1_03##"] = 251.850,-- Paphos / 79X
+    ["##RADIO1_04##"] = 251.700,-- Akrotiri / 107X
+    ["##RADIO1_05##"] = 251.900,-- Larnaca
+    ["##RADIO1_06##"] = 250.200,-- Hama
+    ["##RADIO1_07##"] = 250.250,-- Hatay
+    ["##RADIO1_08##"] = 251.550,-- Al Qusayr
+    ["##RADIO1_09##"] = 251.350,-- Shayrat
+    ["##RADIO1_10##"] = 273.500,-- G.Washington / 73X
+    ["##RADIO1_11##"] = 276.000,-- JTAC UNIFORM
+    ["##RADIO1_12##"] = 276.250,-- STRIKE UNIFORM
+    ["##RADIO1_13##"] = 276.500,-- GROUND UNIFORM
+    ["##RADIO1_14##"] = 276.750,-- CAP UNIFORM
+    ["##RADIO1_15##"] = 277.500,-- GCI AXEMAN
+    ["##RADIO1_16##"] = 271.500,-- AWACS DARKSTAR
+    ["##RADIO1_17##"] = 266.500,-- Texaco-1/BS/66Y
+    ["##RADIO1_18##"] = 267.500,-- Shell-1/BM/67Y
+    ["##RADIO1_19##"] = 268.500,-- Arco-1/BS/68Y
+    ["##RADIO1_20##"] = 243.000,-- GUARD
+
+    -- radio 1 : left radio, red radio, UHF radio - channel names
+    ["##RADIO1_NAME_01##"] = "TACTICAL UNIFORM",
+    ["##RADIO1_NAME_02##"] = "Bassel / 98X",
+    ["##RADIO1_NAME_03##"] = "Paphos / 79X",
+    ["##RADIO1_NAME_04##"] = "Akrotiri / 107X",
+    ["##RADIO1_NAME_05##"] = "Larnaca",
+    ["##RADIO1_NAME_06##"] = "Hama",
+    ["##RADIO1_NAME_07##"] = "Hatay",
+    ["##RADIO1_NAME_08##"] = "Al Qusayr",
+    ["##RADIO1_NAME_09##"] = "Shayrat",
+    ["##RADIO1_NAME_10##"] = "G.Washington / 73X",
+    ["##RADIO1_NAME_11##"] = "JTAC UNIFORM",
+    ["##RADIO1_NAME_12##"] = "STRIKE UNIFORM",
+    ["##RADIO1_NAME_13##"] = "GROUND UNIFORM",
+    ["##RADIO1_NAME_14##"] = "CAP UNIFORM",
+    ["##RADIO1_NAME_15##"] = "GCI AXEMAN",
+    ["##RADIO1_NAME_16##"] = "AWACS DARKSTAR",
+    ["##RADIO1_NAME_17##"] = "Texaco-1/BS/66Y",
+    ["##RADIO1_NAME_18##"] = "Shell-1/BM/67Y",
+    ["##RADIO1_NAME_19##"] = "Arco-1/BS/68Y",
+    ["##RADIO1_NAME_20##"] = "GUARD",
+
+    -- radio 2 : right radio, green radio, VHF radio - channel frequency  (Default range is 118MHz to 150MHz)
+    ["##RADIO2_01##"] = 134.000,-- TACTICAL VICTOR
+    ["##RADIO2_02##"] = 118.100,-- Bassel / 98X
+    ["##RADIO2_03##"] = 119.900,-- Paphos / 79X
+    ["##RADIO2_04##"] = 128.000,-- Akrotiri / 107X
+    ["##RADIO2_05##"] = 121.200,-- Larnaca
+    ["##RADIO2_06##"] = 118.050,-- Hama
+    ["##RADIO2_07##"] = 128.500,-- Hatay
+    ["##RADIO2_08##"] = 119.200,-- Al Qusayr
+    ["##RADIO2_09##"] = 120.200,-- Shayrat
+    ["##RADIO2_10##"] = 133.500,-- G.Washington / LSO
+    ["##RADIO2_11##"] = 126.000,-- JTAC VICTOR
+    ["##RADIO2_12##"] = 126.250,-- STRIKE VICTOR
+    ["##RADIO2_13##"] = 126.500,-- GROUND VICTOR
+    ["##RADIO2_14##"] = 126.750,-- CAP VICTOR
+    ["##RADIO2_15##"] = 127.500,-- GCI VICTOR
+    ["##RADIO2_16##"] = 138.000,-- INTER-FLIGHT #1
+    ["##RADIO2_17##"] = 138.250,-- INTER-FLIGHT #2
+    ["##RADIO2_18##"] = 138.500,-- INTER-FLIGHT #3
+    ["##RADIO2_19##"] = 138.750,-- INTER-FLIGHT #4
+    ["##RADIO2_20##"] = 139.000,-- INTER-FLIGHT #5
+
+    -- radio 2 : right radio, green radio, VHF radio - channel names
+    ["##RADIO2_NAME_01##"] = "TACTICAL VICTOR",
+    ["##RADIO2_NAME_02##"] = "Bassel / 98X",
+    ["##RADIO2_NAME_03##"] = "Paphos / 79X",
+    ["##RADIO2_NAME_04##"] = "Akrotiri / 107X",
+    ["##RADIO2_NAME_05##"] = "Larnaca",
+    ["##RADIO2_NAME_06##"] = "Hama",
+    ["##RADIO2_NAME_07##"] = "Hatay",
+    ["##RADIO2_NAME_08##"] = "Al Qusayr",
+    ["##RADIO2_NAME_09##"] = "Shayrat",
+    ["##RADIO2_NAME_10##"] = "G.Washington / LSO",
+    ["##RADIO2_NAME_11##"] = "JTAC VICTOR",
+    ["##RADIO2_NAME_12##"] = "STRIKE VICTOR",
+    ["##RADIO2_NAME_13##"] = "GROUND VICTOR",
+    ["##RADIO2_NAME_14##"] = "CAP VICTOR",
+    ["##RADIO2_NAME_15##"] = "GCI VICTOR",
+    ["##RADIO2_NAME_16##"] = "INTER-FLIGHT #1",
+    ["##RADIO2_NAME_17##"] = "INTER-FLIGHT #2",
+    ["##RADIO2_NAME_18##"] = "INTER-FLIGHT #3",
+    ["##RADIO2_NAME_19##"] = "INTER-FLIGHT #4",
+    ["##RADIO2_NAME_20##"] = "INTER-FLIGHT #5",
+
+    -- radio 3 : FM radio  - channel frequency (Default range is 20MHz (Russian Aircrafts) or 30MHz (NATO) to 59MHz (Russian aircrafts) or 87MHz (NATO))
+    ["##RADIO3_01##"] = 31.000,
+    ["##RADIO3_02##"] = 32.000,
+    ["##RADIO3_03##"] = 33.000,
+    ["##RADIO3_04##"] = 34.000,
+    ["##RADIO3_05##"] = 35.000,
+    ["##RADIO3_06##"] = 36.000,
+    ["##RADIO3_07##"] = 37.000,
+    ["##RADIO3_08##"] = 38.000,
+    ["##RADIO3_09##"] = 39.000,
+    ["##RADIO3_10##"] = 40.000,
+    ["##RADIO3_11##"] = 41.000,
+    ["##RADIO3_12##"] = 42.000,
+    ["##RADIO3_13##"] = 43.000,
+    ["##RADIO3_14##"] = 44.000,
+    ["##RADIO3_15##"] = 45.000,
+    ["##RADIO3_16##"] = 46.000,
+    ["##RADIO3_17##"] = 47.000,
+    ["##RADIO3_18##"] = 48.000,
+    ["##RADIO3_19##"] = 49.000,
+    ["##RADIO3_20##"] = 50.000,
+    ["##RADIO3_21##"] = 51.000,
+    ["##RADIO3_22##"] = 52.000,
+    ["##RADIO3_23##"] = 53.000,
+    ["##RADIO3_24##"] = 54.000,
+    ["##RADIO3_25##"] = 55.000,
+    ["##RADIO3_26##"] = 56.000,
+    ["##RADIO3_27##"] = 57.000,
+    ["##RADIO3_28##"] = 58.000,
+    ["##RADIO3_29##"] = 59.000,
+    ["##RADIO3_30##"] = 60.000,
+
+    -- radio 3 : FM radio  - channel name
+    ["##RADIO3_NAME_01##"] = "RADIO 3 - PRESET 01",
+    ["##RADIO3_NAME_02##"] = "RADIO 3 - PRESET 02",
+    ["##RADIO3_NAME_03##"] = "RADIO 3 - PRESET 03",
+    ["##RADIO3_NAME_04##"] = "RADIO 3 - PRESET 04",
+    ["##RADIO3_NAME_05##"] = "RADIO 3 - PRESET 05",
+    ["##RADIO3_NAME_06##"] = "RADIO 3 - PRESET 06",
+    ["##RADIO3_NAME_07##"] = "RADIO 3 - PRESET 07",
+    ["##RADIO3_NAME_08##"] = "RADIO 3 - PRESET 08",
+    ["##RADIO3_NAME_09##"] = "RADIO 3 - PRESET 09",
+    ["##RADIO3_NAME_10##"] = "RADIO 3 - PRESET 10",
+    ["##RADIO3_NAME_11##"] = "RADIO 3 - PRESET 11",
+    ["##RADIO3_NAME_12##"] = "RADIO 3 - PRESET 12",
+    ["##RADIO3_NAME_13##"] = "RADIO 3 - PRESET 13",
+    ["##RADIO3_NAME_14##"] = "RADIO 3 - PRESET 14",
+    ["##RADIO3_NAME_15##"] = "RADIO 3 - PRESET 15",
+    ["##RADIO3_NAME_16##"] = "RADIO 3 - PRESET 16",
+    ["##RADIO3_NAME_17##"] = "RADIO 3 - PRESET 17",
+    ["##RADIO3_NAME_18##"] = "RADIO 3 - PRESET 18",
+    ["##RADIO3_NAME_19##"] = "RADIO 3 - PRESET 19",
+    ["##RADIO3_NAME_20##"] = "RADIO 3 - PRESET 20",
+    ["##RADIO3_NAME_21##"] = "RADIO 3 - PRESET 21",
+    ["##RADIO3_NAME_22##"] = "RADIO 3 - PRESET 22",
+    ["##RADIO3_NAME_23##"] = "RADIO 3 - PRESET 23",
+    ["##RADIO3_NAME_24##"] = "RADIO 3 - PRESET 24",
+    ["##RADIO3_NAME_25##"] = "RADIO 3 - PRESET 25",
+    ["##RADIO3_NAME_26##"] = "RADIO 3 - PRESET 26",
+    ["##RADIO3_NAME_27##"] = "RADIO 3 - PRESET 27",
+    ["##RADIO3_NAME_28##"] = "RADIO 3 - PRESET 28",
+    ["##RADIO3_NAME_29##"] = "RADIO 3 - PRESET 29",
+    ["##RADIO3_NAME_30##"] = "RADIO 3 - PRESET 30",
+}
+
+radioPresetsRed =
+{
+    -- radio 1 : left radio, red radio, UHF radio (Default range is 225MHz to 390MHz)
+    ["##RADIO1_01##"] = 243.000,
+    ["##RADIO1_02##"] = 260.000,
+    ["##RADIO1_03##"] = 270.000,
+    ["##RADIO1_04##"] = 259.000,
+    ["##RADIO1_05##"] = 263.000,
+    ["##RADIO1_06##"] = 256.000,
+    ["##RADIO1_07##"] = 258.000,
+    ["##RADIO1_08##"] = 267.000,
+    ["##RADIO1_09##"] = 269.000,
+    ["##RADIO1_10##"] = 225.000,
+    ["##RADIO1_11##"] = 226.000,
+    ["##RADIO1_12##"] = 227.000,
+    ["##RADIO1_13##"] = 228.000,
+    ["##RADIO1_14##"] = 282.200,
+    ["##RADIO1_15##"] = 291.000,
+    ["##RADIO1_16##"] = 305.100,
+    ["##RADIO1_17##"] = 290.100,
+    ["##RADIO1_18##"] = 290.300,
+    ["##RADIO1_19##"] = 290.400,
+    ["##RADIO1_20##"] = 290.500,
+
+    -- radio 2 : right radio, green radio, VHF radio (Default range is 118MHz to 150MHz)
+    ["##RADIO2_01##"] = 121.500,
+    ["##RADIO2_02##"] = 120.000,
+    ["##RADIO2_03##"] = 120.100,
+    ["##RADIO2_04##"] = 120.200,
+    ["##RADIO2_05##"] = 120.300,
+    ["##RADIO2_06##"] = 120.400,
+    ["##RADIO2_07##"] = 120.500,
+    ["##RADIO2_08##"] = 120.600,
+    ["##RADIO2_09##"] = 120.700,
+    ["##RADIO2_10##"] = 120.800,
+    ["##RADIO2_11##"] = 120.900,
+    ["##RADIO2_12##"] = 121.100,
+    ["##RADIO2_13##"] = 121.200,
+    ["##RADIO2_14##"] = 121.300,
+    ["##RADIO2_15##"] = 121.400,
+    ["##RADIO2_16##"] = 121.600,
+    ["##RADIO2_17##"] = 121.700,
+    ["##RADIO2_18##"] = 118.800,
+    ["##RADIO2_19##"] = 118.900,
+    ["##RADIO2_20##"] = 118.850,
+
+    -- radio 3 : FM radio (Default range is 20MHz (Russian Aircrafts) or 30MHz (NATO) to 59MHz (Russian aircrafts) or 87MHz (NATO))
+    ["##RADIO3_01##"] = 30.000,
+    ["##RADIO3_02##"] = 31.000,
+    ["##RADIO3_03##"] = 32.000,
+    ["##RADIO3_04##"] = 33.000,
+    ["##RADIO3_05##"] = 34.000,
+    ["##RADIO3_06##"] = 35.000,
+    ["##RADIO3_07##"] = 36.000,
+    ["##RADIO3_08##"] = 37.000,
+    ["##RADIO3_09##"] = 38.000,
+    ["##RADIO3_10##"] = 39.000,
+    ["##RADIO3_11##"] = 40.000,
+    ["##RADIO3_12##"] = 41.000,
+    ["##RADIO3_13##"] = 42.000,
+    ["##RADIO3_14##"] = 43.000,
+    ["##RADIO3_15##"] = 44.000,
+    ["##RADIO3_16##"] = 45.000,
+    ["##RADIO3_17##"] = 46.000,
+    ["##RADIO3_18##"] = 47.000,
+    ["##RADIO3_19##"] = 48.000,
+    ["##RADIO3_20##"] = 49.000,
+    ["##RADIO3_21##"] = 50.000,
+    ["##RADIO3_22##"] = 51.000,
+    ["##RADIO3_23##"] = 52.000,
+    ["##RADIO3_24##"] = 53.000,
+    ["##RADIO3_25##"] = 54.000,
+    ["##RADIO3_26##"] = 55.000,
+    ["##RADIO3_27##"] = 56.000,
+    ["##RADIO3_28##"] = 57.000,
+    ["##RADIO3_29##"] = 58.000,
+    ["##RADIO3_30##"] = 59.000,
+}
+
+radioPresetsWarbirdBlue = {
+    --Axis
+    ["##RADIO_FuG16_01##"] = 39.000,
+    ["##RADIO_FuG16_02##"] = 38.400,
+    ["##RADIO_FuG16_03##"] = 41.000,
+    ["##RADIO_FuG16_04##"] = 42.000,
+    ["##RADIO_FuG16_BASE##"] = 38.400,
+}
+
+radioPresetsWarbirdRed = {
+    --Axis
+    ["##RADIO_FuG16_01##"] = 39.000,
+    ["##RADIO_FuG16_02##"] = 38.400,
+    ["##RADIO_FuG16_03##"] = 41.000,
+    ["##RADIO_FuG16_04##"] = 42.000,
+    ["##RADIO_FuG16_BASE##"] = 38.400,
+}
+
+-- THIS IS THE TABLE OF RADIO SETTINGS. 
+-- MAKE USE OF THE RADIO PRESETS DEFINED EARLIER IF YOU WANT
+-- BY SETTING THE VALUE OF THE type, coalition, AND country PARAMETERS, YOU CAN TARGET A TEMPLATE TO A SPECIFIC GROUP OF AIRCRAFTS
+radioSettings =
+{
+    -----------------------------------------------------------------------------------------------------------------------------
+    --prop planes
+    -----------------------------------------------------------------------------------------------------------------------------
+
+    -----------------------------------------------------------------------------------------------------------------------------
+    --warbirds
+    ["blue Bf-109K-4"] = {
+        type = "Bf-109K-4",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 38-42MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = radioPresetsWarbirdBlue["##RADIO_FuG16_01##"],
+                    [2] = radioPresetsWarbirdBlue["##RADIO_FuG16_02##"],
+                    [3] = radioPresetsWarbirdBlue["##RADIO_FuG16_03##"],
+                    [4] = radioPresetsWarbirdBlue["##RADIO_FuG16_04##"],
+                    [5] = radioPresetsWarbirdBlue["##RADIO_FuG16_BASE##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red Bf-109K-4"] = {
+        type = "Bf-109K-4",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 38-42MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = radioPresetsWarbirdRed["##RADIO_FuG16_01##"],
+                    [2] = radioPresetsWarbirdRed["##RADIO_FuG16_02##"],
+                    [3] = radioPresetsWarbirdRed["##RADIO_FuG16_03##"],
+                    [4] = radioPresetsWarbirdRed["##RADIO_FuG16_04##"],
+                    [5] = radioPresetsWarbirdRed["##RADIO_FuG16_BASE##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue FW-190s"] = {
+        typePattern = "FW[-]190.*",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 38-42MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = radioPresetsWarbirdBlue["##RADIO_FuG16_01##"],
+                    [2] = radioPresetsWarbirdBlue["##RADIO_FuG16_02##"],
+                    [3] = radioPresetsWarbirdBlue["##RADIO_FuG16_03##"],
+                    [4] = radioPresetsWarbirdBlue["##RADIO_FuG16_04##"],
+                    [5] = radioPresetsWarbirdBlue["##RADIO_FuG16_BASE##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red FW-190s"] = {
+        typePattern = "FW[-]190.*",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 38-42MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = radioPresetsWarbirdRed["##RADIO_FuG16_01##"],
+                    [2] = radioPresetsWarbirdRed["##RADIO_FuG16_02##"],
+                    [3] = radioPresetsWarbirdRed["##RADIO_FuG16_03##"],
+                    [4] = radioPresetsWarbirdRed["##RADIO_FuG16_04##"],
+                    [5] = radioPresetsWarbirdRed["##RADIO_FuG16_BASE##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue I-16"] = {
+        type = "I-16",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red I-16"] = {
+        type = "I-16",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue MosquitoFBMkVI"] = {
+        type = "MosquitoFBMkVI",
+        coalition = "blue",
+        country = nil,
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = 108.9,
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --HF (range 5.5-10MHz) with modulation selection box (but no modulation selection in the ME)
+            [2] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = 9.255,
+                    [2] = 8,
+                    [3] = 7.71,
+                    [4] = 6.872,
+                    [5] = 5.955,
+                    [6] = 5.85,
+                    [7] = 5.75,
+                    [8] = 5.65,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+            --HF (range 3-5.5MHz) with modulation selection box (but no modulation selection in the ME)
+            [3] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = 5.25,
+                    [2] = 5,
+                    [3] = 4.75,
+                    [4] = 4.5,
+                    [5] = 4.25,
+                    [6] = 3.25,
+                    [7] = 3.012,
+                    [8] = 3.011,
+                }, -- end of ["channels"]
+            }, -- end of [3]
+            --LF/MF (range 0.2-0.5MHz) with modulation selection box (but no modulation selection in the ME)
+            [4] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = 0.444,
+                    [2] = 0.421,
+                    [3] = 0.303,
+                    [4] = 0.3,
+                    [5] = 0.27,
+                    [6] = 0.26,
+                    [7] = 0.25,
+                    [8] = 0.24,
+                }, -- end of ["channels"]
+            }, -- end of [4]
+        }, -- end of ["Radio"]
+    },
+
+    ["red MosquitoFBMkVI"] = {
+        type = "MosquitoFBMkVI",
+        coalition = "red",
+        country = nil,
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                    [5]  = 108.9,
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --HF (range 5.5-10MHz) with modulation selection box (but no modulation selection in the ME)
+            [2] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = 9.255,
+                    [2] = 8,
+                    [3] = 7.71,
+                    [4] = 6.872,
+                    [5] = 5.955,
+                    [6] = 5.85,
+                    [7] = 5.75,
+                    [8] = 5.65,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+            --HF (range 3-5.5MHz) with modulation selection box (but no modulation selection in the ME)
+            [3] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = 5.25,
+                    [2] = 5,
+                    [3] = 4.75,
+                    [4] = 4.5,
+                    [5] = 4.25,
+                    [6] = 3.25,
+                    [7] = 3.012,
+                    [8] = 3.011,
+                }, -- end of ["channels"]
+            }, -- end of [3]
+            --LF/MF (range 0.2-0.5MHz) with modulation selection box (but no modulation selection in the ME)
+            [4] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = 0.444,
+                    [2] = 0.421,
+                    [3] = 0.303,
+                    [4] = 0.3,
+                    [5] = 0.27,
+                    [6] = 0.26,
+                    [7] = 0.25,
+                    [8] = 0.24,
+                }, -- end of ["channels"]
+            }, -- end of [4]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue P-47Ds"] = {
+        typePattern = "P[-]47D.*",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --Radio Beacon Finder Base frequency (range 100-200MHz)
+            [2] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = 108.9,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["red P-47Ds"] = {
+        typePattern = "P[-]47D.*",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --Radio Beacon Finder Base frequency (range 100-200MHz)
+            [2] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = 108.9,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue P-51Ds"] = {
+        typePattern = "P[-]51D.*",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --Radio Beacon Finder Base frequency (range 100-200MHz)
+            [2] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = 108.9,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["red P-51Ds"] = {
+        typePattern = "P[-]51D.*",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --Radio Beacon Finder Base frequency (range 100-200MHz)
+            [2] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = 108.9,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue TF-51D"] = {
+        type = "TF-51D",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --Radio Beacon Finder Base frequency (range 100-200MHz)
+            [2] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = 108.9,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["red TF-51D"] = {
+        type = "TF-51D",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --Radio Beacon Finder Base frequency (range 100-200MHz)
+            [2] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = 108.9,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue Spitfires"] = {
+        typePattern = "Spitfire.*",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = 108.9,
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red Spitfires"] = {
+        typePattern = "Spitfire.*",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (range 100-156MHz) without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                    [5]  = 108.9,
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    -----------------------------------------------------------------------------------------------------------------------------
+    --tourist planes
+
+    ["blue Christen Eagle II"] = {
+        type = "Christen Eagle II",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --V/UHF with modulation selection box (but no modulation selection in ME)
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = radioPresetsBlue["##RADIO2_05##"],
+                    [6]  = radioPresetsBlue["##RADIO2_06##"],
+                    [7]  = radioPresetsBlue["##RADIO2_07##"],
+                    [8]  = radioPresetsBlue["##RADIO2_08##"],
+                    [9]  = radioPresetsBlue["##RADIO2_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_10##"],
+                    [11] = radioPresetsBlue["##RADIO2_11##"],
+                    [12] = radioPresetsBlue["##RADIO2_12##"],
+                    [13] = radioPresetsBlue["##RADIO2_13##"],
+                    [14] = radioPresetsBlue["##RADIO2_14##"],
+                    [15] = radioPresetsBlue["##RADIO2_15##"],
+                    [16] = radioPresetsBlue["##RADIO2_16##"],
+                    [17] = radioPresetsBlue["##RADIO2_17##"],
+                    [18] = radioPresetsBlue["##RADIO2_18##"],
+                    [19] = radioPresetsBlue["##RADIO2_19##"],
+                    [20] = radioPresetsBlue["##RADIO2_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red Christen Eagle II"] = {
+        type = "Christen Eagle II",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --V/UHF with modulation selection box (but no modulation selection in ME)
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                    [5]  = radioPresetsRed["##RADIO2_05##"],
+                    [6]  = radioPresetsRed["##RADIO2_06##"],
+                    [7]  = radioPresetsRed["##RADIO2_07##"],
+                    [8]  = radioPresetsRed["##RADIO2_08##"],
+                    [9]  = radioPresetsRed["##RADIO2_09##"],
+                    [10] = radioPresetsRed["##RADIO2_10##"],
+                    [11] = radioPresetsRed["##RADIO2_11##"],
+                    [12] = radioPresetsRed["##RADIO2_12##"],
+                    [13] = radioPresetsRed["##RADIO2_13##"],
+                    [14] = radioPresetsRed["##RADIO2_14##"],
+                    [15] = radioPresetsRed["##RADIO2_15##"],
+                    [16] = radioPresetsRed["##RADIO2_16##"],
+                    [17] = radioPresetsRed["##RADIO2_17##"],
+                    [18] = radioPresetsRed["##RADIO2_18##"],
+                    [19] = radioPresetsRed["##RADIO2_19##"],
+                    [20] = radioPresetsRed["##RADIO2_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue Yak-52"] = {
+        type = "Yak-52",
+        coalition = "blue",
+        country = nil,
+
+        --ARK-15M ADF (Range 0.1-1.795MHz)
+        ["Radio"] = 
+        {
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = 0.625,
+                    [2] = 0.303,
+                    [3] = 0.289,
+                    [4] = 0.591,
+                    [5] = 0.408,
+                    [6] = 0.803,
+                    [7] = 0.443,
+                    [8] = 0.215,
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red Yak-52"] = {
+        type = "Yak-52",
+        coalition = "red",
+        country = nil,
+
+        --ARK-15M ADF (Range 0.1-1.795MHz)
+        ["Radio"] = 
+        {
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1] = 0.625,
+                    [2] = 0.303,
+                    [3] = 0.289,
+                    [4] = 0.591,
+                    [5] = 0.408,
+                    [6] = 0.803,
+                    [7] = 0.443,
+                    [8] = 0.215,
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    -----------------------------------------------------------------------------------------------------------------------------
+    --jets
+    -----------------------------------------------------------------------------------------------------------------------------
+
+    -----------------------------------------------------------------------------------------------------------------------------
+    --ww2
+
+    --["blue Me-262"] = {}, --ED plz
+
+    --["red Me-262"] = {}, --ED plz
+
+    --["blue Meteor F.3"] = {}, --ED plz
+
+    --["red Meteor F.3"] = {}, --ED plz
+
+    -----------------------------------------------------------------------------------------------------------------------------
+    --korea
+
+    ["blue F-86F Sabre"] = {
+        type = "F-86F Sabre",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --UHF without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red F-86F Sabre"] = {
+        type = "F-86F Sabre",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --UHF without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    --["blue MiG-15Bis"] = {}, --no presets
+
+    --["red MiG-15Bis"] = {}, --no presets
+
+    -----------------------------------------------------------------------------------------------------------------------------
+    --cold war
+
+    ["blue AJS37"] = {
+        type = "AJS37",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --V/UHF (down to 103MHz) with modulation selection box (but no modulation selection in the ME)
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                    [27] = 0,
+                    [28] = 0,
+                    [29] = 0,
+                    [30] = 0,
+                    [31] = 0,
+                    [32] = 0,
+                    [33] = 0,
+                    [34] = 0,
+                    [35] = 0,
+                    [36] = 0,
+                    [37] = 0,
+                    [38] = 0,
+                    [39] = 0,
+                    [40] = 0,
+                    [41] = 1,
+                    [42] = 1,
+                    [43] = 1,
+                    [44] = 1,
+                    [45] = 1,
+                    [46] = 0,
+                    [47] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = 0, -- channel 100
+                    [2]  = radioPresetsBlue["##RADIO1_01##"], -- channel 101
+                    [3]  = radioPresetsBlue["##RADIO1_02##"], -- channel 102
+                    [4]  = radioPresetsBlue["##RADIO1_03##"],
+                    [5]  = radioPresetsBlue["##RADIO1_04##"],
+                    [6]  = radioPresetsBlue["##RADIO1_05##"],
+                    [7]  = radioPresetsBlue["##RADIO1_06##"],
+                    [8]  = radioPresetsBlue["##RADIO1_07##"],
+                    [9]  = radioPresetsBlue["##RADIO1_08##"],
+                    [10] = radioPresetsBlue["##RADIO1_09##"],
+                    [11] = radioPresetsBlue["##RADIO1_10##"],
+                    [12] = radioPresetsBlue["##RADIO1_11##"],
+                    [13] = radioPresetsBlue["##RADIO1_12##"],
+                    [14] = radioPresetsBlue["##RADIO1_13##"],
+                    [15] = radioPresetsBlue["##RADIO1_14##"],
+                    [16] = radioPresetsBlue["##RADIO1_15##"],
+                    [17] = radioPresetsBlue["##RADIO1_16##"],
+                    [18] = radioPresetsBlue["##RADIO1_17##"],
+                    [19] = radioPresetsBlue["##RADIO1_18##"],
+                    [20] = radioPresetsBlue["##RADIO1_19##"],
+                    [21] = radioPresetsBlue["##RADIO1_20##"],
+                    [22] = radioPresetsBlue["##RADIO2_01##"],
+                    [23] = radioPresetsBlue["##RADIO2_02##"],
+                    [24] = radioPresetsBlue["##RADIO2_03##"],
+                    [25] = radioPresetsBlue["##RADIO2_04##"],
+                    [26] = radioPresetsBlue["##RADIO2_05##"],
+                    [27] = radioPresetsBlue["##RADIO2_06##"],
+                    [28] = radioPresetsBlue["##RADIO2_07##"],
+                    [29] = radioPresetsBlue["##RADIO2_08##"],
+                    [30] = radioPresetsBlue["##RADIO2_09##"],
+                    [31] = radioPresetsBlue["##RADIO2_10##"],
+                    [32] = radioPresetsBlue["##RADIO2_11##"],
+                    [33] = radioPresetsBlue["##RADIO2_12##"],
+                    [34] = radioPresetsBlue["##RADIO2_13##"],
+                    [35] = radioPresetsBlue["##RADIO2_14##"],
+                    [36] = radioPresetsBlue["##RADIO2_15##"],
+                    [37] = radioPresetsBlue["##RADIO2_16##"],
+                    [38] = radioPresetsBlue["##RADIO2_17##"],
+                    [39] = radioPresetsBlue["##RADIO2_18##"],
+                    [40] = radioPresetsBlue["##RADIO2_19##"], -- channel 139
+                    [41] = 284.000,                                -- channel Special 1 - FR22
+                    [42] = 271.500,                                -- channel Special 2 - FR22
+                    [43] = 277.500,                                -- channel Special 3 - FR22
+                    [44] = 126.250,                                -- channel E - FR24
+                    [45] = 126.500,                                -- channel F - FR24
+                    [46] = 127.5,                             -- channel G - FR24
+                    [47] = 284.000,                               -- channel H (LARM/GUARD) - FR24
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red AJS37"] = {
+        type = "AJS37",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --V/UHF (down to 103MHz) with modulation selection box (but no modulation selection in the ME)
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                    [27] = 0,
+                    [28] = 0,
+                    [29] = 0,
+                    [30] = 0,
+                    [31] = 0,
+                    [32] = 0,
+                    [33] = 0,
+                    [34] = 0,
+                    [35] = 0,
+                    [36] = 0,
+                    [37] = 0,
+                    [38] = 0,
+                    [39] = 0,
+                    [40] = 0,
+                    [41] = 1,
+                    [42] = 1,
+                    [43] = 1,
+                    [44] = 1,
+                    [45] = 1,
+                    [46] = 0,
+                    [47] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = 0, -- channel 100
+                    [2]  = radioPresetsRed["##RADIO1_01##"], -- channel 101
+                    [3]  = radioPresetsRed["##RADIO1_02##"], -- channel 102
+                    [4]  = radioPresetsRed["##RADIO1_03##"],
+                    [5]  = radioPresetsRed["##RADIO1_04##"],
+                    [6]  = radioPresetsRed["##RADIO1_05##"],
+                    [7]  = radioPresetsRed["##RADIO1_06##"],
+                    [8]  = radioPresetsRed["##RADIO1_07##"],
+                    [9]  = radioPresetsRed["##RADIO1_08##"],
+                    [10] = radioPresetsRed["##RADIO1_09##"],
+                    [11] = radioPresetsRed["##RADIO1_10##"],
+                    [12] = radioPresetsRed["##RADIO1_11##"],
+                    [13] = radioPresetsRed["##RADIO1_12##"],
+                    [14] = radioPresetsRed["##RADIO1_13##"],
+                    [15] = radioPresetsRed["##RADIO1_14##"],
+                    [16] = radioPresetsRed["##RADIO1_15##"],
+                    [17] = radioPresetsRed["##RADIO1_16##"],
+                    [18] = radioPresetsRed["##RADIO1_17##"],
+                    [19] = radioPresetsRed["##RADIO1_18##"],
+                    [20] = radioPresetsRed["##RADIO1_19##"],
+                    [21] = radioPresetsRed["##RADIO1_20##"],
+                    [22] = radioPresetsRed["##RADIO2_01##"],
+                    [23] = radioPresetsRed["##RADIO2_02##"],
+                    [24] = radioPresetsRed["##RADIO2_03##"],
+                    [25] = radioPresetsRed["##RADIO2_04##"],
+                    [26] = radioPresetsRed["##RADIO2_05##"],
+                    [27] = radioPresetsRed["##RADIO2_06##"],
+                    [28] = radioPresetsRed["##RADIO2_07##"],
+                    [29] = radioPresetsRed["##RADIO2_08##"],
+                    [30] = radioPresetsRed["##RADIO2_09##"],
+                    [31] = radioPresetsRed["##RADIO2_10##"],
+                    [32] = radioPresetsRed["##RADIO2_11##"],
+                    [33] = radioPresetsRed["##RADIO2_12##"],
+                    [34] = radioPresetsRed["##RADIO2_13##"],
+                    [35] = radioPresetsRed["##RADIO2_14##"],
+                    [36] = radioPresetsRed["##RADIO2_15##"],
+                    [37] = radioPresetsRed["##RADIO2_16##"],
+                    [38] = radioPresetsRed["##RADIO2_17##"],
+                    [39] = radioPresetsRed["##RADIO2_18##"],
+                    [40] = radioPresetsRed["##RADIO2_19##"], -- channel 139
+                    [41] = 30,                                -- channel Special 1 - FR22
+                    [42] = 31,                                -- channel Special 2 - FR22
+                    [43] = 32,                                -- channel Special 3 - FR22
+                    [44] = 33,                                -- channel E - FR24
+                    [45] = 34,                                -- channel F - FR24
+                    [46] = 127.5,                             -- channel G - FR24
+                    [47] = 243,                               -- channel H (LARM/GUARD) - FR24
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue A-4E-C"] = {
+        type = "A-4E-C",
+        coalition = "blue",
+        country = nil,
+        
+        ["Radio"] =
+        {
+            --UHF with modulation selection box (but no modulation selection in the ME)
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        },
+    },
+
+    ["red A-4E-C"] = {
+        type = "A-4E-C",
+        coalition = "red",
+        country = nil,
+        
+        ["Radio"] =
+        {
+            --UHF with modulation selection box (but no modulation selection in the ME)
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        },
+    },
+
+    ["blue F-5E-3"] = {
+        type = "F-5E-3",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --UHF without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red F-5E-3"] = {
+        type = "F-5E-3",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --UHF without modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue MiG-19P"] = {
+        type = "MiG-19P",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (down to 100MHz) with modulation selection box (but no modulation selection in the ME)
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = radioPresetsBlue["##RADIO2_05##"],
+                    [6]  = radioPresetsBlue["##RADIO2_06##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red MiG-19P"] = {
+        type = "MiG-19P",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --VHF (down to 100MHz) with modulation selection box (but no modulation selection in the ME)
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                    [5]  = radioPresetsRed["##RADIO2_05##"],
+                    [6]  = radioPresetsRed["##RADIO2_06##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue MiG-21Bis"] = {
+        type = "MiG-21Bis",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            --V/UHF with modulation selection box (but no modulation selection in the ME)
+            [1] = {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red MiG-21Bis"] = {
+        type = "MiG-21Bis",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = {
+            --V/UHF with modulation selection box (but no modulation selection in the ME)
+            [1] = {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue Mirage-F1s"] = {
+        typePattern = "Mirage[-]F1.*",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --V/UHF without modulation selection box
+            [1] =
+            {
+                ["modulations"] =
+                {
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = radioPresetsBlue["##RADIO2_05##"],
+                    [6]  = radioPresetsBlue["##RADIO2_06##"],
+                    [7]  = radioPresetsBlue["##RADIO2_07##"],
+                    [8]  = radioPresetsBlue["##RADIO2_08##"],
+                    [9]  = radioPresetsBlue["##RADIO2_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_10##"],
+                    [11] = radioPresetsBlue["##RADIO2_11##"],
+                    [12] = radioPresetsBlue["##RADIO2_12##"],
+                    [13] = radioPresetsBlue["##RADIO2_13##"],
+                    [14] = radioPresetsBlue["##RADIO2_14##"],
+                    [15] = radioPresetsBlue["##RADIO2_15##"],
+                    [16] = radioPresetsBlue["##RADIO2_16##"],
+                    [17] = radioPresetsBlue["##RADIO2_17##"],
+                    [18] = radioPresetsBlue["##RADIO2_18##"],
+                    [19] = radioPresetsBlue["##RADIO2_19##"],
+                    [20] = radioPresetsBlue["##RADIO2_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --UHF without modulation selection box
+            [2] =
+            {
+                ["modulations"] =
+                {
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        },
+    },
+
+    ["red Mirage-F1s"] = {
+        typePattern = "Mirage[-]F1.*",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --V/UHF without modulation selection box
+            [1] =
+            {
+                ["modulations"] =
+                {
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                    [5]  = radioPresetsRed["##RADIO2_05##"],
+                    [6]  = radioPresetsRed["##RADIO2_06##"],
+                    [7]  = radioPresetsRed["##RADIO2_07##"],
+                    [8]  = radioPresetsRed["##RADIO2_08##"],
+                    [9]  = radioPresetsRed["##RADIO2_09##"],
+                    [10] = radioPresetsRed["##RADIO2_10##"],
+                    [11] = radioPresetsRed["##RADIO2_11##"],
+                    [12] = radioPresetsRed["##RADIO2_12##"],
+                    [13] = radioPresetsRed["##RADIO2_13##"],
+                    [14] = radioPresetsRed["##RADIO2_14##"],
+                    [15] = radioPresetsRed["##RADIO2_15##"],
+                    [16] = radioPresetsRed["##RADIO2_16##"],
+                    [17] = radioPresetsRed["##RADIO2_17##"],
+                    [18] = radioPresetsRed["##RADIO2_18##"],
+                    [19] = radioPresetsRed["##RADIO2_19##"],
+                    [20] = radioPresetsRed["##RADIO2_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --UHF without modulation selection box
+            [2] =
+            {
+                ["modulations"] =
+                {
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        },
+    },
+
+    -----------------------------------------------------------------------------------------------------------------------------
+    --modern
+
+    ["blue A-10Cs"] = {
+        typePattern = "A[-]10C.*",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            --Digital V/UHF 
+            [1] = {
+                ["channels"] = {
+                    [01] = radioPresetsBlue["##RADIO2_01##"],
+                    [02] = radioPresetsBlue["##RADIO2_02##"],
+                    [03] = radioPresetsBlue["##RADIO2_03##"],
+                    [04] = radioPresetsBlue["##RADIO2_04##"],
+                    [05] = radioPresetsBlue["##RADIO2_05##"],
+                    [06] = radioPresetsBlue["##RADIO2_06##"],
+                    [07] = radioPresetsBlue["##RADIO2_07##"],
+                    [08] = radioPresetsBlue["##RADIO2_08##"],
+                    [09] = radioPresetsBlue["##RADIO2_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_10##"],
+                    [11] = radioPresetsBlue["##RADIO2_11##"],
+                    [12] = radioPresetsBlue["##RADIO2_12##"],
+                    [13] = radioPresetsBlue["##RADIO2_13##"],
+                    [14] = radioPresetsBlue["##RADIO2_14##"],
+                    [15] = radioPresetsBlue["##RADIO2_15##"],
+                    [16] = radioPresetsBlue["##RADIO2_16##"],
+                    [17] = radioPresetsBlue["##RADIO2_17##"],
+                    [18] = radioPresetsBlue["##RADIO2_18##"],
+                    [19] = radioPresetsBlue["##RADIO2_19##"],
+                    [20] = radioPresetsBlue["##RADIO2_20##"],
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                }, -- end of ["channels"]
+                ["channelsNames"] =
+                {
+                    [01] = radioPresetsBlue["##RADIO2_NAME_01##"],
+                    [02] = radioPresetsBlue["##RADIO2_NAME_02##"],
+                    [03] = radioPresetsBlue["##RADIO2_NAME_03##"],
+                    [04] = radioPresetsBlue["##RADIO2_NAME_04##"],
+                    [05] = radioPresetsBlue["##RADIO2_NAME_05##"],
+                    [06] = radioPresetsBlue["##RADIO2_NAME_06##"],
+                    [07] = radioPresetsBlue["##RADIO2_NAME_07##"],
+                    [08] = radioPresetsBlue["##RADIO2_NAME_08##"],
+                    [09] = radioPresetsBlue["##RADIO2_NAME_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_NAME_10##"],
+                    [11] = radioPresetsBlue["##RADIO2_NAME_11##"],
+                    [12] = radioPresetsBlue["##RADIO2_NAME_12##"],
+                    [13] = radioPresetsBlue["##RADIO2_NAME_13##"],
+                    [14] = radioPresetsBlue["##RADIO2_NAME_14##"],
+                    [15] = radioPresetsBlue["##RADIO2_NAME_15##"],
+                    [16] = radioPresetsBlue["##RADIO2_NAME_16##"],
+                    [17] = radioPresetsBlue["##RADIO2_NAME_17##"],
+                    [18] = radioPresetsBlue["##RADIO2_NAME_18##"],
+                    [19] = radioPresetsBlue["##RADIO2_NAME_19##"],
+                    [20] = radioPresetsBlue["##RADIO2_NAME_20##"],
+                    [21] = "Radio 1 - Channel 21",
+                    [22] = "Radio 1 - Channel 22",
+                    [23] = "Radio 1 - Channel 23",
+                    [24] = "Radio 1 - Channel 24",
+                    [25] = "Radio 1 - Channel 25",
+                }, -- end of ["channelsNames"]
+                ["modulations"] = {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 1,
+                    [22] = 1,
+                    [23] = 1,
+                    [24] = 1,
+                    [25] = 1,
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+            --UHF 
+            [2] = {
+                ["channels"] = {
+                    [01] = radioPresetsBlue["##RADIO1_01##"],
+                    [02] = radioPresetsBlue["##RADIO1_02##"],
+                    [03] = radioPresetsBlue["##RADIO1_03##"],
+                    [04] = radioPresetsBlue["##RADIO1_04##"],
+                    [05] = radioPresetsBlue["##RADIO1_05##"],
+                    [06] = radioPresetsBlue["##RADIO1_06##"],
+                    [07] = radioPresetsBlue["##RADIO1_07##"],
+                    [08] = radioPresetsBlue["##RADIO1_08##"],
+                    [09] = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                }, -- end of ["channels"]
+                ["channelsNames"] =
+                {
+                    [01] = radioPresetsBlue["##RADIO1_NAME_01##"],
+                    [02] = radioPresetsBlue["##RADIO1_NAME_02##"],
+                    [03] = radioPresetsBlue["##RADIO1_NAME_03##"],
+                    [04] = radioPresetsBlue["##RADIO1_NAME_04##"],
+                    [05] = radioPresetsBlue["##RADIO1_NAME_05##"],
+                    [06] = radioPresetsBlue["##RADIO1_NAME_06##"],
+                    [07] = radioPresetsBlue["##RADIO1_NAME_07##"],
+                    [08] = radioPresetsBlue["##RADIO1_NAME_08##"],
+                    [09] = radioPresetsBlue["##RADIO1_NAME_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_NAME_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_NAME_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_NAME_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_NAME_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_NAME_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_NAME_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_NAME_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_NAME_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_NAME_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_NAME_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_NAME_20##"],
+                    [21] = "Radio 2 - Channel 21",
+                    [22] = "Radio 2 - Channel 22",
+                    [23] = "Radio 2 - Channel 23",
+                    [24] = "Radio 2 - Channel 24",
+                    [25] = "Radio 2 - Channel 25",
+                }, -- end of ["channelsNames"]
+                ["modulations"] = {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 1,
+                    [22] = 1,
+                    [23] = 1,
+                    [24] = 1,
+                    [25] = 1,
+                    [26] = 1,
+                }, -- end of ["modulations"]
+            }, -- end of [2]
+            --VHF FM
+            [3] = {
+                ["channels"] = {
+                    [01] = radioPresetsBlue["##RADIO3_01##"],
+                    [02] = radioPresetsBlue["##RADIO3_02##"],
+                    [03] = radioPresetsBlue["##RADIO3_03##"],
+                    [04] = radioPresetsBlue["##RADIO3_04##"],
+                    [05] = radioPresetsBlue["##RADIO3_05##"],
+                    [06] = radioPresetsBlue["##RADIO3_06##"],
+                    [07] = radioPresetsBlue["##RADIO3_07##"],
+                    [08] = radioPresetsBlue["##RADIO3_08##"],
+                    [09] = radioPresetsBlue["##RADIO3_09##"],
+                    [10] = radioPresetsBlue["##RADIO3_10##"],
+                    [11] = radioPresetsBlue["##RADIO3_11##"],
+                    [12] = radioPresetsBlue["##RADIO3_12##"],
+                    [13] = radioPresetsBlue["##RADIO3_13##"],
+                    [14] = radioPresetsBlue["##RADIO3_14##"],
+                    [15] = radioPresetsBlue["##RADIO3_15##"],
+                    [16] = radioPresetsBlue["##RADIO3_16##"],
+                    [17] = radioPresetsBlue["##RADIO3_17##"],
+                    [18] = radioPresetsBlue["##RADIO3_18##"],
+                    [19] = radioPresetsBlue["##RADIO3_19##"],
+                    [20] = radioPresetsBlue["##RADIO3_20##"],
+                    [21] = 50,
+                    [22] = 51,
+                    [23] = 52,
+                    [24] = 53,
+                    [25] = 54,
+                    [26] = 55,
+                    [27] = 56,
+                    [28] = 57,
+                    [29] = 58,
+                    [30] = 59,
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                    [1] = 1,
+                    [2] = 1,
+                    [3] = 1,
+                    [4] = 1,
+                    [5] = 1,
+                    [6] = 1,
+                    [7] = 1,
+                    [8] = 1,
+                    [9] = 1,
+                    [10] = 1,
+                    [11] = 1,
+                    [12] = 1,
+                    [13] = 1,
+                    [14] = 1,
+                    [15] = 1,
+                    [16] = 1,
+                    [17] = 1,
+                    [18] = 1,
+                    [19] = 1,
+                    [20] = 1,
+                    [21] = 1,
+                    [22] = 1,
+                    [23] = 1,
+                    [24] = 1,
+                    [25] = 1,
+                    [26] = 1,
+                    [27] = 1,
+                    [28] = 1,
+                    [29] = 1,
+                    [30] = 1,
+                }, -- end of ["modulations"]
+            }, -- end of [3]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue F-14s"] = {
+        typePattern = "F[-]14.*",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --UHF without modulation selection box
+            [1] =
+            {
+                ["modulations"] =
+                {
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --V/UHF (down to 30MHz) with modulation selection box (but no modulation selection in the ME)
+            [2] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 1,
+                    [22] = 1,
+                    [23] = 1,
+                    [24] = 1,
+                    [25] = 1,
+                    [26] = 1,
+                    [27] = 1,
+                    [28] = 1,
+                    [29] = 1,
+                    [30] = 1,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = radioPresetsBlue["##RADIO2_05##"],
+                    [6]  = radioPresetsBlue["##RADIO2_06##"],
+                    [7]  = radioPresetsBlue["##RADIO2_07##"],
+                    [8]  = radioPresetsBlue["##RADIO2_08##"],
+                    [9]  = radioPresetsBlue["##RADIO2_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_10##"],
+                    [11] = radioPresetsBlue["##RADIO2_11##"],
+                    [12] = radioPresetsBlue["##RADIO2_12##"],
+                    [13] = radioPresetsBlue["##RADIO2_13##"],
+                    [14] = radioPresetsBlue["##RADIO2_14##"],
+                    [15] = radioPresetsBlue["##RADIO2_15##"],
+                    [16] = radioPresetsBlue["##RADIO2_16##"],
+                    [17] = radioPresetsBlue["##RADIO2_17##"],
+                    [18] = radioPresetsBlue["##RADIO2_18##"],
+                    [19] = radioPresetsBlue["##RADIO2_19##"],
+                    [20] = radioPresetsBlue["##RADIO2_20##"],
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                    [27] = 0,
+                    [28] = 0,
+                    [29] = 0,
+                    [30] = 0,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+    ["blue F-4Es"] = {
+        typePattern = "F[-]4E.*",
+        coalition = "blue",
+        country = nil,
+        ["Radio"] = {
+            -- Radio UHF (225.0 MHz to 399.95 MHz)
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                }, -- end of ["channels"]
+                ["channelsNames"] = {
+                }, -- end of ["channelsNames"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+            -- Radio AUX UHF (265.0 MHz to 284.9 MHz)
+            [2] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                }, -- end of ["channels"]
+                ["channelsNames"] = {
+                }, -- end of ["channelsNames"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["red F-14s"] = {
+        typePattern = "F[-]14.*",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --UHF without modulation selection box
+            [1] =
+            {
+                ["modulations"] =
+                {
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --V/UHF (down to 30MHz) with modulation selection box (but no modulation selection in the ME)
+            [2] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 1,
+                    [22] = 1,
+                    [23] = 1,
+                    [24] = 1,
+                    [25] = 1,
+                    [26] = 1,
+                    [27] = 1,
+                    [28] = 1,
+                    [29] = 1,
+                    [30] = 1,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                    [5]  = radioPresetsRed["##RADIO2_05##"],
+                    [6]  = radioPresetsRed["##RADIO2_06##"],
+                    [7]  = radioPresetsRed["##RADIO2_07##"],
+                    [8]  = radioPresetsRed["##RADIO2_08##"],
+                    [9]  = radioPresetsRed["##RADIO2_09##"],
+                    [10] = radioPresetsRed["##RADIO2_10##"],
+                    [11] = radioPresetsRed["##RADIO2_11##"],
+                    [12] = radioPresetsRed["##RADIO2_12##"],
+                    [13] = radioPresetsRed["##RADIO2_13##"],
+                    [14] = radioPresetsRed["##RADIO2_14##"],
+                    [15] = radioPresetsRed["##RADIO2_15##"],
+                    [16] = radioPresetsRed["##RADIO2_16##"],
+                    [17] = radioPresetsRed["##RADIO2_17##"],
+                    [18] = radioPresetsRed["##RADIO2_18##"],
+                    [19] = radioPresetsRed["##RADIO2_19##"],
+                    [20] = radioPresetsRed["##RADIO2_20##"],
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                    [27] = 0,
+                    [28] = 0,
+                    [29] = 0,
+                    [30] = 0,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue FA-18C_hornet"] = {
+        type = "FA-18C_hornet",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --V/UHF (down to 30MHz) with modulation selection box
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --V/UHF (down to 30MHz) with modulation selection box
+            [2] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = radioPresetsBlue["##RADIO2_05##"],
+                    [6]  = radioPresetsBlue["##RADIO2_06##"],
+                    [7]  = radioPresetsBlue["##RADIO2_07##"],
+                    [8]  = radioPresetsBlue["##RADIO2_08##"],
+                    [9]  = radioPresetsBlue["##RADIO2_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_10##"],
+                    [11] = radioPresetsBlue["##RADIO2_11##"],
+                    [12] = radioPresetsBlue["##RADIO2_12##"],
+                    [13] = radioPresetsBlue["##RADIO2_13##"],
+                    [14] = radioPresetsBlue["##RADIO2_14##"],
+                    [15] = radioPresetsBlue["##RADIO2_15##"],
+                    [16] = radioPresetsBlue["##RADIO2_16##"],
+                    [17] = radioPresetsBlue["##RADIO2_17##"],
+                    [18] = radioPresetsBlue["##RADIO2_18##"],
+                    [19] = radioPresetsBlue["##RADIO2_19##"],
+                    [20] = radioPresetsBlue["##RADIO2_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        },
+    },
+
+    ["red FA-18C_hornet"] = {
+        type = "FA-18C_hornet",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --V/UHF (down to 30MHz) with modulation selection box
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --V/UHF (down to 30MHz) with modulation selection box
+            [2] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                    [5]  = radioPresetsRed["##RADIO2_05##"],
+                    [6]  = radioPresetsRed["##RADIO2_06##"],
+                    [7]  = radioPresetsRed["##RADIO2_07##"],
+                    [8]  = radioPresetsRed["##RADIO2_08##"],
+                    [9]  = radioPresetsRed["##RADIO2_09##"],
+                    [10] = radioPresetsRed["##RADIO2_10##"],
+                    [11] = radioPresetsRed["##RADIO2_11##"],
+                    [12] = radioPresetsRed["##RADIO2_12##"],
+                    [13] = radioPresetsRed["##RADIO2_13##"],
+                    [14] = radioPresetsRed["##RADIO2_14##"],
+                    [15] = radioPresetsRed["##RADIO2_15##"],
+                    [16] = radioPresetsRed["##RADIO2_16##"],
+                    [17] = radioPresetsRed["##RADIO2_17##"],
+                    [18] = radioPresetsRed["##RADIO2_18##"],
+                    [19] = radioPresetsRed["##RADIO2_19##"],
+                    [20] = radioPresetsRed["##RADIO2_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        },
+    },
+
+    ["blue F-16C"] = {
+        type = "F-16C_50",
+        coalition = "blue",
+        country = nil,
+        ["Radio"] =
+        {
+            --UHF with modulation selection box (but no modulation selection in the ME)
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --VHF (down to 30MHz) with modulation selection box (but no modulation selection in the ME)
+            [2] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = radioPresetsBlue["##RADIO2_05##"],
+                    [6]  = radioPresetsBlue["##RADIO2_06##"],
+                    [7]  = radioPresetsBlue["##RADIO2_07##"],
+                    [8]  = radioPresetsBlue["##RADIO2_08##"],
+                    [9]  = radioPresetsBlue["##RADIO2_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_10##"],
+                    [11] = radioPresetsBlue["##RADIO2_11##"],
+                    [12] = radioPresetsBlue["##RADIO2_12##"],
+                    [13] = radioPresetsBlue["##RADIO2_13##"],
+                    [14] = radioPresetsBlue["##RADIO2_14##"],
+                    [15] = radioPresetsBlue["##RADIO2_15##"],
+                    [16] = radioPresetsBlue["##RADIO2_16##"],
+                    [17] = radioPresetsBlue["##RADIO2_17##"],
+                    [18] = radioPresetsBlue["##RADIO2_18##"],
+                    [19] = radioPresetsBlue["##RADIO2_19##"],
+                    [20] = radioPresetsBlue["##RADIO2_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        },
+    },
+
+    ["red F-16C"] = {
+        type = "F-16C_50",
+        coalition = "red",
+        country = nil,
+        ["Radio"] =
+        {
+            --UHF with modulation selection box (but no modulation selection in the ME)
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --VHF (down to 30MHz) with modulation selection box (but no modulation selection in the ME)
+            [2] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                    [5]  = radioPresetsRed["##RADIO2_05##"],
+                    [6]  = radioPresetsRed["##RADIO2_06##"],
+                    [7]  = radioPresetsRed["##RADIO2_07##"],
+                    [8]  = radioPresetsRed["##RADIO2_08##"],
+                    [9]  = radioPresetsRed["##RADIO2_09##"],
+                    [10] = radioPresetsRed["##RADIO2_10##"],
+                    [11] = radioPresetsRed["##RADIO2_11##"],
+                    [12] = radioPresetsRed["##RADIO2_12##"],
+                    [13] = radioPresetsRed["##RADIO2_13##"],
+                    [14] = radioPresetsRed["##RADIO2_14##"],
+                    [15] = radioPresetsRed["##RADIO2_15##"],
+                    [16] = radioPresetsRed["##RADIO2_16##"],
+                    [17] = radioPresetsRed["##RADIO2_17##"],
+                    [18] = radioPresetsRed["##RADIO2_18##"],
+                    [19] = radioPresetsRed["##RADIO2_19##"],
+                    [20] = radioPresetsRed["##RADIO2_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        },
+    },
+
+    ["blue Harrier"] = {
+        type = "AV8BNA",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --V/UHF (down to 30MHz) with modulation selection box (but no modulation selection in the ME)
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 1,
+                    [22] = 1,
+                    [23] = 1,
+                    [24] = 1,
+                    [25] = 1,
+                    [26] = 1,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --V/UHF (down to 30MHz) with modulation selection box (but no modulation selection in the ME)
+            [2] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 1,
+                    [22] = 1,
+                    [23] = 1,
+                    [24] = 1,
+                    [25] = 1,
+                    [26] = 1,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = radioPresetsBlue["##RADIO2_05##"],
+                    [6]  = radioPresetsBlue["##RADIO2_06##"],
+                    [7]  = radioPresetsBlue["##RADIO2_07##"],
+                    [8]  = radioPresetsBlue["##RADIO2_08##"],
+                    [9]  = radioPresetsBlue["##RADIO2_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_10##"],
+                    [11] = radioPresetsBlue["##RADIO2_11##"],
+                    [12] = radioPresetsBlue["##RADIO2_12##"],
+                    [13] = radioPresetsBlue["##RADIO2_13##"],
+                    [14] = radioPresetsBlue["##RADIO2_14##"],
+                    [15] = radioPresetsBlue["##RADIO2_15##"],
+                    [16] = radioPresetsBlue["##RADIO2_16##"],
+                    [17] = radioPresetsBlue["##RADIO2_17##"],
+                    [18] = radioPresetsBlue["##RADIO2_18##"],
+                    [19] = radioPresetsBlue["##RADIO2_19##"],
+                    [20] = radioPresetsBlue["##RADIO2_20##"],
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+            --V/UHF (down to 30MHz) with modulation selection box (but no modulation selection in the ME)
+            [3] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  1,
+                    [2] =  1,
+                    [3] =  1,
+                    [4] =  1,
+                    [5] =  1,
+                    [6] =  1,
+                    [7] =  1,
+                    [8] =  1,
+                    [9] =  1,
+                    [10] = 1,
+                    [11] = 1,
+                    [12] = 1,
+                    [13] = 1,
+                    [14] = 1,
+                    [15] = 1,
+                    [16] = 1,
+                    [17] = 1,
+                    [18] = 1,
+                    [19] = 1,
+                    [20] = 1,
+                    [21] = 1,
+                    [22] = 1,
+                    [23] = 1,
+                    [24] = 1,
+                    [25] = 1,
+                    [26] = 1,
+                    [27] = 1,
+                    [28] = 1,
+                    [29] = 1,
+                    [30] = 1,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO3_01##"],
+                    [2]  = radioPresetsBlue["##RADIO3_02##"],
+                    [3]  = radioPresetsBlue["##RADIO3_03##"],
+                    [4]  = radioPresetsBlue["##RADIO3_04##"],
+                    [5]  = radioPresetsBlue["##RADIO3_05##"],
+                    [6]  = radioPresetsBlue["##RADIO3_06##"],
+                    [7]  = radioPresetsBlue["##RADIO3_07##"],
+                    [8]  = radioPresetsBlue["##RADIO3_08##"],
+                    [9]  = radioPresetsBlue["##RADIO3_09##"],
+                    [10] = radioPresetsBlue["##RADIO3_10##"],
+                    [11] = radioPresetsBlue["##RADIO3_11##"],
+                    [12] = radioPresetsBlue["##RADIO3_12##"],
+                    [13] = radioPresetsBlue["##RADIO3_13##"],
+                    [14] = radioPresetsBlue["##RADIO3_14##"],
+                    [15] = radioPresetsBlue["##RADIO3_15##"],
+                    [16] = radioPresetsBlue["##RADIO3_16##"],
+                    [17] = radioPresetsBlue["##RADIO3_17##"],
+                    [18] = radioPresetsBlue["##RADIO3_18##"],
+                    [19] = radioPresetsBlue["##RADIO3_19##"],
+                    [20] = radioPresetsBlue["##RADIO3_20##"],
+                    [21] = radioPresetsBlue["##RADIO3_21##"],
+                    [22] = radioPresetsBlue["##RADIO3_22##"],
+                    [23] = radioPresetsBlue["##RADIO3_23##"],
+                    [24] = radioPresetsBlue["##RADIO3_24##"],
+                    [25] = radioPresetsBlue["##RADIO3_25##"],
+                    [26] = radioPresetsBlue["##RADIO3_26##"],
+                    [27] = radioPresetsBlue["##RADIO3_27##"],
+                    [28] = radioPresetsBlue["##RADIO3_28##"],
+                    [29] = radioPresetsBlue["##RADIO3_29##"],
+                    [30] = radioPresetsBlue["##RADIO3_30##"],
+                }, -- end of ["channels"]
+            }, -- end of [3]
+        },
+    },
+
+    ["red Harrier"] = {
+        type = "AV8BNA",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --V/UHF (down to 30MHz) with modulation selection box (but no modulation selection in the ME)
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 1,
+                    [22] = 1,
+                    [23] = 1,
+                    [24] = 1,
+                    [25] = 1,
+                    [26] = 1,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --V/UHF (down to 30MHz) with modulation selection box (but no modulation selection in the ME)
+            [2] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 1,
+                    [22] = 1,
+                    [23] = 1,
+                    [24] = 1,
+                    [25] = 1,
+                    [26] = 1,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                    [5]  = radioPresetsRed["##RADIO2_05##"],
+                    [6]  = radioPresetsRed["##RADIO2_06##"],
+                    [7]  = radioPresetsRed["##RADIO2_07##"],
+                    [8]  = radioPresetsRed["##RADIO2_08##"],
+                    [9]  = radioPresetsRed["##RADIO2_09##"],
+                    [10] = radioPresetsRed["##RADIO2_10##"],
+                    [11] = radioPresetsRed["##RADIO2_11##"],
+                    [12] = radioPresetsRed["##RADIO2_12##"],
+                    [13] = radioPresetsRed["##RADIO2_13##"],
+                    [14] = radioPresetsRed["##RADIO2_14##"],
+                    [15] = radioPresetsRed["##RADIO2_15##"],
+                    [16] = radioPresetsRed["##RADIO2_16##"],
+                    [17] = radioPresetsRed["##RADIO2_17##"],
+                    [18] = radioPresetsRed["##RADIO2_18##"],
+                    [19] = radioPresetsRed["##RADIO2_19##"],
+                    [20] = radioPresetsRed["##RADIO2_20##"],
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+            --V/UHF (down to 30MHz) with modulation selection box (but no modulation selection in the ME)
+            [3] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  1,
+                    [2] =  1,
+                    [3] =  1,
+                    [4] =  1,
+                    [5] =  1,
+                    [6] =  1,
+                    [7] =  1,
+                    [8] =  1,
+                    [9] =  1,
+                    [10] = 1,
+                    [11] = 1,
+                    [12] = 1,
+                    [13] = 1,
+                    [14] = 1,
+                    [15] = 1,
+                    [16] = 1,
+                    [17] = 1,
+                    [18] = 1,
+                    [19] = 1,
+                    [20] = 1,
+                    [21] = 1,
+                    [22] = 1,
+                    [23] = 1,
+                    [24] = 1,
+                    [25] = 1,
+                    [26] = 1,
+                    [27] = 1,
+                    [28] = 1,
+                    [29] = 1,
+                    [30] = 1,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO3_01##"],
+                    [2]  = radioPresetsRed["##RADIO3_02##"],
+                    [3]  = radioPresetsRed["##RADIO3_03##"],
+                    [4]  = radioPresetsRed["##RADIO3_04##"],
+                    [5]  = radioPresetsRed["##RADIO3_05##"],
+                    [6]  = radioPresetsRed["##RADIO3_06##"],
+                    [7]  = radioPresetsRed["##RADIO3_07##"],
+                    [8]  = radioPresetsRed["##RADIO3_08##"],
+                    [9]  = radioPresetsRed["##RADIO3_09##"],
+                    [10] = radioPresetsRed["##RADIO3_10##"],
+                    [11] = radioPresetsRed["##RADIO3_11##"],
+                    [12] = radioPresetsRed["##RADIO3_12##"],
+                    [13] = radioPresetsRed["##RADIO3_13##"],
+                    [14] = radioPresetsRed["##RADIO3_14##"],
+                    [15] = radioPresetsRed["##RADIO3_15##"],
+                    [16] = radioPresetsRed["##RADIO3_16##"],
+                    [17] = radioPresetsRed["##RADIO3_17##"],
+                    [18] = radioPresetsRed["##RADIO3_18##"],
+                    [19] = radioPresetsRed["##RADIO3_19##"],
+                    [20] = radioPresetsRed["##RADIO3_20##"],
+                    [21] = radioPresetsRed["##RADIO3_21##"],
+                    [22] = radioPresetsRed["##RADIO3_22##"],
+                    [23] = radioPresetsRed["##RADIO3_23##"],
+                    [24] = radioPresetsRed["##RADIO3_24##"],
+                    [25] = radioPresetsRed["##RADIO3_25##"],
+                    [26] = radioPresetsRed["##RADIO3_26##"],
+                    [27] = radioPresetsRed["##RADIO3_27##"],
+                    [28] = radioPresetsRed["##RADIO3_28##"],
+                    [29] = radioPresetsRed["##RADIO3_29##"],
+                    [30] = radioPresetsRed["##RADIO3_30##"],
+                }, -- end of ["channels"]
+            }, -- end of [3]
+        },
+    },
+
+    ["blue JF-17"] = {
+        type = "JF-17",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --V/UHF (down to 30MHz) with modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red JF-17"] = {
+        type = "JF-17",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = 
+        {
+            --V/UHF (down to 30MHz) with modulation selection box
+            [1] = 
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue Mirage 2000"] = {
+        type = "M-2000C",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --UHF with modulation selection box (but no modulation selection in the ME)
+            [1] =
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --V/UHF with modulation selection box (but no modulation selection in the ME)
+            [2] =
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = radioPresetsBlue["##RADIO2_05##"],
+                    [6]  = radioPresetsBlue["##RADIO2_06##"],
+                    [7]  = radioPresetsBlue["##RADIO2_07##"],
+                    [8]  = radioPresetsBlue["##RADIO2_08##"],
+                    [9]  = radioPresetsBlue["##RADIO2_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_10##"],
+                    [11] = radioPresetsBlue["##RADIO2_11##"],
+                    [12] = radioPresetsBlue["##RADIO2_12##"],
+                    [13] = radioPresetsBlue["##RADIO2_13##"],
+                    [14] = radioPresetsBlue["##RADIO2_14##"],
+                    [15] = radioPresetsBlue["##RADIO2_15##"],
+                    [16] = radioPresetsBlue["##RADIO2_16##"],
+                    [17] = radioPresetsBlue["##RADIO2_17##"],
+                    [18] = radioPresetsBlue["##RADIO2_18##"],
+                    [19] = radioPresetsBlue["##RADIO2_19##"],
+                    [20] = radioPresetsBlue["##RADIO2_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        },
+    },
+
+    ["red Mirage 2000"] = {
+        type = "M-2000C",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --UHF with modulation selection box (but no modulation selection in the ME)
+            [1] =
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --V/UHF with modulation selection box (but no modulation selection in the ME)
+            [2] =
+            {
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                    [5]  = radioPresetsRed["##RADIO2_05##"],
+                    [6]  = radioPresetsRed["##RADIO2_06##"],
+                    [7]  = radioPresetsRed["##RADIO2_07##"],
+                    [8]  = radioPresetsRed["##RADIO2_08##"],
+                    [9]  = radioPresetsRed["##RADIO2_09##"],
+                    [10] = radioPresetsRed["##RADIO2_10##"],
+                    [11] = radioPresetsRed["##RADIO2_11##"],
+                    [12] = radioPresetsRed["##RADIO2_12##"],
+                    [13] = radioPresetsRed["##RADIO2_13##"],
+                    [14] = radioPresetsRed["##RADIO2_14##"],
+                    [15] = radioPresetsRed["##RADIO2_15##"],
+                    [16] = radioPresetsRed["##RADIO2_16##"],
+                    [17] = radioPresetsRed["##RADIO2_17##"],
+                    [18] = radioPresetsRed["##RADIO2_18##"],
+                    [19] = radioPresetsRed["##RADIO2_19##"],
+                    [20] = radioPresetsRed["##RADIO2_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        },
+    },
+
+    ["blue F-15E_strike eagle"] = {
+        type = "F-15ESE",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+                ["channelsNames"] = {
+                    [1]  = radioPresetsBlue["##RADIO1_NAME_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_NAME_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_NAME_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_NAME_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_NAME_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_NAME_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_NAME_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_NAME_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_NAME_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_NAME_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_NAME_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_NAME_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_NAME_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_NAME_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_NAME_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_NAME_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_NAME_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_NAME_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_NAME_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_NAME_20##"],
+                }, -- end of ["channelsNames"]
+                ["modulations"] = {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+            [2] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = radioPresetsBlue["##RADIO2_05##"],
+                    [6]  = radioPresetsBlue["##RADIO2_06##"],
+                    [7]  = radioPresetsBlue["##RADIO2_07##"],
+                    [8]  = radioPresetsBlue["##RADIO2_08##"],
+                    [9]  = radioPresetsBlue["##RADIO2_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_10##"],
+                    [11] = radioPresetsBlue["##RADIO2_11##"],
+                    [12] = radioPresetsBlue["##RADIO2_12##"],
+                    [13] = radioPresetsBlue["##RADIO2_13##"],
+                    [14] = radioPresetsBlue["##RADIO2_14##"],
+                    [15] = radioPresetsBlue["##RADIO2_15##"],
+                    [16] = radioPresetsBlue["##RADIO2_16##"],
+                    [17] = radioPresetsBlue["##RADIO2_17##"],
+                    [18] = radioPresetsBlue["##RADIO2_18##"],
+                    [19] = radioPresetsBlue["##RADIO2_19##"],
+                    [20] = radioPresetsBlue["##RADIO2_20##"],
+                    [21] = 123,
+                    [22] = 124,
+                    [23] = 135,
+                    [24] = 136,
+                    [25] = 141,
+                    [26] = 127,
+                    [27] = 127,
+                    [28] = 127,
+                    [29] = 127,
+                    [30] = 127,
+                    [31] = 123,
+                    [32] = 124,
+                    [33] = 135,
+                    [34] = 136,
+                    [35] = 141,
+                    [36] = 127,
+                    [37] = 127,
+                    [38] = 127,
+                    [39] = 127,
+                    [40] = 127,
+                }, -- end of ["channels"]
+                ["channelsNames"] = {
+                    [1]  = radioPresetsBlue["##RADIO2_NAME_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_NAME_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_NAME_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_NAME_04##"],
+                    [5]  = radioPresetsBlue["##RADIO2_NAME_05##"],
+                    [6]  = radioPresetsBlue["##RADIO2_NAME_06##"],
+                    [7]  = radioPresetsBlue["##RADIO2_NAME_07##"],
+                    [8]  = radioPresetsBlue["##RADIO2_NAME_08##"],
+                    [9]  = radioPresetsBlue["##RADIO2_NAME_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_NAME_10##"],
+                    [11] = radioPresetsBlue["##RADIO2_NAME_11##"],
+                    [12] = radioPresetsBlue["##RADIO2_NAME_12##"],
+                    [13] = radioPresetsBlue["##RADIO2_NAME_13##"],
+                    [14] = radioPresetsBlue["##RADIO2_NAME_14##"],
+                    [15] = radioPresetsBlue["##RADIO2_NAME_15##"],
+                    [16] = radioPresetsBlue["##RADIO2_NAME_16##"],
+                    [17] = radioPresetsBlue["##RADIO2_NAME_17##"],
+                    [18] = radioPresetsBlue["##RADIO2_NAME_18##"],
+                    [19] = radioPresetsBlue["##RADIO2_NAME_19##"],
+                    [20] = radioPresetsBlue["##RADIO2_NAME_20##"],
+                    [21] = "Radio 2 Channel 21",
+                    [22] = "Radio 2 Channel 22",
+                    [23] = "Radio 2 Channel 23",
+                    [24] = "Radio 2 Channel 24",
+                    [25] = "Radio 2 Channel 25",
+                    [26] = "Radio 2 Channel 26",
+                    [27] = "Radio 2 Channel 27",
+                    [28] = "Radio 2 Channel 28",
+                    [29] = "Radio 2 Channel 29",
+                    [30] = "Radio 2 Channel 30",
+                    [31] = "Radio 2 Channel 31",
+                    [32] = "Radio 2 Channel 32",
+                    [33] = "Radio 2 Channel 33",
+                    [34] = "Radio 2 Channel 34",
+                    [35] = "Radio 2 Channel 35",
+                    [36] = "Radio 2 Channel 36",
+                    [37] = "Radio 2 Channel 37",
+                    [38] = "Radio 2 Channel 38",
+                    [39] = "Radio 2 Channel 39",
+                    [40] = "Radio 2 Channel 40",
+                }, -- end of ["channelsNames"]
+                ["modulations"] = {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                    [27] = 0,
+                    [28] = 0,
+                    [29] = 0,
+                    [30] = 0,
+                    [31] = 0,
+                    [32] = 0,
+                    [33] = 0,
+                    [34] = 0,
+                    [35] = 0,
+                    [36] = 0,
+                    [37] = 0,
+                    [38] = 0,
+                    [39] = 0,
+                    [40] = 0,
+                }, -- end of ["modulations"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    -----------------------------------------------------------------------------------------------------------------------------
+    --trainers
+
+    ["blue C-101s"] = {
+        typePattern = "C[-]101.*",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            --V/UHF without modulation selection box
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red C-101s"] = {
+        typePattern = "C[-]101.*",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = {
+            --V/UHF without modulation selection box
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue L-39s"] = {
+        typePattern = "L[-]39.*",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --V/UHF with modulation selection box (but no modulation selection in the ME)
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        },
+    },
+
+    ["red L-39s"] = {
+        typePattern = "L[-]39.*",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --V/UHF with modulation selection box (but no modulation selection in the ME)
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        },
+    },
+
+    ["blue T-45"] = {
+        type = "T-45",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --Unknown
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                    [27] = 0,
+                    [28] = 0,
+                    [29] = 0,
+                    [30] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                    [27] = 0,
+                    [28] = 0,
+                    [29] = 0,
+                    [30] = 0,
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red T-45"] = {
+        type = "T-45",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --Unknown
+            [1] =
+            {
+                ["modulations"] =
+                {
+                    [1] =  0,
+                    [2] =  0,
+                    [3] =  0,
+                    [4] =  0,
+                    [5] =  0,
+                    [6] =  0,
+                    [7] =  0,
+                    [8] =  0,
+                    [9] =  0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                    [27] = 0,
+                    [28] = 0,
+                    [29] = 0,
+                    [30] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                    [21] = 0,
+                    [22] = 0,
+                    [23] = 0,
+                    [24] = 0,
+                    [25] = 0,
+                    [26] = 0,
+                    [27] = 0,
+                    [28] = 0,
+                    [29] = 0,
+                    [30] = 0,
+                }, -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ------------------------------------------------------------------------------------------------------------------------------------------
+    --helicopters
+    ------------------------------------------------------------------------------------------------------------------------------------------
+
+
+    ["blue AH-64D"] = {
+        type = "AH-64D_BLK_II",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            --VHF with modulation selection box (but no modulation selection in ME)
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"],
+                    [2]  = radioPresetsBlue["##RADIO2_02##"],
+                    [3]  = radioPresetsBlue["##RADIO2_03##"],
+                    [4]  = radioPresetsBlue["##RADIO2_04##"],
+                    [5]  = radioPresetsBlue["##RADIO2_05##"],
+                    [6]  = radioPresetsBlue["##RADIO2_06##"],
+                    [7]  = radioPresetsBlue["##RADIO2_07##"],
+                    [8]  = radioPresetsBlue["##RADIO2_08##"],
+                    [9]  = radioPresetsBlue["##RADIO2_09##"],
+                    [10] = radioPresetsBlue["##RADIO2_10##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+            --UHF with modulation selection box (but no modulation selection in ME)
+            [2] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                }, -- end of ["modulations"]
+            }, -- end of [2]
+            --FM without modulation selection box
+            [3] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO3_01##"],
+                    [2]  = radioPresetsBlue["##RADIO3_02##"],
+                    [3]  = radioPresetsBlue["##RADIO3_03##"],
+                    [4]  = radioPresetsBlue["##RADIO3_04##"],
+                    [5]  = radioPresetsBlue["##RADIO3_05##"],
+                    [6]  = radioPresetsBlue["##RADIO3_06##"],
+                    [7]  = radioPresetsBlue["##RADIO3_07##"],
+                    [8]  = radioPresetsBlue["##RADIO3_08##"],
+                    [9]  = radioPresetsBlue["##RADIO3_09##"],
+                    [10] = radioPresetsBlue["##RADIO3_10##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [3]
+            --FM without modulation selection box
+            [4] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO3_11##"],
+                    [2]  = radioPresetsBlue["##RADIO3_12##"],
+                    [3]  = radioPresetsBlue["##RADIO3_13##"],
+                    [4]  = radioPresetsBlue["##RADIO3_14##"],
+                    [5]  = radioPresetsBlue["##RADIO3_15##"],
+                    [6]  = radioPresetsBlue["##RADIO3_16##"],
+                    [7]  = radioPresetsBlue["##RADIO3_17##"],
+                    [8]  = radioPresetsBlue["##RADIO3_18##"],
+                    [9]  = radioPresetsBlue["##RADIO3_19##"],
+                    [10] = radioPresetsBlue["##RADIO3_20##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [4]
+        }, -- end of ["Radio"]
+    },
+
+    ["red AH-64D"] = {
+        type = "AH-64D_BLK_II",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = {
+            --VHF with modulation selection box (but no modulation selection in ME)
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsRed["##RADIO2_01##"],
+                    [2]  = radioPresetsRed["##RADIO2_02##"],
+                    [3]  = radioPresetsRed["##RADIO2_03##"],
+                    [4]  = radioPresetsRed["##RADIO2_04##"],
+                    [5]  = radioPresetsRed["##RADIO2_05##"],
+                    [6]  = radioPresetsRed["##RADIO2_06##"],
+                    [7]  = radioPresetsRed["##RADIO2_07##"],
+                    [8]  = radioPresetsRed["##RADIO2_08##"],
+                    [9]  = radioPresetsRed["##RADIO2_09##"],
+                    [10] = radioPresetsRed["##RADIO2_10##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+            --UHF with modulation selection box (but no modulation selection in ME)
+            [2] = {
+                ["channels"] = {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                }, -- end of ["modulations"]
+            }, -- end of [2]
+            --FM without modulation selection box
+            [3] = {
+                ["channels"] = {
+                    [1]  = radioPresetsRed["##RADIO3_01##"],
+                    [2]  = radioPresetsRed["##RADIO3_02##"],
+                    [3]  = radioPresetsRed["##RADIO3_03##"],
+                    [4]  = radioPresetsRed["##RADIO3_04##"],
+                    [5]  = radioPresetsRed["##RADIO3_05##"],
+                    [6]  = radioPresetsRed["##RADIO3_06##"],
+                    [7]  = radioPresetsRed["##RADIO3_07##"],
+                    [8]  = radioPresetsRed["##RADIO3_08##"],
+                    [9]  = radioPresetsRed["##RADIO3_09##"],
+                    [10] = radioPresetsRed["##RADIO3_10##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [3]
+            --FM without modulation selection box
+            [4] = {
+                ["channels"] = {
+                    [1] = 30,
+                    [2] = 30.01,
+                    [3] = 30.015,
+                    [4] = 30.02,
+                    [5] = 30.025,
+                    [6] = 30.03,
+                    [7] = 30.035,
+                    [8] = 30.04,
+                    [9] = 30.045,
+                    [10] = 30.05,
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [4]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue Gazelles"] = {
+        typePattern = "SA342.+",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            --FM with modulation selection box (but no modulation selection in ME)
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO3_01##"],
+                    [2]  = radioPresetsBlue["##RADIO3_02##"],
+                    [3]  = radioPresetsBlue["##RADIO3_03##"],
+                    [4]  = radioPresetsBlue["##RADIO3_04##"],
+                    [5]  = radioPresetsBlue["##RADIO3_05##"],
+                    [6]  = radioPresetsBlue["##RADIO3_06##"],
+                    [7]  = radioPresetsBlue["##RADIO3_07##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                    [1]  = 0,
+                    [2]  = 0,
+                    [3]  = 0,
+                    [4]  = 0,
+                    [5]  = 0,
+                    [6]  = 0,
+                    [7]  = 0,
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red Gazelles"] = {
+        typePattern = "SA342.+",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = {
+            --FM with modulation selection box (but no modulation selection in ME)
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsRed["##RADIO3_01##"],
+                    [2]  = radioPresetsRed["##RADIO3_02##"],
+                    [3]  = radioPresetsRed["##RADIO3_03##"],
+                    [4]  = radioPresetsRed["##RADIO3_04##"],
+                    [5]  = radioPresetsRed["##RADIO3_05##"],
+                    [6]  = radioPresetsRed["##RADIO3_06##"],
+                    [7]  = radioPresetsRed["##RADIO3_07##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                    [1]  = 0,
+                    [2]  = 0,
+                    [3]  = 0,
+                    [4]  = 0,
+                    [5]  = 0,
+                    [6]  = 0,
+                    [7]  = 0,
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue Ka-50s"] = {
+        typePattern = "Ka[-]50.*",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --FM without modulation selection box
+            [1] =
+            {
+                ["modulations"] =
+                {
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsBlue["##RADIO3_01##"],
+                    [2]  = radioPresetsBlue["##RADIO3_02##"],
+                    [3]  = radioPresetsBlue["##RADIO3_03##"],
+                    [4]  = radioPresetsBlue["##RADIO3_04##"],
+                    [5]  = radioPresetsBlue["##RADIO3_05##"],
+                    [6]  = radioPresetsBlue["##RADIO3_06##"],
+                    [7]  = radioPresetsBlue["##RADIO3_07##"],
+                    [8]  = radioPresetsBlue["##RADIO3_08##"],
+                    [9]  = radioPresetsBlue["##RADIO3_09##"],
+                    [10] = radioPresetsBlue["##RADIO3_10##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --ARK-22 ADF (Range 0.15 to 1.75MHz)
+            [2] =
+            {
+                ["modulations"] =
+                {
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = 0.441,
+                    [2]  = 0.442,
+                    [3]  = 0.443,
+                    [4]  = 0.444,
+                    [5]  = 0.445,
+                    [6]  = 0.446,
+                    [7]  = 0.447,
+                    [8]  = 0.448,
+                    [9]  = 0.449,
+                    [10] = 0.450,
+                    [11] = 0.451,
+                    [12] = 0.452,
+                    [13] = 0.453,
+                    [14] = 0.454,
+                    [15] = 0.455,
+                    [16] = 0.456,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["red Ka-50s"] = {
+        typePattern = "Ka[-]50.*",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] =
+        {
+            --FM without modulation selection box
+            [1] =
+            {
+                ["modulations"] =
+                {
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = radioPresetsRed["##RADIO3_01##"],
+                    [2]  = radioPresetsRed["##RADIO3_02##"],
+                    [3]  = radioPresetsRed["##RADIO3_03##"],
+                    [4]  = radioPresetsRed["##RADIO3_04##"],
+                    [5]  = radioPresetsRed["##RADIO3_05##"],
+                    [6]  = radioPresetsRed["##RADIO3_06##"],
+                    [7]  = radioPresetsRed["##RADIO3_07##"],
+                    [8]  = radioPresetsRed["##RADIO3_08##"],
+                    [9]  = radioPresetsRed["##RADIO3_09##"],
+                    [10] = radioPresetsRed["##RADIO3_10##"],
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            --ARK-22 ADF (Range 0.15 to 1.75MHz)
+            [2] =
+            {
+                ["modulations"] =
+                {
+                }, -- end of ["modulations"]
+                ["channels"] =
+                {
+                    [1]  = 0.441,
+                    [2]  = 0.442,
+                    [3]  = 0.443,
+                    [4]  = 0.444,
+                    [5]  = 0.445,
+                    [6]  = 0.446,
+                    [7]  = 0.447,
+                    [8]  = 0.448,
+                    [9]  = 0.449,
+                    [10] = 0.450,
+                    [11] = 0.451,
+                    [12] = 0.452,
+                    [13] = 0.453,
+                    [14] = 0.454,
+                    [15] = 0.455,
+                    [16] = 0.456,
+                }, -- end of ["channels"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue Mi-8MT"] = {
+        type = "Mi-8MT",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            --V/UHF without modulation selection box
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+            --FM without modulation selection box
+            [2] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO3_01##"],
+                    [2]  = radioPresetsBlue["##RADIO3_02##"],
+                    [3]  = radioPresetsBlue["##RADIO3_03##"],
+                    [4]  = radioPresetsBlue["##RADIO3_04##"],
+                    [5]  = radioPresetsBlue["##RADIO3_05##"],
+                    [6]  = radioPresetsBlue["##RADIO3_06##"],
+                    [7]  = radioPresetsBlue["##RADIO3_07##"],
+                    [8]  = radioPresetsBlue["##RADIO3_08##"],
+                    [9]  = radioPresetsBlue["##RADIO3_09##"],
+                    [10] = radioPresetsBlue["##RADIO3_10##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["red Mi-8MT"] = {
+        type = "Mi-8MT",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = {
+            --V/UHF without modulation selection box
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+            --FM without modulation selection box
+            [2] = {
+                ["channels"] = {
+                    [1]  = radioPresetsRed["##RADIO3_01##"],
+                    [2]  = radioPresetsRed["##RADIO3_02##"],
+                    [3]  = radioPresetsRed["##RADIO3_03##"],
+                    [4]  = radioPresetsRed["##RADIO3_04##"],
+                    [5]  = radioPresetsRed["##RADIO3_05##"],
+                    [6]  = radioPresetsRed["##RADIO3_06##"],
+                    [7]  = radioPresetsRed["##RADIO3_07##"],
+                    [8]  = radioPresetsRed["##RADIO3_08##"],
+                    [9]  = radioPresetsRed["##RADIO3_09##"],
+                    [10] = radioPresetsRed["##RADIO3_10##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+    
+    ["blue Mi-24P"] = {
+        type = "Mi-24P",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            --V/UHF without modulation selection box
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO1_20##"], -- channel 0
+                    [2]  = radioPresetsBlue["##RADIO1_01##"], -- channel 1
+                    [3]  = radioPresetsBlue["##RADIO1_02##"],
+                    [4]  = radioPresetsBlue["##RADIO1_03##"],
+                    [5]  = radioPresetsBlue["##RADIO1_04##"],
+                    [6]  = radioPresetsBlue["##RADIO1_05##"],
+                    [7]  = radioPresetsBlue["##RADIO1_06##"],
+                    [8]  = radioPresetsBlue["##RADIO1_07##"],
+                    [9]  = radioPresetsBlue["##RADIO1_08##"],
+                    [10] = radioPresetsBlue["##RADIO1_09##"],
+                    [11] = radioPresetsBlue["##RADIO1_10##"],
+                    [12] = radioPresetsBlue["##RADIO1_11##"],
+                    [13] = radioPresetsBlue["##RADIO1_12##"],
+                    [14] = radioPresetsBlue["##RADIO1_13##"],
+                    [15] = radioPresetsBlue["##RADIO1_14##"],
+                    [16] = radioPresetsBlue["##RADIO1_15##"],
+                    [17] = radioPresetsBlue["##RADIO1_16##"],
+                    [18] = radioPresetsBlue["##RADIO1_17##"],
+                    [19] = radioPresetsBlue["##RADIO1_18##"],
+                    [20] = radioPresetsBlue["##RADIO1_19##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+            --FM without modulation selection box
+            [2] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO3_01##"],
+                    [2]  = radioPresetsBlue["##RADIO3_02##"],
+                    [3]  = radioPresetsBlue["##RADIO3_03##"],
+                    [4]  = radioPresetsBlue["##RADIO3_04##"],
+                    [5]  = radioPresetsBlue["##RADIO3_05##"],
+                    [6]  = radioPresetsBlue["##RADIO3_06##"],
+                    [7]  = radioPresetsBlue["##RADIO3_07##"],
+                    [8]  = radioPresetsBlue["##RADIO3_08##"],
+                    [9]  = radioPresetsBlue["##RADIO3_09##"],
+                    [10] = radioPresetsBlue["##RADIO3_10##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["red Mi-24P"] = {
+        type = "Mi-24P",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = {
+            --V/UHF without modulation selection box
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsRed["##RADIO1_20##"], -- channel 0
+                    [2]  = radioPresetsRed["##RADIO1_01##"], -- channel 1
+                    [3]  = radioPresetsRed["##RADIO1_02##"],
+                    [4]  = radioPresetsRed["##RADIO1_03##"],
+                    [5]  = radioPresetsRed["##RADIO1_04##"],
+                    [6]  = radioPresetsRed["##RADIO1_05##"],
+                    [7]  = radioPresetsRed["##RADIO1_06##"],
+                    [8]  = radioPresetsRed["##RADIO1_07##"],
+                    [9]  = radioPresetsRed["##RADIO1_08##"],
+                    [10] = radioPresetsRed["##RADIO1_09##"],
+                    [11] = radioPresetsRed["##RADIO1_10##"],
+                    [12] = radioPresetsRed["##RADIO1_11##"],
+                    [13] = radioPresetsRed["##RADIO1_12##"],
+                    [14] = radioPresetsRed["##RADIO1_13##"],
+                    [15] = radioPresetsRed["##RADIO1_14##"],
+                    [16] = radioPresetsRed["##RADIO1_15##"],
+                    [17] = radioPresetsRed["##RADIO1_16##"],
+                    [18] = radioPresetsRed["##RADIO1_17##"],
+                    [19] = radioPresetsRed["##RADIO1_18##"],
+                    [20] = radioPresetsRed["##RADIO1_19##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+            --FM without modulation selection box
+            [2] = {
+                ["channels"] = {
+                    [1]  = radioPresetsRed["##RADIO3_01##"],
+                    [2]  = radioPresetsRed["##RADIO3_02##"],
+                    [3]  = radioPresetsRed["##RADIO3_03##"],
+                    [4]  = radioPresetsRed["##RADIO3_04##"],
+                    [5]  = radioPresetsRed["##RADIO3_05##"],
+                    [6]  = radioPresetsRed["##RADIO3_06##"],
+                    [7]  = radioPresetsRed["##RADIO3_07##"],
+                    [8]  = radioPresetsRed["##RADIO3_08##"],
+                    [9]  = radioPresetsRed["##RADIO3_09##"],
+                    [10] = radioPresetsRed["##RADIO3_10##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [2]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue UH-1H"] = {
+        type = "UH-1H",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            --UHF without modulation selection box
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"],
+                    [2]  = radioPresetsBlue["##RADIO1_02##"],
+                    [3]  = radioPresetsBlue["##RADIO1_03##"],
+                    [4]  = radioPresetsBlue["##RADIO1_04##"],
+                    [5]  = radioPresetsBlue["##RADIO1_05##"],
+                    [6]  = radioPresetsBlue["##RADIO1_06##"],
+                    [7]  = radioPresetsBlue["##RADIO1_07##"],
+                    [8]  = radioPresetsBlue["##RADIO1_08##"],
+                    [9]  = radioPresetsBlue["##RADIO1_09##"],
+                    [10] = radioPresetsBlue["##RADIO1_10##"],
+                    [11] = radioPresetsBlue["##RADIO1_11##"],
+                    [12] = radioPresetsBlue["##RADIO1_12##"],
+                    [13] = radioPresetsBlue["##RADIO1_13##"],
+                    [14] = radioPresetsBlue["##RADIO1_14##"],
+                    [15] = radioPresetsBlue["##RADIO1_15##"],
+                    [16] = radioPresetsBlue["##RADIO1_16##"],
+                    [17] = radioPresetsBlue["##RADIO1_17##"],
+                    [18] = radioPresetsBlue["##RADIO1_18##"],
+                    [19] = radioPresetsBlue["##RADIO1_19##"],
+                    [20] = radioPresetsBlue["##RADIO1_20##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["red UH-1H"] = {
+        type = "UH-1H",
+        coalition = "red",
+        country = nil,
+
+        ["Radio"] = {
+            --UHF without modulation selection box
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsRed["##RADIO1_01##"],
+                    [2]  = radioPresetsRed["##RADIO1_02##"],
+                    [3]  = radioPresetsRed["##RADIO1_03##"],
+                    [4]  = radioPresetsRed["##RADIO1_04##"],
+                    [5]  = radioPresetsRed["##RADIO1_05##"],
+                    [6]  = radioPresetsRed["##RADIO1_06##"],
+                    [7]  = radioPresetsRed["##RADIO1_07##"],
+                    [8]  = radioPresetsRed["##RADIO1_08##"],
+                    [9]  = radioPresetsRed["##RADIO1_09##"],
+                    [10] = radioPresetsRed["##RADIO1_10##"],
+                    [11] = radioPresetsRed["##RADIO1_11##"],
+                    [12] = radioPresetsRed["##RADIO1_12##"],
+                    [13] = radioPresetsRed["##RADIO1_13##"],
+                    [14] = radioPresetsRed["##RADIO1_14##"],
+                    [15] = radioPresetsRed["##RADIO1_15##"],
+                    [16] = radioPresetsRed["##RADIO1_16##"],
+                    [17] = radioPresetsRed["##RADIO1_17##"],
+                    [18] = radioPresetsRed["##RADIO1_18##"],
+                    [19] = radioPresetsRed["##RADIO1_19##"],
+                    [20] = radioPresetsRed["##RADIO1_20##"],
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue OH-58D"] = {
+        type = "OH58D",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            --UHF with a first "M" channel and 19 shifted main channels
+            [1] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO1_01##"], -- "M" channel
+                    [2]  = radioPresetsBlue["##RADIO1_01##"],
+                    [3]  = radioPresetsBlue["##RADIO1_02##"],
+                    [4]  = radioPresetsBlue["##RADIO1_03##"],
+                    [5]  = radioPresetsBlue["##RADIO1_04##"],
+                    [6]  = radioPresetsBlue["##RADIO1_05##"],
+                    [7]  = radioPresetsBlue["##RADIO1_06##"],
+                    [8]  = radioPresetsBlue["##RADIO1_07##"],
+                    [9]  = radioPresetsBlue["##RADIO1_08##"],
+                    [10] = radioPresetsBlue["##RADIO1_09##"],
+                    [11] = radioPresetsBlue["##RADIO1_10##"],
+                    [12] = radioPresetsBlue["##RADIO1_11##"],
+                    [13] = radioPresetsBlue["##RADIO1_12##"],
+                    [14] = radioPresetsBlue["##RADIO1_13##"],
+                    [15] = radioPresetsBlue["##RADIO1_14##"],
+                    [16] = radioPresetsBlue["##RADIO1_15##"],
+                    [17] = radioPresetsBlue["##RADIO1_16##"],
+                    [18] = radioPresetsBlue["##RADIO1_17##"],
+                    [19] = radioPresetsBlue["##RADIO1_18##"],
+                    [20] = radioPresetsBlue["##RADIO1_19##"]
+                } -- end of ["channels"]
+            }, -- end of [1]
+            --VHF with a first "M" channel and 19 shifted main channels
+            [2] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO2_01##"], -- "M" channel
+                    [2]  = radioPresetsBlue["##RADIO2_01##"],
+                    [3]  = radioPresetsBlue["##RADIO2_02##"],
+                    [4]  = radioPresetsBlue["##RADIO2_03##"],
+                    [5]  = radioPresetsBlue["##RADIO2_04##"],
+                    [6]  = radioPresetsBlue["##RADIO2_05##"],
+                    [7]  = radioPresetsBlue["##RADIO2_06##"],
+                    [8]  = radioPresetsBlue["##RADIO2_07##"],
+                    [9]  = radioPresetsBlue["##RADIO2_08##"],
+                    [10] = radioPresetsBlue["##RADIO2_09##"],
+                    [11] = radioPresetsBlue["##RADIO2_10##"],
+                    [12] = radioPresetsBlue["##RADIO2_11##"],
+                    [13] = radioPresetsBlue["##RADIO2_12##"],
+                    [14] = radioPresetsBlue["##RADIO2_13##"],
+                    [15] = radioPresetsBlue["##RADIO2_14##"],
+                    [16] = radioPresetsBlue["##RADIO2_15##"],
+                    [17] = radioPresetsBlue["##RADIO2_16##"],
+                    [18] = radioPresetsBlue["##RADIO2_17##"],
+                    [19] = radioPresetsBlue["##RADIO2_18##"],
+                    [20] = radioPresetsBlue["##RADIO2_19##"]
+                } -- end of ["channels"]
+            }, -- end of [2]
+            --FM1 with a first "C" channel, a second "M" channel and 19 shifted main channels
+            [3] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO3_01##"], -- "C" channel
+                    [2]  = radioPresetsBlue["##RADIO3_01##"], -- "M" channel
+                    [3]  = radioPresetsBlue["##RADIO3_01##"],
+                    [4]  = radioPresetsBlue["##RADIO3_02##"],
+                    [5]  = radioPresetsBlue["##RADIO3_03##"],
+                    [6]  = radioPresetsBlue["##RADIO3_04##"],
+                    [7]  = radioPresetsBlue["##RADIO3_05##"],
+                    [8]  = radioPresetsBlue["##RADIO3_06##"],
+                    [9]  = radioPresetsBlue["##RADIO3_07##"],
+                    [10] = radioPresetsBlue["##RADIO3_08##"],
+                    [11] = radioPresetsBlue["##RADIO3_09##"],
+                    [12] = radioPresetsBlue["##RADIO3_10##"],
+                    [13] = radioPresetsBlue["##RADIO3_11##"],
+                    [14] = radioPresetsBlue["##RADIO3_12##"],
+                    [15] = radioPresetsBlue["##RADIO3_13##"],
+                    [16] = radioPresetsBlue["##RADIO3_14##"],
+                    [17] = radioPresetsBlue["##RADIO3_15##"],
+                    [18] = radioPresetsBlue["##RADIO3_16##"],
+                    [19] = radioPresetsBlue["##RADIO3_17##"],
+                    [20] = radioPresetsBlue["##RADIO3_18##"],
+                    [21] = radioPresetsBlue["##RADIO3_19##"]
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [3]
+            --FM2 with a first "C" channel, a second "M" channel and 19 shifted main channels
+            [4] = {
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO3_01##"], -- "C" channel
+                    [2]  = radioPresetsBlue["##RADIO3_01##"], -- "M" channel
+                    [3]  = radioPresetsBlue["##RADIO3_01##"],
+                    [4]  = radioPresetsBlue["##RADIO3_02##"],
+                    [5]  = radioPresetsBlue["##RADIO3_03##"],
+                    [6]  = radioPresetsBlue["##RADIO3_04##"],
+                    [7]  = radioPresetsBlue["##RADIO3_05##"],
+                    [8]  = radioPresetsBlue["##RADIO3_06##"],
+                    [9]  = radioPresetsBlue["##RADIO3_07##"],
+                    [10] = radioPresetsBlue["##RADIO3_08##"],
+                    [11] = radioPresetsBlue["##RADIO3_09##"],
+                    [12] = radioPresetsBlue["##RADIO3_10##"],
+                    [13] = radioPresetsBlue["##RADIO3_11##"],
+                    [14] = radioPresetsBlue["##RADIO3_12##"],
+                    [15] = radioPresetsBlue["##RADIO3_13##"],
+                    [16] = radioPresetsBlue["##RADIO3_14##"],
+                    [17] = radioPresetsBlue["##RADIO3_15##"],
+                    [18] = radioPresetsBlue["##RADIO3_16##"],
+                    [19] = radioPresetsBlue["##RADIO3_17##"],
+                    [20] = radioPresetsBlue["##RADIO3_18##"],
+                    [21] = radioPresetsBlue["##RADIO3_19##"]
+                }, -- end of ["channels"]
+                ["modulations"] = {
+                }, -- end of ["modulations"]
+            }, -- end of [4]
+        }, -- end of ["Radio"]
+    },
+
+    ["blue OH-6A"] = {
+        type = "OH-6A",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            --UHF with a first "M" channel and 19 shifted main channels
+            [1] = {
+                ["channelsNames"] = {},
+                ["modulations"] = {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = {
+                    [1]  = radioPresetsBlue["##RADIO1_02##"],
+                    [2]  = radioPresetsBlue["##RADIO1_03##"],
+                    [3]  = radioPresetsBlue["##RADIO1_04##"],
+                    [4]  = radioPresetsBlue["##RADIO1_05##"],
+                    [5]  = radioPresetsBlue["##RADIO1_06##"],
+                    [6]  = radioPresetsBlue["##RADIO1_07##"],
+                    [7]  = radioPresetsBlue["##RADIO1_08##"],
+                    [8]  = radioPresetsBlue["##RADIO1_09##"],
+                    [9]  = radioPresetsBlue["##RADIO1_10##"],
+                    [10] = radioPresetsBlue["##RADIO1_11##"],
+                    [11] = radioPresetsBlue["##RADIO1_12##"],
+                    [12] = radioPresetsBlue["##RADIO1_13##"],
+                    [13] = radioPresetsBlue["##RADIO1_14##"],
+                    [14] = radioPresetsBlue["##RADIO1_15##"],
+                    [15] = radioPresetsBlue["##RADIO1_16##"],
+                    [16] = radioPresetsBlue["##RADIO1_17##"],
+                    [17] = radioPresetsBlue["##RADIO1_18##"],
+                    [18] = radioPresetsBlue["##RADIO1_19##"],
+                    [19] = radioPresetsBlue["##RADIO1_20##"],
+                    [20] = radioPresetsBlue["##RADIO1_01##"]
+                } -- end of ["channels"]
+            }, -- end of [1]
+        }, -- end of ["Radio"]
+    },
+    
+    ["blue CH-47F"] = {
+        type = "CH-47Fbl1",
+        coalition = "blue",
+        country = nil,
+
+        ["Radio"] = {
+            --VHF/FM radio
+            [1] = 
+            {
+                ["channelsNames"] = {},
+                ["modulations"] = 
+                {
+                    [1] = 0,
+                    [2] = 0,
+                    [3] = 0,
+                    [4] = 0,
+                    [5] = 0,
+                    [6] = 0,
+                    [7] = 0,
+                    [8] = 0,
+                    [9] = 0,
+                    [10] = 0,
+                    [11] = 0,
+                    [12] = 0,
+                    [13] = 0,
+                    [14] = 0,
+                    [15] = 0,
+                    [16] = 0,
+                    [17] = 0,
+                    [18] = 0,
+                    [19] = 0,
+                    [20] = 0,
+                }, -- end of ["modulations"]
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO2_20##"],
+                    [2]  = radioPresetsBlue["##RADIO2_01##"],
+                    [3]  = radioPresetsBlue["##RADIO2_02##"],
+                    [4]  = radioPresetsBlue["##RADIO2_03##"],
+                    [5]  = radioPresetsBlue["##RADIO2_04##"],
+                    [6]  = radioPresetsBlue["##RADIO2_05##"],
+                    [7]  = radioPresetsBlue["##RADIO2_06##"],
+                    [8]  = radioPresetsBlue["##RADIO2_07##"],
+                    [9]  = radioPresetsBlue["##RADIO2_08##"],
+                    [10] = radioPresetsBlue["##RADIO2_09##"],
+                    [11] = radioPresetsBlue["##RADIO2_10##"],
+                    [12] = radioPresetsBlue["##RADIO2_11##"],
+                    [13] = radioPresetsBlue["##RADIO2_12##"],
+                    [14] = radioPresetsBlue["##RADIO2_13##"],
+                    [15] = radioPresetsBlue["##RADIO2_14##"],
+                    [16] = radioPresetsBlue["##RADIO2_15##"],
+                    [17] = radioPresetsBlue["##RADIO2_16##"],
+                    [18] = radioPresetsBlue["##RADIO2_17##"],
+                    [19] = radioPresetsBlue["##RADIO2_18##"],
+                    [20] = radioPresetsBlue["##RADIO2_19##"]
+                }, -- end of ["channels"]
+            }, -- end of [1]
+            -- UHF radio
+            [2] = 
+            {
+                ["channelsNames"] = {},
+                ["modulations"] = {},
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsBlue["##RADIO1_20##"],
+                    [2]  = radioPresetsBlue["##RADIO1_01##"],
+                    [3]  = radioPresetsBlue["##RADIO1_02##"],
+                    [4]  = radioPresetsBlue["##RADIO1_03##"],
+                    [5]  = radioPresetsBlue["##RADIO1_04##"],
+                    [6]  = radioPresetsBlue["##RADIO1_05##"],
+                    [7]  = radioPresetsBlue["##RADIO1_06##"],
+                    [8]  = radioPresetsBlue["##RADIO1_07##"],
+                    [9]  = radioPresetsBlue["##RADIO1_08##"],
+                    [10] = radioPresetsBlue["##RADIO1_09##"],
+                    [11] = radioPresetsBlue["##RADIO1_10##"],
+                    [12] = radioPresetsBlue["##RADIO1_11##"],
+                    [13] = radioPresetsBlue["##RADIO1_12##"],
+                    [14] = radioPresetsBlue["##RADIO1_13##"],
+                    [15] = radioPresetsBlue["##RADIO1_14##"],
+                    [16] = radioPresetsBlue["##RADIO1_15##"],
+                    [17] = radioPresetsBlue["##RADIO1_16##"],
+                    [18] = radioPresetsBlue["##RADIO1_17##"],
+                    [19] = radioPresetsBlue["##RADIO1_18##"],
+                    [20] = radioPresetsBlue["##RADIO1_19##"]
+                }, -- end of ["channels"]
+            }, -- end of [2]
+            [3] = 
+            {
+                ["channelsNames"] = {},
+                ["modulations"] = {},
+                ["channels"] = 
+                {
+                    [1]  = radioPresetsRed["##RADIO3_01##"],
+                    [2]  = radioPresetsRed["##RADIO3_02##"],
+                    [3]  = radioPresetsRed["##RADIO3_03##"],
+                    [4]  = radioPresetsRed["##RADIO3_04##"],
+                    [5]  = radioPresetsRed["##RADIO3_05##"],
+                    [6]  = radioPresetsRed["##RADIO3_06##"],
+                    [7]  = radioPresetsRed["##RADIO3_07##"],
+                    [8]  = radioPresetsRed["##RADIO3_08##"],
+                    [9]  = radioPresetsRed["##RADIO3_09##"],
+                    [10] = radioPresetsRed["##RADIO3_10##"],
+                }, -- end of ["channels"]
+            }, -- end of [3]
+        }, -- end of ["Radio"]
+    },
+}


### PR DESCRIPTION
## PRESETS-FIDELITY-002 (spike) — design + regression fixture

Doc-only deliverable that unblocks the PRESETS-FIDELITY-001 fix (to be implemented in a follow-up). No code change.

### What's in here
- **`docs/adr/0003-presets-fidelity.md`** — decodes the v5 per-aircraft `["Radio"]` channel tables and the two reference quirks from a real Tripack mission:
  - **Mi-24P**: channel rotation (DCS channel 0 = preset #20, then 1–19) + a second FM radio.
  - **AJS37**: leading dummy (1-channel offset), 20 UHF + 19 VHF refs, 7 hardcoded special frequencies, and an AM/FM `modulations` table.
  - Confirms the **v6 model already represents all of this** (`RadioDefinition.to_dict()` emits explicit `channels: {number: freq}`, presets map multiple radios, the injector writes the same shape DCS expects → iso-functional by construction). The only gap is the per-channel `mod` field, currently commented out — the fix will re-enable it.
  - Locks the fix design + the two decisions (modulations included; merge on green with this fixture, verify in-game post-merge).
- **`test/python/mission_builder/fixtures/tripack_radioSettings.lua`** — the real v5 `radioSettings.lua` (Mi-24P/V, AJS37, …) used as the regression fixture for the 001 fix.

### Why merge the spike on its own
So `develop-v6` carries the design + fixture, giving the follow-up implementation a clean starting point. The 001 fix (converter + injector `mod` support + regression tests) lands in its own PR.

https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z87JwsAJeBZz2vxG5xwjw)_