### PR TITLE
docs(INVESTIGATE-REDFOR-ZONES): document TUM territory-zones start-up error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Documentation
-- **Documented the `TUM` "no territory zones / no airfields" start-up error** (INVESTIGATE-REDFOR-ZONES spike). Traced the runtime error `Coalition red has no territory zones and/or controls no airfields. Please add zone with a name starting with REDFOR…` to the bundled third-party **The Universal Mission (TUM)** community script (`TUM.territories.onStartUp()`), reached when a mission selects `TUM: true` (the build auto-calls `TUM.initialize()` since TUM-INIT). It is an expected TUM mission-design prerequisite — not a VEAF bug: TUM makes every airbase neutral and re-assigns zones/airfields from `BLUFOR…`/`REDFOR…` trigger zones, requiring each side to own at least one zone containing an airbase. `MISSION_YAML_REFERENCE` (FR/EN) now documents this prerequisite next to the `TUM` module id. No code change
+- **Documented the `TUM` "no territory zones / no airfields" start-up error** (INVESTIGATE-REDFOR-ZONES spike). The runtime error `Coalition red has no territory zones and/or controls no airfields…` comes from the third-party **The Universal Mission (TUM)** community script, not from VEAF: it is an expected TUM mission-design prerequisite (`BLUFOR…`/`REDFOR…` trigger zones, each owning an airbase). `MISSION_YAML_REFERENCE` (FR/EN) now documents this next to the `TUM` module id. Full analysis journaled in `backlog.md`. No code change
 
 ## [6.5.0] — 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Documentation
+- **Documented the `TUM` "no territory zones / no airfields" start-up error** (INVESTIGATE-REDFOR-ZONES spike). Traced the runtime error `Coalition red has no territory zones and/or controls no airfields. Please add zone with a name starting with REDFOR…` to the bundled third-party **The Universal Mission (TUM)** community script (`TUM.territories.onStartUp()`), reached when a mission selects `TUM: true` (the build auto-calls `TUM.initialize()` since TUM-INIT). It is an expected TUM mission-design prerequisite — not a VEAF bug: TUM makes every airbase neutral and re-assigns zones/airfields from `BLUFOR…`/`REDFOR…` trigger zones, requiring each side to own at least one zone containing an airbase. `MISSION_YAML_REFERENCE` (FR/EN) now documents this prerequisite next to the `TUM` module id. No code change
+
 ## [6.5.0] — 2026-06-13
 
 ### Changed

--- a/backlog.md
+++ b/backlog.md
@@ -15,7 +15,7 @@
 |-----|--------|
 | Lot CUSTOM-SCRIPTS-TRIGGERS — custom_scripts not loaded in static (trig/trigrules divergence); unify trigger emission + fix (Flogas feedback) | 🔄 |
 | Lot TUM-AUTOINIT — call TheUniversalMission init automatically when TUM is selected | ⬜ |
-| Lot INVESTIGATE-REDFOR-ZONES — understand the "Coalition red has no territory zones / controls no airfields" runtime error | ⬜ |
+| Lot INVESTIGATE-REDFOR-ZONES — understand the "Coalition red has no territory zones / controls no airfields" runtime error | ✅ |
 | Lot FIX-CONVERT-V5-INVALID-YAML — convert-v5 produces a mission.yaml that fails YAML parsing (indentation error) | ⬜ |
 | Lot DOC-REVIEW — full documentation proofreading pass (FR/EN), accuracy vs current behaviour after the 6.5.0 changes | ⬜ |
 | Phase 0b — GitHub cleanup | ✅ |
@@ -80,9 +80,19 @@
 
 **Goal**: understand the runtime error `ERROR: Coalition red has no territory zones and/or controls no airfields. Please add zone with a name starting with REDFOR in the mission editor and make sure at least one contains an airbase.` Identify which module/script raises it (REDFOR/BLUEFOR zone convention — likely a community or campaign-style script), when it fires, whether it is expected/benign or a VEAF-side issue, and what (if anything) the build or docs should do about it.
 
