### PR TITLE
fix(community): TUM opt-in + auto-init (TUM-AUTOINIT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **`TUM` (The Universal Mission) is now opt-in and auto-initialized** (TUM-AUTOINIT). TUM imposes a mission-design contract (BLUFOR/REDFOR territory zones, each owning an airbase) and aborts at start-up otherwise, so it must never start on its own. It is now the only community script that is **off by default**: a vanilla mission, a freshly v5-converted mission, or a `modules:` block that omits `TUM` all leave it disabled — only an explicit `TUM: true` enables it (the other community scripts stay opt-out, active unless set to `false`). Previously TUM followed the opt-out default, so it was enabled — and `TUM.initialize()` emitted — for missions that never set it up, producing the `Coalition red has no territory zones…` runtime error. When `TUM: true`, the build now calls `TUM.initialize()` automatically at start-up, so no manual `mission-script.lua` wiring is needed. `convert-v5` emits `TUM: false` even when the TUM file is detected
+
 ### Documentation
 - **Documented the `TUM` "no territory zones / no airfields" start-up error** (INVESTIGATE-REDFOR-ZONES spike). The runtime error `Coalition red has no territory zones and/or controls no airfields…` comes from the third-party **The Universal Mission (TUM)** community script, not from VEAF: it is an expected TUM mission-design prerequisite (`BLUFOR…`/`REDFOR…` trigger zones, each owning an airbase). `MISSION_YAML_REFERENCE` (FR/EN) now documents this next to the `TUM` module id. Full analysis journaled in `backlog.md`. No code change
 

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 | Lot | Status |
 |-----|--------|
 | Lot CUSTOM-SCRIPTS-TRIGGERS — custom_scripts not loaded in static (trig/trigrules divergence); unify trigger emission + fix (Flogas feedback) | 🔄 |
-| Lot TUM-AUTOINIT — call TheUniversalMission init automatically when TUM is selected | ⬜ |
+| Lot TUM-AUTOINIT — call TheUniversalMission init automatically when TUM is selected | ✅ |
 | Lot INVESTIGATE-REDFOR-ZONES — understand the "Coalition red has no territory zones / controls no airfields" runtime error | ✅ |
 | Lot FIX-CONVERT-V5-INVALID-YAML — convert-v5 produces a mission.yaml that fails YAML parsing (indentation error) | ⬜ |
 | Lot DOC-REVIEW — full documentation proofreading pass (FR/EN), accuracy vs current behaviour after the 6.5.0 changes | ⬜ |
@@ -68,11 +68,13 @@
 
 ## Lot TUM-AUTOINIT — auto-init TheUniversalMission when selected
 
-**Goal**: when `TUM` is selected in `mission.yaml` `modules:`, `TUM.initialize()` (TheUniversalMission) must be called automatically. A prior lot (TUM-INIT, ✅) already emits `if TUM then TUM.initialize() end` in the generated `veaf-config.lua` — so this is to **verify/repair** the end-to-end path (is the TUM community script actually loaded before that block when selected? is the init call reached?) and fix whatever prevents auto-init in practice.
+**Goal**: when `TUM` is selected in `mission.yaml` `modules:`, `TUM.initialize()` (TheUniversalMission) must be called automatically — **but TUM must never be enabled by default** (vanilla mission or `convert-v5`), because it aborts at start-up without BLUFOR/REDFOR territory zones.
+
+**Done**: made TUM **opt-in** across the build. New `get_optin_community_script_ids()` (`mission_constants.py`) returns `{"tum"}`; the builder enablement (`enabled_community_script_ids`, `_active_community_scripts`, `_community_enabled`), the generator `_community_enabled` (None-branch), and `convert-v5` output now treat opt-in ids as OFF unless an explicit `<ID>: true` is set — while opt-out scripts (ctld, csar, …) keep their active-by-default behaviour. When `TUM: true`, the generator still emits `if TUM then TUM.initialize() end`. `convert-v5` emits `TUM: false` even when the TUM file is detected. Tests added (builder opt-in parsing, generator default-off, convert-v5 emit). Doc: `MISSION_YAML_REFERENCE` (FR/EN) opt-in note, default `mission.yaml` comment, CHANGELOG.
 
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
-| TUM-AUTOINIT-001 | Verify TUM is loaded + initialized when `TUM: true`; fix the missing/ordering link so `TUM.initialize()` runs without manual code | `veaf_libs/lua_config_generator.py`, mission_builder, `test/python/` | fix | ⬜ |
+| TUM-AUTOINIT-001 | Make TUM opt-in (off by default everywhere) and auto-init `TUM.initialize()` only when `TUM: true` | `mission_tools/mission_constants.py`, `mission_builder/mission_builder_worker.py`, `mission_builder/v5_converter.py`, `veaf_libs/lua_config_generator.py`, `test/python/` | fix | ✅ |
 
 ---
 

--- a/doc/MISSION_YAML_REFERENCE.en.md
+++ b/doc/MISSION_YAML_REFERENCE.en.md
@@ -310,6 +310,8 @@ modules:
 > `Coalition red has no territory zones and/or controls no airfields. Please add zone with a name starting with REDFOR…`
 >
 > This is **not a VEAF bug**: it is a TUM design prerequisite. To use it, create in the mission editor a trigger zone whose name starts with `BLUFOR` and another starting with `REDFOR`, each containing **at least one airbase**, plus at least one other mission zone. Only enable `TUM` for a TUM-style mission.
+>
+> **Opt-in (unlike the other community scripts).** TUM is the only community script that is **off by default**: a vanilla mission, a freshly v5-converted mission, or a `modules:` block that does not mention `TUM` all leave it **disabled**. Only an explicit `TUM: true` turns it on. The other community scripts are *opt-out* (active unless you set them to `false`). When `TUM: true`, the build automatically calls `TUM.initialize()` at start-up — you do not need to add anything to `mission-script.lua`.
 
 **VEAF module IDs:**
 

--- a/doc/MISSION_YAML_REFERENCE.md
+++ b/doc/MISSION_YAML_REFERENCE.md
@@ -310,6 +310,8 @@ modules:
 > `Coalition red has no territory zones and/or controls no airfields. Please add zone with a name starting with REDFOR…`
 >
 > Ce n'est **pas un bug VEAF** : c'est un prérequis de design de TUM. Pour l'utiliser, créez dans l'éditeur de mission une zone dont le nom commence par `BLUFOR` et une autre commençant par `REDFOR`, chacune contenant **au moins un aérodrome**, plus au moins une autre zone de mission. N'activez `TUM` que pour une mission de type TUM.
+>
+> **Opt-in (contrairement aux autres scripts communautaires).** TUM est le seul script communautaire **désactivé par défaut** : une mission vanilla, une mission fraîchement convertie depuis la v5, ou un bloc `modules:` qui ne mentionne pas `TUM` le laissent **éteint**. Seul un `TUM: true` explicite l'active. Les autres scripts communautaires sont *opt-out* (actifs sauf si vous les passez à `false`). Quand `TUM: true`, le build appelle automatiquement `TUM.initialize()` au démarrage — vous n'avez rien à ajouter dans `mission-script.lua`.
 
 **IDs de modules VEAF :**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.5.1"
+version = "6.5.2"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/defaults/mission-folder/mission.yaml
+++ b/src/defaults/mission-folder/mission.yaml
@@ -165,7 +165,7 @@ modules:
   CSAR: false               # extended: CSAR -> { enabled: true, settings: { enableAllslots: true } }
   HERCULES: false
   SKYNET: false             # extended: SKYNET -> { enabled: true, include_red_in_radio: false, ... }
-  TUM: false
+  TUM: false                # opt-in: off unless set to true; when enabled it auto-runs TUM.initialize() and REQUIRES BLUFOR/REDFOR territory zones
 
 # Note: SKYNET, CTLD, CSAR and QRA are configured entirely inside the `modules:`
 # block above (single source of truth). There is no separate `external_modules:`

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -21,6 +21,7 @@ from mission_tools import (
     get_community_sound_files,
     get_mission_data_files,
     get_mission_script_files,
+    get_optin_community_script_ids,
     read_miz,
     write_miz,
 )
@@ -374,14 +375,17 @@ class MissionBuilderWorker(BaseWorker):
         if comm_raw is not None and not isinstance(comm_raw, dict):
             logger.warning(t("builder.community_scripts_not_mapping", type=type(comm_raw).__name__))
             comm_raw = None
-        # Empty dict {} is treated the same as absent: all scripts remain active.
+        # Empty dict {} is treated the same as absent: opt-out scripts stay active,
+        # opt-in scripts (e.g. TUM) stay disabled (see _active_community_scripts).
+        optin_ids = get_optin_community_script_ids()
         if not comm_raw:
             self.enabled_community_script_ids: set[str] | None = None
         else:
-            # Opt-out semantics: start with all ids enabled, remove those explicitly disabled.
+            # Opt-out scripts start enabled; opt-in scripts (e.g. TUM) start disabled
+            # and are only turned on by an explicit `<ID>: true`.
             all_community_scripts = get_community_script_files()
             all_ids = {s["id"] for s in all_community_scripts}
-            self.enabled_community_script_ids = set(all_ids)
+            self.enabled_community_script_ids = set(all_ids) - optin_ids
             for script_id, script_cfg in comm_raw.items():
                 if script_id not in all_ids:
                     logger.warning(t("builder.unknown_community_script", id=script_id))
@@ -403,7 +407,9 @@ class MissionBuilderWorker(BaseWorker):
                     if explicitly_disabled:
                         logger.warning(t("builder.mandatory_community_kept", id=script_id))
                     enabled = True
-                if not enabled:
+                if enabled:
+                    self.enabled_community_script_ids.add(script_id)
+                else:
                     self.enabled_community_script_ids.discard(script_id)
 
         # Parse dcs_bridge section from mission.yaml
@@ -447,7 +453,9 @@ class MissionBuilderWorker(BaseWorker):
         """Return community script descriptors filtered by enabled_community_script_ids."""
         all_scripts = get_community_script_files()
         if self.enabled_community_script_ids is None:
-            return all_scripts
+            # No community_scripts section: opt-out scripts active, opt-in (e.g. TUM) off.
+            optin_ids = get_optin_community_script_ids()
+            return [s for s in all_scripts if s["id"] not in optin_ids]
         return [s for s in all_scripts if s["id"] in self.enabled_community_script_ids]
 
     def _community_enabled(self, script_id: str) -> bool:
@@ -457,11 +465,12 @@ class MissionBuilderWorker(BaseWorker):
             script_id: The community script id (e.g. ``"ctld"``).
 
         Returns:
-            True when the id is enabled. ``enabled_community_script_ids is None``
-            means "all enabled" (opt-out semantics, no ``community_scripts:`` section).
+            True when the id is enabled. With no ``community_scripts:`` section
+            (``enabled_community_script_ids is None``), opt-out scripts are enabled
+            and opt-in scripts (e.g. TUM) are not.
         """
         if self.enabled_community_script_ids is None:
-            return True
+            return script_id not in get_optin_community_script_ids()
         return script_id in self.enabled_community_script_ids
 
     def _find_community_sound_resource_keys(self) -> list[str]:

--- a/src/python/veaf-tools/mission_builder/mission_builder_worker.py
+++ b/src/python/veaf-tools/mission_builder/mission_builder_worker.py
@@ -22,6 +22,7 @@ from mission_tools import (
     get_mission_data_files,
     get_mission_script_files,
     get_optin_community_script_ids,
+    is_community_script_enabled_by_default,
     read_miz,
     write_miz,
 )
@@ -470,7 +471,7 @@ class MissionBuilderWorker(BaseWorker):
             and opt-in scripts (e.g. TUM) are not.
         """
         if self.enabled_community_script_ids is None:
-            return script_id not in get_optin_community_script_ids()
+            return is_community_script_enabled_by_default(script_id)
         return script_id in self.enabled_community_script_ids
 
     def _find_community_sound_resource_keys(self) -> list[str]:

--- a/src/python/veaf-tools/mission_builder/v5_converter.py
+++ b/src/python/veaf-tools/mission_builder/v5_converter.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml  # type: ignore[import-untyped]
-from mission_tools.mission_constants import get_community_script_files
+from mission_tools.mission_constants import get_community_script_files, get_optin_community_script_ids
 from veaf_libs.i18n import t
 from veaf_libs.lua_config_generator import (
     MANDATORY_MODULES,
@@ -1220,6 +1220,9 @@ class V5Converter:
         # Community scripts appended at end of modules: block (IDs in uppercase)
         all_community = get_community_script_files()
         detected_comm = report.detected_community_script_ids
+        # Opt-in scripts (e.g. TUM) must never be enabled automatically — they need a
+        # specific mission-design setup — even when their .lua is present in the bundle.
+        optin_comm = get_optin_community_script_ids()
         if all_community:
             lines.append(t("converter.yaml.community.header"))
             lines.append(t("converter.yaml.community.desc"))
@@ -1242,6 +1245,9 @@ class V5Converter:
                     lines.append("    settings:")
                     for key, value in _ctld_csar_settings(mr, upper).items():
                         lines.append(f"      {key}: {_yaml_scalar(value)}")
+                elif sid in optin_comm:
+                    # Opt-in: keep disabled by default; the maker enables it explicitly.
+                    lines.append(f"  {upper}: false")
                 else:
                     lines.append(f"  {upper}: {'true' if detected else 'false'}")
         lines.append("")

--- a/src/python/veaf-tools/mission_tools/__init__.py
+++ b/src/python/veaf-tools/mission_tools/__init__.py
@@ -19,6 +19,7 @@ from .mission_constants import (
     get_mission_data_files,
     get_mission_files_to_cleanup_on_extract,
     get_mission_script_files,
+    get_optin_community_script_ids,
     get_veaf_script_files,
 )
 from .miz_tools import DcsMission, Group, create_miz, extract_miz, read_miz, write_miz
@@ -36,6 +37,7 @@ __all__ = [
     "Group",
     "DEFAULT_SCRIPTS_LOCATION",
     "get_community_script_files",
+    "get_optin_community_script_ids",
     "get_community_sound_files",
     "get_mission_data_files",
     "get_mission_script_files",

--- a/src/python/veaf-tools/mission_tools/__init__.py
+++ b/src/python/veaf-tools/mission_tools/__init__.py
@@ -21,6 +21,7 @@ from .mission_constants import (
     get_mission_script_files,
     get_optin_community_script_ids,
     get_veaf_script_files,
+    is_community_script_enabled_by_default,
 )
 from .miz_tools import DcsMission, Group, create_miz, extract_miz, read_miz, write_miz
 
@@ -38,6 +39,7 @@ __all__ = [
     "DEFAULT_SCRIPTS_LOCATION",
     "get_community_script_files",
     "get_optin_community_script_ids",
+    "is_community_script_enabled_by_default",
     "get_community_sound_files",
     "get_mission_data_files",
     "get_mission_script_files",

--- a/src/python/veaf-tools/mission_tools/mission_constants.py
+++ b/src/python/veaf-tools/mission_tools/mission_constants.py
@@ -39,6 +39,19 @@ def get_community_script_files() -> list[dict[str, str]]:
     ]
 
 
+def get_optin_community_script_ids() -> set[str]:
+    """Community script ids that are OFF unless explicitly enabled (opt-in).
+
+    Most community scripts are opt-out (active by default unless turned off). A few
+    impose a mission-design contract and must never start on their own — e.g. TUM
+    (TheUniversalMission) requires BLUFOR/REDFOR territory zones each owning an
+    airbase, and raises a start-up error otherwise. Those are opt-in: a vanilla
+    mission, a freshly converted v5 mission, or a ``modules:`` block that does not
+    mention them leaves them disabled; only ``<ID>: true`` turns them on.
+    """
+    return {"tum"}
+
+
 def get_community_sound_files() -> dict[str, tuple[str, ...]]:
     """Sound assets required by community scripts, keyed by community script id.
 

--- a/src/python/veaf-tools/mission_tools/mission_constants.py
+++ b/src/python/veaf-tools/mission_tools/mission_constants.py
@@ -52,6 +52,24 @@ def get_optin_community_script_ids() -> set[str]:
     return {"tum"}
 
 
+def is_community_script_enabled_by_default(script_id: str) -> bool:
+    """Return whether a community script is active when not explicitly listed.
+
+    This is the single source of truth for the "no ``community_scripts:`` section,
+    or id not listed" case, shared by the builder enablement and the config
+    generator so the two paths cannot drift apart: opt-out scripts default to
+    enabled, opt-in scripts (see :func:`get_optin_community_script_ids`) default
+    to disabled.
+
+    Args:
+        script_id: The community script id (e.g. ``"ctld"``, ``"tum"``).
+
+    Returns:
+        True when the script is on by default, False for opt-in scripts.
+    """
+    return script_id not in get_optin_community_script_ids()
+
+
 def get_community_sound_files() -> dict[str, tuple[str, ...]]:
     """Sound assets required by community scripts, keyed by community script id.
 

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -758,11 +758,11 @@ def _community_enabled(mission_yaml: dict, script_id: str) -> bool:
     otherwise the value's truthiness. Mirrors ``MissionBuilderWorker`` community
     parsing so the generated init matches what is actually injected.
     """
-    from mission_tools.mission_constants import get_optin_community_script_ids
+    from mission_tools.mission_constants import is_community_script_enabled_by_default
 
     comm = mission_yaml.get("community_scripts")
     if not isinstance(comm, dict) or not comm or script_id not in comm:
-        return script_id not in get_optin_community_script_ids()
+        return is_community_script_enabled_by_default(script_id)
     cfg = comm[script_id]
     if isinstance(cfg, dict):
         return bool(cfg.get("enabled", True))

--- a/src/python/veaf-tools/veaf_libs/lua_config_generator.py
+++ b/src/python/veaf-tools/veaf_libs/lua_config_generator.py
@@ -750,16 +750,19 @@ def _resolve_deps(effective: dict) -> dict:
 
 
 def _community_enabled(mission_yaml: dict, script_id: str) -> bool:
-    """Return whether a community script is enabled, matching the build's opt-out rule.
+    """Return whether a community script is enabled, matching the build's enable rule.
 
-    No ``community_scripts`` section (or the id absent) means enabled; a dict uses
-    its ``enabled`` flag (default true); ``None`` means disabled; otherwise the
-    value's truthiness. Mirrors ``MissionBuilderWorker`` community parsing so the
-    generated init matches what is actually injected.
+    When the ``community_scripts`` section is absent or the id is not listed: an
+    opt-out script is enabled, an opt-in script (e.g. TUM) is not. When listed, a
+    dict uses its ``enabled`` flag (default true); ``None`` means disabled;
+    otherwise the value's truthiness. Mirrors ``MissionBuilderWorker`` community
+    parsing so the generated init matches what is actually injected.
     """
+    from mission_tools.mission_constants import get_optin_community_script_ids
+
     comm = mission_yaml.get("community_scripts")
     if not isinstance(comm, dict) or not comm or script_id not in comm:
-        return True
+        return script_id not in get_optin_community_script_ids()
     cfg = comm[script_id]
     if isinstance(cfg, dict):
         return bool(cfg.get("enabled", True))

--- a/test/python/mission_builder/test_community_scripts_toggle.py
+++ b/test/python/mission_builder/test_community_scripts_toggle.py
@@ -7,7 +7,7 @@ import unittest
 from pathlib import Path
 
 from mission_builder.mission_builder_worker import MissionBuilderWorker
-from mission_tools.mission_constants import get_community_script_files
+from mission_tools.mission_constants import get_community_script_files, get_optin_community_script_ids
 
 
 def _make_worker(yaml_content: str) -> MissionBuilderWorker:
@@ -127,12 +127,21 @@ class TestMistMandatory(unittest.TestCase):
 class TestActiveCommunityScripts(unittest.TestCase):
     """Unit tests for _active_community_scripts helper."""
 
-    def test_none_returns_all(self) -> None:
-        """_active_community_scripts returns all scripts when enabled_community_script_ids is None."""
+    def test_none_returns_all_optout(self) -> None:
+        """_active_community_scripts returns every opt-out script (all but opt-in ids) when the set is None."""
         worker: MissionBuilderWorker = object.__new__(MissionBuilderWorker)
         worker.enabled_community_script_ids = None
         result = worker._active_community_scripts()
-        self.assertEqual(result, get_community_script_files())
+        expected = [s for s in get_community_script_files() if s["id"] not in get_optin_community_script_ids()]
+        self.assertEqual(result, expected)
+
+    def test_none_excludes_optin_scripts(self) -> None:
+        """Opt-in scripts (e.g. TUM) are NOT active by default when the set is None."""
+        worker: MissionBuilderWorker = object.__new__(MissionBuilderWorker)
+        worker.enabled_community_script_ids = None
+        active_ids = {s["id"] for s in worker._active_community_scripts()}
+        for optin in get_optin_community_script_ids():
+            self.assertNotIn(optin, active_ids)
 
     def test_empty_set_returns_nothing(self) -> None:
         """_active_community_scripts returns empty list when no ids are enabled."""
@@ -159,6 +168,36 @@ class TestActiveCommunityScripts(unittest.TestCase):
         # All other community scripts remain active
         self.assertIn("mist", active_ids)
         self.assertIn("ctld", active_ids)
+
+
+class TestOptInScripts(unittest.TestCase):
+    """Opt-in community scripts (e.g. TUM) are OFF unless explicitly enabled — TUM-AUTOINIT."""
+
+    def test_optin_absent_from_section_is_disabled(self) -> None:
+        """A community_scripts section that omits an opt-in id leaves it disabled."""
+        worker = _make_worker("community_scripts:\n  ctld: {enabled: true}\n")
+        assert worker.enabled_community_script_ids is not None
+        for optin in get_optin_community_script_ids():
+            self.assertNotIn(optin, worker.enabled_community_script_ids)
+        self.assertIn("ctld", worker.enabled_community_script_ids)
+
+    def test_optin_disabled_when_bare_modules_block(self) -> None:
+        """A modules: block without the opt-in key leaves it inactive (vanilla/convert-v5 default)."""
+        worker = _make_worker("modules:\n  RADIO: true\n  SPAWN: true\n")
+        active_ids = {s["id"] for s in worker._active_community_scripts()}
+        self.assertNotIn("tum", active_ids)
+
+    def test_optin_enabled_when_explicitly_true(self) -> None:
+        """Only an explicit <ID>: true turns an opt-in script on."""
+        worker = _make_worker("community_scripts:\n  tum: {enabled: true}\n")
+        assert worker.enabled_community_script_ids is not None
+        self.assertIn("tum", worker.enabled_community_script_ids)
+
+    def test_optin_disabled_when_explicitly_false(self) -> None:
+        """An explicit <ID>: false keeps the opt-in script off."""
+        worker = _make_worker("community_scripts:\n  tum: {enabled: false}\n")
+        assert worker.enabled_community_script_ids is not None
+        self.assertNotIn("tum", worker.enabled_community_script_ids)
 
 
 if __name__ == "__main__":

--- a/test/python/mission_builder/test_community_scripts_toggle.py
+++ b/test/python/mission_builder/test_community_scripts_toggle.py
@@ -7,7 +7,11 @@ import unittest
 from pathlib import Path
 
 from mission_builder.mission_builder_worker import MissionBuilderWorker
-from mission_tools.mission_constants import get_community_script_files, get_optin_community_script_ids
+from mission_tools.mission_constants import (
+    get_community_script_files,
+    get_optin_community_script_ids,
+    is_community_script_enabled_by_default,
+)
 
 
 def _make_worker(yaml_content: str) -> MissionBuilderWorker:
@@ -198,6 +202,13 @@ class TestOptInScripts(unittest.TestCase):
         worker = _make_worker("community_scripts:\n  tum: {enabled: false}\n")
         assert worker.enabled_community_script_ids is not None
         self.assertNotIn("tum", worker.enabled_community_script_ids)
+
+    def test_shared_default_helper(self) -> None:
+        """is_community_script_enabled_by_default: opt-out → True, opt-in → False (shared source of truth)."""
+        for optin in get_optin_community_script_ids():
+            self.assertFalse(is_community_script_enabled_by_default(optin))
+        self.assertTrue(is_community_script_enabled_by_default("ctld"))
+        self.assertTrue(is_community_script_enabled_by_default("csar"))
 
 
 if __name__ == "__main__":

--- a/test/python/mission_builder/test_v5_converter.py
+++ b/test/python/mission_builder/test_v5_converter.py
@@ -527,6 +527,19 @@ class TestV5ConverterIntegration(unittest.TestCase):
             assert normalized["external_modules"]["ctld"]["hoverPickup"] is True
             assert normalized["external_modules"]["ctld"]["maximumDistanceLimit"] == 200
 
+    def test_mission_yaml_optin_script_false_even_when_detected(self) -> None:
+        # TUM-AUTOINIT: opt-in scripts (TUM) must be emitted as false even when the
+        # community file is present, so a freshly converted v5 mission never auto-starts them.
+        with tempfile.TemporaryDirectory() as td:
+            folder = Path(td)
+            self._make_missionconfig(folder, "-- test\n")
+            self._make_community_folder(folder, ["mist.lua", "TheUniversalMission.lua"])
+            V5Converter().convert(folder, backup=False)
+            yaml_content = (folder / "mission.yaml").read_text()
+            self.assertIn("MIST: true", yaml_content)  # opt-out, detected → true
+            self.assertIn("TUM: false", yaml_content)  # opt-in, even when detected → false
+            self.assertNotIn("TUM: true", yaml_content)
+
     def test_mission_yaml_silence_atc_emitted_when_v5_active(self) -> None:
         # CONVERT-FIDELITY-003: an active call → mission.silence_atc_on_all_airbases: true.
         with tempfile.TemporaryDirectory() as td:

--- a/test/python/veaf_libs/test_lua_config_generator.py
+++ b/test/python/veaf_libs/test_lua_config_generator.py
@@ -405,3 +405,22 @@ def test_tum_initialize_absent_when_disabled():
     """No TUM.initialize() when tum is disabled."""
     lua = generate_config_lua({"community_scripts": {"tum": False}})
     assert "TUM.initialize()" not in lua
+
+
+def test_tum_initialize_absent_by_default():
+    """TUM is opt-in: omitting it (vanilla / convert-v5 default) must NOT emit TUM.initialize() (TUM-AUTOINIT)."""
+    # community_scripts present but TUM not listed → still disabled
+    lua = generate_config_lua({"community_scripts": {"ctld": True}})
+    assert "TUM.initialize()" not in lua
+    # no community_scripts section at all → still disabled
+    assert "TUM.initialize()" not in generate_config_lua({"modules": {"RADIO": True}})
+
+
+def test_optout_script_still_enabled_by_default():
+    """Opt-out scripts (e.g. ctld) stay enabled when absent — the opt-in change must not regress them."""
+    from mission_builder.mission_builder_worker import _normalize_mission_yaml
+    from veaf_libs.lua_config_generator import _community_enabled
+
+    normalized = _normalize_mission_yaml({"modules": {"RADIO": True}})
+    assert _community_enabled(normalized, "ctld") is True
+    assert _community_enabled(normalized, "tum") is False


### PR DESCRIPTION
## TUM-AUTOINIT — TUM opt-in, never on by default

**The Universal Mission (TUM)** imposes a mission-design contract (BLUFOR/REDFOR territory zones, each owning an airbase) and aborts at start-up otherwise:

> `Coalition red has no territory zones and/or controls no airfields…`

As an opt-out community script, TUM was **enabled by default**, so vanilla and freshly v5-converted missions emitted `TUM.initialize()` and hit that runtime error.

### Change
TUM is now **opt-in** — the only community script that is off by default:
- vanilla mission / `convert-v5` / a `modules:` block omitting `TUM` → **disabled**;
- only an explicit `TUM: true` enables it;
- opt-out scripts (ctld, csar, …) keep their active-by-default behaviour;
- when enabled, the build auto-calls `TUM.initialize()` (no manual `mission-script.lua` wiring).

### How
- `mission_constants`: new `get_optin_community_script_ids() -> {"tum"}` (+ export)
- `mission_builder_worker`: opt-in ids excluded from the default enabled set, from `_active_community_scripts` and `_community_enabled` (None-branches)
- `lua_config_generator`: `_community_enabled` None-branch is opt-out-only
- `v5_converter`: emits `TUM: false` even when the TUM file is detected
- docs: default `mission.yaml` comment + `MISSION_YAML_REFERENCE` (FR/EN) opt-in note + CHANGELOG

### Tests
Builder opt-in parsing, generator default-off / opt-out-still-on, convert-v5 emits `TUM: false`. Full gate green: `pytest` 1392 passed (coverage 68.36% ≥ 67), ruff check/format, mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make the TUM community script opt-in across the build and ensure it is auto-initialized only when explicitly enabled.

New Features:
- Introduce support for opt-in community scripts, currently applied to TUM, which remain disabled unless explicitly enabled in mission configuration.

Bug Fixes:
- Prevent TUM from being enabled by default in vanilla and v5-converted missions to avoid startup failures when its mission-design prerequisites are not met.

Enhancements:
- Align mission builder, Lua config generation, and v5 conversion logic so that TUM auto-initializes only when explicitly turned on while preserving existing opt-out behavior for other community scripts.
- Expose a new mission tools constant for opt-in community script ids and export it for reuse across components.

Build:
- Bump veaf-tools package version from 6.5.1 to 6.5.2.

Documentation:
- Document TUM's new opt-in behavior and auto-init semantics in the mission YAML reference (EN/FR), default mission.yaml template, backlog entry, and changelog.

Tests:
- Add unit tests covering opt-in parsing in the mission builder, default-off behavior and opt-out preservation in Lua config generation, and v5 converter emission of TUM as disabled by default.