### PR TITLE
release(6.5.0): release notes, version bump + documentation review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.5.0] — 2026-06-13
+
 ### Changed
 - **`SHORTCUTS` enabled by default** in the shipped `mission.yaml`, so the built-in spawn aliases (`-shilka`, `-sa2`, …) work out of the box. The default previously left `SHORTCUTS` commented as "needs a list", which was misleading — a `shortcuts:` list is only needed to add *custom* aliases on top of the built-in ones
 - **`CASMISSION` and `TRANSPORTMISSION` enabled by default**. Both are marker-driven (`_cas` / `_transport`), need no configuration and impose nothing, so they join the default baseline. Default policy: a module ships ON when it is useful to everyone, needs no config block and changes nothing on its own; it stays OFF when it requires a config block (ASSETS/SANCTUARY/COMBATMISSION/COMBATZONE/QRA/AIRWAVES), changes gameplay (MISSILEGUARDIAN), is carrier-specific, or is a community script

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,141 +1,39 @@
-# VEAF Mission Creation Tools — v6.4.0
+# VEAF Mission Creation Tools — 6.5.0
 
-**Version de consolidation** — unification de la configuration `mission.yaml`,
-internationalisation complète, refonte de la documentation et nombreuses
-corrections de la conversion v5→v6.
+Cette version sort les données VEAF du Lua maintenu à la main vers du **YAML généré au build**, ajoute les **Dynamic Slots** DCS, **localise les messages en jeu**, et embarque un **assistant de documentation** — accompagné d'un large lot de corrections build et runtime.
 
-Un grand merci à **Tripack** pour ses contributions et ses retours qui ont
-nourri la qualité de cette version.
+## ✨ Nouveautés
 
----
+- **Base de spawn en YAML** — les définitions d'unités/groupes de `_spawn` vivent désormais en YAML, injectées dans le `.miz` au build. Extensible/surchargeable via un `src/spawn-groups.yaml` optionnel (plus de Lua à éditer).
+- **Warehouses Dynamic-Slot** — un nouveau `src/warehouses.yaml` configure les Dynamic Slots DCS par coalition (aéroports, carburant/munitions/stock, et le modèle `dynSpawnTemplate` qui fournit emport/livrée/route).
+- **Localisation en jeu (FR/EN)** — les messages pilote VEAF sont traduits ; la langue suit `mission.language`, sinon celle des outils (les logs restent en anglais).
+- **Assistant de documentation** — posez une question à la doc VEAF et obtenez une réponse sourcée, dans la barre latérale du site **et** en CLI : `veaf-tools ask "comment activer CTLD ?"` (sans clé API).
+- **Données DCS issues du datamine** — unités, pays, aérodromes et specs radio régénérés de façon reproductible via `veaf-build update-dcs-data`, sans installation DCS.
+- **Plus de groupes sol bleu+rouge obligatoires** — le build ajoute une unité placeholder cachée à une coalition vide pour que DCS enregistre le camp.
+- **Détection automatique de l'ère** — `build` déduit `WW2`/`COLD_WAR`/`MODERN` quand `mission.era` n'est pas défini (une valeur manuelle gagne).
+- **Défauts plus malins** — un `mission.yaml` neuf active une baseline VEAF (menu F10, spawn, raccourcis, CAS/transport à la demande…) : une nouvelle mission marche d'emblée.
 
-## ⚠️ Migrations à effectuer
+## 🔧 Corrections notables
 
-### `versions.yaml` remplace `missions.yaml`
+- **Chargement dynamique des scripts** fiable en DEV et PROD ; plusieurs bugs du mode dynamique corrigés (modules initialisés deux fois → effets dupliqués, scripts non chargés, `_spawn` non enregistré).
+- **Presets radio** : la mission se sauve toujours (fini « Invalid frequency ») — les fréquences hors plage d'un appareil sont retirées au lieu de casser la sauvegarde.
+- **Injection de waypoints** : le décollage et un waypoint à heure verrouillée sont préservés → fini « flight delayed to start » / « no waypoints with locked time ».
+- **Injection d'avions** d'un pays absent de la mission source : plus de crash du Mission Editor.
+- **UX spawn** : un paramètre marqueur mal orthographié est signalé au pilote (« vouliez-vous dire… ? ») et la commande est annulée au lieu de spawner n'importe quoi.
+- **`convert-v5`** : préserve les éléments v5 commentés, les presets radio sur-mesure et `silenceAtc`, avec un rapport plus clair.
 
