### PR TITLE
fix(aircrafts): dynamic-slot airplane templates filed under helicopters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [6.6.1] — 2026-06-22
+## [Unreleased]
+
+### Fixed
+- **Airplane dynamic-slot templates are no longer filed under `helicopters:`** (FIX-DYNSLOT-TEMPLATE-CATEGORY). DCS files dynamic-slot *template* groups under the **helicopter** table in the `.miz` regardless of the real aircraft, so the aircraft-groups extraction — which routed each group by its DCS location — filed **every** airplane template (A-10C II, F-16, MiGs…) under `airplanes`'s sibling `helicopters:`. They were then injected as a *helicopter group* in the Mission Editor (group titled "GROUPE D'HÉLICOPTÈRES", aircraft type mismatched). #478 fixed the same symptom for the default CAP `spawnables.yaml` but not the dynamic-slot pipeline (Tripack). The extraction now categorizes each group by its unit's **real DCS category** (`dcsUnits.yaml`: Plane → `airplanes`, Helicopter → `helicopters`), falling back to the DCS location only for types unknown to the database. The shipped default `dynamic-slot-templates.yaml` has been regenerated category-correct (78 airplane templates moved out of `helicopters:`), and a guard test pins both the helper and the shipped default.
 
 ### Fixed
 - **Every CLI command is now reachable from the interactive TUI** (FIX-TUI-MISSING-COMMANDS). Four commands had no `CommandSpec`, so they were absent from the wizard menu (and from the CLI↔TUI bridge) — a user launching the TUI (e.g. by double-clicking `veaf-tools.exe`) could not run `validate`, `migrate-config`, `generate-config` or `user-config` (David). They now appear in the command selector with their primary prompts; only `migrate-config`'s mandatory `input_file` is `required` (so the bridge drops into the wizard when it's missing). A guard test now asserts every Typer-registered command has a `CommandSpec`, preventing future omissions. FR/EN labels added.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.6.1"
+version = "6.6.2"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/defaults/mission-folder/src/dynamic-slot-templates.yaml
+++ b/src/defaults/mission-folder/src/dynamic-slot-templates.yaml
@@ -1,6 +1,4 @@
 airplanes:
-  coalitions: {}
-helicopters:
   coalitions:
     blue:
       CJTF Blue:
@@ -234,326 +232,6 @@ helicopters:
               speed: 138.88888888889
               type: A-10C_2
               unitId: 599
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        A-4E-C Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 254
-          groupId: 499
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: A-4E-C Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 2000
-                alt_type: BARO
-                formation_template: ''
-                name: A-4E-C Template
-                speed: 138.88888888889
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: Option
-                            params:
-                              name: 35
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                Auto_Catapult_Power: false
-                CBU2ATPP: 0
-                CBU2BATPP: 0
-                CMS_BURSTS: 1
-                CMS_BURST_INTERVAL: 1
-                CMS_SALVOS: 1
-                CMS_SALVO_INTERVAL: 1
-                HideECMPanel: false
-                Night_Vision: false
-              alt: 2000
-              alt_type: BARO
-              callsign:
-                1: 7
-                2: 6
-                name: Chevy65
-                3: 5
-              heading: 2.1757446334553
-              livery_id: unmarked
-              name: 'A-4E-C Template #01'
-              onboard_num: '013'
-              payload:
-                ammo_type: 1
-                chaff: 30
-                flare: 30
-                fuel: 2467.5454273299
-                gun: 100
-                pylons: {}
-              psi: -2.2499848619125
-              skill: Client
-              speed: 138.88888888889
-              type: A-4E-C
-              unitId: 583
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        AH-64D Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 225
-          groupId: 461
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: AH-64D Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 500
-                alt_type: BARO
-                formation_template: ''
-                name: AH-64D Template
-                speed: 55.555555555556
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 2
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                AIDisabled: false
-                CpgNVG: true
-                FCR_RFI_removed: false
-                FlareBurstCount: 0
-                FlareBurstInterval: 0
-                FlareProgramDelay: 0
-                FlareSalvoCount: 0
-                FlareSalvoInterval: 0
-                HumanOrchestra: false
-                NetCrewControlPriority: 0
-                OverrideIFF: 0
-                OwnshipCallSign: G-1
-                PltNVG: true
-                TN_IDM_LB: '1'
-                TrackAirTargets: true
-              alt: 500
-              alt_type: BARO
-              callsign:
-                1: 7
-                2: 1
-                name: Chevy14
-                3: 4
-              datalinks:
-                IDM:
-                  network:
-                    presets:
-                      1:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 9
-                      2:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 9
-                      3:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 9
-                      4:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 9
-                      5:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 9
-                      6:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 9
-                      7:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 9
-                      8:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 9
-                      9:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 9
-                      10:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 9
-                  settings:
-                    presets:
-                      1:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 1
-                        presetName: PRESET 1
-                        primaryFreq: 1
-                      2:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 2
-                        presetName: PRESET 2
-                        primaryFreq: 2
-                      3:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 3
-                        presetName: PRESET 3
-                        primaryFreq: 3
-                      4:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 4
-                        presetName: PRESET 4
-                        primaryFreq: 4
-                      5:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 5
-                        presetName: PRESET 5
-                        primaryFreq: 0
-                      6:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 6
-                        presetName: PRESET 6
-                        primaryFreq: 0
-                      7:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 7
-                        presetName: PRESET 7
-                        primaryFreq: 0
-                      8:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 8
-                        presetName: PRESET 8
-                        primaryFreq: 0
-                      9:
-                        LB_Net: false
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 9
-                        presetName: PRESET 9
-                        primaryFreq: 0
-                      10:
-                        LB_Net: false
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE10
-                        presetName: PRESET10
-                        primaryFreq: 0
-              heading: -2.1935960373391
-              livery_id: default
-              name: 'AH-64D Template #01'
-              onboard_num: '014'
-              payload:
-                ammo_type: 1
-                chaff: 30
-                flare: 60
-                fuel: 1140
-                gun: 100
-                pylons:
-                  1:
-                    CLSID: M261_MK151
-                  2:
-                    CLSID: '{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}'
-                  3:
-                    CLSID: '{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}'
-                  4:
-                    CLSID: M261_MK151
-              psi: 2.1935960373391
-              skill: Client
-              speed: 55.555555555556
-              type: AH-64D_BLK_II
-              unitId: 542
               x: 0
               y: 0
           x: 0
@@ -889,72 +567,6 @@ helicopters:
               speed: 138.88888888889
               type: C-101CC
               unitId: 546
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        CH-47F Template-1:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 251
-          groupId: 460
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: CH-47F Template-1
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: CH-47F Template
-                speed: 46.25
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                NetCrewControlPriority: 0
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 7
-                2: 1
-                name: Chevy13
-                3: 3
-              heading: 0.68067840827779
-              livery_id: us army standard
-              name: 'CH-47F Template-1 #01'
-              onboard_num: '032'
-              payload:
-                chaff: 120
-                flare: 120
-                fuel: 3054.592
-                gun: 100
-                pylons: {}
-              psi: -0.68067840827779
-              ropeLength: 15
-              skill: Client
-              speed: 46.25
-              type: CH-47Fbl1
-              unitId: 541
               x: 0
               y: 0
           x: 0
@@ -2322,140 +1934,6 @@ helicopters:
               y: 0
           x: 0
           y: 0
-        Ka-50 Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 124
-          groupId: 459
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: Ka-50 Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 480
-                alt_type: BARO
-                formation_template: ''
-                name: Ka-50 Template
-                speed: 55.555555555556
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              alt: 480
-              alt_type: BARO
-              callsign:
-                1: 7
-                2: 1
-                name: Chevy12
-                3: 2
-              heading: 2.2689280275926
-              livery_id: italy aeronautica militare
-              name: 'Ka-50 Template #01'
-              onboard_num: '010'
-              payload:
-                chaff: 0
-                flare: 128
-                fuel: '1450'
-                gun: 100
-                pylons: {}
-              psi: -2.2689280275926
-              ropeLength: 15
-              skill: Client
-              speed: 55.555555555556
-              type: Ka-50
-              unitId: 540
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        Ka-50III Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 124
-          groupId: 456
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: Ka-50III Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 430
-                alt_type: BARO
-                formation_template: ''
-                name: Ka-50III Template
-                speed: 46.25
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                ExhaustScreen: true
-                Helmet-mounted device: 0
-                IMU alignment type: 1
-                Realistic INS: 0
-                modification: Ka-50_3
-              alt: 430
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 9
-                name: Ford97
-                3: 7
-              heading: 5.846852994181
-              livery_id: default
-              name: 'Ka-50III Template #01'
-              onboard_num: '024'
-              payload:
-                chaff: 0
-                flare: 128
-                fuel: 1160
-                gun: 100
-                pylons: {}
-              psi: -5.846852994181
-              ropeLength: 15
-              skill: Client
-              speed: 46.25
-              type: Ka-50_3
-              unitId: 537
-              x: 0
-              y: 0
-          x: 0
-          y: 0
         L-39C Template:
           communication: true
           dynSpawnTemplate: true
