### PR TITLE
fix(luadata-nil): accept Lua nil values in the pure-Python parser (FIX-LUADATA-NIL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `veafSecurity`: stopped logging the cleartext password at debug level (SECREV-009)
 
 ### Fixed
+- **`convert-v5` lost tables containing `nil` values** (regression from SECREV-001): the pure-Python `luadata` parser never handled Lua `nil`, so any table with a `key = nil` entry — pervasive in v5 (`country = nil`, commented-out `["waypoints"]` blocks) — failed to parse (`Unserialize luadata failed … unexpected character`) and was silently dropped (e.g. the `settings` table of `waypointsSettings.lua`). `nil` values are now accepted and dropped per Lua semantics (the entry does not exist); no code execution is reintroduced (FIX-LUADATA-NIL-001)
 - `prepare` **broken in the packaged exe** (IMC2-001): default files were resolved relative to `__file__` (a PyInstaller temp dir in the frozen exe) → `Default files not found`. They are now resolved from the target mission folder's `published/src/defaults/mission-folder` (where the updater installs them from `published.zip`), with the dev checkout as fallback
 - The updater no longer **moves `README.md` into the mission folder** (IMC2-002): it had dead relative links and overwrote the user's own README. The online documentation is the single source; the README stays under `/published/`
 - Scaffold `.gitignore` now excludes built `*.miz` files and the `/missions/` output folder, and drops the stale `/build/` entry (IMC2-006). Existing missions must apply this to their own `.gitignore` (it is `NEVER_OVERWRITE`)

--- a/backlog.md
+++ b/backlog.md
@@ -20,6 +20,7 @@
 | Lot FIX-BUILD-BARE-NAME-PATH — `build` with a bare mission name produces a relative output path, breaking the weather step | ✅ |
 | Lot FIX-EXTRACT-COMMUNITY-DICT — `extract` crashes with KeyError on community script dicts | ✅ |
 | Lot FIX-I18N-CONVERT-V5 — Hardcoded English messages in convert-v5 | ✅ |
+| Lot FIX-LUADATA-NIL — pure-Python luadata parser (SECREV-001) rejects `nil` values, breaking convert-v5 on `country = nil` | ✅ |
 | Lot PREREL-BUGS — pre-release code review findings (briefing over-capture, exit codes, i18n, error handling) | ✅ |
 | Lot SECREV — full-repo code review findings (lupa RCE, helicopter extraction data loss, zip hardening, Lua nil-derefs) | ✅ |
 | Lot TODO0609-MODULES-UNIFY — single `modules:` block as source of truth (QRA + community config nested), CTLD/CSAR extracted from v5 | ✅ |
@@ -96,6 +97,18 @@
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
 | FIX-EXTRACT-COMMUNITY-DICT-001 | Normalize the cleanup loop in `extract_mission` to accept both tuple (VEAF/legacy) and dict (community) script descriptors; add an end-to-end regression test extracting a `.miz` that bundles a community script. | `mission_extractor/mission_extractor_worker.py`, `test/python/mission_extractor/test_mission_extractor_worker.py` | fix | ✅ |
+
+---
+
+## Lot FIX-LUADATA-NIL — pure-Python luadata parser rejects `nil` values
+
+**Goal**: SECREV-001 replaced the lua-executing `luadata.unserialize` with a pure-Python state machine that never handled `nil` as a value. Real v5 configs write `key = nil` everywhere (notably `country = nil` and commented-out `["waypoints"]` blocks), so `convert-v5` failed to parse the `settings` table of `waypointsSettings.lua` (and any table with a `nil` value) — logged as `Unserialize luadata failed … unexpected character`, silently dropping that table's data. Discovered during IMC-Day 6.4.0 testing while reproducing IMC2-003.
+
+**Branch**: `fix/luadata-nil-values` → PR → `develop-v6`
+
+| # | Ticket | Files | Type | Status |
+|---|--------|-------|------|--------|
+| FIX-LUADATA-NIL-001 | Handle Lua `nil` as a value in the pure-Python unserializer: a `key = nil` entry is dropped (Lua semantics — the entry does not exist), matching the former lua-execution behaviour. No code execution reintroduced. Regression tests for named/bracketed `nil`, `nil` before a table key, and sibling preservation. | `luadata/serializer/unserialize.py`, `test/python/security/test_luadata_nil.py` | fix | ✅ |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.4.13"
+version = "6.4.14"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/luadata/serializer/unserialize.py
+++ b/src/python/veaf-tools/luadata/serializer/unserialize.py
@@ -165,6 +165,13 @@ def _unserialize(raw: str, encoding: str = "utf-8", multival: bool = False, verb
                 state = "VALUE_END"
                 key = None
                 pos = pos + 4
+            elif byte_current == b"n" and sbins[pos: pos + 3] == b"nil":
+                # Lua `nil` value: in Lua a table entry assigned nil simply does
+                # not exist, so we drop the entry (do not append it) — matching
+                # the original lua-execution behaviour for `country = nil` etc.
+                state = "VALUE_END"
+                key = None
+                pos = pos + 2
             elif byte_current == b"{":
                 stack.append({"node": node, "state": state, "key": key})
                 state = "SEEK_CHILD"

--- a/test/python/security/test_luadata_nil.py
+++ b/test/python/security/test_luadata_nil.py
@@ -1,0 +1,31 @@
+"""Regression: the pure-Python luadata parser must accept Lua `nil` values.
+
+SECREV-001 replaced the lua-executing `luadata.unserialize` with a pure-Python
+state machine that did not handle `nil` as a value. v5 configs commonly write
+`country = nil` (and other `key = nil`), so parsing real `radioSettings.lua` /
+`waypointsSettings.lua` `settings` tables crashed with "unexpected character".
+In Lua a `nil`-valued entry simply does not exist, so it is dropped.
+"""
+
+from __future__ import annotations
+
+import luadata
+
+
+class TestLuadataNil:
+    def test_named_key_nil_is_dropped(self) -> None:
+        assert luadata.unserialize("__c = { x = nil }", all_is_dict=True) == {}
+
+    def test_nil_keeps_sibling_entries(self) -> None:
+        assert luadata.unserialize("__c = { a = 1, b = nil, c = 3 }", all_is_dict=True) == {"a": 1, "c": 3}
+
+    def test_nil_followed_by_table_key(self) -> None:
+        # The exact v5 shape: `country = nil,` then a nested `["waypoints"] = {…}`.
+        result = luadata.unserialize(
+            '__c = { category = "plane", country = nil,\n ["waypoints"] = { [1] = 5 } }',
+            all_is_dict=True,
+        )
+        assert result == {"category": "plane", "waypoints": {1: 5}}
+
+    def test_bracketed_key_nil_is_dropped(self) -> None:
+        assert luadata.unserialize('__c = { ["country"] = nil, ["x"] = 1 }', all_is_dict=True) == {"x": 1}


### PR DESCRIPTION
## Summary

Regression from **SECREV-001**: the pure-Python `luadata.unserialize` (which replaced the lua-executing parser to remove RCE) never handled Lua **`nil`** as a value. Real v5 configs write `key = nil` everywhere — `country = nil`, commented-out `["waypoints"]` blocks, etc. — so `convert-v5` failed to parse the `settings` table of `waypointsSettings.lua` (and any table with a `nil` value):

```
Unserialize luadata failed on pos 163:
    nts"] =          ← ["waypoi**nts**"] after `country = nil,`
        ^
    unexpected character.
```

The failure was caught (conversion continued) but the table's data was **silently dropped** (e.g. waypoint `settings` lost).

## Fix

The `VALUE` state now recognises `nil` and **drops the entry** (Lua semantics: a `nil`-valued key does not exist), matching the former lua-execution behaviour. **No code execution is reintroduced** — it's a literal token match.

```lua
{ a = 1, b = nil, c = 3 }   -- → {a=1, c=3}
{ country = nil, ["waypoints"] = {…} }  -- → {waypoints={…}}
```

## Notes
- Found while reproducing **IMC2-003** on the IMC-Day 6.4.0 mission (the conversion crashed before that test could proceed). Independent of IMC-FEEDBACK-2.
- Verified end-to-end on the real `waypointsSettings.lua`: no parse failure, `settings` section now produced.

## Tests / quality
- New `test/python/security/test_luadata_nil.py` (named/bracketed nil, nil-before-table-key, sibling preservation).
- `poetry run pytest` — 1271 passed, 1 skipped; coverage 66.3%. `ruff` + `mypy` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle Lua `nil` values in the pure-Python luadata unserializer to prevent data loss in v5 conversions and bump patch version.

Bug Fixes:
- Accept Lua `nil` as a value in the pure-Python `luadata.unserialize` parser and drop the corresponding key per Lua table semantics, restoring successful parsing of v5 configs with `key = nil` entries.
- Document in the changelog that `convert-v5` no longer drops entire tables when they contain `nil`-valued entries.

Enhancements:
- Add regression tests ensuring the luadata parser correctly drops `nil`-valued keys while preserving sibling entries, including bracketed keys and `nil` preceding nested table keys.

Build:
- Bump project version from 6.4.13 to 6.4.14 to release the luadata `nil` handling fix.

Documentation:
- Extend backlog documentation with a new FIX-LUADATA-NIL lot describing the regression and its resolution.

Tests:
- Introduce `test/python/security/test_luadata_nil.py` to cover multiple `nil` handling scenarios in the luadata parser.