### PR TITLE
test(build-autoversion): commit missing resolve_auto_version test (BUILD-AUTOVERSION-001)

### DIFF
--- a/test/python/veaf_build/test_resolve_auto_version.py
+++ b/test/python/veaf_build/test_resolve_auto_version.py
@@ -1,0 +1,50 @@
+"""Auto-computed release build number (BUILD-AUTOVERSION-001).
+
+`resolve_auto_version` derives `X.Y.Z.BUILD` from the project base (pyproject) and
+the previously published.zip version: same base → increment build number;
+different base (or no published.zip) → build number 1.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from veaf_build.worker import BuildAndReleaseWorker
+
+
+def _worker(tmp_path: Path) -> BuildAndReleaseWorker:
+    return BuildAndReleaseWorker(output_path=tmp_path)
+
+
+def _write_published(tmp_path: Path, version: str) -> None:
+    with zipfile.ZipFile(tmp_path / "published.zip", "w") as zf:
+        zf.writestr("veaf-version.json", json.dumps({"version": version}))
+
+
+def test_no_published_zip_starts_at_build_1(tmp_path: Path) -> None:
+    worker = _worker(tmp_path)
+    base = worker.get_version_from_file()
+    assert worker.resolve_auto_version() == f"{base}.1"
+
+
+def test_same_base_increments_build_number(tmp_path: Path) -> None:
+    worker = _worker(tmp_path)
+    base = worker.get_version_from_file()
+    _write_published(tmp_path, f"{base}.3")
+    assert worker.resolve_auto_version() == f"{base}.4"
+
+
+def test_different_base_resets_to_build_1(tmp_path: Path) -> None:
+    worker = _worker(tmp_path)
+    base = worker.get_version_from_file()
+    _write_published(tmp_path, "0.0.1.99")  # unrelated base
+    assert worker.resolve_auto_version() == f"{base}.1"
+
+
+def test_published_without_build_number_resets_to_1(tmp_path: Path) -> None:
+    worker = _worker(tmp_path)
+    base = worker.get_version_from_file()
+    _write_published(tmp_path, base)  # no build segment
+    assert worker.resolve_auto_version() == f"{base}.1"


### PR DESCRIPTION
## Missing test for an already-shipped feature

`resolve_auto_version` (auto-computed `X.Y.Z.BUILD` release number, BUILD-AUTOVERSION-001) shipped in #446, but its unit test was never committed — the file lived only in the working tree, so CI never exercised it.

This PR commits that test, covering the four behaviours:
- no `published.zip` → build number `.1`
- same base → increment build number
- different base → reset to `.1`
- published version with no build segment → reset to `.1`

No production code change. `veaf_build` is outside the coverage source, so the gate is unaffected; `pytest` green (67.45% ≥ 66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tests:
- Add unit tests covering build number initialization, incrementation, and reset scenarios for resolve_auto_version when reading existing or absent published.zip metadata.