@@ -2702,179 +2180,6 @@ helicopters:
               speed: 138.88888888889
               type: M-2000C
               unitId: 601
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        Mi-24P Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 127.5
-          groupId: 457
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: Mi-24P Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 430
-                alt_type: BARO
-                formation_template: ''
-                name: Mi-24P Template
-                speed: 46.25
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                ExhaustScreen: true
-                GunnersAISkill: 90
-                HideAngleBoxes: false
-                HumanOrchestra: false
-                LeftEngineResource: 90
-                NS430allow: true
-                NetCrewControlPriority: 0
-                OperatorNVG: true
-                OverrideIFF: 0
-                PilotNVG: true
-                R60equipment: false
-                RightEngineResource: 90
-                SimplifiedAI: false
-                TrackAirTargets: true
-              alt: 430
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 9
-                name: Ford98
-                3: 8
-              heading: 5.846852994181
-              livery_id: 99.735 coyotes - crocodile - veaf
-              name: 'Mi-24P Template #01'
-              onboard_num: '010'
-              payload:
-                ammo_type: 1
-                chaff: 0
-                flare: 192
-                fuel: 1191
-                gun: 100
-                pylons:
-                  1:
-                    CLSID: '{2x9M120_Ataka_V}'
-                  2:
-                    CLSID: '{2x9M120_Ataka_V_with_adapter}'
-                  3:
-                    CLSID: '{6A4B9E69-64FE-439a-9163-3A87FB6A4D81}'
-                  4:
-                    CLSID: '{6A4B9E69-64FE-439a-9163-3A87FB6A4D81}'
-                  5:
-                    CLSID: '{2x9M120_Ataka_V_with_adapter}'
-                  6:
-                    CLSID: '{2x9M120_Ataka_V}'
-                restricted:
-                  2:
-                    1: '{APU-60-1_R_60M}'
-                    2: '{B0DBC591-0F52-4F7D-AD7B-51E67725FB81}'
-                  5:
-                    1: '{APU-60-1_R_60M}'
-                    2: '{275A2855-4A79-4B2D-B082-91EA2ADF4691}'
-              psi: -5.846852994181
-              ropeLength: 15
-              skill: Client
-              speed: 46.25
-              type: Mi-24P
-              unitId: 538
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        Mi-8MTV2 Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 127.5
-          groupId: 454
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: Mi-8MTV2 Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: Mi-8MTV2 Template
-                speed: 55.555555555556
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Transport
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                AdditionalArmor: true
-                CargoHalfdoor: true
-                ExhaustScreen: true
-                GunnersAISkill: 90
-                HumanOrchestra: false
-                LeftEngineResource: 90
-                NS430allow: true
-                NetCrewControlPriority: -2
-                RightEngineResource: 90
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 9
-                name: Ford95
-                3: 5
-              hardpoint_racks: true
-              heading: 0.93857425772792
-              livery_id: Russia_VVS_Standard
-              name: 'Mi-8MTV2 Template #01'
-              onboard_num: 019
-              payload:
-                chaff: 0
-                flare: 128
-                fuel: 965
-                gun: 100
-                pylons: {}
-              psi: -2.6179938779915
-              ropeLength: 15
-              skill: Client
-              speed: 55.555555555556
-              type: Mi-8MT
-              unitId: 535
               x: 0
               y: 0
           x: 0
@@ -3719,177 +3024,6 @@ helicopters:
               y: 0
           x: 0
           y: 0
-        OH-58 Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 116
-          groupId: 463
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: OH-58 Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: OH-58 Template
-                speed: 46.25
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 1
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                ALQ144: false
-                AllowHidePDU: true
-                MMS removal: false
-                NetCrewControlPriority: 0
-                PDU: false
-                Rapid Deployment Gear: false
-                Remove doors: false
-                Rifles: true
-                importDrawings: true
-                tacNet: 1
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 7
-                2: 1
-                name: Chevy16
-                3: 6
-              hardpoint_racks: true
-              heading: 5.8992128717408
-              livery_id: default
-              name: 'OH-58 Template #01'
-              onboard_num: '011'
-              payload:
-                chaff: 0
-                flare: 30
-                fuel: 333.69
-                gun: 100
-                pylons: {}
-              psi: -5.8992128717408
-              skill: Client
-              speed: 46.25
-              type: OH58D
-              unitId: 544
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        OV-10A Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 127.5
-          groupId: 494
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: OV-10A Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: OV-10A Template
-                speed: 107.91666666667
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 2
-                              value: true
-                      2:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 2
-                        params:
-                          action:
-                            id: Option
-                            params:
-                              name: 35
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 7
-                2: 5
-                name: Chevy58
-                3: 8
-              heading: 5.4628805587423
-              livery_id: tass 19th usaf 67-14657
-              name: 'OV-10A Template #01'
-              onboard_num: 018
-              payload:
-                chaff: 0
-                flare: 0
-                fuel: 940
-                gun: 100
-                pylons: {}
-              psi: -5.4628805587423
-              skill: Client
-              speed: 107.91666666667
-              type: Bronco-OV-10A
-              unitId: 578
-              x: 0
-              y: 0
-          x: 0
-          y: 0
         P-47D Template:
           communication: true
           dynSpawnTemplate: true
@@ -4040,248 +3174,6 @@ helicopters:
               speed: 138.88888888889
               type: P-51D
               unitId: 579
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        SA342L Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 124
-          groupId: 462
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: SA342L Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: SA342L Template
-                speed: 44.444444444444
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 4
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                NS430allow: true
-                RemoveTablet: false
-                SA342RemoveDoors: false
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 7
-                2: 1
-                name: Chevy15
-                3: 5
-              heading: 5.9341194567807
-              livery_id: fr alat ce 1985
-              name: 'SA342L Template #01'
-              onboard_num: '022'
-              payload:
-                chaff: 0
-                flare: 32
-                fuel: 416.33
-                gun: 100
-                pylons: {}
-              psi: -5.9341194567807
-              ropeLength: 15
-              skill: Client
-              speed: 44.444444444444
-              type: SA342L
-              unitId: 543
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        SA342M Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 124
-          groupId: 458
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: SA342M Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: SA342M Template
-                speed: 46.25
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 5
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                NS430allow: true
-                RemoveTablet: false
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 9
-                name: Ford99
-                3: 9
-              heading: 5.9341194567807
-              livery_id: fr alat ce 1985
-              name: 'SA342M Template #01'
-              onboard_num: 028
-              payload:
-                chaff: 0
-                flare: 32
-                fuel: 333
-                gun: 100
-                pylons:
-                  1:
-                    CLSID: '{HOT3_R2_M}'
-                  2:
-                    CLSID: '{HOT3_L2_M}'
-                  4:
-                    CLSID: '{IR_Deflector}'
-              psi: -5.9341194567807
-              ropeLength: 15
-              skill: Client
-              speed: 46.25
-              type: SA342M
-              unitId: 539
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        SA342Minigun Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 124
-          groupId: 464
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: SA342Minigun Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: SA342Minigun Template
-                speed: 44.444444444444
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 3
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                NS430allow: true
-                RemoveTablet: false
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 7
-                2: 1
-                name: Chevy17
-                3: 7
-              heading: 5.9341194567807
-              livery_id: fr alat ce 1985
-              name: 'SA342Minigun Template #01'
-              onboard_num: '021'
-              payload:
-                ammo_type: 1
-                chaff: 0
-                flare: 32
-                fuel: 416.33
-                gun: 100
-                pylons: {}
-              psi: -5.9341194567807
-              ropeLength: 15
-              skill: Client
-              speed: 44.444444444444
-              type: SA342Minigun
-              unitId: 545
               x: 0
               y: 0
           x: 0
@@ -4658,77 +3550,6 @@ helicopters:
               y: 0
           x: 0
           y: 0
-        UH-1H Template:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 251
-          groupId: 455
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: UH-1H Template
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 500
-                alt_type: BARO
-                formation_template: ''
-                name: UH-1H Template
-                speed: 55.555555555556
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                EngineResource: 90
-                ExhaustScreen: true
-                GunnersAISkill: 90
-                NetCrewControlPriority: -2
-                SoloFlight: false
-              alt: 500
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 9
-                name: Ford96
-                3: 6
-              hardpoint_racks: true
-              heading: 0.94881750304937
-              livery_id: French Army
-              name: 'UH-1H Template #01'
-              onboard_num: '015'
-              payload:
-                chaff: 0
-                flare: 60
-                fuel: '631'
-                gun: 100
-                pylons: {}
-              psi: -0.94862592345254
-              ropeLength: 15
-              skill: Client
-              speed: 55.555555555556
-              type: UH-1H
-              unitId: 536
-              x: 0
-              y: 0
-          x: 0
-          y: 0
         Yak-52 Template:
           communication: true
           dynSpawnTemplate: true
