### PR TITLE
chore(release): 6.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [6.6.1] — 2026-06-22
 
 ### Fixed
 - **Every CLI command is now reachable from the interactive TUI** (FIX-TUI-MISSING-COMMANDS). Four commands had no `CommandSpec`, so they were absent from the wizard menu (and from the CLI↔TUI bridge) — a user launching the TUI (e.g. by double-clicking `veaf-tools.exe`) could not run `validate`, `migrate-config`, `generate-config` or `user-config` (David). They now appear in the command selector with their primary prompts; only `migrate-config`'s mandatory `input_file` is `required` (so the bridge drops into the wizard when it's missing). A guard test now asserts every Typer-registered command has a `CommandSpec`, preventing future omissions. FR/EN labels added.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,51 +1,12 @@
-# VEAF Mission Creation Tools — 6.6.0
+# VEAF Mission Creation Tools — 6.6.1
 
-Cette version est une étape de **consolidation et d'améliorations** : elle ouvre l'outillage v6 à l'**adoption de missions tierces** (campagnes Foothold), enrichit la **boîte à outils des mission makers** (validation avant build, gabarits de modules, assistant interactif), et corrige un large lot de problèmes remontés en test — notamment autour de `convert-v5`, des slots dynamiques et des zones de combat.
+Version de **correctifs** dans la lignée de la 6.6.0 : elle complète l'assistant interactif et répare l'injection des slots dynamiques. Aucun changement cassant — une mission existante se reconstruit sans modification.
 
-> Pas de changement cassant : une mission v6 existante se reconstruit sans modification.
+## 🐛 Corrections
 
