### PR TITLE
test(spawn-refactor): characterization tests for veafSpawnParser.markTextAnalysis (SPAWN-REFACTOR-001)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -47,7 +47,7 @@
 | Lot TODO0609-DEFAULTS-AUDIT — audit `defaults/mission-folder` for genuinely-unused leftover files | ✅ |
 | Lot UXPILOT-FEEDBACK — surface command errors to pilots (global pcall guard + unified feedback + unknown-parameter hints) | ⬜ |
 | Lot QUALITY-GATE — erode mypy `ignore_errors` and ratchet the coverage gate, one worker per lot | ✅ |
-| Lot SPAWN-REFACTOR — characterize `veafSpawnParser` with tests, then de-duplicate the spawn subsystem | ⬜ |
+| Lot SPAWN-REFACTOR — characterize `veafSpawnParser` with tests, then de-duplicate the spawn subsystem | 🟡 |
 | Lot DYNSLOT-WAREHOUSE — wire injected `dynSpawnTemplate` groups into the `.miz` `warehouses` so DCS offers them as Dynamic Slots | ✅ |
 | Lot DOC-CHATBOT — free RAG documentation chatbot (Cloudflare Worker + in-Worker cosine + Gemini) embedded in the MkDocs site | ✅ |
 | Lot CHATBOT-CLI — expose the doc chatbot as a `veaf-tools` CLI command (`ask`) + TUI entry, reusing the CI-built index | ✅ |
@@ -713,7 +713,7 @@ Conclusion: nothing to remove. The `doc/mission-maker/GUIDE` project-layout tree
 
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
-| SPAWN-REFACTOR-001 | Characterization tests for `veafSpawnParser.markTextAnalysis`: 30+ marker variants incl. typos, missing values, and multiple parameters; lock current behaviour before any change. Prerequisite for UXPILOT-003 and for any dedup. | `test/lua/test_veafSpawnParser.lua` (new) | feat | ⬜ |
+| SPAWN-REFACTOR-001 | Characterization tests for `veafSpawnParser.markTextAnalysis`: 41 marker variants (rejects/typos/missing values, every command + defaults, air-role defaults, parameter parsing), captured against the live parser and asserting only deterministic fields (math.random defaults left unasserted). Locks behaviour before any dedup; unblocks UXPILOT-003. | `test/lua/test_veafSpawnParser.lua` | feat | ✅ |
 | SPAWN-REFACTOR-002 | Extract a spawn-type **descriptor table** (`{type → {defaults, validators}}`) consumed by the parser, and a shared `VeafSpawner` base for the duplicated validation/debug blocks. Only within the scope of a lot already touching these files. | `src/scripts/veaf/veafSpawnParser.lua`, `veafSpawnAircraft.lua`, `veafSpawnGround.lua`, `veafSpawnCore.lua`, `test/lua/` | refactor | ⬜ |
 
 ---