@@ -4929,326 +3750,6 @@ helicopters:
               speed: 138.88888888889
               type: A-10C_2
               unitId: 303
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        A-4E-C Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 254
-          groupId: 314
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: A-4E-C Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 2000
-                alt_type: BARO
-                formation_template: ''
-                name: A-4E-C Template Red
-                speed: 138.88888888889
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: Option
-                            params:
-                              name: 35
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                Auto_Catapult_Power: false
-                CBU2ATPP: 0
-                CBU2BATPP: 0
-                CMS_BURSTS: 1
-                CMS_BURST_INTERVAL: 1
-                CMS_SALVOS: 1
-                CMS_SALVO_INTERVAL: 1
-                HideECMPanel: false
-                Night_Vision: false
-              alt: 2000
-              alt_type: BARO
-              callsign:
-                1: 4
-                2: 2
-                name: Colt25
-                3: 5
-              heading: 2.1757446334553
-              livery_id: community a-4e ii
-              name: 'A-4E-C Template Red #01'
-              onboard_num: '045'
-              payload:
-                ammo_type: 1
-                chaff: 30
-                flare: 30
-                fuel: 2467.5454273299
-                gun: 100
-                pylons: {}
-              psi: -2.2499848619125
-              skill: Client
-              speed: 138.88888888889
-              type: A-4E-C
-              unitId: 216
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        AH-64D Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 225
-          groupId: 412
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: AH-64D Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 500
-                alt_type: BARO
-                formation_template: ''
-                name: AH-64D Template Red
-                speed: 55.555555555556
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 7
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                AIDisabled: false
-                CpgNVG: true
-                FCR_RFI_removed: false
-                FlareBurstCount: 0
-                FlareBurstInterval: 0
-                FlareProgramDelay: 0
-                FlareSalvoCount: 0
-                FlareSalvoInterval: 0
-                HumanOrchestra: false
-                NetCrewControlPriority: 0
-                OverrideIFF: 0
-                OwnshipCallSign: G-2
-                PltNVG: true
-                TN_IDM_LB: '2'
-                TrackAirTargets: true
-              alt: 500
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 4
-                name: Ford49
-                3: 9
-              datalinks:
-                IDM:
-                  network:
-                    presets:
-                      1:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 80
-                      2:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 80
-                      3:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 80
-                      4:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 80
-                      5:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 80
-                      6:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 80
-                      7:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 80
-                      8:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 80
-                      9:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 80
-                      10:
-                        members:
-                          1:
-                            PRI_value: true
-                            TM_value: true
-                            missionUnitId: 80
-                  settings:
-                    presets:
-                      1:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 1
-                        presetName: PRESET 1
-                        primaryFreq: 1
-                      2:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 2
-                        presetName: PRESET 2
-                        primaryFreq: 2
-                      3:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 3
-                        presetName: PRESET 3
-                        primaryFreq: 3
-                      4:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 4
-                        presetName: PRESET 4
-                        primaryFreq: 4
-                      5:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 5
-                        presetName: PRESET 5
-                        primaryFreq: 0
-                      6:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 6
-                        presetName: PRESET 6
-                        primaryFreq: 0
-                      7:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 7
-                        presetName: PRESET 7
-                        primaryFreq: 0
-                      8:
-                        LB_Net: true
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 8
-                        presetName: PRESET 8
-                        primaryFreq: 0
-                      9:
-                        LB_Net: false
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE 9
-                        presetName: PRESET 9
-                        primaryFreq: 0
-                      10:
-                        LB_Net: false
-                        NoAcknowledgmentRetries: 2
-                        autoAcknowledgment: true
-                        callSign: PRE10
-                        presetName: PRESET10
-                        primaryFreq: 0
-              heading: -2.1935960373391
-              livery_id: default
-              name: 'AH-64D Template Red #01'
-              onboard_num: '047'
-              payload:
-                ammo_type: 1
-                chaff: 30
-                flare: 60
-                fuel: 1140
-                gun: 100
-                pylons:
-                  1:
-                    CLSID: M261_MK151
-                  2:
-                    CLSID: '{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}'
-                  3:
-                    CLSID: '{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}'
-                  4:
-                    CLSID: M261_MK151
-              psi: 2.1935960373391
-              skill: Client
-              speed: 55.555555555556
-              type: AH-64D_BLK_II
-              unitId: 420
               x: 0
               y: 0
           x: 0
@@ -5584,72 +4085,6 @@ helicopters:
               speed: 138.88888888889
               type: C-101CC
               unitId: 203
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        CH-47F Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 251
-          groupId: 419
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: CH-47F Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: CH-47F Template Red
-                speed: 46.25
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                NetCrewControlPriority: 0
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 5
-                name: Ford58
-                3: 8
-              heading: 0.68067840827779
-              livery_id: dark green
-              name: 'CH-47F Template Red #01'
-              onboard_num: 078
-              payload:
-                chaff: 120
-                flare: 120
-                fuel: 3054.592
-                gun: 100
-                pylons: {}
-              psi: -0.68067840827779
-              ropeLength: 15
-              skill: Client
-              speed: 46.25
-              type: CH-47Fbl1
-              unitId: 427
               x: 0
               y: 0
           x: 0
@@ -6895,140 +5330,6 @@ helicopters:
               y: 0
           x: 0
           y: 0
-        Ka-50 Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 124
-          groupId: 417
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: Ka-50 Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 480
-                alt_type: BARO
-                formation_template: ''
-                name: Ka-50 Template Red
-                speed: 55.555555555556
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              alt: 480
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 5
-                name: Ford56
-                3: 6
-              heading: 2.2689280275926
-              livery_id: italy aeronautica militare
-              name: 'Ka-50 Template Red #01'
-              onboard_num: 039
-              payload:
-                chaff: 0
-                flare: 128
-                fuel: '1450'
-                gun: 100
-                pylons: {}
-              psi: -2.2689280275926
-              ropeLength: 15
-              skill: Client
-              speed: 55.555555555556
-              type: Ka-50
-              unitId: 425
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        Ka-50III Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 124
-          groupId: 414
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: Ka-50III Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 430
-                alt_type: BARO
-                formation_template: ''
-                name: Ka-50III Template Red
-                speed: 46.25
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                ExhaustScreen: true
-                Helmet-mounted device: 0
-                IMU alignment type: 1
-                Realistic INS: 0
-                modification: Ka-50_3
-              alt: 430
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 5
-                name: Ford53
-                3: 3
-              heading: 5.846852994181
-              livery_id: default
-              name: 'Ka-50III Template Red #01'
-              onboard_num: '066'
-              payload:
-                chaff: 0
-                flare: 128
-                fuel: 1160
-                gun: 100
-                pylons: {}
-              psi: -5.846852994181
-              ropeLength: 15
-              skill: Client
-              speed: 46.25
-              type: Ka-50_3
-              unitId: 422
-              x: 0
-              y: 0
-          x: 0
-          y: 0
         L-39C Template Red:
           communication: true
           dynSpawnTemplate: true
@@ -7275,179 +5576,6 @@ helicopters:
               speed: 138.88888888889
               type: M-2000C
               unitId: 196
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        Mi-24P Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 127.5
-          groupId: 409
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: Mi-24P Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 430
-                alt_type: BARO
-                formation_template: ''
-                name: Mi-24P Template Red
-                speed: 46.25
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                ExhaustScreen: true
-                GunnersAISkill: 90
-                HideAngleBoxes: false
-                HumanOrchestra: false
-                LeftEngineResource: 90
-                NS430allow: true
-                NetCrewControlPriority: 0
-                OperatorNVG: true
-                OverrideIFF: 0
-                PilotNVG: true
-                R60equipment: false
-                RightEngineResource: 90
-                SimplifiedAI: false
-                TrackAirTargets: true
-              alt: 430
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 4
-                name: Ford46
-                3: 6
-              heading: 5.846852994181
-              livery_id: russian air force
-              name: 'Mi-24P Template Red #01'
-              onboard_num: '050'
-              payload:
-                ammo_type: 1
-                chaff: 0
-                flare: 192
-                fuel: 1191
-                gun: 100
-                pylons:
-                  1:
-                    CLSID: '{2x9M120_Ataka_V}'
-                  2:
-                    CLSID: '{2x9M120_Ataka_V_with_adapter}'
-                  3:
-                    CLSID: '{6A4B9E69-64FE-439a-9163-3A87FB6A4D81}'
-                  4:
-                    CLSID: '{6A4B9E69-64FE-439a-9163-3A87FB6A4D81}'
-                  5:
-                    CLSID: '{2x9M120_Ataka_V_with_adapter}'
-                  6:
-                    CLSID: '{2x9M120_Ataka_V}'
-                restricted:
-                  2:
-                    1: '{APU-60-1_R_60M}'
-                    2: '{B0DBC591-0F52-4F7D-AD7B-51E67725FB81}'
-                  5:
-                    1: '{APU-60-1_R_60M}'
-                    2: '{275A2855-4A79-4B2D-B082-91EA2ADF4691}'
-              psi: -5.846852994181
-              ropeLength: 15
-              skill: Client
-              speed: 46.25
-              type: Mi-24P
-              unitId: 416
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        Mi-8MTV2 Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 127.5
-          groupId: 413
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: Mi-8MTV2 Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: Mi-8MTV2 Template Red
-                speed: 55.555555555556
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Transport
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                AdditionalArmor: true
-                CargoHalfdoor: true
-                ExhaustScreen: true
-                GunnersAISkill: 90
-                HumanOrchestra: false
-                LeftEngineResource: 90
-                NS430allow: true
-                NetCrewControlPriority: -2
-                RightEngineResource: 90
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 5
-                name: Ford52
-                3: 2
-              hardpoint_racks: true
-              heading: 0.93857425772792
-              livery_id: russia_vvs_standard
-              name: 'Mi-8MTV2 Template Red #01'
-              onboard_num: 059
-              payload:
-                chaff: 0
-                flare: 128
-                fuel: 965
-                gun: 100
-                pylons: {}
-              psi: -2.6179938779915
-              ropeLength: 15
-              skill: Client
-              speed: 55.555555555556
-              type: Mi-8MT
-              unitId: 421
               x: 0
               y: 0
           x: 0
@@ -8292,177 +6420,6 @@ helicopters:
               y: 0
           x: 0
           y: 0
