### PR TITLE
chore(veaf): remove dead deprecated veaf.weatherReport stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 - **WeatherMark community script retired**: its weather-report helpers were already replaced by `veafWeather` (the only remaining usage was a commented-out, deprecated `veaf.weatherReport` body). Removed `src/scripts/community/WeatherMark.lua`, the `weathermark` community-script entry, the dead `veaf.weatherReport` body, and the docs reference (WEATHERMARK-REMOVE-001)
+- Removed the now-empty deprecated `veaf.weatherReport` stub entirely (no callers; superseded by `veafWeatherData.getWeatherString`) (WEATHERMARK-REMOVE-002)
 
 ### Added
 - `TUM` now actually starts: when enabled, `veaf-config.lua` emits `if TUM then TUM.initialize() end` so TheUniversalMission is initialized at runtime (previously `TUM: true` loaded the script but never called `initialize()`) (TUM-INIT-001)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.4.27"
+version = "6.4.28"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/scripts/veaf/veaf.lua
+++ b/src/scripts/veaf/veaf.lua
@@ -2411,12 +2411,6 @@ function veaf.outTextForGroup(unitName, message, duration)
   return veaf.outTextForUnit(unitName, message, duration, true)
 end
 
---- Weather Report. Report pressure QFE/QNH, temperature, wind at certain location.
---- @deprecated use veafWeatherData.getWeatherString instead
-function veaf.weatherReport(vec3, alt, withLASTE)
-  return "veaf.weatherReport is deprecated, use veafWeatherData.getWeatherString instead"
-end
-
 local function _initializeCountriesAndCoalitions()
   veaf.countriesByCoalition = {}
   veaf.coalitionByCountry = {}


### PR DESCRIPTION
Removes the deprecated `veaf.weatherReport` function entirely — it had no callers (the two `weatherReport` hits in veafWeather.lua are a local variable, not `veaf.weatherReport`) and was superseded by `veafWeatherData.getWeatherString`. Completes the dead-code cleanup started in #446.

`poetry run test-lua` — 32 suites OK; `stylua --check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the deprecated veaf.weatherReport stub and bump the package version to document the cleanup.

Enhancements:
- Remove the deprecated veaf.weatherReport function stub that no longer has any callers.

Build:
- Bump veaf-tools package version from 6.4.27 to 6.4.28 to reflect the cleanup change.

Documentation:
- Document the removal of the deprecated veaf.weatherReport stub in the changelog.