### PR TITLE
fix(docs-chatbot): pass --preview false to wrangler kv in CI

### DIFF
--- a/.github/workflows/docs-chatbot-index.yml
+++ b/.github/workflows/docs-chatbot-index.yml
@@ -56,7 +56,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npx wrangler kv key  put --binding CHAT_KV "idx:vec:fr" --path vec-fr.bin
-          npx wrangler kv key  put --binding CHAT_KV "idx:vec:en" --path vec-en.bin
-          npx wrangler kv bulk put --binding CHAT_KV txt-fr.json
-          npx wrangler kv bulk put --binding CHAT_KV txt-en.json
+          npx wrangler kv key  put --binding CHAT_KV --preview false "idx:vec:fr" --path vec-fr.bin
+          npx wrangler kv key  put --binding CHAT_KV --preview false "idx:vec:en" --path vec-en.bin
+          npx wrangler kv bulk put --binding CHAT_KV --preview false txt-fr.json
+          npx wrangler kv bulk put --binding CHAT_KV --preview false txt-en.json

--- a/poc/doc-chatbot/README.md
+++ b/poc/doc-chatbot/README.md
@@ -63,10 +63,10 @@ npx wrangler secret put GEMINI_API_KEY
 node scripts/build-index.mjs
 
 # Upload to KV:
-npx wrangler kv key  put --binding CHAT_KV "idx:vec:fr" --path vec-fr.bin
-npx wrangler kv key  put --binding CHAT_KV "idx:vec:en" --path vec-en.bin
-npx wrangler kv bulk put --binding CHAT_KV txt-fr.json
-npx wrangler kv bulk put --binding CHAT_KV txt-en.json
+npx wrangler kv key  put --binding CHAT_KV --preview false "idx:vec:fr" --path vec-fr.bin
+npx wrangler kv key  put --binding CHAT_KV --preview false "idx:vec:en" --path vec-en.bin
+npx wrangler kv bulk put --binding CHAT_KV --preview false txt-fr.json
+npx wrangler kv bulk put --binding CHAT_KV --preview false txt-en.json
 ```
 
 Re-run these whenever the documentation changes (this is what the CI workflow automates).

--- a/poc/doc-chatbot/worker/wrangler.toml
+++ b/poc/doc-chatbot/worker/wrangler.toml
@@ -5,10 +5,10 @@ compatibility_date = "2025-01-01"
 # KV namespace: per-IP rate-limit counters AND the embeddings index (binary vectors + texts).
 # The similarity search runs in the Worker, so no paid vector DB is needed. Load the index with:
 #   node scripts/build-index.mjs   # writes vec-{lang}.bin + txt-{lang}.json
-#   npx wrangler kv key  put --binding CHAT_KV "idx:vec:fr" --path vec-fr.bin
-#   npx wrangler kv key  put --binding CHAT_KV "idx:vec:en" --path vec-en.bin
-#   npx wrangler kv bulk put --binding CHAT_KV txt-fr.json
-#   npx wrangler kv bulk put --binding CHAT_KV txt-en.json
+#   npx wrangler kv key  put --binding CHAT_KV --preview false "idx:vec:fr" --path vec-fr.bin
+#   npx wrangler kv key  put --binding CHAT_KV --preview false "idx:vec:en" --path vec-en.bin
+#   npx wrangler kv bulk put --binding CHAT_KV --preview false txt-fr.json
+#   npx wrangler kv bulk put --binding CHAT_KV --preview false txt-en.json
 [[kv_namespaces]]
 binding = "CHAT_KV"
 id = "9599c6c3af6649b291ed8fdc26545dce"


### PR DESCRIPTION
The CHAT_KV binding has both a namespace ID and a preview ID, so `wrangler kv key/bulk put` require `--preview false` to target the production namespace. Without it the CI 'Upload the index to KV' step fails with *"Specify --preview or --preview false"*. Adds the flag to the workflow and to the matching README / wrangler.toml commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure docs chatbot KV upload commands target the production namespace instead of the preview KV.

Bug Fixes:
- Fix CI docs chatbot index upload step by explicitly passing --preview false to wrangler KV commands.

CI:
- Update docs chatbot index workflow to pass --preview false to wrangler kv key and bulk put commands when uploading the index.

Documentation:
- Align README and wrangler.toml KV upload instructions with the updated wrangler commands using --preview false.