-        OH-58 Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 116
-          groupId: 415
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: OH-58 Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: OH-58 Template Red
-                speed: 46.25
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 6
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                ALQ144: false
-                AllowHidePDU: true
-                MMS removal: false
-                NetCrewControlPriority: 0
-                PDU: false
-                Rapid Deployment Gear: false
-                Remove doors: false
-                Rifles: true
-                importDrawings: true
-                tacNet: 1
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 5
-                name: Ford54
-                3: 4
-              hardpoint_racks: true
-              heading: 5.8992128717408
-              livery_id: ru army fictional
-              name: 'OH-58 Template Red #01'
-              onboard_num: '042'
-              payload:
-                chaff: 0
-                flare: 30
-                fuel: 333.69
-                gun: 100
-                pylons: {}
-              psi: -5.8992128717408
-              skill: Client
-              speed: 46.25
-              type: OH58D
-              unitId: 423
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        OV-10A Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 127.5
-          groupId: 283
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: OV-10A Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: OV-10A Template Red
-                speed: 107.91666666667
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 9
-                              value: true
-                      2:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 2
-                        params:
-                          action:
-                            id: Option
-                            params:
-                              name: 35
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 3
-                2: 6
-                name: Uzi69
-                3: 9
-              heading: 5.4628805587423
-              livery_id: tass 22nd usaf 67-14647wh
-              name: 'OV-10A Template Red #01'
-              onboard_num: '057'
-              payload:
-                chaff: 0
-                flare: 0
-                fuel: 940
-                gun: 100
-                pylons: {}
-              psi: -5.4628805587423
-              skill: Client
-              speed: 107.91666666667
-              type: Bronco-OV-10A
-              unitId: 180
-              x: 0
-              y: 0
-          x: 0
-          y: 0
         P-47D Template Red:
           communication: true
           dynSpawnTemplate: true
@@ -8613,248 +6570,6 @@ helicopters:
               speed: 138.88888888889
               type: P-51D
               unitId: 206
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        SA342L Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 124
-          groupId: 416
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: SA342L Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: SA342L Template Red
-                speed: 44.444444444444
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 9
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                NS430allow: true
-                RemoveTablet: false
-                SA342RemoveDoors: false
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 5
-                name: Ford55
-                3: 5
-              heading: 5.9341194567807
-              livery_id: gen olive drab
-              name: 'SA342L Template Red #01'
-              onboard_num: '063'
-              payload:
-                chaff: 0
-                flare: 32
-                fuel: 416.33
-                gun: 100
-                pylons: {}
-              psi: -5.9341194567807
-              ropeLength: 15
-              skill: Client
-              speed: 44.444444444444
-              type: SA342L
-              unitId: 424
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        SA342M Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 124
-          groupId: 418
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: SA342M Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: SA342M Template Red
-                speed: 46.25
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 10
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                NS430allow: true
-                RemoveTablet: false
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 5
-                name: Ford57
-                3: 7
-              heading: 5.9341194567807
-              livery_id: gen olive drab
-              name: 'SA342M Template Red #01'
-              onboard_num: '073'
-              payload:
-                chaff: 0
-                flare: 32
-                fuel: 333
-                gun: 100
-                pylons:
-                  1:
-                    CLSID: '{HOT3_R2_M}'
-                  2:
-                    CLSID: '{HOT3_L2_M}'
-                  4:
-                    CLSID: '{IR_Deflector}'
-              psi: -5.9341194567807
-              ropeLength: 15
-              skill: Client
-              speed: 46.25
-              type: SA342M
-              unitId: 426
-              x: 0
-              y: 0
-          x: 0
-          y: 0
-        SA342Minigun Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 124
-          groupId: 411
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: SA342Minigun Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 30
-                alt_type: BARO
-                formation_template: ''
-                name: SA342Minigun Template Red
-                speed: 44.444444444444
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks:
-                      1:
-                        auto: true
-                        enabled: true
-                        id: WrappedAction
-                        number: 1
-                        params:
-                          action:
-                            id: EPLRS
-                            params:
-                              groupId: 8
-                              value: true
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                NS430allow: true
-                RemoveTablet: false
-              alt: 30
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 4
-                name: Ford48
-                3: 8
-              heading: 5.9341194567807
-              livery_id: gen olive drab
-              name: 'SA342Minigun Template Red #01'
-              onboard_num: '062'
-              payload:
-                ammo_type: 1
-                chaff: 0
-                flare: 32
-                fuel: 416.33
-                gun: 100
-                pylons: {}
-              psi: -5.9341194567807
-              ropeLength: 15
-              skill: Client
-              speed: 44.444444444444
-              type: SA342Minigun
-              unitId: 419
               x: 0
               y: 0
           x: 0
@@ -9231,77 +6946,6 @@ helicopters:
               y: 0
           x: 0
           y: 0
-        UH-1H Template Red:
-          communication: true
-          dynSpawnTemplate: true
-          frequency: 251
-          groupId: 410
-          hidden: true
-          lateActivation: true
-          modulation: 0
-          name: UH-1H Template Red
-          radioSet: false
-          route:
-            points:
-              1:
-                ETA: 0
-                ETA_locked: true
-                action: Turning Point
-                alt: 500
-                alt_type: BARO
-                formation_template: ''
-                name: UH-1H Template Red
-                speed: 55.555555555556
-                speed_locked: true
-                task:
-                  id: ComboTask
-                  params:
-                    tasks: {}
-                type: Turning Point
-                x: 0
-                y: 0
-          start_time: 0
-          task: Nothing
-          taskSelected: true
-          tasks: {}
-          uncontrollable: false
-          uncontrolled: false
-          units:
-            1:
-              AddPropAircraft:
-                EngineResource: 90
-                ExhaustScreen: true
-                GunnersAISkill: 90
-                NetCrewControlPriority: -2
-                SoloFlight: false
-              alt: 500
-              alt_type: BARO
-              callsign:
-                1: 6
-                2: 4
-                name: Ford47
-                3: 7
-              hardpoint_racks: true
-              heading: 0.94881750304937
-              livery_id: Ukrainian Army
-              name: 'UH-1H Template Red #01'
-              onboard_num: 049
-              payload:
-                chaff: 0
-                flare: 60
-                fuel: '631'
-                gun: 100
-                pylons: {}
-              psi: -0.94862592345254
-              ropeLength: 15
-              skill: Client
-              speed: 55.555555555556
-              type: UH-1H
-              unitId: 418
-              x: 0
-              y: 0
-          x: 0
-          y: 0
         Yak-52 Template Red:
           communication: true
           dynSpawnTemplate: true
