### PR TITLE
fix(docs-chatbot): map Gemini 429 to localized rate-limit message (DOC-CHATBOT-005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Documentation chatbot — Gemini 429 handling** (DOC-CHATBOT-005): when the Gemini free-tier quota is hit, the docs chatbot now answers with the localized "too many requests, retry shortly" message instead of the generic "temporarily unavailable", on both the generation and embedding paths. Completes the chatbot lot (repo secrets set; the widget already ships to the versioned `mike` docs via `mkdocs.yml`)
 - `build`: **automatic CTLD/CSAR sound packaging** (BUILD-COMMUNITY-SOUNDS-001). CTLD and CSAR play their sounds by filename at runtime, so the files must be in the mission's `l10n/DEFAULT/`. The tools now ship the canonical sounds (`beacon.ogg`, `beaconsilent.ogg`, `CSAR.ogg`, sourced upstream) under `src/scripts/community/sounds/` and, when CTLD or CSAR is enabled, inject the ones a mission is missing — **without overwriting** sounds the mission already provides. Nothing is injected when both modules are off. A required sound shipped by neither the tools nor the mission (e.g. `radiobeep.ogg`, the JTAC fallback beep, which upstream does not redistribute) is reported with a build warning so the mission maker can add it. No DCS trigger or `mapResource` entry is created — packaging the file in `l10n/DEFAULT/` is sufficient
 
 ### Fixed

--- a/backlog.md
+++ b/backlog.md
@@ -49,7 +49,7 @@
 | Lot QUALITY-GATE — erode mypy `ignore_errors` and ratchet the coverage gate, one worker per lot | ✅ |
 | Lot SPAWN-REFACTOR — characterize `veafSpawnParser` with tests, then de-duplicate the spawn subsystem | ⬜ |
 | Lot DYNSLOT-WAREHOUSE — wire injected `dynSpawnTemplate` groups into the `.miz` `warehouses` so DCS offers them as Dynamic Slots | ⬜ |
-| Lot DOC-CHATBOT — free RAG documentation chatbot (Cloudflare Worker + Vectorize + Gemini) embedded in the MkDocs site | 🔄 |
+| Lot DOC-CHATBOT — free RAG documentation chatbot (Cloudflare Worker + in-Worker cosine + Gemini) embedded in the MkDocs site | ✅ |
 | Lot CHATBOT-CLI — expose the doc chatbot as a `veaf-tools` CLI command (`ask`) + TUI entry, reusing the CI-built index | ⬜ |
 | Lot IMC-FEEDBACK-2 — second-round IMC-Day user feedback (tested with 6.4.0 on 2026-06-10) | ✅ |
 | Lot DCSDATA — fix the missing-country-id ME crash, generate DCS country data from the datamine, consolidate all DCS-data generators under one `veaf-build` command with freshness guards, and lift the 2-ground-group mission requirement | 🔄 |
@@ -110,7 +110,7 @@
 | DOC-CHATBOT-002 | Index build script: walk `doc/`, chunk markdown (greedy merge, oversized-paragraph safe), embed in throttled batches, emit per-language binary Float32 blobs + text bulk files for KV. Unit tests for the chunker + Worker helpers. | `poc/doc-chatbot/worker/scripts/build-index.mjs`, `poc/doc-chatbot/worker/test/unit.test.mjs` | feat | ✅ |
 | DOC-CHATBOT-003 | MkDocs widget: vanilla-JS resizable sidebar (Solde-style), language auto-detection, SSE consume, sanitized DOM rendering (DOMPurify, no innerHTML), lazy CDN load; environment-aware endpoint config; wired via `mkdocs.yml`. | `doc/assets/chatbot/*.js`, `doc/assets/chatbot/*.css`, `mkdocs.yml` | feat | ✅ |
 | DOC-CHATBOT-004 | CI workflow to rebuild the index and upload it to KV whenever docs change (keeps answers fresh). | `.github/workflows/docs-chatbot-index.yml` | feat | ✅ |
-| DOC-CHATBOT-005 | Productionization prerequisites (do NOT merge before): add repo secrets `GEMINI_API_KEY`, `CLOUDFLARE_API_TOKEN` (KV edit), `CLOUDFLARE_ACCOUNT_ID`; ship the widget to the versioned (mike) docs; map a Gemini 429 to the localized "too many requests" message. (No paid plan needed — the search runs in the Worker.) | — | feat | ⬜ |
+| DOC-CHATBOT-005 | Productionization prerequisites. **Done**: (1) repo secrets `GEMINI_API_KEY` / `CLOUDFLARE_API_TOKEN` (KV edit) / `CLOUDFLARE_ACCOUNT_ID` set by David; (2) the widget already ships to the versioned (mike) docs — it is wired in `mkdocs.yml` (`extra_javascript`/`extra_css`) and `docs.yml` deploys via `mike deploy`, which builds with that config, so every version includes it (no extra work); (3) a Gemini **429** now maps to the localized "too many requests" message instead of the generic "unavailable", on both the generation and embedding paths (`upstreamErrorMessage`). | `poc/doc-chatbot/worker/src/index.js`, `poc/doc-chatbot/worker/test/unit.test.mjs` | feat | ✅ |
 
 ---
 

--- a/poc/doc-chatbot/worker/src/index.js
+++ b/poc/doc-chatbot/worker/src/index.js
@@ -52,6 +52,15 @@ const MESSAGES = {
   },
 };
 