--- a/test/lua/test_veafSpawnParser.lua
+++ b/test/lua/test_veafSpawnParser.lua
@@ -1,0 +1,260 @@
+--- Characterization tests for veafSpawn.markTextAnalysis (veafSpawnParser.lua).
+---
+--- These lock the CURRENT behaviour of the spawn-command text parser before any
+--- de-duplication refactor (SPAWN-REFACTOR-001). They assert only DETERMINISTIC
+--- fields — several group/convoy defaults use math.random and are intentionally
+--- left unasserted (a per-keyword `size N` makes size deterministic, so those are
+--- checked). Captured against the live parser, not hand-guessed.
+local _base = debug.getinfo(1, "S").source:match("^@(.+)[\\/]") or "."
+luaunit = dofile(_base .. "/luaunit.lua")
+dofile(_base .. "/dcs_mocks.lua")
+local src = _base .. "/../../src/scripts/veaf"
+dofile(src .. "/veaf.lua")
+dofile(src .. "/veafSpawn.lua")
+
+local function analyse(text)
+  return veafSpawn.markTextAnalysis(text)
+end
+
+-- ---------------------------------------------------------------------------
+-- Rejected inputs (return nil)
+-- ---------------------------------------------------------------------------
+TestParserRejects = {}
+
+function TestParserRejects:test_keyphrase_alone()
+  luaunit.assertNil(analyse("_spawn"))
+end
+
+function TestParserRejects:test_unknown_subcommand()
+  luaunit.assertNil(analyse("_spawn wibble"))
+end
+
+function TestParserRejects:test_typo_subcommand()
+  -- "unti" is not "unit"; nothing else matches -> nil
+  luaunit.assertNil(analyse("_spawn unti, name X"))
+end
+
+function TestParserRejects:test_unit_without_name()
+  luaunit.assertNil(analyse("_spawn unit"))
+end
+
+function TestParserRejects:test_group_without_name()
+  luaunit.assertNil(analyse("_spawn group"))
+end
+
+function TestParserRejects:test_name_keyword_with_empty_value()
+  -- "name" with no value leaves name="" -> group still rejected
+  luaunit.assertNil(analyse("_spawn group, name"))
+end
+
+function TestParserRejects:test_mm_flagon_without_name()
+  luaunit.assertNil(analyse("_mm flagon"))
+end
+
+function TestParserRejects:test_mm_run_without_name()
+  luaunit.assertNil(analyse("_mm run"))
+end
+
+function TestParserRejects:test_empty_string()
+  luaunit.assertNil(analyse(""))
+end
+
+-- ---------------------------------------------------------------------------
+-- Command flags + defaults
+-- ---------------------------------------------------------------------------
+TestParserCommands = {}
+
+function TestParserCommands:test_unit()
+  local r = analyse("_spawn unit, name F-16C")
+  luaunit.assertTrue(r.unit)
+  luaunit.assertEquals(r.name, "F-16C")
+  luaunit.assertEquals(r.spacing, 5)
+  luaunit.assertFalse(r.forceStatic)
+  luaunit.assertFalse(r.immortal)
+end
+
+function TestParserCommands:test_group()
+  local r = analyse("_spawn group, name MyGroup")
+  luaunit.assertTrue(r.group)
+  luaunit.assertEquals(r.name, "MyGroup")
+end
+
+function TestParserCommands:test_smoke_default_color_red()
+  local r = analyse("_spawn smoke")
+  luaunit.assertTrue(r.smoke)
+  luaunit.assertEquals(r.smokeColor, trigger.smokeColor.RED)
+end
+
+function TestParserCommands:test_flare()
+  luaunit.assertTrue(analyse("_spawn flare").flare)
+end
+
+function TestParserCommands:test_signal()
+  luaunit.assertTrue(analyse("_spawn signal").signal)
+end
+
+function TestParserCommands:test_cargo_defaults()
+  local r = analyse("_spawn cargo")
+  luaunit.assertTrue(r.cargo)
+  luaunit.assertEquals(r.cargoType, "container_cargo")
+  luaunit.assertEquals(r.cargoWeightBias, 2)
+  luaunit.assertFalse(r.cargoSmoke)
+end
+
+function TestParserCommands:test_logistic()
+  luaunit.assertTrue(analyse("_spawn logistic").logistic)
+end
+
+function TestParserCommands:test_bomb_defaults()
+  local r = analyse("_spawn bomb")
+  luaunit.assertTrue(r.bomb)
+  luaunit.assertEquals(r.power, 100)
+  luaunit.assertEquals(r.shells, 1)
+end
+
+function TestParserCommands:test_cap()
+  local r = analyse("_spawn cap")
+  luaunit.assertTrue(r.cap)
+  luaunit.assertNil(r.speed)
+  luaunit.assertNil(r.capradius)
+end
+
+function TestParserCommands:test_farp()
+  local r = analyse("_spawn farp")
+  luaunit.assertTrue(r.farp)
+  luaunit.assertFalse(r.noFarpMarkers)
+end
+
+function TestParserCommands:test_fob()
+  luaunit.assertTrue(analyse("_spawn fob").fob)
+end
+
+function TestParserCommands:test_convoy_default_size_is_ten()
+  local r = analyse("_spawn convoy")
+  luaunit.assertTrue(r.convoy)
+  luaunit.assertEquals(r.size, 10)
+end
+
+function TestParserCommands:test_destroy()
+  luaunit.assertTrue(analyse("_destroy").destroy)
+end
+
+function TestParserCommands:test_teleport()
+  luaunit.assertTrue(analyse("_teleport").teleport)
+end
+
+function TestParserCommands:test_drawing_add()
+  luaunit.assertTrue(analyse("_drawing add").addDrawing)
+end
+
+function TestParserCommands:test_drawing_erase()
+  luaunit.assertTrue(analyse("_drawing erase").eraseDrawing)
+end
+
+function TestParserCommands:test_drawing_square()
+  luaunit.assertTrue(analyse("_drawing square").drawSquare)
+end
+
+function TestParserCommands:test_drawing_circle()
+  luaunit.assertTrue(analyse("_drawing circle").drawCircle)
+end
+
+function TestParserCommands:test_mm_getflag_no_name_required()
+  -- getflag (unlike flagon/flagoff/run) does NOT require a name
+  local r = analyse("_mm getflag, name f1")
+  luaunit.assertTrue(r.mmGetFlag)
+  luaunit.assertEquals(r.name, "f1")
+end
+
+-- ---------------------------------------------------------------------------
+-- Air-role defaults (afac / jtac / tacan)
+-- ---------------------------------------------------------------------------
+TestParserAirRoles = {}
+
+function TestParserAirRoles:test_afac_defaults()
+  local r = analyse("_spawn afac")
+  luaunit.assertTrue(r.afac)
+  luaunit.assertEquals(r.name, "mq-9")
+  luaunit.assertEquals(r.country, "USA")
+  luaunit.assertEquals(r.laserCode, 1688)
+  luaunit.assertEquals(r.mod, "fm")
+  luaunit.assertEquals(r.freq, veafSpawn.convertLaserToFreq(1688))
+end
+
+function TestParserAirRoles:test_jtac_defaults()
+  local r = analyse("_spawn jtac")
+  luaunit.assertEquals(r.role, "jtac")
+  luaunit.assertTrue(r.unit)
+  luaunit.assertEquals(r.name, "LUV HMMWV Jeep")
+  luaunit.assertEquals(r.unitName, "JTAC1")
+  luaunit.assertEquals(r.country, "USA")
+  luaunit.assertEquals(r.laserCode, 1688)
+end
+
+function TestParserAirRoles:test_tacan_defaults()
+  local r = analyse("_spawn tacan")
+  luaunit.assertEquals(r.role, "tacan")
+  luaunit.assertTrue(r.unit)
+  luaunit.assertEquals(r.name, "TACAN_beacon")
+  luaunit.assertEquals(r.unitName, "TACAN TCN")
+end
+
+-- ---------------------------------------------------------------------------
+-- Parameter parsing
+-- ---------------------------------------------------------------------------
+TestParserParams = {}
+
+function TestParserParams:test_side_blue_is_two()
+  luaunit.assertEquals(analyse("_spawn unit, name F-16C, side blue").side, 2)
+end
+
+function TestParserParams:test_country_and_heading_and_alt()
+  local r = analyse("_spawn unit, name F-16C, country USA, heading 270, alt 5000")
+  luaunit.assertEquals(r.country, "USA")
+  luaunit.assertEquals(r.heading, 270)
+  luaunit.assertEquals(r.altitude, 5000)
+end
+
+function TestParserParams:test_laser_sets_code_and_freq()
+  local r = analyse("_spawn unit, name F-16C, laser 1688")
+  luaunit.assertEquals(r.laserCode, 1688)
+  luaunit.assertEquals(r.freq, veafSpawn.convertLaserToFreq(1688))
+end
+
+function TestParserParams:test_explicit_size_and_spacing()
+  local r = analyse("_spawn group, name g, size 5, spacing 10")
+  luaunit.assertEquals(r.size, 5)
+  luaunit.assertEquals(r.spacing, 10)
+end
+
+function TestParserParams:test_bomb_power_and_shells()
+  local r = analyse("_spawn bomb, power 50, shells 3")
+  luaunit.assertEquals(r.power, 50)
+  luaunit.assertEquals(r.shells, 3)
+end
+
+function TestParserParams:test_cargo_name_sets_cargo_type()
+  luaunit.assertEquals(analyse("_spawn cargo, name ammo_cargo").cargoType, "ammo_cargo")
+end
+
+function TestParserParams:test_cargo_smoke_flag()
+  luaunit.assertTrue(analyse("_spawn cargo, smoke").cargoSmoke)
+end
+
+function TestParserParams:test_farp_nofarpmarkers_flag()
+  luaunit.assertTrue(analyse("_spawn farp, nofarpmarkers").noFarpMarkers)
+end
+
+function TestParserParams:test_color_green_sets_smoke_color()
+  local r = analyse("_spawn smoke, color green")
+  luaunit.assertEquals(r.smokeColor, trigger.smokeColor.GREEN)
+  luaunit.assertEquals(r.drawColor, "green")
+end
+
+function TestParserParams:test_static_and_immortal_flags()
+  local r = analyse("_spawn unit, name X, static, immortal")
+  luaunit.assertTrue(r.forceStatic)
+  luaunit.assertTrue(r.immortal)
+end
+
+os.exit(luaunit.LuaUnit.run())