-## 🆕 Adopter une mission tierce (non-VEAF) sur l'outillage v6
-
-Tout un écosystème pour reprendre une mission externe (pilote : la campagne Foothold de Lekaa) :
-
-- **`veaf-tools convert-other`** — adopte un `.miz` tiers : extraction, détection des scripts chargés par les triggers natifs, génération d'un `mission.yaml` avec un bloc `custom_scripts:` ordonné (ordre de chargement préservé).
-- **Profils de conversion (`--profile`)** — le profil `foothold` active les bons modules VEAF, normalise les noms de scripts versionnés (`Moose_2026-xx-xx.lua` → `Moose.lua`), désactive automatiquement les libs communautaires fournies par la mission (Moose, CTLD, AIEN…), et signale les modules incompatibles.
-- **`config_override:`** — ne réécris que les globales Lua que tu changes (validées lexicalement), sans toucher la config amont d'origine.
-- **`strip_native_triggers:`** — le build retire les triggers de chargement natifs de la mission pour éviter le double chargement.
-- **`convert-other --update`** — réimporte une nouvelle version amont du `.miz` en préservant ton `mission.yaml` réglé, et rapporte les scripts ajoutés/modifiés/retirés.
-- **Build multi-variant** — un même dossier produit plusieurs `.miz` en un seul `build` (ex. Modern / Cold-War) via `build_variants:`.
-
-## 🛠️ Nouveaux outils pour les mission makers
-
-- **`veaf-tools validate`** — un *linter* qui vérifie un dossier de mission **avant** le build (syntaxe `mission.yaml`, modules, scripts déclarés, groupes/zones référencés) et regroupe tous les problèmes en une passe.
-- **Validation des références au build** — le `build` signale désormais, dans un **récapitulatif bien visible en fin de build** (sans bloquer), toute référence de `mission.yaml` vers un objet du Mission Editor introuvable (zones de déclenchement, groupes, unités, aérodromes).
-- **`prepare --template`** — échafaude un `mission.yaml` à partir d'un gabarit de modules (`minimal` / `standard` / `full` / `custom` interactif).
-- **Pont CLI ↔ TUI** — n'importe quelle commande bascule dans l'assistant interactif si un paramètre requis manque (ou avec `--tui`), avec navigation arrière (Ctrl-B).
-- **`veaf-build publish-local <dir>`** — déploie un build dans un dossier de mission local pour tester l'outillage sans passer par GitHub.
-
-## ✨ Fonctionnalités de mission
-
-- **`active_at_start: true`** — active une zone de combat dès le début de la mission depuis `mission.yaml` (retrouve en déclaratif ce qui s'écrivait à la main en Lua).
-- **`radiobeep.ogg`** — le bip JTAC de secours est maintenant fourni et injecté automatiquement quand CTLD est activé.
-
-## 🐛 Corrections notables
-
-- **AirWaves** — une zone définie par centre + rayon avec une `trigger_zone_name` absente ne déclenche plus une ERREUR en jeu (avertissement seulement ; la zone fonctionne via centre/rayon). Et la config AirWaves générée ne fait plus planter la mission au démarrage.
-- **`convert-v5`** — extrait correctement les **sous-zones d'une opération de combat** (gori) et résout leurs références ; n'émet plus de modules/QRA fantômes depuis de la config commentée ; ne produit plus de `mission.yaml` inparsable quand une QRA était désactivée en v5.
-- **Slots dynamiques / templates** — les avions ne sont plus rangés sous la catégorie *hélicoptère* (50 templates CAP par défaut **et** templates de slots dynamiques) ; une radio ADF/kHz (Yak-52 ARK-15M) ne corrompt plus la fréquence principale du slot (*« Fréquence invalide 0.625 MHz »*) ; les templates injectés par l'outil ne polluent plus la liste des slots multijoueur.
-- **`cap_missions`** — plus de fausse alerte « groupe manquant » : la validation tient compte du préfixe `OnDemand-`.
-- **Intégration des libs communautaires** — VEAF n'applique plus son intégration à une lib que la mission a désactivée (cas du maker qui fournit sa propre version).
-- **`custom_scripts:`** — l'ordre de déclaration est désormais réellement respecté à l'exécution.
-- **Cartes** — table des aérodromes mise à jour pour l'extension de la carte Syrie ; gabarit AFAC MQ-9 restauré dans les `spawnables.yaml` par défaut.
-
-## 🔧 Changements
-
-- **`TUM` (The Universal Mission)** est désormais **opt-in** et auto-initialisé quand il est activé.
-
-## 📚 Documentation
-
-- Réécriture en profondeur des pages de scripts/API pour coller au vrai code Lua v6 (suppression d'API inexistantes), parité FR/EN, et guides dédiés à l'adoption Foothold.
+- **Toutes les commandes sont accessibles depuis l'assistant interactif (TUI)** — `validate`, `migrate-config`, `generate-config` et `user-config` manquaient au menu : on ne pouvait pas les lancer en double-cliquant sur `veaf-tools.exe`. Elles y figurent désormais (et `migrate-config` ouvre l'assistant quand son fichier d'entrée n'est pas fourni).
+- **Plus de plantage à l'injection des templates de slots dynamiques** — sur une mission fraîchement extraite (`extract`), l'injection échouait pour **tous** les templates avec `'dict' object has no attribute 'append'` quand le conteneur de groupes du pays cible était vide. Le build injecte désormais correctement les slots dynamiques.
 
 ## 🙏 Remerciements
 
-Un grand merci à **Tripack** pour ses retours de test approfondis sur la VEAF-Demo-Mission, à l'origine d'une grande partie des correctifs de cette version.
+Merci à **Tripack** pour le signalement et la mission de test (`test-tripack`) qui ont permis de reproduire le bug d'injection.

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -39,7 +39,8 @@ Ce document décrit la direction prévue pour le projet. Les éléments sont cla
 - ✅ **Mission YAML → sélection de modules** — la section `lua_modules` dans `mission.yaml` pilote quels modules sont inclus et comment ils sont initialisés
 
 ### Release
-- ✅ **Releases v6.x** — publication continue depuis `develop-v6` (tags `published-vx.y.z`) ; version courante **6.6.0**. Le merge `develop-v6` → `master` est réservé aux jalons stables.
+- ✅ **Releases v6.x** — publication continue depuis `develop-v6` (tags `published-vx.y.z`) ; version courante **6.6.1**. Le merge `develop-v6` → `master` est réservé aux jalons stables.
+- ✅ **Release v6.6.1** — correctifs : toutes les commandes CLI accessibles depuis le TUI (FIX-TUI-MISSING-COMMANDS) ; injection des slots dynamiques réparée (`'dict' object has no attribute 'append'`, FIX-AIRCRAFT-INJECT-DICT-GROUP).
 - ✅ **Release v6.6.0** — consolidation et améliorations : adoption de missions tierces (`convert-other` + profils Foothold, `config_override:`, build multi-variant), outils mission-maker (`validate`, `prepare --template`, pont CLI↔TUI, validation des références au build), et un large lot de correctifs (`convert-v5` sous-zones d'opération, AirWaves, slots dynamiques, catégories de templates).
 - ✅ **Release v6.3.0** — corrections de bugs et améliorations UX (Lot 26 + FIX-SORT) : correction du crash convert-v5, auto-pause au double-clic, filtrage des smart defaults, vérification nil de veaf.initialize()
 - ✅ **Release v6.3.3** — stabilisation et corrections de bugs : crashs des initialize() Lua, corrections du pipeline de build, profils de build, CSAR YAML-first, résolution automatique des dépendances

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.6.2"
+version = "6.6.1"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"


### PR DESCRIPTION
## Release 6.6.1 — fixes

Patch release after `published-v6.6.0`.

- `RELEASE_NOTES.md` rewritten for 6.6.1 (FR, community-facing).
- `CHANGELOG.md`: `[Unreleased]` → `[6.6.1] — 2026-06-22`.
- `pyproject.toml`: → `6.6.1`.
- `doc/ROADMAP.md`: current version + 6.6.1 line.

### Contents
- All CLI commands reachable from the interactive TUI (FIX-TUI-MISSING-COMMANDS).
- Dynamic-slot template injection no longer crashes on a dict group container (FIX-AIRCRAFT-INJECT-DICT-GROUP).

No breaking changes. Thanks to **Tripack**.

### After merge
Tag `published-v6.6.1` on `develop-v6` → triggers `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Release 6.6.1 as a patch version with TUI accessibility fixes and stability improvements for dynamic slot injection, plus associated versioning and documentation updates.

Bug Fixes:
- Ensure all CLI commands are available from the interactive TUI, including previously missing validation and config commands.
- Fix crashes when injecting dynamic slot templates into missions whose target country group container was empty.

Build:
- Bump project version to 6.6.1 in build configuration.

Documentation:
- Update release notes and roadmap to describe the 6.6.1 bugfix release and current version status.

Chores:
- Finalize changelog entry for the 6.6.1 release.