### PR TITLE
docs(defaults): document warehouses + spawn_data pipeline steps in mission.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- **Default `mission.yaml` documents the newest pipeline steps**: the commented `pipeline:` block (shipped default + the `convert-v5`/generated template) now also lists `warehouses` (Dynamic-Slot warehouses, `src/warehouses.yaml`) and `spawn_data` (always-on spawn-database injection, extended by `src/spawn-groups.yaml`), so mission makers discover them. No behaviour change — both steps and their default files already shipped; only the inline documentation was stale
 - **In-game default language now follows the tools' language** (LUA-I18N). When `mission.yaml` does not set `mission.language`, the build emits `veaf.config.language` from the tools' resolved language (`--lang` > `VEAF_LANG` > user config > OS locale > `en`) instead of a hard-coded `fr`. So a mission built by a French maker defaults to French in-game and others to their locale; `mission.language` still overrides, and the Lua-side `veaf.I18N_DEFAULT_LANGUAGE = "fr"` remains only as the ultimate runtime fallback. No new CLI surface — the existing global `veaf-tools --lang` already drives it
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.4.42"
+version = "6.4.43"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/defaults/mission-folder/mission.yaml
+++ b/src/defaults/mission-folder/mission.yaml
@@ -216,6 +216,8 @@ modules:
 #     file: src/spawnables.yaml
 #     mode: replace
 #   dynamic_slot_templates: true    # src/dynamic-slot-templates.yaml (dynSpawnTemplate)
+#   warehouses: true                # src/warehouses.yaml (Dynamic-Slot warehouses)
+#   spawn_data: true                # always on; src/spawn-groups.yaml extends the spawn DB. false = disable
 #   weather: false
 
 # ── Build settings ────────────────────────────────────────────────────────────

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -1165,6 +1165,8 @@ def generate_mission_yaml_template(
         "#   waypoints: true               # src/waypoints.yaml",
         "#   spawnable_aircrafts: true     # src/spawnables.yaml",
         "#   dynamic_slot_templates: true  # src/dynamic-slot-templates.yaml",
+        "#   warehouses: true              # src/warehouses.yaml (Dynamic-Slot warehouses)",
+        "#   spawn_data: true              # always on; src/spawn-groups.yaml extends the spawn DB",
         "#   weather: true                 # src/versions.yaml",
     ]
 


### PR DESCRIPTION
## Summary

Audit follow-up: the shipped default `mission.yaml` (and the `convert-v5`/generated template) documented the `pipeline:` steps `presets`, `waypoints`, `spawnable_aircrafts`, `dynamic_slot_templates`, `weather` — but **not** the two newest steps added since v6.4.0:
- `warehouses` (Dynamic-Slot warehouses, `src/warehouses.yaml`)
- `spawn_data` (always-on spawn-database injection, extended by `src/spawn-groups.yaml`)

Both steps and their default `src/` files already shipped and work; only the inline documentation was stale, so mission makers couldn't discover them by reading the default. This adds the two commented lines to both the shipped default and the generated template (defaults-lockstep).

**No missing default files**: the audit confirmed all per-mission `src/` defaults for the new features are present (`spawn-groups.yaml`, `warehouses.yaml`, …) and wired into the auto-copy map; `veaf-units.yaml` is framework data bundled in the package (not a mission default).

## Tests / quality
- `pytest`: 1375 passed. `ruff` / `ruff format` / `mypy`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the previously undocumented `warehouses` and `spawn_data` pipeline steps in the default and generated `mission.yaml` templates, and bump the package version.

Build:
- Bump project version from 6.4.42 to 6.4.43 in `pyproject.toml`.

Documentation:
- Clarify the `pipeline:` section in the shipped default `mission.yaml` to include `warehouses` and `spawn_data` with brief explanations.
- Update the generated `mission.yaml` template from `lua_config_generator` to list `warehouses` and `spawn_data` alongside existing pipeline steps.