### PR DESCRIPTION
## SPAWN-REFACTOR-001 — lock the spawn parser before refactoring

The spawn subsystem (`veafSpawnParser`, `veafSpawnAircraft`, `veafSpawnGround`) carries heavy copy-paste and is the most pilot-facing code. Before any de-duplication, this PR locks the current behaviour of the command text parser with **41 characterization tests**, so a later refactor can't silently change parsing.

Captured against the **live parser** (not hand-guessed), asserting only **deterministic** fields:
- **Rejected inputs** → `nil`: keyphrase alone, unknown/typo subcommand, `unit`/`group`/`_mm flagon`/`_mm run` without the mandatory name, empty name value, empty string.
- **Every command** flag + defaults: unit, group, smoke/flare/signal (RED), cargo (`container_cargo`, bias 2), logistic, bomb (power 100/shells 1), cap, farp, fob, convoy (size 10), destroy, teleport, drawing add/erase/square/circle, `_mm getflag` (no name required).
- **Air roles**: afac / jtac / tacan defaults (name, country, role, unitName, laserCode, freq, mod).
- **Parameter parsing**: `side blue → 2`, country/heading/alt, `laser → laserCode + freq`, explicit `size`/`spacing`, bomb `power`/`shells`, cargo `name → cargoType`, cargo `smoke`, farp `nofarpmarkers`, `color green → smokeColor`, `static`/`immortal`.

