### PR TITLE
chore(types): erode remaining mypy ignore_errors workers (QUALITY-GATE-FINISH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Internal
+- **mypy `ignore_errors` debt fully eroded** (QUALITY-GATE-FINISH). The six remaining application workers under the mypy `ignore_errors` override (`mission_converter_worker`, `mission_extractor_worker`, `waypoints_manager`, `weather_injector`'s `lua_converter` / `dcs_weather_converter` / `weather_injector_worker`) are now type-checked. Four had no errors; the seven surfaced errors were fixed without behaviour change (annotate `config: dict[str, Any]` in the weather lua-converter; drop redundant `: Path` re-annotations and rename a shadowed loop variable in the extractor). Only the bundled third-party `luadata` library stays excluded. The whole `src/python/veaf-tools` tree now passes `mypy` with no per-module opt-outs
+
 ### Fixed
 - **The generated `_version.py` no longer shows up as permanently "modified"** (FIX-VERSION-PY-EOL). `veaf-build` wrote `veaf_tools/_version.py` in text mode, so on Windows Python translated `\n` to `\r\n`; the git-tracked stub is normalized to LF (`.gitattributes` `eol=lf`), so every build left the working tree dirty with a CRLF-only, content-less diff. `_write_version_py` / `_restore_version_py` now pass `newline="\n"`. The same latent issue in `radio_specs_updater` (the tracked `dcs-radio-specs.yaml` / `.md` artifacts) was fixed too, aligning it with the other `dcs_data` generators that already force LF
 

--- a/backlog.md
+++ b/backlog.md
@@ -16,7 +16,7 @@
 | Lot FIX-VERSION-PY-EOL — generated `_version.py` written in text mode → CRLF on Windows vs `eol=lf` → working tree always dirty; force LF | ✅ |
 | Lot LUACHECK-CI — add `luacheck` to the CI Lua quality gate (only `stylua --check` runs today) | ⬜ |
 | Lot LUA-COVERAGE — establish a Lua test-coverage objective for the runtime modules | ⬜ |
-| Lot QUALITY-GATE-FINISH — erode the remaining mypy `ignore_errors` workers + final coverage ratchet | ⬜ |
+| Lot QUALITY-GATE-FINISH — erode the remaining mypy `ignore_errors` workers + final coverage ratchet | ✅ |
 | Lot VALIDATE — `veaf-tools validate`: lint `mission.yaml` + `.miz` before build | ⬜ |
 | Lot SCAFFOLD — `veaf-tools new`: scaffold a ready-to-use mission folder from templates | ⬜ |
 | Lot BUILD-PUBLISH-LOCAL — `veaf-build` local publish mode: deploy `published/` + the two `.exe` into a user-given VEAF mission source folder instead of GitHub | ⬜ |
@@ -107,9 +107,11 @@
 
 **Goal**: finish the Quality Ratchet Policy (`CLAUDE.md` §3) — the `QUALITY-GATE` lot is closed but, per policy, the dedicated lot still mops up whatever workers no other lot reopened. Remaining `ignore_errors = true` application workers (the bundled `luadata` library stays excluded as third-party): `mission_converter.mission_converter_worker`, `mission_extractor.mission_extractor_worker`, `waypoints_injector.waypoints_manager`, `weather_injector.utils.lua_converter`, `weather_injector.weather.dcs_weather_converter`, `weather_injector.weather_injector_worker`. Drop each entry, fix the surfaced type errors, and do a final `--cov-fail-under` ratchet.
 
+**Done**: removed all six application-worker entries from the mypy `ignore_errors` override (only `luadata*` third-party stays). Measuring first showed just **7 errors across 2 files** — the other four workers were error-free. Fixes were behaviour-preserving: `config: dict[str, Any]` annotation in `weather_injector/utils/lua_converter.py` (4 errors), and in `mission_extractor_worker.py` renamed a shadowed loop variable + dropped two redundant `: Path` re-annotations (3 errors). The whole `src/python/veaf-tools` tree now passes `mypy` with no per-module opt-outs. No `--cov-fail-under` bump: the lot adds no tests and coverage is unchanged (68.37 % vs gate 67, gap < 2). No behaviour change → existing tests cover (suite green).
+
 | # | Ticket | Files | Type | Status |
 |---|--------|-------|------|--------|
-| QUALITY-GATE-FINISH-001 | Remove the remaining application-worker entries from the mypy `ignore_errors` list and fix the surfaced errors (keep `luadata*` third-party exclusion); bump `--cov-fail-under` per policy | `pyproject.toml`, `src/python/veaf-tools/**`, `test/python/` | chore | ⬜ |
+| QUALITY-GATE-FINISH-001 | Remove the remaining application-worker entries from the mypy `ignore_errors` list and fix the surfaced errors (keep `luadata*` third-party exclusion); bump `--cov-fail-under` per policy | `pyproject.toml`, `src/python/veaf-tools/**`, `test/python/` | chore | ✅ |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.5.3"
+version = "6.5.4"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"
@@ -104,13 +104,6 @@ module = [
     # Third-party bundled library
     "luadata",
     "luadata.*",
-    # Existing application files with known type errors
-    "mission_converter.mission_converter_worker",
-    "mission_extractor.mission_extractor_worker",
-    "waypoints_injector.waypoints_manager",
-    "weather_injector.utils.lua_converter",
-    "weather_injector.weather.dcs_weather_converter",
-    "weather_injector.weather_injector_worker",
 ]
 ignore_errors = true
 

--- a/src/python/veaf-tools/mission_extractor/mission_extractor_worker.py
+++ b/src/python/veaf-tools/mission_extractor/mission_extractor_worker.py
@@ -97,8 +97,8 @@ class MissionExtractorWorker(BaseWorker):
             # VEAF and legacy entries are (path, dest) tuples; community entries are dicts.
             script_files: list[tuple[str, str]] = list(get_veaf_script_files()) + list(get_legacy_script_files())
             script_files += [(s["path"], s["dest"]) for s in get_community_script_files()]
-            for file_in_mission in [Path(dest) / Path(path).name for path, dest in script_files]:
-                file_in_temp: Path = temp_dir / file_in_mission
+            for veaf_file_in_mission in [Path(dest) / Path(path).name for path, dest in script_files]:
+                file_in_temp: Path = temp_dir / veaf_file_in_mission
                 rm_file_or_dir(file_in_temp)
 
             # Create the src and src/scripts folders if needed
@@ -109,7 +109,7 @@ class MissionExtractorWorker(BaseWorker):
 
             # Remove or move the extracted mission files (remove unwanted files or move files not present in the src folder)
             for file_in_mission, move_to_mission_src_folder_if_not_exist in get_mission_files_to_cleanup_on_extract():
-                file_in_temp: Path = temp_dir / file_in_mission
+                file_in_temp = temp_dir / file_in_mission
                 remove = True
                 if move_to_mission_src_folder_if_not_exist:
                     file_in_mission_name = Path(file_in_mission).name
@@ -123,7 +123,7 @@ class MissionExtractorWorker(BaseWorker):
             # Remove or move the additional mission script files (remove LUA files present in the src/scripts folder or move files not present)
             temp_mission_dir = temp_dir / "l10n" / "DEFAULT"
             for file_in_temp in temp_mission_dir.glob("*.lua"):
-                file_in_mission_src_folder: Path = src_scripts_folder / file_in_temp.name
+                file_in_mission_src_folder = src_scripts_folder / file_in_temp.name
                 if file_in_mission_src_folder.exists():
                     rm_file_or_dir(file_in_temp)  # delete temp file
                 else:

--- a/src/python/veaf-tools/weather_injector/utils/lua_converter.py
+++ b/src/python/veaf-tools/weather_injector/utils/lua_converter.py
@@ -91,7 +91,7 @@ class LuaToYamlConverter:
         ```
         """
         try:
-            config = {}
+            config: dict[str, Any] = {}
 
             # Parse position
             position = LuaToYamlConverter._extract_table(lua_content, "position")


### PR DESCRIPTION
## Lot QUALITY-GATE-FINISH

Finishes the Quality Ratchet Policy (`CLAUDE.md` §3): removes the six application-worker entries still under the mypy `ignore_errors` override. Only the bundled third-party `luadata` library stays excluded.

### What was done
Measuring first showed just **7 errors across 2 files** — the other four workers (`mission_converter_worker`, `waypoints_manager`, `dcs_weather_converter`, `weather_injector_worker`) were already error-free.

Behaviour-preserving fixes:
- `weather_injector/utils/lua_converter.py`: `config: dict[str, Any]` annotation (the `{}` froze its type on first use) — 4 errors.
- `mission_extractor_worker.py`: renamed a shadowed loop variable + dropped two redundant `: Path` re-annotations — 3 errors.

The whole `src/python/veaf-tools` tree now passes `mypy` with **no per-module opt-outs**.

### Quality
- `mypy`: clean (88 files, 0 issues)
- `ruff check` + `ruff format --check`: pass
- `pytest`: full suite green, coverage 68.37 % (gate 67)
- No `--cov-fail-under` bump: no new tests, coverage unchanged, gap < 2 (policy only mandates a bump when a lot *adds* tests)
- No behaviour change → existing tests cover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove remaining mypy ignore_errors overrides for application workers and fix surfaced type issues to complete the quality gate.

Enhancements:
- Enable mypy type checking on all remaining worker modules by removing per-module ignore_errors overrides and fixing the few reported issues.
- Adjust mission extractor and weather Lua converter code to use clearer variable naming and explicit typing without changing runtime behaviour.

Build:
- Bump veaf-tools package version from 6.5.3 to 6.5.4.

Documentation:
- Update backlog and changelog to record completion of the QUALITY-GATE-FINISH lot and the removal of the remaining mypy ignore_errors debt.