@@ -9494,6 +7138,2366 @@ helicopters:
               speed: 138.88888888889
               type: F-15ESE
               unitId: 482
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+helicopters:
+  coalitions:
+    blue:
+      CJTF Blue:
+        A-4E-C Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 254
+          groupId: 499
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: A-4E-C Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 2000
+                alt_type: BARO
+                formation_template: ''
+                name: A-4E-C Template
+                speed: 138.88888888889
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: Option
+                            params:
+                              name: 35
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                Auto_Catapult_Power: false
+                CBU2ATPP: 0
+                CBU2BATPP: 0
+                CMS_BURSTS: 1
+                CMS_BURST_INTERVAL: 1
+                CMS_SALVOS: 1
+                CMS_SALVO_INTERVAL: 1
+                HideECMPanel: false
+                Night_Vision: false
+              alt: 2000
+              alt_type: BARO
+              callsign:
+                1: 7
+                2: 6
+                name: Chevy65
+                3: 5
+              heading: 2.1757446334553
+              livery_id: unmarked
+              name: 'A-4E-C Template #01'
+              onboard_num: '013'
+              payload:
+                ammo_type: 1
+                chaff: 30
+                flare: 30
+                fuel: 2467.5454273299
+                gun: 100
+                pylons: {}
+              psi: -2.2499848619125
+              skill: Client
+              speed: 138.88888888889
+              type: A-4E-C
+              unitId: 583
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        AH-64D Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 225
+          groupId: 461
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: AH-64D Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 500
+                alt_type: BARO
+                formation_template: ''
+                name: AH-64D Template
+                speed: 55.555555555556
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 2
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                AIDisabled: false
+                CpgNVG: true
+                FCR_RFI_removed: false
+                FlareBurstCount: 0
+                FlareBurstInterval: 0
+                FlareProgramDelay: 0
+                FlareSalvoCount: 0
+                FlareSalvoInterval: 0
+                HumanOrchestra: false
+                NetCrewControlPriority: 0
+                OverrideIFF: 0
+                OwnshipCallSign: G-1
+                PltNVG: true
+                TN_IDM_LB: '1'
+                TrackAirTargets: true
+              alt: 500
+              alt_type: BARO
+              callsign:
+                1: 7
+                2: 1
+                name: Chevy14
+                3: 4
+              datalinks:
+                IDM:
+                  network:
+                    presets:
+                      1:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 9
+                      2:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 9
+                      3:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 9
+                      4:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 9
+                      5:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 9
+                      6:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 9
+                      7:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 9
+                      8:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 9
+                      9:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 9
+                      10:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 9
+                  settings:
+                    presets:
+                      1:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 1
+                        presetName: PRESET 1
+                        primaryFreq: 1
+                      2:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 2
+                        presetName: PRESET 2
+                        primaryFreq: 2
+                      3:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 3
+                        presetName: PRESET 3
+                        primaryFreq: 3
+                      4:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 4
+                        presetName: PRESET 4
+                        primaryFreq: 4
+                      5:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 5
+                        presetName: PRESET 5
+                        primaryFreq: 0
+                      6:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 6
+                        presetName: PRESET 6
+                        primaryFreq: 0
+                      7:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 7
+                        presetName: PRESET 7
+                        primaryFreq: 0
+                      8:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 8
+                        presetName: PRESET 8
+                        primaryFreq: 0
+                      9:
+                        LB_Net: false
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 9
+                        presetName: PRESET 9
+                        primaryFreq: 0
+                      10:
+                        LB_Net: false
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE10
+                        presetName: PRESET10
+                        primaryFreq: 0
+              heading: -2.1935960373391
+              livery_id: default
+              name: 'AH-64D Template #01'
+              onboard_num: '014'
+              payload:
+                ammo_type: 1
+                chaff: 30
+                flare: 60
+                fuel: 1140
+                gun: 100
+                pylons:
+                  1:
+                    CLSID: M261_MK151
+                  2:
+                    CLSID: '{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}'
+                  3:
+                    CLSID: '{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}'
+                  4:
+                    CLSID: M261_MK151
+              psi: 2.1935960373391
+              skill: Client
+              speed: 55.555555555556
+              type: AH-64D_BLK_II
+              unitId: 542
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        CH-47F Template-1:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 251
+          groupId: 460
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: CH-47F Template-1
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: CH-47F Template
+                speed: 46.25
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                NetCrewControlPriority: 0
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 7
+                2: 1
+                name: Chevy13
+                3: 3
+              heading: 0.68067840827779
+              livery_id: us army standard
+              name: 'CH-47F Template-1 #01'
+              onboard_num: '032'
+              payload:
+                chaff: 120
+                flare: 120
+                fuel: 3054.592
+                gun: 100
+                pylons: {}
+              psi: -0.68067840827779
+              ropeLength: 15
+              skill: Client
+              speed: 46.25
+              type: CH-47Fbl1
+              unitId: 541
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        Ka-50 Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 124
+          groupId: 459
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: Ka-50 Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 480
+                alt_type: BARO
+                formation_template: ''
+                name: Ka-50 Template
+                speed: 55.555555555556
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              alt: 480
+              alt_type: BARO
+              callsign:
+                1: 7
+                2: 1
+                name: Chevy12
+                3: 2
+              heading: 2.2689280275926
+              livery_id: italy aeronautica militare
+              name: 'Ka-50 Template #01'
+              onboard_num: '010'
+              payload:
+                chaff: 0
+                flare: 128
+                fuel: '1450'
+                gun: 100
+                pylons: {}
+              psi: -2.2689280275926
+              ropeLength: 15
+              skill: Client
+              speed: 55.555555555556
+              type: Ka-50
+              unitId: 540
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        Ka-50III Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 124
+          groupId: 456
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: Ka-50III Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 430
+                alt_type: BARO
+                formation_template: ''
+                name: Ka-50III Template
+                speed: 46.25
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                ExhaustScreen: true
+                Helmet-mounted device: 0
+                IMU alignment type: 1
+                Realistic INS: 0
+                modification: Ka-50_3
+              alt: 430
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 9
+                name: Ford97
+                3: 7
+              heading: 5.846852994181
+              livery_id: default
+              name: 'Ka-50III Template #01'
+              onboard_num: '024'
+              payload:
+                chaff: 0
+                flare: 128
+                fuel: 1160
+                gun: 100
+                pylons: {}
+              psi: -5.846852994181
+              ropeLength: 15
+              skill: Client
+              speed: 46.25
+              type: Ka-50_3
+              unitId: 537
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        Mi-24P Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 127.5
+          groupId: 457
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: Mi-24P Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 430
+                alt_type: BARO
+                formation_template: ''
+                name: Mi-24P Template
+                speed: 46.25
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                ExhaustScreen: true
+                GunnersAISkill: 90
+                HideAngleBoxes: false
+                HumanOrchestra: false
+                LeftEngineResource: 90
+                NS430allow: true
+                NetCrewControlPriority: 0
+                OperatorNVG: true
+                OverrideIFF: 0
+                PilotNVG: true
+                R60equipment: false
+                RightEngineResource: 90
+                SimplifiedAI: false
+                TrackAirTargets: true
+              alt: 430
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 9
+                name: Ford98
+                3: 8
+              heading: 5.846852994181
+              livery_id: 99.735 coyotes - crocodile - veaf
+              name: 'Mi-24P Template #01'
+              onboard_num: '010'
+              payload:
+                ammo_type: 1
+                chaff: 0
+                flare: 192
+                fuel: 1191
+                gun: 100
+                pylons:
+                  1:
+                    CLSID: '{2x9M120_Ataka_V}'
+                  2:
+                    CLSID: '{2x9M120_Ataka_V_with_adapter}'
+                  3:
+                    CLSID: '{6A4B9E69-64FE-439a-9163-3A87FB6A4D81}'
+                  4:
+                    CLSID: '{6A4B9E69-64FE-439a-9163-3A87FB6A4D81}'
+                  5:
+                    CLSID: '{2x9M120_Ataka_V_with_adapter}'
+                  6:
+                    CLSID: '{2x9M120_Ataka_V}'
+                restricted:
+                  2:
+                    1: '{APU-60-1_R_60M}'
+                    2: '{B0DBC591-0F52-4F7D-AD7B-51E67725FB81}'
+                  5:
+                    1: '{APU-60-1_R_60M}'
+                    2: '{275A2855-4A79-4B2D-B082-91EA2ADF4691}'
+              psi: -5.846852994181
+              ropeLength: 15
+              skill: Client
+              speed: 46.25
+              type: Mi-24P
+              unitId: 538
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        Mi-8MTV2 Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 127.5
+          groupId: 454
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: Mi-8MTV2 Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: Mi-8MTV2 Template
+                speed: 55.555555555556
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Transport
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                AdditionalArmor: true
+                CargoHalfdoor: true
+                ExhaustScreen: true
+                GunnersAISkill: 90
+                HumanOrchestra: false
+                LeftEngineResource: 90
+                NS430allow: true
+                NetCrewControlPriority: -2
+                RightEngineResource: 90
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 9
+                name: Ford95
+                3: 5
+              hardpoint_racks: true
+              heading: 0.93857425772792
+              livery_id: Russia_VVS_Standard
+              name: 'Mi-8MTV2 Template #01'
+              onboard_num: 019
+              payload:
+                chaff: 0
+                flare: 128
+                fuel: 965
+                gun: 100
+                pylons: {}
+              psi: -2.6179938779915
+              ropeLength: 15
+              skill: Client
+              speed: 55.555555555556
+              type: Mi-8MT
+              unitId: 535
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        OH-58 Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 116
+          groupId: 463
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: OH-58 Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: OH-58 Template
+                speed: 46.25
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 1
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                ALQ144: false
+                AllowHidePDU: true
+                MMS removal: false
+                NetCrewControlPriority: 0
+                PDU: false
+                Rapid Deployment Gear: false
+                Remove doors: false
+                Rifles: true
+                importDrawings: true
+                tacNet: 1
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 7
+                2: 1
+                name: Chevy16
+                3: 6
+              hardpoint_racks: true
+              heading: 5.8992128717408
+              livery_id: default
+              name: 'OH-58 Template #01'
+              onboard_num: '011'
+              payload:
+                chaff: 0
+                flare: 30
+                fuel: 333.69
+                gun: 100
+                pylons: {}
+              psi: -5.8992128717408
+              skill: Client
+              speed: 46.25
+              type: OH58D
+              unitId: 544
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        OV-10A Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 127.5
+          groupId: 494
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: OV-10A Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: OV-10A Template
+                speed: 107.91666666667
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 2
+                              value: true
+                      2:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 2
+                        params:
+                          action:
+                            id: Option
+                            params:
+                              name: 35
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 7
+                2: 5
+                name: Chevy58
+                3: 8
+              heading: 5.4628805587423
+              livery_id: tass 19th usaf 67-14657
+              name: 'OV-10A Template #01'
+              onboard_num: 018
+              payload:
+                chaff: 0
+                flare: 0
+                fuel: 940
+                gun: 100
+                pylons: {}
+              psi: -5.4628805587423
+              skill: Client
+              speed: 107.91666666667
+              type: Bronco-OV-10A
+              unitId: 578
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        SA342L Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 124
+          groupId: 462
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: SA342L Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: SA342L Template
+                speed: 44.444444444444
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 4
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                NS430allow: true
+                RemoveTablet: false
+                SA342RemoveDoors: false
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 7
+                2: 1
+                name: Chevy15
+                3: 5
+              heading: 5.9341194567807
+              livery_id: fr alat ce 1985
+              name: 'SA342L Template #01'
+              onboard_num: '022'
+              payload:
+                chaff: 0
+                flare: 32
+                fuel: 416.33
+                gun: 100
+                pylons: {}
+              psi: -5.9341194567807
+              ropeLength: 15
+              skill: Client
+              speed: 44.444444444444
+              type: SA342L
+              unitId: 543
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        SA342M Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 124
+          groupId: 458
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: SA342M Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: SA342M Template
+                speed: 46.25
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 5
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                NS430allow: true
+                RemoveTablet: false
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 9
+                name: Ford99
+                3: 9
+              heading: 5.9341194567807
+              livery_id: fr alat ce 1985
+              name: 'SA342M Template #01'
+              onboard_num: 028
+              payload:
+                chaff: 0
+                flare: 32
+                fuel: 333
+                gun: 100
+                pylons:
+                  1:
+                    CLSID: '{HOT3_R2_M}'
+                  2:
+                    CLSID: '{HOT3_L2_M}'
+                  4:
+                    CLSID: '{IR_Deflector}'
+              psi: -5.9341194567807
+              ropeLength: 15
+              skill: Client
+              speed: 46.25
+              type: SA342M
+              unitId: 539
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        SA342Minigun Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 124
+          groupId: 464
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: SA342Minigun Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: SA342Minigun Template
+                speed: 44.444444444444
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 3
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                NS430allow: true
+                RemoveTablet: false
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 7
+                2: 1
+                name: Chevy17
+                3: 7
+              heading: 5.9341194567807
+              livery_id: fr alat ce 1985
+              name: 'SA342Minigun Template #01'
+              onboard_num: '021'
+              payload:
+                ammo_type: 1
+                chaff: 0
+                flare: 32
+                fuel: 416.33
+                gun: 100
+                pylons: {}
+              psi: -5.9341194567807
+              ropeLength: 15
+              skill: Client
+              speed: 44.444444444444
+              type: SA342Minigun
+              unitId: 545
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        UH-1H Template:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 251
+          groupId: 455
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: UH-1H Template
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 500
+                alt_type: BARO
+                formation_template: ''
+                name: UH-1H Template
+                speed: 55.555555555556
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                EngineResource: 90
+                ExhaustScreen: true
+                GunnersAISkill: 90
+                NetCrewControlPriority: -2
+                SoloFlight: false
+              alt: 500
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 9
+                name: Ford96
+                3: 6
+              hardpoint_racks: true
+              heading: 0.94881750304937
+              livery_id: French Army
+              name: 'UH-1H Template #01'
+              onboard_num: '015'
+              payload:
+                chaff: 0
+                flare: 60
+                fuel: '631'
+                gun: 100
+                pylons: {}
+              psi: -0.94862592345254
+              ropeLength: 15
+              skill: Client
+              speed: 55.555555555556
+              type: UH-1H
+              unitId: 536
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+    red:
+      CJTF Red:
+        A-4E-C Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 254
+          groupId: 314
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: A-4E-C Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 2000
+                alt_type: BARO
+                formation_template: ''
+                name: A-4E-C Template Red
+                speed: 138.88888888889
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: Option
+                            params:
+                              name: 35
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                Auto_Catapult_Power: false
+                CBU2ATPP: 0
+                CBU2BATPP: 0
+                CMS_BURSTS: 1
+                CMS_BURST_INTERVAL: 1
+                CMS_SALVOS: 1
+                CMS_SALVO_INTERVAL: 1
+                HideECMPanel: false
+                Night_Vision: false
+              alt: 2000
+              alt_type: BARO
+              callsign:
+                1: 4
+                2: 2
+                name: Colt25
+                3: 5
+              heading: 2.1757446334553
+              livery_id: community a-4e ii
+              name: 'A-4E-C Template Red #01'
+              onboard_num: '045'
+              payload:
+                ammo_type: 1
+                chaff: 30
+                flare: 30
+                fuel: 2467.5454273299
+                gun: 100
+                pylons: {}
+              psi: -2.2499848619125
+              skill: Client
+              speed: 138.88888888889
+              type: A-4E-C
+              unitId: 216
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        AH-64D Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 225
+          groupId: 412
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: AH-64D Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 500
+                alt_type: BARO
+                formation_template: ''
+                name: AH-64D Template Red
+                speed: 55.555555555556
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 7
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                AIDisabled: false
+                CpgNVG: true
+                FCR_RFI_removed: false
+                FlareBurstCount: 0
+                FlareBurstInterval: 0
+                FlareProgramDelay: 0
+                FlareSalvoCount: 0
+                FlareSalvoInterval: 0
+                HumanOrchestra: false
+                NetCrewControlPriority: 0
+                OverrideIFF: 0
+                OwnshipCallSign: G-2
+                PltNVG: true
+                TN_IDM_LB: '2'
+                TrackAirTargets: true
+              alt: 500
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 4
+                name: Ford49
+                3: 9
+              datalinks:
+                IDM:
+                  network:
+                    presets:
+                      1:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 80
+                      2:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 80
+                      3:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 80
+                      4:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 80
+                      5:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 80
+                      6:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 80
+                      7:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 80
+                      8:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 80
+                      9:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 80
+                      10:
+                        members:
+                          1:
+                            PRI_value: true
+                            TM_value: true
+                            missionUnitId: 80
+                  settings:
+                    presets:
+                      1:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 1
+                        presetName: PRESET 1
+                        primaryFreq: 1
+                      2:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 2
+                        presetName: PRESET 2
+                        primaryFreq: 2
+                      3:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 3
+                        presetName: PRESET 3
+                        primaryFreq: 3
+                      4:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 4
+                        presetName: PRESET 4
+                        primaryFreq: 4
+                      5:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 5
+                        presetName: PRESET 5
+                        primaryFreq: 0
+                      6:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 6
+                        presetName: PRESET 6
+                        primaryFreq: 0
+                      7:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 7
+                        presetName: PRESET 7
+                        primaryFreq: 0
+                      8:
+                        LB_Net: true
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 8
+                        presetName: PRESET 8
+                        primaryFreq: 0
+                      9:
+                        LB_Net: false
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE 9
+                        presetName: PRESET 9
+                        primaryFreq: 0
+                      10:
+                        LB_Net: false
+                        NoAcknowledgmentRetries: 2
+                        autoAcknowledgment: true
+                        callSign: PRE10
+                        presetName: PRESET10
+                        primaryFreq: 0
+              heading: -2.1935960373391
+              livery_id: default
+              name: 'AH-64D Template Red #01'
+              onboard_num: '047'
+              payload:
+                ammo_type: 1
+                chaff: 30
+                flare: 60
+                fuel: 1140
+                gun: 100
+                pylons:
+                  1:
+                    CLSID: M261_MK151
+                  2:
+                    CLSID: '{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}'
+                  3:
+                    CLSID: '{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}'
+                  4:
+                    CLSID: M261_MK151
+              psi: 2.1935960373391
+              skill: Client
+              speed: 55.555555555556
+              type: AH-64D_BLK_II
+              unitId: 420
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        CH-47F Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 251
+          groupId: 419
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: CH-47F Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: CH-47F Template Red
+                speed: 46.25
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                NetCrewControlPriority: 0
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 5
+                name: Ford58
+                3: 8
+              heading: 0.68067840827779
+              livery_id: dark green
+              name: 'CH-47F Template Red #01'
+              onboard_num: 078
+              payload:
+                chaff: 120
+                flare: 120
+                fuel: 3054.592
+                gun: 100
+                pylons: {}
+              psi: -0.68067840827779
+              ropeLength: 15
+              skill: Client
+              speed: 46.25
+              type: CH-47Fbl1
+              unitId: 427
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        Ka-50 Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 124
+          groupId: 417
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: Ka-50 Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 480
+                alt_type: BARO
+                formation_template: ''
+                name: Ka-50 Template Red
+                speed: 55.555555555556
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              alt: 480
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 5
+                name: Ford56
+                3: 6
+              heading: 2.2689280275926
+              livery_id: italy aeronautica militare
+              name: 'Ka-50 Template Red #01'
+              onboard_num: 039
+              payload:
+                chaff: 0
+                flare: 128
+                fuel: '1450'
+                gun: 100
+                pylons: {}
+              psi: -2.2689280275926
+              ropeLength: 15
+              skill: Client
+              speed: 55.555555555556
+              type: Ka-50
+              unitId: 425
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        Ka-50III Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 124
+          groupId: 414
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: Ka-50III Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 430
+                alt_type: BARO
+                formation_template: ''
+                name: Ka-50III Template Red
+                speed: 46.25
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                ExhaustScreen: true
+                Helmet-mounted device: 0
+                IMU alignment type: 1
+                Realistic INS: 0
+                modification: Ka-50_3
+              alt: 430
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 5
+                name: Ford53
+                3: 3
+              heading: 5.846852994181
+              livery_id: default
+              name: 'Ka-50III Template Red #01'
+              onboard_num: '066'
+              payload:
+                chaff: 0
+                flare: 128
+                fuel: 1160
+                gun: 100
+                pylons: {}
+              psi: -5.846852994181
+              ropeLength: 15
+              skill: Client
+              speed: 46.25
+              type: Ka-50_3
+              unitId: 422
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        Mi-24P Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 127.5
+          groupId: 409
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: Mi-24P Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 430
+                alt_type: BARO
+                formation_template: ''
+                name: Mi-24P Template Red
+                speed: 46.25
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                ExhaustScreen: true
+                GunnersAISkill: 90
+                HideAngleBoxes: false
+                HumanOrchestra: false
+                LeftEngineResource: 90
+                NS430allow: true
+                NetCrewControlPriority: 0
+                OperatorNVG: true
+                OverrideIFF: 0
+                PilotNVG: true
+                R60equipment: false
+                RightEngineResource: 90
+                SimplifiedAI: false
+                TrackAirTargets: true
+              alt: 430
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 4
+                name: Ford46
+                3: 6
+              heading: 5.846852994181
+              livery_id: russian air force
+              name: 'Mi-24P Template Red #01'
+              onboard_num: '050'
+              payload:
+                ammo_type: 1
+                chaff: 0
+                flare: 192
+                fuel: 1191
+                gun: 100
+                pylons:
+                  1:
+                    CLSID: '{2x9M120_Ataka_V}'
+                  2:
+                    CLSID: '{2x9M120_Ataka_V_with_adapter}'
+                  3:
+                    CLSID: '{6A4B9E69-64FE-439a-9163-3A87FB6A4D81}'
+                  4:
+                    CLSID: '{6A4B9E69-64FE-439a-9163-3A87FB6A4D81}'
+                  5:
+                    CLSID: '{2x9M120_Ataka_V_with_adapter}'
+                  6:
+                    CLSID: '{2x9M120_Ataka_V}'
+                restricted:
+                  2:
+                    1: '{APU-60-1_R_60M}'
+                    2: '{B0DBC591-0F52-4F7D-AD7B-51E67725FB81}'
+                  5:
+                    1: '{APU-60-1_R_60M}'
+                    2: '{275A2855-4A79-4B2D-B082-91EA2ADF4691}'
+              psi: -5.846852994181
+              ropeLength: 15
+              skill: Client
+              speed: 46.25
+              type: Mi-24P
+              unitId: 416
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        Mi-8MTV2 Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 127.5
+          groupId: 413
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: Mi-8MTV2 Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: Mi-8MTV2 Template Red
+                speed: 55.555555555556
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Transport
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                AdditionalArmor: true
+                CargoHalfdoor: true
+                ExhaustScreen: true
+                GunnersAISkill: 90
+                HumanOrchestra: false
+                LeftEngineResource: 90
+                NS430allow: true
+                NetCrewControlPriority: -2
+                RightEngineResource: 90
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 5
+                name: Ford52
+                3: 2
+              hardpoint_racks: true
+              heading: 0.93857425772792
+              livery_id: russia_vvs_standard
+              name: 'Mi-8MTV2 Template Red #01'
+              onboard_num: 059
+              payload:
+                chaff: 0
+                flare: 128
+                fuel: 965
+                gun: 100
+                pylons: {}
+              psi: -2.6179938779915
+              ropeLength: 15
+              skill: Client
+              speed: 55.555555555556
+              type: Mi-8MT
+              unitId: 421
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        OH-58 Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 116
+          groupId: 415
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: OH-58 Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: OH-58 Template Red
+                speed: 46.25
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 6
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                ALQ144: false
+                AllowHidePDU: true
+                MMS removal: false
+                NetCrewControlPriority: 0
+                PDU: false
+                Rapid Deployment Gear: false
+                Remove doors: false
+                Rifles: true
+                importDrawings: true
+                tacNet: 1
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 5
+                name: Ford54
+                3: 4
+              hardpoint_racks: true
+              heading: 5.8992128717408
+              livery_id: ru army fictional
+              name: 'OH-58 Template Red #01'
+              onboard_num: '042'
+              payload:
+                chaff: 0
+                flare: 30
+                fuel: 333.69
+                gun: 100
+                pylons: {}
+              psi: -5.8992128717408
+              skill: Client
+              speed: 46.25
+              type: OH58D
+              unitId: 423
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        OV-10A Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 127.5
+          groupId: 283
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: OV-10A Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: OV-10A Template Red
+                speed: 107.91666666667
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 9
+                              value: true
+                      2:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 2
+                        params:
+                          action:
+                            id: Option
+                            params:
+                              name: 35
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 3
+                2: 6
+                name: Uzi69
+                3: 9
+              heading: 5.4628805587423
+              livery_id: tass 22nd usaf 67-14647wh
+              name: 'OV-10A Template Red #01'
+              onboard_num: '057'
+              payload:
+                chaff: 0
+                flare: 0
+                fuel: 940
+                gun: 100
+                pylons: {}
+              psi: -5.4628805587423
+              skill: Client
+              speed: 107.91666666667
+              type: Bronco-OV-10A
+              unitId: 180
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        SA342L Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 124
+          groupId: 416
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: SA342L Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: SA342L Template Red
+                speed: 44.444444444444
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 9
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                NS430allow: true
+                RemoveTablet: false
+                SA342RemoveDoors: false
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 5
+                name: Ford55
+                3: 5
+              heading: 5.9341194567807
+              livery_id: gen olive drab
+              name: 'SA342L Template Red #01'
+              onboard_num: '063'
+              payload:
+                chaff: 0
+                flare: 32
+                fuel: 416.33
+                gun: 100
+                pylons: {}
+              psi: -5.9341194567807
+              ropeLength: 15
+              skill: Client
+              speed: 44.444444444444
+              type: SA342L
+              unitId: 424
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        SA342M Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 124
+          groupId: 418
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: SA342M Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: SA342M Template Red
+                speed: 46.25
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 10
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                NS430allow: true
+                RemoveTablet: false
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 5
+                name: Ford57
+                3: 7
+              heading: 5.9341194567807
+              livery_id: gen olive drab
+              name: 'SA342M Template Red #01'
+              onboard_num: '073'
+              payload:
+                chaff: 0
+                flare: 32
+                fuel: 333
+                gun: 100
+                pylons:
+                  1:
+                    CLSID: '{HOT3_R2_M}'
+                  2:
+                    CLSID: '{HOT3_L2_M}'
+                  4:
+                    CLSID: '{IR_Deflector}'
+              psi: -5.9341194567807
+              ropeLength: 15
+              skill: Client
+              speed: 46.25
+              type: SA342M
+              unitId: 426
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        SA342Minigun Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 124
+          groupId: 411
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: SA342Minigun Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 30
+                alt_type: BARO
+                formation_template: ''
+                name: SA342Minigun Template Red
+                speed: 44.444444444444
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks:
+                      1:
+                        auto: true
+                        enabled: true
+                        id: WrappedAction
+                        number: 1
+                        params:
+                          action:
+                            id: EPLRS
+                            params:
+                              groupId: 8
+                              value: true
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                NS430allow: true
+                RemoveTablet: false
+              alt: 30
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 4
+                name: Ford48
+                3: 8
+              heading: 5.9341194567807
+              livery_id: gen olive drab
+              name: 'SA342Minigun Template Red #01'
+              onboard_num: '062'
+              payload:
+                ammo_type: 1
+                chaff: 0
+                flare: 32
+                fuel: 416.33
+                gun: 100
+                pylons: {}
+              psi: -5.9341194567807
+              ropeLength: 15
+              skill: Client
+              speed: 44.444444444444
+              type: SA342Minigun
+              unitId: 419
+              x: 0
+              y: 0
+          x: 0
+          y: 0
+        UH-1H Template Red:
+          communication: true
+          dynSpawnTemplate: true
+          frequency: 251
+          groupId: 410
+          hidden: true
+          lateActivation: true
+          modulation: 0
+          name: UH-1H Template Red
+          radioSet: false
+          route:
+            points:
+              1:
+                ETA: 0
+                ETA_locked: true
+                action: Turning Point
+                alt: 500
+                alt_type: BARO
+                formation_template: ''
+                name: UH-1H Template Red
+                speed: 55.555555555556
+                speed_locked: true
+                task:
+                  id: ComboTask
+                  params:
+                    tasks: {}
+                type: Turning Point
+                x: 0
+                y: 0
+          start_time: 0
+          task: Nothing
+          taskSelected: true
+          tasks: {}
+          uncontrollable: false
+          uncontrolled: false
+          units:
+            1:
+              AddPropAircraft:
+                EngineResource: 90
+                ExhaustScreen: true
+                GunnersAISkill: 90
+                NetCrewControlPriority: -2
+                SoloFlight: false
+              alt: 500
+              alt_type: BARO
+              callsign:
+                1: 6
+                2: 4
+                name: Ford47
+                3: 7
+              hardpoint_racks: true
+              heading: 0.94881750304937
+              livery_id: Ukrainian Army
+              name: 'UH-1H Template Red #01'
+              onboard_num: 049
+              payload:
+                chaff: 0
+                flare: 60
+                fuel: '631'
+                gun: 100
+                pylons: {}
+              psi: -0.94862592345254
+              ropeLength: 15
+              skill: Client
+              speed: 55.555555555556
+              type: UH-1H
+              unitId: 418
               x: 0
               y: 0
           x: 0