+/**
+ * Map an upstream Gemini failure status to the right localized user message.
+ * A 429 (the free-tier quota was hit) becomes the "too many requests" message
+ * rather than the generic "unavailable", so the pilot knows to simply retry.
+ */
+function upstreamErrorMessage(lang, status) {
+  return status === 429 ? MESSAGES[lang].rateLimited : MESSAGES[lang].unavailable;
+}
+
 /** Build the system instruction that frames the model as the VEAF docs assistant. */
 function systemInstruction(lang, passages) {
   const langName = lang === "en" ? "English" : "French";
@@ -117,7 +126,11 @@ async function embed(env, text, taskType) {
       outputDimensionality: EMBED_DIMS,
     }),
   });
-  if (!res.ok) throw new Error(`embed ${res.status}`);
+  if (!res.ok) {
+    const err = new Error(`embed ${res.status}`);
+    err.status = res.status;
+    throw err;
+  }
   const json = await res.json();
   return json.embedding.values;
 }
@@ -215,7 +228,7 @@ async function streamGemini(env, lang, messages, passages) {
         controller.enqueue(encoder.encode(sse({ error: msg })));
         controller.close();
       };
-      if (!upstream.ok || !upstream.body) return fail(MESSAGES[lang].unavailable);
+      if (!upstream.ok || !upstream.body) return fail(upstreamErrorMessage(lang, upstream.status));
 
       const reader = upstream.body.getReader();
       let buffer = "";
@@ -261,7 +274,7 @@ function latestQuery(messages) {
 }
 
 // Named exports for unit testing (unused by the Workers runtime, which only calls the default export).
