### PR TITLE
docs(spawn-externalize): spike — YAML-sourced spawn data design + tickets (SPAWN-EXTERNALIZE-001)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -37,7 +37,7 @@
 | Lot TODO0609-MODULES-UNIFY — single `modules:` block as source of truth (QRA + community config nested), CTLD/CSAR extracted from v5 | ✅ |
 | Lot TODO0609-CONVERT-FIDELITY — convert-v5 report fidelity: comment full migrated blocks, emit commented-out v5 elements, silenceAtc key | ✅ |
 | Lot TODO0609-ERA-AUTODETECT — auto-detect mission era (incl. WW2) from `.miz` content, manual override wins | ✅ |
-| Lot TODO0609-SPAWN-EXTERNALIZE — externalize spawn group / veafUnits / dcsUnits definitions from Lua to YAML (spike + impl) | ⬜ |
+| Lot TODO0609-SPAWN-EXTERNALIZE — externalize spawn group / veafUnits definitions from Lua to YAML (spike ✅ + impl) | 🟡 |
 | Lot TODO0609-DYNLOAD-CLARIFY — clarify `veafDynamicConfig.lua` vs `VeafDynamicLoader.lua`, find obsolete one (spike) | ✅ |
 | Lot TODO0609-PRESETS-FIDELITY — iso-functional v5 presets conversion (fix) + presets data-structure/defaults analysis (spike) | ✅ |
 | Lot TODO0609-TRIGGERS-VERIFY — verify DCS trigger migration behaviour for custom scripts (with Flogas) | 🟡 |
@@ -514,10 +514,19 @@ was constrained to a working branch.
 
 **Branch**: `feat/spawn-externalize` → PR → `develop-v6`
 
+**Spike result (001 ✅)** — see [ADR 0005](docs/adr/0005-spawn-data-externalization.md):
+
+- Source of truth = **YAML**; the Lua tables (`veafUnits.UnitsDatabase` / `GroupsDatabase`) are **generated**. Two sources: shipped `veaf-units.yaml` (framework) + per-mission `src/spawn-groups.yaml`.
+- Generation happens at the **mission build (`veaf-tools build`)** — a new pipeline step merges framework + mission YAML, renders a Lua data module, injects it into the `.miz`. (Differs from `dcsUnits`, which `veaf-build` regenerates into a committed file — here the per-mission overrides only exist at mission-build time.) DCS can't parse YAML at runtime, so the injected module assigns the Lua tables, loaded after the framework bundle (which now defaults them empty).
+- `dcsUnits.lua` is **already** externalized (DCSDATA-008) — out of scope.
+
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
-| SPAWN-EXTERNALIZE-001 (spike) | Design note: target YAML shape for unit/group definitions; how the Lua runtime consumes it (static vs dynamic loading); how the ad-hoc generator scripts that build `veafUnits` / `dcsUnits.lua` are adapted; per-mission override mechanism for `_spawn group`. Deliverable: reco + implementation tickets. | `src/scripts/veaf/veafUnits.lua`, `dcsUnits.lua`, generator scripts | spike | ⬜ |
-| SPAWN-EXTERNALIZE-002 | Implement per the spike (placeholder — split into concrete tickets once -001 lands). | TBD | feat | ⬜ |
+| SPAWN-EXTERNALIZE-001 (spike) | Design note (see ADR 0005): YAML shape, mission-build YAML→Lua generation, per-mission override mechanism. Deliverable: reco + tickets. | `docs/adr/0005-…`, `backlog.md` | spike | ✅ |
+| SPAWN-EXTERNALIZE-002 | Extract the framework `UnitsDatabase` + `GroupsDatabase` from `veafUnits.lua` into a shipped `veaf-units.yaml`; build a Lua emitter; **parity-check** the generated Lua is semantically equal to today's tables (oracle, like DCSDATA-008); then default the in-`veafUnits.lua` tables to empty. | `src/scripts/veaf/veafUnits.lua`, `veaf-units.yaml`, emitter, `test/` | feat | ⬜ |
+| SPAWN-EXTERNALIZE-003 | New `veaf-tools build` pipeline step: render the spawn-data Lua from the shipped `veaf-units.yaml` and inject it into the `.miz`; runtime populates `veafUnits.*` after the framework loads. End-to-end test (built `.miz` has the data; `_spawn group <alias>` resolves). | `veaf_tools/commands/build.py`, new worker, `mission_builder/`, `test/python/` | feat | ⬜ |
+| SPAWN-EXTERNALIZE-004 | Per-mission `src/spawn-groups.yaml` (+ optional `src/spawn-units.yaml`): merge over the framework data (alias collision → mission wins), so `_spawn group <custom>` works. Commented default + FR/EN docs + tests. | `warehouses_injector`-style worker, `src/defaults/`, `doc/`, `test/python/` | feat | ⬜ |
+| SPAWN-EXTERNALIZE-005 (= SPAWN-REFACTOR-002) | De-duplicate the spawn subsystem (shared validation/debug blocks, descriptor table) now that data is external and the parser is characterized. | `src/scripts/veaf/veafSpawn*.lua`, `test/lua/` | refactor | ⬜ |
 
 ---
 