The `math.random` group/convoy defaults are intentionally left unasserted (a per-keyword `size N` makes size deterministic, so that path is covered).

**Unblocks** UXPILOT-003 (unknown-parameter hints) and SPAWN-REFACTOR-002 (de-dup).

### Tests
`poetry run test-lua` green — 41 new cases, all 33 suites pass. No source change (test-only); stylua-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Lua characterization tests to lock the current behaviour of veafSpawnParser.markTextAnalysis before spawn subsystem refactoring.

New Features:
- Introduce a comprehensive Lua test suite for veafSpawn.markTextAnalysis covering valid commands, defaults, and parameter parsing.
- Add tests for air-role spawn commands (AFAC, JTAC, TACAN) to validate their default configurations.
- Add tests for meta-commands like drawing operations and mission-management flags to ensure parser support and defaults.

Documentation:
- Document SPAWN-REFACTOR-001 in the backlog with updated scope, determinism constraints, and completion status.

Tests:
- Cover parser rejection of invalid or incomplete spawn and mission-management commands with characterization tests.
- Assert deterministic defaults and flags for spawn commands including unit, group, cargo, logistic, bomb, CAP, FARP, FOB, convoy, destroy, and teleport.
- Validate parsing of side, country, heading, altitude, laser parameters, size/spacing, cargo options, FARP markers, color, and static/immortal flags in spawn commands.

Chores:
- Update backlog status and description for SPAWN-REFACTOR-001 to reflect the new test coverage and completion.