### PR TITLE
fix(aircrafts): dynamic-slot injection crashes on a dict group container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Aircraft-group injection no longer crashes when the target country's group container is a dict** (FIX-AIRCRAFT-INJECT-DICT-GROUP). On a freshly `extract`-ed mission, a country whose `plane`/`helicopter` `["group"]` was an empty Lua `{}` (or a numerically-keyed table) is deserialized as a **dict**, not a list — so `_ensure_aircraft_category` returned a dict and the dynamic-slot template injection failed for **every** template with `'dict' object has no attribute 'append'` (David, on `test-tripack` after `prepare --template standard` + `extract`; the spawnables, landing in a list container, were unaffected). The injector now normalizes the container to a list (empty dict → `[]`, keyed dict → its group values, preserving any existing groups) before appending.
+
 ## [6.6.0] — 2026-06-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.6.0"
+version = "6.6.1"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/aircrafts_injector/aircrafts_injector_worker.py
+++ b/src/python/veaf-tools/aircrafts_injector/aircrafts_injector_worker.py
@@ -653,6 +653,13 @@ class AircraftGroupsInjectorWorker(BaseWorker):
         if "group" not in country[category]:
             country[category]["group"] = []
 
+        # An empty Lua `{}` (or a numerically-keyed table) is deserialized as a dict,
+        # not a list, so a freshly-extracted mission can carry the group container as a
+        # dict. Normalize it to a list (empty dict -> [], keyed dict -> its values) so
+        # the caller can .append() / index it. See FIX-AIRCRAFT-INJECT-DICT-GROUP.
+        if isinstance(country[category]["group"], dict):
+            country[category]["group"] = list(country[category]["group"].values())
+
         return country[category]["group"]
 
     def work(self) -> InjectionResult:

--- a/test/python/aircrafts_injector/test_aircrafts_injector_worker.py
+++ b/test/python/aircrafts_injector/test_aircrafts_injector_worker.py
@@ -346,5 +346,47 @@ class TestInjectedTemplateHiddenFromSlotList(unittest.TestCase):
         self.assertTrue(injected["password"])  # locked slot password (b)
 
 
+class TestInjectGroupsDictContainer(unittest.TestCase):
+    """FIX-AIRCRAFT-INJECT-DICT-GROUP — a country whose ["group"] is a dict (luadata turns an
+    empty `{}` or a keyed Lua table into a dict, not a list) must not crash inject_groups."""
+
+    @staticmethod
+    def _mission_with_plane_group(plane_group: object) -> DcsMission:
+        mission_content = {
+            "coalition": {
+                "blue": {
+                    "country": [
+                        {"name": "USA", "id": 2, "plane": {"group": plane_group}, "helicopter": {"group": []}}
+                    ]
+                }
+            }
+        }
+        return DcsMission(file_path=Path("/dev/null"), mission_content=mission_content)
+
+    def test_empty_dict_group_container(self) -> None:
+        """An empty `{}` group container (Lua `{}` → dict) is normalized to a list and injection works."""
+        worker = _worker()
+        worker.dcs_mission = self._mission_with_plane_group({})
+        worker.yaml_data = _yaml_data(["new-group"])
+
+        result = worker.inject_groups(mode="add", silent=True)
+
+        self.assertTrue(result.success)
+        self.assertEqual([g["name"] for g in _get_groups(worker)], ["new-group"])
+
+    def test_keyed_dict_group_container_preserves_existing(self) -> None:
+        """A keyed dict group container (e.g. {1: group}) keeps existing groups and appends the new one."""
+        worker = _worker()
+        worker.dcs_mission = self._mission_with_plane_group({1: {"name": "existing", "units": []}})
+        worker.yaml_data = _yaml_data(["new-group"])
+
+        result = worker.inject_groups(mode="add", silent=True)
+
+        self.assertTrue(result.success)
+        names = [g["name"] for g in _get_groups(worker)]
+        self.assertIn("existing", names)
+        self.assertIn("new-group", names)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Bug
At build, the dynamic-slot template injection failed for **every** template with `Failed to inject group <X>: 'dict' object has no attribute 'append'` (David, on `test-tripack` after `prepare --template standard` + `extract`). The preceding spawnables injection (same method, different country/coalition) succeeded.

## Root cause
`_ensure_aircraft_category` guarantees that `country[category]["group"]` **exists** but not that it is a **list**. On a freshly-extracted mission, a country whose `["group"]` was an empty Lua `{}` (or a numerically-keyed table) is deserialized by luadata as a **dict**, not a list — so the method returned a dict and `inject_groups` then did `groups_list.append(...)` → crash. The spawnables landed in a country whose container was a list, hence no crash there.

## Fix
In `_ensure_aircraft_category`, normalize the container to a list before returning: empty dict → `[]`, keyed dict → `list(values())` (preserving any pre-existing groups), written back into `country`.

## Tests
TDD: two new cases (empty-dict and keyed-dict group containers) — they reproduce the exact crash before the fix and pass after; existing groups are preserved. Full suite green; ruff/format/mypy clean.

Build-time only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent aircraft-group injection from crashing when mission group containers are deserialized as dicts instead of lists.

Bug Fixes:
- Normalize aircraft group containers that are dicts into lists to allow dynamic-slot injection without crashes on freshly extracted missions.

Build:
- Bump veaf-tools package version from 6.6.0 to 6.6.1.

Documentation:
- Document the aircraft-group injection crash fix and its conditions in the unreleased changelog section.

Tests:
- Add regression tests covering empty and keyed dict group containers to ensure injection succeeds and existing groups are preserved.