-L'étape *weather* du build utilise désormais **exclusivement** `src/versions.yaml`.
-Le nom `missions.yaml` n'est plus reconnu. **Renommez votre fichier
-`src/missions.yaml` en `src/versions.yaml`** avant de relancer un build.
+## ⚠️ Rupture — templates avions
 
-### Syntaxe `mission.yaml` unifiée
+L'injection des groupes avions est scindée en deux étapes : **avions spawnables** (`src/spawnables.yaml`) et **templates Dynamic-Slot** (`src/dynamic-slot-templates.yaml`). Les anciens `aircraft-templates.yaml` / `templates.yaml` ne sont **plus injectés** — régénérez-les avec `extract-aircraft-groups` (le build prévient s'il trouve les anciens fichiers).
 
-Les sections `lua_modules:` et `community_scripts:` fusionnent dans un bloc
-**`modules:`** unique. Autres changements :
+## 🔒 Sécurité
 
-- les modules obligatoires s'écrivent `MODULE:` (valeur nulle) au lieu de `MODULE: {}` ;
-- la clé `enable:` devient `enabled:` ;
-- les listes en bloc remplacent la notation `[...]` ;
-- un en-tête aide-mémoire de syntaxe YAML est ajouté aux fichiers générés.
+Le parseur `.miz` n'exécute plus de Lua embarqué (parseur pur-Python) — ouvrir/convertir une mission ne peut plus exécuter de code arbitraire. Extraction d'archives durcie et parsing `.miz` ~2,6× plus rapide.
 
-> Les anciennes clés restent acceptées avec un avertissement de dépréciation —
-> mais il est recommandé de migrer vers la nouvelle syntaxe.
+## 🙏 Remerciements
 
----
-
-## Nouveautés
-
-### Validation des fréquences radio DCS
-
-L'injection des presets vérifie maintenant chaque fréquence contre les
-capacités matérielles réelles de l'avion **au moment du build**. Une fréquence
-invalide (par ex. 284 MHz sur un MiG-19P ou une Gazelle M) déclenche un
-avertissement *avant* que DCS ne la rejette au chargement de la mission.
-
-Une table de référence lisible des plages de fréquences valides pour les
-**85 avions pilotables de DCS** est fournie dans
-`doc/mission-maker/dcs-radio-specs.md`.
-
-### Injection automatique de `dcs-bridge.lua`
-
-Nouvelle section `dcs_bridge` dans `mission.yaml` : injecte `dcs-bridge.lua`
-comme premier trigger DO SCRIPT FILE de la mission. Si `lua_path` est absent,
-le fichier est téléchargé automatiquement depuis GitHub (`VEAF/VEAF-dcs-bridge`).
-
-### Activation fine des scripts communautaires
-
-La section `community_scripts:` (intégrée au nouveau bloc `modules:`) permet
-d'activer ou désactiver individuellement les scripts Lua communautaires
-(MIST, CTLD, CSAR…). En l'absence de cette section, tous les scripts restent actifs.
-
-### Affichage console épuré
-
-La sortie des outils en ligne de commande est désormais « épurée » : les
-messages de progression de faible importance défilent sur une seule ligne
-réécrite, tandis que les lignes techniques permanentes et les en-têtes d'étape
-restent affichés. Chaque étape du build se termine par une ligne de résultat
-concise (« injected presets into 127 aircraft », « created 6 weather
-variants »…), si bien qu'un compteur à `0` signale immédiatement un problème de
-configuration. `--verbose` rétablit l'affichage classique ligne par ligne ; le
-fichier de log complet reste inchangé.
-
-### Internationalisation complète
-
-Tous les messages des outils (build, injecteurs de presets et waypoints,
-validateur de fréquences, convertisseur v5…) sont désormais traduits en
-français — plus aucun texte anglais en dur dans les logs en français.
-
-### Profil de coloration Klogg
-
-Un profil de mise en évidence des logs DCS est fourni dans
-`tools/klogg/veaf.conf` pour faciliter l'analyse des journaux.
+Merci à **Flogas** et **Tripack** pour les tests et retours.
 
 ---
 
