### PR TITLE
docs(backlog): add Lot CHATBOT-CLI

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -36,6 +36,7 @@
 | Lot QUALITY-GATE — erode mypy `ignore_errors` and ratchet the coverage gate, one worker per lot | ✅ |
 | Lot SPAWN-REFACTOR — characterize `veafSpawnParser` with tests, then de-duplicate the spawn subsystem | ⬜ |
 | Lot DOC-CHATBOT — free RAG documentation chatbot (Cloudflare Worker + Vectorize + Gemini) embedded in the MkDocs site | 🔄 |
+| Lot CHATBOT-CLI — expose the doc chatbot as a `veaf-tools` CLI command (`ask`) + TUI entry, reusing the CI-built index | ⬜ |
 
 ---
 
@@ -52,6 +53,23 @@
 | DOC-CHATBOT-003 | MkDocs widget: vanilla-JS resizable sidebar (Solde-style), language auto-detection, SSE consume, sanitized DOM rendering (DOMPurify, no innerHTML), lazy CDN load; environment-aware endpoint config; wired via `mkdocs.yml`. | `doc/assets/chatbot/*.js`, `doc/assets/chatbot/*.css`, `mkdocs.yml` | feat | ✅ |
 | DOC-CHATBOT-004 | CI workflow to rebuild the index and upload it to KV whenever docs change (keeps answers fresh). | `.github/workflows/docs-chatbot-index.yml` | feat | ✅ |
 | DOC-CHATBOT-005 | Productionization prerequisites (do NOT merge before): add repo secrets `GEMINI_API_KEY`, `CLOUDFLARE_API_TOKEN` (KV edit), `CLOUDFLARE_ACCOUNT_ID`; ship the widget to the versioned (mike) docs; map a Gemini 429 to the localized "too many requests" message. (No paid plan needed — the search runs in the Worker.) | — | feat | ⬜ |
+
+---
+
+## Lot CHATBOT-CLI — doc chatbot as a `veaf-tools` CLI command + TUI entry
+
+**Goal**: Bring the documentation chatbot (ask a question about the VEAF docs, get a grounded AI answer) to the design-time tooling — a `veaf-tools ask` CLI command (one-shot + interactive REPL with session history) and a TUI menu entry — **reusing the same RAG index built by the docs CI** (single source of truth). The index (`vec-{lang}.bin` + `txt-{lang}.json` from `poc/doc-chatbot/worker/scripts/build-index.mjs`) is published as a public artifact; the Python tool downloads + caches it, then only embeds the question and generates the answer with the *user's own* `GEMINI_API_KEY`. No local re-embedding, no Cloudflare credentials, no extra runtime dependency (`requests` + pure-Python cosine). Approach decided over full-injection (wastes the user's quota at ~100k tokens/question) and over calling the deployed Worker (Origin allow-list 403 + burns the project's quota). Idiomatic to veaf-tools: Typer command in `commands/`, `BaseWorker` pattern, InquirerPy TUI, config via env var / `~/veafmct.yaml`, `veaf_libs.logger`, i18n `t()`, tests in `test/python/`.
+
+**Branch**: `feature/chatbot-cli` → PR → `develop-v6`
+
+| # | Ticket | Files | Type | Status |
+|---|--------|-------|------|--------|
+| CHATBOT-CLI-001 | Publish the embeddings index as a public artifact in the docs CI (in addition to the KV upload), e.g. to gh-pages, so non-Cloudflare clients can fetch it. | `.github/workflows/docs-chatbot-index.yml` (or `docs.yml`) | feat | ⬜ |
+| CHATBOT-CLI-002 | `index_store`: download the published `vec-{lang}.bin` + `txt-{lang}.json`, cache under `~/.veaf/doc-index/` with a version/etag check, expose load helpers (Float32 vectors + texts). | `doc_chatbot/index_store.py`, `test/python/doc_chatbot/test_index_store.py` | feat | ⬜ |
+| CHATBOT-CLI-003 | `DocChatWorker` (`BaseWorker`): embed the question (`gemini-embedding-001`, 768d, user key) → cosine top-K over the cached index → stream a grounded answer from `gemini-2.5-flash-lite` (SSE via `requests`). Resolve the key from `GEMINI_API_KEY` env or `~/veafmct.yaml`; clear localized error if missing. | `doc_chatbot/doc_chat_worker.py`, `veaf_libs/user_config.py`, `test/python/doc_chatbot/test_doc_chat_worker.py` | feat | ⬜ |
+| CHATBOT-CLI-004 | `ask` CLI command: one-shot (`veaf-tools ask "…"`) + interactive REPL (session history, `quit`); language from the global `--lang`; rendered via Rich `console`. | `veaf_tools/commands/ask.py`, `veaf_tools/commands/__init__.py`, `veaf_libs/locales/{en,fr}.json` | feat | ⬜ |
+| CHATBOT-CLI-005 | TUI entry « Ask the documentation »: InquirerPy Q&A loop (ask → answer → another?/back), reusing `DocChatWorker`. | `veaf_libs/tui.py`, `veaf_libs/locales/{en,fr}.json` | feat | ⬜ |
+| CHATBOT-CLI-006 | Docs (`doc/TOOLS_REFERENCE*.md` + TUI mention), `CHANGELOG`, and bump the coverage gate per the ratchet policy. | `doc/TOOLS_REFERENCE.md`, `doc/TOOLS_REFERENCE.en.md`, `CHANGELOG.md`, `pyproject.toml` | feat | ⬜ |
 
 ---
 


### PR DESCRIPTION
Records the planned lot to expose the doc chatbot as a `veaf-tools` CLI command (`ask`, one-shot + interactive) and a TUI entry, reusing the CI-built RAG index (published as a public artifact) with the user's own Gemini key. Plan only — no implementation in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Expand the backlog with a new section describing the CHATBOT-CLI lot, including goals, workflow, and task breakdown for integrating the documentation chatbot into CLI and TUI tools.