--- a/docs/adr/0005-spawn-data-externalization.md
+++ b/docs/adr/0005-spawn-data-externalization.md
@@ -1,0 +1,67 @@
+---
+status: accepted
+---
+
+# Externalize spawn unit/group definitions to YAML (SPAWN-EXTERNALIZE-001 spike)
+
+`veafUnits.lua` (2287 lines) hand-codes two large data tables consumed at runtime
+by the `_spawn` marker commands:
+
+- `veafUnits.UnitsDatabase` — `{ aliases = {...}, unitType = "..." }` entries, the
+  alias table for `_spawn unit <alias>`.
+- `veafUnits.GroupsDatabase` — `{ aliases = {...}, group = { disposition, units,
+  description, groupName } }` entries (~78: SAM sites, convoys, …), the table for
+  `_spawn group <alias>`.
+
+Editing these means editing Lua by hand; there is no per-mission way to add a
+custom spawn group (a mission maker can only edit the shared framework file).
+This note records the design for moving them to YAML. (The sibling `dcsUnits.lua`
+DCS unit DB was already externalized to `dcsUnits.yaml` by DCSDATA-008; it is out
+of scope here — HANDOFF §6: this is the *generate-a-Lua-base* axis, distinct from
+the *inject-groups* axis of TODO0609-AIRCRAFT-INJECT.)
+
+## Decision
+
+**Source of truth is YAML; the Lua tables are generated.** Two YAML sources:
+
+- **Framework data** — `veaf-units.yaml`, shipped with the tool (in `published.zip`
+  beside the community scripts), replacing the hand-coded `UnitsDatabase` /
+  `GroupsDatabase` literals in `veafUnits.lua`.
+- **Per-mission data** — `src/spawn-groups.yaml` (and optionally `src/spawn-units.yaml`)
+  in the mission folder, letting a mission maker add or override spawn groups/units.
+
+**Generation happens at the MISSION build (`veaf-tools build`), not at `veaf-build`.**
+This is the key difference from `dcsUnits` (which `veaf-build update-dcs-data`
+regenerates into a committed framework file): here a new `veaf-tools build`
+pipeline step reads the shipped framework YAML, merges the mission's YAML over it,
+renders a Lua data module, and injects it into the `.miz`. Rationale: the
+per-mission overrides only exist at mission-build time, so the merge + render must
+live there; doing the framework data the same way keeps a single code path.
+
+**DCS Lua cannot parse YAML at runtime** (no YAML library in the mission
+environment), so runtime consumption stays Lua: the injected data module assigns
+`veafUnits.UnitsDatabase` / `veafUnits.GroupsDatabase`. It is loaded **after** the
+framework bundle (`veafUnits.lua` defines the functions and now defaults the two
+tables to empty); the injected module then populates them.
+
+**Merge semantics**: per-mission entries are appended; an alias collision lets the
+mission entry win (override), so a mission can replace a framework group by reusing
+its alias. (Confirm exact collision policy in -004.)
+
+## Consequences
+
+- The mission build **always** runs the spawn-data step (even with no per-mission
+  YAML) so the framework groups are present; a mission built by an older tool that
+  skips it would have empty databases — acceptable since the step ships on by default.
+- `veafUnits.lua` stops carrying ~1400 lines of data; a one-time extraction must be
+  **parity-checked** (generated Lua semantically equal to today's tables) before the
+  literals are removed — same oracle approach as DCSDATA-008.
+- This unblocks de-duplicating the spawn subsystem (SPAWN-REFACTOR-002): with the
+  data external and the parser characterized (SPAWN-REFACTOR-001), the duplicated
+  validation/debug blocks can be consolidated safely.
+
+## Implementation tickets
+
+See the SPAWN-EXTERNALIZE lot in `backlog.md` (002 extract framework YAML +
+parity; 003 mission-build render+inject + runtime; 004 per-mission overrides;
+005 spawn de-dup).


### PR DESCRIPTION
## SPAWN-EXTERNALIZE-001 (spike)

Design note ([ADR 0005](docs/adr/0005-spawn-data-externalization.md)) + concrete implementation tickets for moving the spawn unit/group definitions out of hand-edited Lua into YAML.

### Decisions (confirmed with David)
- **Source of truth = YAML**; the Lua tables (`veafUnits.UnitsDatabase` / `GroupsDatabase`) are **generated**. Two sources: shipped `veaf-units.yaml` (framework) + per-mission `src/spawn-groups.yaml`.
- **Generation at the mission build (`veaf-tools build`)**, not `veaf-build`: a new pipeline step merges framework + mission YAML, renders a Lua data module, and injects it into the `.miz`. (The per-mission overrides only exist at mission-build time, so the merge/render lives there — unlike `dcsUnits`, regenerated by `veaf-build` into a committed file.)
- DCS can't parse YAML at runtime → the injected module assigns the Lua tables, loaded after the framework bundle (which now defaults them empty).
- `dcsUnits.lua` is already externalized (DCSDATA-008) → out of scope.

### Tickets (in backlog)
- **002** extract framework `UnitsDatabase`/`GroupsDatabase` → `veaf-units.yaml` + emitter + **parity check** (oracle like DCSDATA-008), then default the in-Lua tables empty.
- **003** mission-build render + inject + runtime population; end-to-end test.
- **004** per-mission `src/spawn-groups.yaml` overrides (alias collision → mission wins) + default + docs.
- **005** (= SPAWN-REFACTOR-002) de-dup the spawn subsystem.

Docs-only (ADR + backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the design and implementation plan for externalizing spawn unit and group definitions from Lua to YAML and update the backlog to reflect the spike outcome and follow-up work.

Documentation:
- Add ADR 0005 describing the decision to make YAML the source of truth for spawn unit/group definitions and to generate Lua tables at mission build time, including merge semantics and consequences.

Chores:
- Update the SPAWN-EXTERNALIZE backlog entries to mark the spike as complete and split the implementation into concrete follow-up tickets with clearer scopes and responsibilities.