+**Branch**: `feature/INVESTIGATE-REDFOR-ZONES` → PR → `develop-v6`
+
+**Findings (spike DONE)**:
+
+- **Source**: the message is emitted by **TheUniversalMission (TUM)**, the bundled third-party community script `src/scripts/community/TheUniversalMission.lua` (akaAgar's *the-universal-mission-for-dcs-world*) — **not** by any VEAF script. Exact site: `TUM.territories.onStartUp()` (`TheUniversalMission.lua:29272-29279`), reached via `TUM.initialize()` → local `startUpMission()` (`:30300`).
+- **When it fires**: only when **TUM is initialized**. Since lot **TUM-INIT**, the VEAF build emits `if TUM then TUM.initialize() end` in the generated `veaf-config.lua` whenever the mission selects `TUM: true` in `mission.yaml` `modules:`. So selecting the `TUM` community module on a mission that was not authored as a TUM mission triggers this code path at mission start.
+- **Why**: TUM is a self-contained PvE mission generator that takes over the whole map. At startup `TUM.territories.onStartUp()` (1) **strips every airbase to NEUTRAL** (`autoCapture(false)` + `setCoalition(NEUTRAL)`), then (2) scans all trigger zones: a zone whose name starts (case-insensitively) with `BLUFOR`/`REDFOR` is assigned to BLUE/RED and **captures every airbase geographically inside it** for that side (`addZoneToCoalition`, `:29138`). It then requires **each** side to own **≥1 territory zone AND ≥1 airbase**; otherwise it logs this ERROR and aborts (`return false` → `trigger.action.outText("A critical error has happened, cannot start the mission.")`). The `for side=1,2` loop maps `side 1 → RED → "REDFOR"`, `side 2 → BLUE → "BLUFOR"`.
+- **Verdict — expected, not a VEAF bug**: this is a **mission-design prerequisite of the TUM framework**, working as TUM intends. It is benign in the sense that nothing in the VEAF tooling is broken; the mission maker enabled a self-contained mission framework without giving it the map it needs. (TUM has further prerequisites that abort `startUpMission()` the same way: Player/Client slots present, exactly one `Player` slot in single-player, ≥1 generic mission zone, and `autoexec.cfg` enabling `net.dostring_in`.)
+- **Resolution (no code change)**: build behaviour is correct — we must not silently swallow a community script's startup contract. Documented the prerequisite in `MISSION_YAML_REFERENCE` (FR/EN) next to the `TUM` module id: enable `TUM` only for a TUM-style mission, and set up the ME with a `BLUFOR…` zone and a `REDFOR…` zone, each containing at least one airbase (plus ≥1 other mission zone). No build-time guard added: VEAF cannot know whether the maker intends a TUM mission, and TUM's own error message already tells the pilot exactly what to add.
+
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
-| INVESTIGATE-REDFOR-ZONES-001 | Trace the source of the REDFOR-zones error; document the cause and the fix or the required mission-editor setup | TBD | spike | ⬜ |
+| INVESTIGATE-REDFOR-ZONES-001 | Trace the source of the REDFOR-zones error; document the cause and the required mission-editor setup. **Done**: traced to TUM's `TUM.territories.onStartUp()` (community script); it is an expected TUM mission-design prerequisite (BLUFOR/REDFOR territory zones each owning an airbase), not a VEAF bug. Documented the prerequisite under the `TUM` module id in `MISSION_YAML_REFERENCE` (FR/EN). No code/guard change. | `doc/MISSION_YAML_REFERENCE.md`, `doc/MISSION_YAML_REFERENCE.en.md` | spike | ✅ |
 
 ---
 

--- a/doc/MISSION_YAML_REFERENCE.en.md
+++ b/doc/MISSION_YAML_REFERENCE.en.md
@@ -305,6 +305,12 @@ modules:
 
 > An unknown identifier triggers a build warning and is ignored.
 
+> **`TUM` (The Universal Mission) — mission prerequisite.** TUM is a self-contained PvE mission generator (third-party community script) that takes over the whole map at start-up: it makes every airbase neutral, then assigns zones and airfields to the coalitions based on the **trigger zones** defined in the mission editor. If you enable `TUM: true` on a mission that was not authored for TUM, the script aborts at start-up with an error such as:
+>
+> `Coalition red has no territory zones and/or controls no airfields. Please add zone with a name starting with REDFOR…`
+>
+> This is **not a VEAF bug**: it is a TUM design prerequisite. To use it, create in the mission editor a trigger zone whose name starts with `BLUFOR` and another starting with `REDFOR`, each containing **at least one airbase**, plus at least one other mission zone. Only enable `TUM` for a TUM-style mission.
+
 **VEAF module IDs:**
 
 | ID | Module | Doc page |

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -305,6 +305,12 @@ modules:
 
 > Un identifiant inconnu déclenche un avertissement au build et est ignoré.
 
+> **`TUM` (The Universal Mission) — prérequis de mission.** TUM est un générateur de mission PvE autonome (script communautaire tiers) qui prend le contrôle de toute la carte à l'initialisation : il rend tous les aérodromes neutres, puis attribue les zones et aérodromes aux camps d'après les **zones de déclencheur** (*trigger zones*) de l'éditeur de mission. Si vous activez `TUM: true` sur une mission qui n'a pas été conçue pour TUM, le script s'interrompt au démarrage avec une erreur du type :
+>
+> `Coalition red has no territory zones and/or controls no airfields. Please add zone with a name starting with REDFOR…`
+>
+> Ce n'est **pas un bug VEAF** : c'est un prérequis de design de TUM. Pour l'utiliser, créez dans l'éditeur de mission une zone dont le nom commence par `BLUFOR` et une autre commençant par `REDFOR`, chacune contenant **au moins un aérodrome**, plus au moins une autre zone de mission. N'activez `TUM` que pour une mission de type TUM.
+
 **IDs de modules VEAF :**
 
 | ID | Module | Page doc |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.5.0"
+version = "6.5.1"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"


### PR DESCRIPTION
## Lot INVESTIGATE-REDFOR-ZONES (spike)

Investigation of the runtime error seen in-game:

> `Coalition red has no territory zones and/or controls no airfields. Please add zone with a name starting with REDFOR…`

### Findings
- **Source**: emitted by the bundled third-party **The Universal Mission (TUM)** community script (`src/scripts/community/TheUniversalMission.lua`, `TUM.territories.onStartUp()` ~L29277) — **not** a VEAF script.
- **When**: only when TUM is initialized. Since TUM-INIT, the build emits `TUM.initialize()` in `veaf-config.lua` whenever the mission selects `TUM: true`, so enabling the `TUM` module triggers this path at start-up.
- **Why**: TUM is a self-contained PvE mission generator. At start-up it makes every airbase neutral, then assigns zones/airfields from `BLUFOR…`/`REDFOR…` trigger zones, requiring each side to own ≥1 zone containing an airbase, else it aborts.
- **Verdict**: expected TUM mission-design prerequisite, **not a VEAF bug**.

### Changes (docs only, no code)
- `doc/MISSION_YAML_REFERENCE.md` / `.en.md`: prerequisite note next to the `TUM` module id (FR/EN).
- `backlog.md`: lot closed (✅) with the full spike conclusion journaled.
- `CHANGELOG.md`: `[Unreleased]` entry.
- `pyproject.toml`: 6.5.0 → 6.5.1.

No build-time guard added: VEAF cannot know whether the maker intends a TUM mission, and TUM's own error already tells the pilot what to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the TUM module’s mission prerequisites and close out the investigation spike for the REDFOR territory-zones start-up error.

Build:
- Bump veaf-tools version from 6.5.0 to 6.5.1 to publish the documentation update.

Documentation:
- Explain in EN/FR mission YAML reference that enabling the TUM module requires BLUFOR/REDFOR trigger zones each containing at least one airbase and that related start-up errors come from TUM, not VEAF.
- Add unreleased changelog entry describing the documented TUM start-up error and its cause.

Chores:
- Mark the INVESTIGATE-REDFOR-ZONES backlog lot and ticket as completed, recording the investigation findings and resolution.