### PR TITLE
fix(docs-chatbot): build-index fails fast on the daily embeddings quota

### DIFF
--- a/poc/doc-chatbot/worker/scripts/build-index.mjs
+++ b/poc/doc-chatbot/worker/scripts/build-index.mjs
@@ -120,10 +120,18 @@ async function embedBatch(key, texts, attempt = 0) {
   });
   if (res.status === 429 && attempt < 6) {
     const body = await res.text();
+    // A per-DAY quota cannot clear by retrying within the run — fail fast with a clear message
+    // (the API sometimes still returns a short retryDelay for it, so detect the quota id/text).
+    if (/per[\s_]?day|RequestsPerDay/i.test(body)) {
+      throw new Error(
+        "Daily embeddings free-tier quota (1000/day for gemini-embedding-001) is exhausted. " +
+          "Re-run after it resets (midnight Pacific).",
+      );
+    }
     const m = body.match(/retry in ([\d.]+)s/i) || body.match(/"retryDelay":\s*"(\d+)s"/);
     const wait = (m ? Math.ceil(parseFloat(m[1])) : 60) + 3;
     if (wait > 120) {
-      throw new Error(`Daily embeddings quota likely exhausted (API asks to retry in ${wait}s). Try again later.`);
+      throw new Error(`Embeddings quota retry delay too long (${wait}s) — aborting; try again later.`);
     }
     console.log(`  quota window hit, waiting ${wait}s then retrying…`);
     await sleep(wait * 1000);


### PR DESCRIPTION
The CI `Rebuild docs chatbot index` job crashed cryptically after exhausting retries: the per-day free-tier embeddings quota (1000/day) was hit, but the API returned a short `retryDelay`, so the script retried 6× then failed. Now it detects the per-day quota in the 429 body and aborts immediately with a clear message ("re-run after it resets at midnight Pacific").

Note: this is a transient-quota handling fix; the durable fix (incremental re-embedding so a doc change doesn't re-embed all ~500 chunks and blow the 1000/day cap) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle daily embeddings quota errors in docs chatbot index build script more clearly and fail fast when per-day limits are hit instead of repeatedly retrying.

Bug Fixes:
- Detect per-day embeddings quota errors from 429 responses and abort the docs chatbot index rebuild with a clear message instead of exhausting retries.
- Refine the error message when the embeddings API suggests an excessively long retry delay so the job exits cleanly rather than looping.