-## Conversion v5 → v6 (`convert-v5`)
-
-De nombreuses améliorations de la conversion automatique des missions v5 :
-
-- **Résolution des dépendances** : activer un module (par ex. `CASMISSION`)
-  active automatiquement les modules requis (`GROUNDAI`, `SPAWN` et leurs
-  dépendances transitives). Le fichier généré reflète fidèlement ce qui
-  s'exécutera ; le rapport de conversion liste les modules auto-activés.
-- **Modules triés par catégorie** (Infrastructure → Core → Features → Combat →
-  External) ; les modules optionnels sans configuration utilisent le raccourci
-  `MODULE: true`.
-- **Presets radio par avion** extraits depuis `radioSettings` : les warbirds
-  (par ex. Bf-109K-4) sont assignés à `{coalition}_warbird`, les avions à VHF
-  primaire (I-16, Spitfire) à un nouveau preset `{coalition}_vhf_primary`.
-- **Briefings multi-lignes** en concaténation Lua (`"ligne1\n" .. "ligne2\n"`)
-  désormais entièrement extraits et convertis en blocs YAML lisibles.
-- **Commentaires localisés** : les utilisateurs francophones voient des
-  commentaires en français dans le `mission.yaml` généré.
-- `global_log_level` par défaut à `info` (au lieu de `debug`).
-- La commande accepte d'être appelée sans argument (répertoire courant par défaut).
-
----
-
-## Corrections notables
-
-- **`presets inject`** : les clés `presets_assignments` acceptent désormais des
-  motifs regex (`A[-]10C.*`, `FW[-]190.*`) — correspondance exacte prioritaire,
-  puis motif, puis repli `all`. Les avertissements de fréquence sont regroupés
-  par type d'avion.
-- **`aircraft-groups inject` (mode `add`)** : les groupes dont le nom existe déjà
-  sont ignorés au lieu d'être dupliqués — évite un crash DCS sur les FA-18C/F-16C
-  privés de `datalinks` après une conversion v5→v6.
-- **Lua** : gardes nil-safe ajoutées dans `veafGrass`, `veafSpawnGround` et
-  `veafSpawnEffects` autour de `ctld.builtFOBS` / `logisticUnits` / `beaconCount`
-  — plus de crash quand CTLD n'est pas chargé.
-- **`veafRadio`** : l'absence du fichier de config SRS n'émet plus d'avertissement
-  (passé en `debug`).
-- **`veaf-tools-updater`** : URL de documentation corrigée lors de la première
-  installation.
-
----
-
-## Documentation
-
-- **Refonte bilingue (FR/EN)** : guide pilote réécrit (dédupliqué, accessible,
-  jargon expliqué) ; exemple `mission.yaml` mis à jour vers le bloc `modules:`
-  unifié ; diagrammes mermaid ajoutés (menu radio F10, pipeline de build,
-  migration v5→v6).
-- **Parité FR/EN** des grandes références : `LUA_API_REFERENCE`,
-  `TOOLS_REFERENCE` et `dcs-radio-specs`.
-- Page française `veafInterpreter` créée (corrige un lien de navigation cassé)
-  et liens brisés de `GUIDE.fr.md` réparés.
-
----
-
-*VEAF Mission Creation Tools est un projet communautaire open-source.
-Contributions et retours bienvenus sur
-[GitHub](https://github.com/VEAF/VEAF-Mission-Creation-Tools).*
+La liste complète et détaillée des changements est dans le [CHANGELOG](CHANGELOG.md).

--- a/doc/LUA_API_REFERENCE.en.md
+++ b/doc/LUA_API_REFERENCE.en.md
@@ -152,6 +152,34 @@ veaf.DEFAULT_SPEED_KTS = 350
 veaf.MIST_MARKER_ID_INITIAL_VALUE = 50000
 ```
 
+#### Localization (i18n) & pilot feedback
+
+In-game pilot-facing messages are localized (FR/EN). The active language is `veaf.config.language` (set from `mission.language`, else the tools' language, default `fr`); logs always stay in English.
+
+##### `veaf.t(key, ...)`
+
+Returns the localized string for `key` from `veaf.i18nCatalog` (populated by `veafI18n.lua`), with `string.format` interpolation. Fallback: requested language → French → the key itself (a missing entry never crashes).
+
+```lua
+trigger.action.outText(veaf.t("spawn.group_spawned", group.description, country), 5)
+```
+
+##### `veaf.reportToPilot(message, duration, coalition)`
+
+Shows `message` in-game. With a `coalition` it uses `outTextForCoalition`; otherwise (or `nil`) it shows it to everyone (`outText`). Use it for command feedback addressed to the requester.
+
+##### `veaf.nearestMatch(word, candidates, maxDistance)`
+
+Returns the closest string in `candidates` within `maxDistance` Levenshtein edits (or `nil`). Used for the "did you mean …?" spawn-parameter hint.
+
+##### `veaf.getRequesterCoalition(event)`
+
+The coalition that issued a command (marker placer / interpreter unit), normalized to `coalition.side.RED`/`.BLUE`, or `nil` when unknown/all. Use it for pilot feedback — **not** for deciding the side of spawned units.
+
+##### `veaf.getOppositeCoalition(side)`
+
+The opposing coalition — the default side of units spawned from a marker (RED↔BLUE; neutral/all → RED). Pass an explicit `side`/`country` parameter to override.
+
 #### JSON Functions
 
 ##### `veaf.json.stringify(obj, as_key)`

--- a/doc/LUA_API_REFERENCE.md
+++ b/doc/LUA_API_REFERENCE.md
@@ -152,6 +152,34 @@ veaf.DEFAULT_SPEED_KTS = 350
 veaf.MIST_MARKER_ID_INITIAL_VALUE = 50000
 ```
 
+#### Localisation (i18n) & retour pilote
+
+Les messages en jeu destinés au pilote sont localisés (FR/EN). La langue active est `veaf.config.language` (issue de `mission.language`, sinon la langue des outils, défaut `fr`) ; les logs restent toujours en anglais.
+
+##### `veaf.t(key, ...)`
+
+Renvoie la chaîne localisée pour `key` depuis `veaf.i18nCatalog` (peuplé par `veafI18n.lua`), avec interpolation `string.format`. Repli : langue demandée → français → la clé elle-même (une entrée manquante ne plante jamais).
+
+```lua
+trigger.action.outText(veaf.t("spawn.group_spawned", group.description, country), 5)
+```
+
+##### `veaf.reportToPilot(message, duration, coalition)`
+
+Affiche `message` en jeu. Avec une `coalition`, utilise `outTextForCoalition` ; sinon (ou `nil`), l'affiche à tous (`outText`). À utiliser pour le feedback de commande adressé à l'émetteur.
+
+##### `veaf.nearestMatch(word, candidates, maxDistance)`
+
+Renvoie la chaîne de `candidates` la plus proche dans la limite de `maxDistance` éditions de Levenshtein (ou `nil`). Sert à l'indice « vouliez-vous dire… ? » des paramètres de spawn.
+
+##### `veaf.getRequesterCoalition(event)`
+
+La coalition qui a émis une commande (poseur du marqueur / unité interpreter), normalisée en `coalition.side.RED`/`.BLUE`, ou `nil` si inconnue/all. À utiliser pour le feedback pilote — **pas** pour décider le camp des unités spawnées.
+
+##### `veaf.getOppositeCoalition(side)`
+
+La coalition opposée — le camp par défaut des unités spawnées depuis un marqueur (RED↔BLUE ; neutre/all → RED). Passez un paramètre `side`/`country` explicite pour surcharger.
+
 #### Fonctions JSON
 
 ##### `veaf.json.stringify(obj, as_key)`

--- a/doc/LUA_API_REFERENCE.md
+++ b/doc/LUA_API_REFERENCE.md
@@ -174,7 +174,7 @@ Renvoie la chaîne de `candidates` la plus proche dans la limite de `maxDistance
 
 ##### `veaf.getRequesterCoalition(event)`
 
-La coalition qui a émis une commande (poseur du marqueur / unité interpreter), normalisée en `coalition.side.RED`/`.BLUE`, ou `nil` si inconnue/all. À utiliser pour le feedback pilote — **pas** pour décider le camp des unités spawnées.
+La coalition qui a émis une commande (poseur du marqueur / unité `veafInterpreter`), normalisée en `coalition.side.RED`/`.BLUE`, ou `nil` si inconnue/all. À utiliser pour le feedback pilote — **pas** pour décider le camp des unités spawnées.
 
 ##### `veaf.getOppositeCoalition(side)`
 

--- a/doc/MISSION_YAML_REFERENCE.en.md
+++ b/doc/MISSION_YAML_REFERENCE.en.md
@@ -554,6 +554,6 @@ veaf-tools.exe build --profile SERVER
 
 ## See Also
 
-- [Pipeline Reference](PIPELINE_REFERENCE.md) — YAML schemas for presets, waypoints, aircraft-templates, versions
+- [Pipeline Reference](PIPELINE_REFERENCE.md) — YAML schemas for presets, waypoints, spawnables, dynamic-slot-templates, warehouses, spawn-groups, versions
 - [Mission Maker Guide](mission-maker/GUIDE.md) — complete workflow
 - [Lua API Reference](LUA_API_REFERENCE.md) — Lua builder chain API for advanced use

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -533,6 +533,6 @@ veaf-tools.exe build --profile SERVER
 
 ## Voir aussi
 
-- [Référence Pipeline](PIPELINE_REFERENCE.md) — schémas YAML pour presets, waypoints, aircraft-templates, versions
+- [Référence Pipeline](PIPELINE_REFERENCE.md) — schémas YAML pour presets, waypoints, spawnables, dynamic-slot-templates, warehouses, spawn-groups, versions
 - [Guide mission maker](mission-maker/GUIDE.md) — workflow complet
 - [Référence API Lua](LUA_API_REFERENCE.md) — API de chaînes de constructeurs Lua pour usage avancé

--- a/doc/ROADMAP.en.md
+++ b/doc/ROADMAP.en.md
@@ -39,7 +39,7 @@ This document describes the intended direction for the project. Items are ordere
 - ✅ **Mission YAML → module selection** — `lua_modules` section in `mission.yaml` drives which modules are included and how they are initialized
 
 ### Release
-- ✅ **v6.2.0 release** — squash merge `develop-v6` → `master`, published 2026-05-30
+- ✅ **v6.x releases** — published continuously from `develop-v6` (`published-vx.y.z` tags); current version **6.5.0**. The `develop-v6` → `master` merge is reserved for stable milestones.
 - ✅ **v6.3.0 release** — bug fixes and UX improvements (Lot 26 + FIX-SORT): convert-v5 crash fix, auto-pause on double-click, smart defaults filtering, veaf.initialize() nil-check
 - ✅ **v6.3.3 release** — stabilization and bug fixes: Lua initialize() crashes, build pipeline fixes, build profiles, CSAR YAML-first, auto dependency resolution
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -39,7 +39,7 @@ Ce document décrit la direction prévue pour le projet. Les éléments sont cla
 - ✅ **Mission YAML → sélection de modules** — la section `lua_modules` dans `mission.yaml` pilote quels modules sont inclus et comment ils sont initialisés
 
 ### Release
-- 🔵 **Release v6.1.0** — squash merge `develop-v6` → `master`, publication avec changelog complet
+- ✅ **Releases v6.x** — publication continue depuis `develop-v6` (tags `published-vx.y.z`) ; version courante **6.5.0**. Le merge `develop-v6` → `master` est réservé aux jalons stables.
 
 ---
 

--- a/doc/mission-maker/GUIDE.en.md
+++ b/doc/mission-maker/GUIDE.en.md
@@ -164,8 +164,10 @@ MyMission/
 │   │   └── veafDynamicConfig.lua # Dynamic script-loading config (dev/test)
 │   ├── options                  # DCS options table injected into the .miz
 │   ├── presets.yaml             # Radio frequency presets (presets step)
-│   ├── spawnables.yaml          # Predefined spawnable groups (SPAWN)
-│   ├── templates.yaml           # Aircraft-group templates (SPAWN)
+│   ├── spawnables.yaml          # Spawnable aircraft groups (veafSpawn- prefix, spawnable_aircrafts step)
+│   ├── dynamic-slot-templates.yaml # Dynamic-Slot templates (dynSpawnTemplate=true, dynamic_slot_templates step)
+│   ├── warehouses.yaml          # Per-coalition Dynamic Slots (warehouses step, optional)
+│   ├── spawn-groups.yaml        # Extend/override the spawn database (spawn_data step, optional)
 │   ├── versions.yaml            # Weather/time variants (weather step)
 │   └── waypoints.yaml           # Bullseye / navigation points (waypoints step)
 ├── published/                    # VEAF scripts & tools (auto-installed)
@@ -212,11 +214,17 @@ flowchart TD
     TRIG --> PIPE{Optional pipeline steps}
     PIPE -->|presets.yaml| P1[inject-presets]
     PIPE -->|waypoints.yaml| P2[inject-waypoints]
-    PIPE -->|aircraft-templates.yaml| P3[inject-aircraft-groups]
+    PIPE -->|spawnables.yaml| P3[inject spawnable aircraft]
+    PIPE -->|dynamic-slot-templates.yaml| P3b[inject Dynamic-Slot templates]
+    PIPE -->|warehouses.yaml| P5[wire Dynamic Slots]
+    PIPE -->|spawn-groups.yaml| P6[inject spawn data]
     PIPE -->|versions.yaml| P4[inject-weather]
     P1 --> OUT[Final .miz ready to fly]
     P2 --> OUT
     P3 --> OUT
+    P3b --> OUT
+    P5 --> OUT
+    P6 --> OUT
     P4 --> OUT
 ```
 

--- a/doc/mission-maker/GUIDE.md
+++ b/doc/mission-maker/GUIDE.md
@@ -163,8 +163,10 @@ MyMission/
 │   │   └── veafDynamicConfig.lua # Config de chargement dynamique des scripts (dev/test)
 │   ├── options                  # Table d'options DCS injectée dans le .miz
 │   ├── presets.yaml             # Préréglages de fréquences radio (étape presets)
-│   ├── spawnables.yaml          # Groupes spawnable prédéfinis (SPAWN)
-│   ├── templates.yaml           # Modèles de groupes d'aéronefs (SPAWN)
+│   ├── spawnables.yaml          # Groupes d'avions spawnables (préfixe veafSpawn-, étape spawnable_aircrafts)
+│   ├── dynamic-slot-templates.yaml # Modèles de Dynamic Slots (dynSpawnTemplate=true, étape dynamic_slot_templates)
+│   ├── warehouses.yaml          # Dynamic Slots par coalition (étape warehouses, optionnel)
+│   ├── spawn-groups.yaml        # Extension/override de la base de spawn (étape spawn_data, optionnel)
 │   ├── versions.yaml            # Variantes météo/horaires (étape weather)
 │   └── waypoints.yaml           # Bullseye / points de navigation (étape waypoints)
 ├── published/                    # Scripts & outils VEAF (auto-installés)
@@ -211,11 +213,17 @@ flowchart TD
     TRIG --> PIPE{Étapes optionnelles du pipeline}
     PIPE -->|presets.yaml| P1[inject-presets]
     PIPE -->|waypoints.yaml| P2[inject-waypoints]
-    PIPE -->|aircraft-templates.yaml| P3[inject-aircraft-groups]
+    PIPE -->|spawnables.yaml| P3[inject spawnable aircraft]
+    PIPE -->|dynamic-slot-templates.yaml| P3b[inject Dynamic-Slot templates]
+    PIPE -->|warehouses.yaml| P5[wire Dynamic Slots]
+    PIPE -->|spawn-groups.yaml| P6[inject spawn data]
     PIPE -->|versions.yaml| P4[inject-weather]
     P1 --> OUT[.miz final prêt à voler]
     P2 --> OUT
     P3 --> OUT
+    P3b --> OUT
+    P5 --> OUT
+    P6 --> OUT
     P4 --> OUT
 ```
 

--- a/doc/mission-maker/scripts/veafCasMission.en.md
+++ b/doc/mission-maker/scripts/veafCasMission.en.md
@@ -28,6 +28,8 @@ veafCasMission.start()
 
 `start()` activates the watchdog that monitors the CAS group.
 
+> **Enabled by default** in the shipped `mission.yaml`. It is marker-driven (`_cas`) and needs no configuration — just place a `_cas` marker. The block below is only needed to tune it.
+
 ---
 
 ## Configuration (`mission.yaml`)

--- a/doc/mission-maker/scripts/veafCasMission.md
+++ b/doc/mission-maker/scripts/veafCasMission.md
@@ -27,6 +27,8 @@ veafCasMission.start()
 
 `start()` active le watchdog qui surveille le groupe CAS.
 
+> **Activé par défaut** dans le `mission.yaml` livré. Piloté par marqueur (`_cas`), sans configuration requise — posez simplement un marqueur `_cas`. Le bloc ci-dessous ne sert qu'à l'ajuster.
+
 ---
 
 ## Configuration (`mission.yaml`)

--- a/doc/mission-maker/scripts/veafMove.en.md
+++ b/doc/mission-maker/scripts/veafMove.en.md
@@ -32,7 +32,7 @@ veafMove.initialize()
 ### Move a group
 
 ```
-_move unit, name [GROUP_NAME]
+_move group, name [GROUP_NAME]
 ```
 
 Moves the named group to the marker position. Ground units will path to the destination; aircraft will fly directly.

--- a/doc/mission-maker/scripts/veafMove.md
+++ b/doc/mission-maker/scripts/veafMove.md
@@ -31,7 +31,7 @@ veafMove.initialize()
 ### Déplacer un groupe
 
 ```
-_move unit, name [NOM_GROUPE]
+_move group, name [NOM_GROUPE]
 ```
 
 Déplace le groupe nommé vers la position du marqueur. Les unités terrestres traceront un itinéraire vers la destination ; les aéronefs voleront directement.

--- a/doc/mission-maker/scripts/veafShortcuts.en.md
+++ b/doc/mission-maker/scripts/veafShortcuts.en.md
@@ -28,6 +28,8 @@ veafShortcuts.initialize()
 
 This automatically registers the default alias list.
 
+> **Enabled by default.** The built-in aliases (`-shilka`, `-sa2`, …) work out of the box — you only need the `shortcuts:` list below to add your *own* custom aliases.
+
 ---
 
 ## Configuration (`mission.yaml`)

--- a/doc/mission-maker/scripts/veafShortcuts.md
+++ b/doc/mission-maker/scripts/veafShortcuts.md
@@ -28,6 +28,8 @@ veafShortcuts.initialize()
 
 Cela enregistre automatiquement la liste d'aliases par défaut.
 
+> **Activé par défaut.** Les alias intégrés (`-shilka`, `-sa2`, …) fonctionnent d'emblée — la liste `shortcuts:` ci-dessous ne sert qu'à ajouter vos *propres* alias custom.
+
 ---
 
 ## Configuration (`mission.yaml`)

--- a/doc/mission-maker/scripts/veafSpawn.en.md
+++ b/doc/mission-maker/scripts/veafSpawn.en.md
@@ -73,7 +73,9 @@ _spawn unit, name T-80, group 4, hdg 270, spacing 50
 _spawn group, name [GROUP_NAME]
 ```
 
-Group must be defined in `spawnables.yaml`.
+The group alias must exist in the **spawn database**: the built-in one (e.g. `sa2`, `sa3`, …) or your optional `src/spawn-groups.yaml`, which extends/overrides it. The database lives in YAML and is injected into the `.miz` at build time (no Lua to edit). See [Pipeline Reference — spawn data](../../PIPELINE_REFERENCE.md).
+
+> **Typos abort the command.** If a parameter is not recognized (e.g. `headng` instead of `heading`), the spawn is **not** performed and the pilot gets a hint (*did you mean 'heading'?*). Fix the marker text and try again.
 
 ### Spawn a CAP patrol
 

--- a/doc/mission-maker/scripts/veafSpawn.md
+++ b/doc/mission-maker/scripts/veafSpawn.md
@@ -72,7 +72,9 @@ _spawn unit, name T-80, group 4, hdg 270, spacing 50
 _spawn group, name [NOM_GROUPE]
 ```
 
-Le groupe doit être défini dans `spawnables.yaml`.
+L'alias de groupe doit exister dans la **base de spawn** : celle intégrée (ex. `sa2`, `sa3`, …) ou votre `src/spawn-groups.yaml` optionnel qui l'étend/la surcharge. La base vit en YAML et est injectée dans le `.miz` au build (pas de Lua à éditer). Voir [Référence Pipeline — données de spawn](../../PIPELINE_REFERENCE.md).
+
+> **Une faute de frappe annule la commande.** Si un paramètre n'est pas reconnu (ex. `headng` au lieu de `heading`), le spawn n'est **pas** effectué et le pilote reçoit un indice (*vouliez-vous dire « heading » ?*). Corrigez le texte du marqueur et réessayez.
 
 ### Faire apparaître une patrouille CAP
 

--- a/doc/mission-maker/scripts/veafTransportMission.en.md
+++ b/doc/mission-maker/scripts/veafTransportMission.en.md
@@ -25,6 +25,8 @@ Creates helicopter/transport pickup-and-delivery missions. Defines cargo or troo
 veafTransportMission.initialize()
 ```
 
+> **Enabled by default** in the shipped `mission.yaml`. It is marker-driven (`_transport`) and needs no configuration — just place a `_transport` marker.
+
 ---
 
 ## Key Concepts

--- a/doc/mission-maker/scripts/veafTransportMission.md
+++ b/doc/mission-maker/scripts/veafTransportMission.md
@@ -24,6 +24,8 @@ Crée des missions de transport en hélicoptère ou aéronef avec des zones de c
 veafTransportMission.initialize()
 ```
 
+> **Activé par défaut** dans le `mission.yaml` livré. Piloté par marqueur (`_transport`), sans configuration requise — posez simplement un marqueur `_transport`.
+
 ---
 
 ## Concepts clés

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.4.43"
+version = "6.5.0"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"


### PR DESCRIPTION
Finalizes the **6.5.0** release.

## Release admin
- **RELEASE_NOTES.md** — 6.5.0 notes (concise, user-facing): YAML data + datamine, Dynamic Slots, in-game i18n (FR/EN), documentation assistant, smarter defaults; notable fixes; the breaking aircraft-template split; security (pure-Python parser). Thanks to **Flogas** and **Tripack**.
- **CHANGELOG.md** — `[Unreleased]` stamped as `[6.5.0] — 2026-06-13`; fresh empty `[Unreleased]`.
- **pyproject.toml** — `6.4.43` → `6.5.0`.
- **doc/ROADMAP.md / .en.md** — reflect the rolling v6 release cadence (current 6.5.0).

## Documentation review (for the release)
Audited the whole `doc/` tree against the changelog and fixed the discrepancies:
- `mission-maker/GUIDE` (FR/EN): project tree + mermaid still named `templates.yaml` / `aircraft-templates.yaml` → split into `spawnables.yaml` + `dynamic-slot-templates.yaml` (+ warehouses / spawn-groups).
- `MISSION_YAML_REFERENCE` (FR/EN): pipeline cross-reference `aircraft-templates` → real files.
- `LUA_API_REFERENCE` (FR/EN): new i18n & helper section (`veaf.t`, `veaf.reportToPilot`, `veaf.nearestMatch`, `veaf.getRequesterCoalition`, `veaf.getOppositeCoalition`).
- `veafSpawn` (FR/EN): `_spawn group` resolves against the spawn database + optional `src/spawn-groups.yaml` (was wrongly "spawnables.yaml"); unknown parameter aborts the command with a hint.
- `veafShortcuts` (FR/EN): built-in aliases enabled by default.
- `veafCasMission` / `veafTransportMission` (FR/EN): enabled by default, marker-driven, no config.
- `veafMove` (FR/EN): fix marker syntax `_move unit, name` → `_move group, name`.

No code change. After merge, the release is published by pushing the `published-v6.5.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Finalize the 6.5.0 release with updated release notes, version metadata, and a documentation sweep to reflect new spawn/Dynamic Slot workflows, in-game localization helpers, and smarter defaults.

New Features:
- Document the new YAML-based spawn database, Dynamic Slot templates and warehouses configuration, and the optional spawn-groups extension.
- Document in-game FR/EN localization helpers and pilot feedback utilities in the Lua API reference.
- Clarify that veafShortcuts, veafCasMission, and veafTransportMission are enabled by default and marker-driven, requiring no configuration to use.

Bug Fixes:
- Correct the veafMove marker syntax in the docs from `_move unit` to `_move group` to match actual behavior.
- Clarify that typos in veafSpawn parameters now abort the command and provide a suggestion, avoiding unintended spawns.

Enhancements:
- Rewrite the release notes to highlight YAML-based spawn data, Dynamic Slots support, in-game localization, the documentation assistant, datamined DCS data, smarter defaults, and security improvements.
- Update mission-maker guides, pipeline references, and diagrams to reflect the split between spawnables and Dynamic Slot templates, the addition of warehouses and spawn-groups YAML files, and the new pipeline steps.
- Expand mission YAML reference cross-links to cover the new YAML artifacts (spawnables, dynamic-slot-templates, warehouses, spawn-groups, versions).
- Describe the security-hardening of the .miz parser as pure-Python and faster, and call out notable runtime/build fixes in the release notes.
- Refresh roadmap documentation to describe the continuous 6.x release model and current 6.5.0 version status.

Build:
- Bump the project version in pyproject.toml from 6.4.43 to 6.5.0 for the new release.

Documentation:
- Add clear usage documentation for the new in-game localization helpers and spawn UX behavior, and align all mission-maker documentation (FR/EN) with the current pipeline and defaults for the 6.5.0 release.