--- a/src/python/veaf-tools/aircrafts_injector/aircrafts_injector_worker.py
+++ b/src/python/veaf-tools/aircrafts_injector/aircrafts_injector_worker.py
@@ -4,6 +4,7 @@ Combines validation and injection of aircraft groups from YAML files into DCS mi
 """
 
 import copy
+import functools
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,11 +25,51 @@ from rich.panel import Panel
 from rich.text import Text
 from veaf_libs.base_worker import BaseWorker
 from veaf_libs.dcs_countries import country_id_for_name
+from veaf_libs.dcs_units_parser import parse_dcs_units
 from veaf_libs.i18n import t
 from veaf_libs.logger import logger
 from veaf_libs.progress import spinner_context
 
 console = Console()
+
+#: Committed DCS units database (relative to this worker).
+_DCS_UNITS_YAML = Path(__file__).resolve().parent.parent / "veaf_libs" / "data" / "dcsUnits.yaml"
+
+#: DCS top-level category → extraction bucket (airplanes/helicopters).
+_CATEGORY_TO_BUCKET = {"plane": "airplanes", "helicopter": "helicopters"}
+
+
+@functools.lru_cache(maxsize=1)
+def _aircraft_family_by_type() -> dict[str, str]:
+    """Map a DCS aircraft type (lowercase) → ``airplanes``/``helicopters`` via the canonical units DB."""
+    mapping: dict[str, str] = {}
+    try:
+        for unit in parse_dcs_units(_DCS_UNITS_YAML):
+            bucket = _CATEGORY_TO_BUCKET.get(unit.category.lower())
+            if bucket:
+                mapping[unit.type_id.lower()] = bucket
+    except (OSError, ValueError):  # never break extraction on a units-DB read issue
+        return {}
+    return mapping
+
+
+def aircraft_category_for_group(group: dict, fallback: str) -> str:
+    """Return ``airplanes``/``helicopters`` from the group's first unit **type** (DCS units DB).
+
+    DCS files dynamic-slot template groups under the *helicopter* table regardless of the real
+    aircraft, so routing by the group's DCS location mis-categorizes airplanes. Categorize by the
+    unit's real DCS category instead; fall back to *fallback* (the DCS location) when the type is
+    unknown to the units DB. See FIX-DYNSLOT-TEMPLATE-CATEGORY.
+    """
+    units = group.get("units") or []
+    if isinstance(units, dict):  # a Lua/keyed table deserializes as a dict, not a list
+        units = list(units.values())
+    if units and isinstance(units[0], dict):
+        unit_type = str(units[0].get("type", "")).lower()
+        family = _aircraft_family_by_type().get(unit_type)
+        if family:
+            return family
+    return fallback
 
 
 # ============================================================================
@@ -1133,12 +1174,16 @@ class AircraftGroupsExtractorWorker(BaseWorker):
                 kind = classify_aircraft_group(group)
                 if kind is None:
                     continue  # ordinary mission group — not a reusable spawn asset
+                # Route by the unit's real DCS category, not its location in the .miz: DCS files
+                # dynamic-slot templates under the helicopter table regardless of the real aircraft
+                # (FIX-DYNSLOT-TEMPLATE-CATEGORY). Fall back to the DCS location for unknown types.
+                resolved_category = aircraft_category_for_group(group, category)
                 nonlocal_count += 1
-                logger.debug(f"Matched {category} group: {group_name} → {kind}")
-                group_key = f"{coalition_name}/{country_name}/{category}/{group_name}"
+                logger.debug(f"Matched {category} group: {group_name} → {kind} ({resolved_category})")
+                group_key = f"{coalition_name}/{country_name}/{resolved_category}/{group_name}"
                 self.matched_groups[group_key] = {
                     "group": group,
-                    "aircraft_category": category,
+                    "aircraft_category": resolved_category,
                     "coalition_name": coalition_name,
                     "country_name": country_name,
                     "group_name": group_name,

--- a/test/python/aircrafts_injector/test_dynslot_defaults_category.py
+++ b/test/python/aircrafts_injector/test_dynslot_defaults_category.py
@@ -1,0 +1,128 @@
+"""FIX-DYNSLOT-TEMPLATE-CATEGORY — dynamic-slot templates must be category-correct.
+
+DCS files dynamic-slot template groups under the *helicopter* table regardless of the real
+aircraft, so the extraction (which used to route by the group's DCS location) filed every
+airplane template under ``helicopters:``. The fix categorizes by the unit's **real** DCS
+category (via ``dcsUnits.yaml``). This guards both the shipped default and the extraction logic.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+from aircrafts_injector.aircrafts_injector_worker import (
+    AircraftGroupsExtractorWorker,
+    aircraft_category_for_group,
+)
+from mission_tools.miz_tools import DcsMission
+from veaf_libs.dcs_units_parser import parse_dcs_units
+
+_REPO_ROOT = Path(__file__).parents[3]
+_DYNSLOT = _REPO_ROOT / "src" / "defaults" / "mission-folder" / "src" / "dynamic-slot-templates.yaml"
+_DCS_UNITS = _REPO_ROOT / "src" / "python" / "veaf-tools" / "veaf_libs" / "data" / "dcsUnits.yaml"
+
+_CATEGORY_TO_BUCKET = {"Plane": "airplanes", "Helicopter": "helicopters"}
+
+
+def _type_to_bucket() -> dict[str, str]:
+    return {u.type_id: _CATEGORY_TO_BUCKET[u.category] for u in parse_dcs_units(_DCS_UNITS) if u.category in _CATEGORY_TO_BUCKET}
+
+
+def _iter_groups(data: dict):
+    for bucket in ("airplanes", "helicopters"):
+        coalitions = (data.get(bucket) or {}).get("coalitions") or {}
+        for coalition, countries in coalitions.items():
+            for country, groups in (countries or {}).items():
+                for group_name, group in (groups or {}).items():
+                    yield bucket, coalition, country, group_name, group
+
+
+class AircraftCategoryForGroupTest(unittest.TestCase):
+    """The type-based categorization helper."""
+
+    def test_airplane_type_overrides_helicopter_location(self) -> None:
+        group = {"units": [{"type": "A-10C_2"}]}
+        self.assertEqual(aircraft_category_for_group(group, fallback="helicopters"), "airplanes")
+
+    def test_helicopter_type_overrides_airplane_location(self) -> None:
+        group = {"units": [{"type": "AH-64D"}]}
+        self.assertEqual(aircraft_category_for_group(group, fallback="airplanes"), "helicopters")
+
+    def test_unknown_type_falls_back_to_location(self) -> None:
+        group = {"units": [{"type": "NotARealUnit_XYZ"}]}
+        self.assertEqual(aircraft_category_for_group(group, fallback="helicopters"), "helicopters")
+
+    def test_no_units_falls_back_to_location(self) -> None:
+        self.assertEqual(aircraft_category_for_group({"units": []}, fallback="airplanes"), "airplanes")
+
+
+class ShippedDynSlotCategoryTest(unittest.TestCase):
+    """The committed default dynamic-slot-templates.yaml must be category-correct."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.data = yaml.safe_load(_DYNSLOT.read_text(encoding="utf-8")) or {}
+        cls.type_bucket = _type_to_bucket()
+
+    def test_every_template_sits_in_its_dcs_category_bucket(self) -> None:
+        groups = list(_iter_groups(self.data))
+        self.assertGreater(len(groups), 0, "no templates found in shipped dynamic-slot-templates.yaml")
+        for bucket, coalition, country, group_name, group in groups:
+            units = group.get("units")
+            if isinstance(units, dict):
+                units = list(units.values())
+            self.assertTrue(units, f"{group_name} ({coalition}/{country}) has no units")
+            utype = units[0].get("type")
+            expected = self.type_bucket.get(utype)
+            if expected is None:
+                continue  # type unknown to dcsUnits.yaml → not enforced (fallback path)
+            self.assertEqual(
+                bucket,
+                expected,
+                f"{group_name} ({coalition}/{country}) is under '{bucket}:' but '{utype}' is a DCS "
+                f"{expected[:-1]} → must be under '{expected}:'",
+            )
+
+
+class ExtractionRoutesByTypeTest(unittest.TestCase):
+    """find_matching_groups must route an airplane filed under the helicopter table to airplanes."""
+
+    def test_airplane_under_helicopter_table_is_extracted_as_airplane(self) -> None:
+        dummy = Path("/dev/null")
+        worker = AircraftGroupsExtractorWorker(
+            input_mission=dummy, input_lua=None, output_spawnables=dummy, output_dynamic_templates=dummy
+        )
+        worker.dcs_mission = DcsMission(
+            file_path=dummy,
+            mission_content={
+                "coalition": {
+                    "blue": {
+                        "country": [
+                            {
+                                "name": "USA",
+                                "plane": {"group": []},
+                                # DCS files the A-10C dynamic-slot template under helicopter:
+                                "helicopter": {
+                                    "group": [
+                                        {
+                                            "name": "A-10C II Template",
+                                            "dynSpawnTemplate": True,
+                                            "units": [{"type": "A-10C_2"}],
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+        )
+        worker.find_matching_groups(silent=True)
+        cats = {info["aircraft_category"] for info in worker.matched_groups.values()}
+        self.assertEqual(cats, {"airplanes"}, "A-10C template should be routed to airplanes, not helicopters")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug
Airplane dynamic-slot templates (A-10C II, F-16, MiGs…) were injected as **helicopter groups** in the Mission Editor (group titled "GROUPE D'HÉLICOPTÈRES", aircraft type mismatched). Reported by Tripack; repro confirmed in our own shipped default.

## Root cause
DCS files dynamic-slot **template** groups under the `helicopter` table in the `.miz` regardless of the real aircraft. The aircraft-groups extraction routed each group by its **DCS location** (`country.plane`→airplanes, `country.helicopter`→helicopters), so every airplane template landed under `helicopters:`. #478 fixed the same symptom for the default CAP `spawnables.yaml` but not the dynamic-slot pipeline.

## Fix
- Extraction now categorizes each group by its unit's **real DCS category** via `dcsUnits.yaml` (`Plane`→`airplanes`, `Helicopter`→`helicopters`), falling back to the DCS location only for types unknown to the DB.
- Regenerated the shipped default `dynamic-slot-templates.yaml` category-correct (**78** airplane templates moved out of `helicopters:`). The big diff is the regenerated data file (same `yaml.dump` format the extraction uses).
- The categorization helper also normalizes a dict `units` container (the luadata empty/keyed-table pitfall).

## Tests
- Helper: airplane-under-helicopter → airplanes, helicopter-under-airplane → helicopters, unknown type → fallback.
- Shipped-default guard: every template sits in its real DCS-category bucket.
- Extraction integration: an A-10C filed under `country.helicopter` is extracted as an **airplane**.

Likely also resolves ticket 002 (QRA only reacting on `react_on_helicopters` for airplane slots) — to confirm in-game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)