-export { latestQuery, toGeminiContents };
+export { latestQuery, toGeminiContents, upstreamErrorMessage };
 
 export default {
   async fetch(request, env) {
@@ -310,9 +323,9 @@ export default {
     let passages;
     try {
       passages = await retrieveContext(env, lang, query);
-    } catch {
-      return new Response(sse({ error: MESSAGES[lang].unavailable }), {
-        status: 502,
+    } catch (err) {
+      return new Response(sse({ error: upstreamErrorMessage(lang, err?.status) }), {
+        status: err?.status === 429 ? 429 : 502,
         headers: { ...cors, "Content-Type": "text/event-stream" },
       });
     }

--- a/poc/doc-chatbot/worker/test/unit.test.mjs
+++ b/poc/doc-chatbot/worker/test/unit.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { chunkMarkdown, MAX_CHARS } from "../scripts/build-index.mjs";
-import { latestQuery, toGeminiContents } from "../src/index.js";
+import { latestQuery, toGeminiContents, upstreamErrorMessage } from "../src/index.js";
 
 test("chunkMarkdown merges many tiny heading-sections instead of one chunk each", () => {
   const md = Array.from({ length: 20 }, (_, i) => `## H${i}\n\nshort body ${i}`).join("\n");
@@ -48,4 +48,15 @@ test("toGeminiContents maps assistant->model, drops empties, trims history", () 
   assert.ok(out.length <= 12, `history not trimmed: ${out.length}`);
   assert.ok(out.every((m) => m.role === "user" || m.role === "model"));
   assert.ok(out.every((m) => m.parts[0].text.trim().length > 0));
+});
+
+test("upstreamErrorMessage maps a Gemini 429 to the localized rate-limit message", () => {
+  assert.equal(upstreamErrorMessage("fr", 429), "Trop de requêtes, réessayez dans un instant.");
+  assert.equal(upstreamErrorMessage("en", 429), "Too many requests, please try again shortly.");
+});
+
+test("upstreamErrorMessage falls back to 'unavailable' for other failures", () => {
+  assert.equal(upstreamErrorMessage("fr", 500), "Assistant momentanément indisponible.");
+  assert.equal(upstreamErrorMessage("en", 503), "Assistant temporarily unavailable.");
+  assert.equal(upstreamErrorMessage("en", undefined), "Assistant temporarily unavailable.");
 });


### PR DESCRIPTION
## Closes the DOC-CHATBOT lot (DOC-CHATBOT-005)

David set the repo secrets (`GEMINI_API_KEY`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`). The remaining productionization items turned out to be one real change:

- **Gemini 429 → localized message** (this PR): the Worker returned the generic `unavailable` message for *any* upstream failure. A 429 (free-tier quota hit) now maps to the localized "too many requests, retry shortly" message instead, on **both** paths:
  - generation (`streamGemini`, was `index.js:218`)
  - embedding/retrieval (`retrieveContext` catch) — `embed()` now attaches the HTTP status to its error so the catch can tell a 429 from a generic failure.
  - Shared helper `upstreamErrorMessage(lang, status)`, unit-tested.

### Already done (no work needed)
- **Widget in versioned docs**: it is wired in `mkdocs.yml` (`extra_javascript`/`extra_css`) and `docs.yml` deploys via `mike deploy`, which builds with that config → every version includes the widget.
- **Repo secrets**: set by David.

### Branch cleanup note
The lot's older branches are **already merged into develop-v6 by content** (verified): the Worker + cosine refactor, the incremental-embedding cache in `build-index.mjs`, the `--preview false` CI fix, and the backlog entries are all present on develop-v6. `claude/cranky-heyrovsky-e6f193`, `feature/incremental-embeddings`, `fix/chatbot-ci-kv-preview`, `docs/backlog-chatbot-cli` are stale and can be deleted.

### Tests
`npm test` in `poc/doc-chatbot/worker` green (8/8, incl. the new 429-mapping cases). No Python/Lua changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Map Gemini 429 responses in the docs chatbot to localized rate-limit messages and mark the DOC-CHATBOT lot as complete.

New Features:
- Return a localized "too many requests, retry shortly" message when Gemini responds with HTTP 429 on both generation and embedding paths of the documentation chatbot.

Enhancements:
- Introduce a shared helper to translate upstream Gemini error statuses into appropriate localized user messages instead of always using a generic unavailable message.

Documentation:
- Update the backlog and changelog to record completion of DOC-CHATBOT-005 and describe the new Gemini 429 handling behavior.

Tests:
- Add unit tests covering the new upstream error message mapping, including the Gemini 429 case and non-429 fallbacks.