### PR TITLE
fix(presets): accept the MiG-15bis HF primary radio frequency at build time

### DIFF
--- a/.backlog/FIX-MIG15-PRIMARY-FREQ/PRD.md
+++ b/.backlog/FIX-MIG15-PRIMARY-FREQ/PRD.md
@@ -1,0 +1,59 @@
+# Lot FIX-MIG15-PRIMARY-FREQ — build wrongly rejects the MiG-15bis HF primary frequency
+
+Status: 🔄 in-progress
+Branch: fix/mig15-primary-freq → PR (targeting develop-v6)
+
+## Problem Statement
+
+Building a mission containing a MiG-15bis (reported by Tripack) fails the radio-presets
+phase with *"Invalid primary radio frequency (below 30.0 MHz …): MiG-15 Template
+(3.75 MHz), MiG-15 Template Red (3.75 MHz)"*. The failure appears **only after** editing
+the mission in the DCS Mission Editor and re-extracting: that is when DCS materialises the
+group's `frequency: 3.75` into `dynamic-slot-templates.yaml`.
+
+## Root cause
+
+The build-time safety net in `PresetsInjectorWorker.process_groups`
+(`presets_injector_worker.py`) applies a blanket floor: any human group whose primary
+`frequency` is below `_MIN_PRIMARY_RADIO_MHZ` (30.0) fails the build. That floor was added
+(FIX-DYNSLOT-RADIO-UNITS) to stop an **ADF** channel (e.g. Yak-52 ARK-15M, 0.625 MHz) from
+being promoted to the primary radio — a case DCS does reject.
+
+But the **MiG-15bis** legitimately has an HF primary radio: its only radio, the RSI-6K,
+operates at **3.75–5.0 MHz** (`dcs-radio-specs.yaml`, `dcs_rejects_on_load: true`). DCS
+itself writes and accepts `frequency: 3.75`, so the blanket floor is a false positive.
+The spec range alone cannot distinguish the two cases: 3.75 is in the RSI-6K range and
+0.625 is in the ARK-15M range.
+
+Discriminator (verified across the whole spec DB): the **only** aircraft with both
+`dcs_rejects_on_load: true` and a sub-30 MHz radio is the MiG-15bis family, and that radio
+is its genuine primary. Every other sub-30 case (Yak-52, Ka-50, Mi-8/24, MiG-29…) is an
+ADF/HF secondary alongside a VHF/UHF primary.
+
+## Solution
+
+Make the build-time safety net spec-aware (the promotion guard in `process_units` is left
+untouched — it has no per-aircraft context). New helper
+`_is_valid_primary_frequency_for_unit(unit_type, freq)`:
+
+- frequency at/above the 30 MHz floor → valid (unchanged);
+- below the floor → valid **only** when DCS strictly validates the aircraft
+  (`is_strict`) **and** the frequency is in its spec ranges (`validate_frequency`).
+
+This accepts the MiG-15bis @ 3.75 while still rejecting the Yak-52 @ 0.625 (non-strict)
+and any unknown aircraft below the floor.
+
+## Testing Decisions
+
+- `process_groups` with a MiG-15bis @ 3.75 human group → does **not** raise (new test).
+- Existing Yak-52 @ 0.625 → still raises (unchanged guard).
+- Helper validated against Tripack's real data: MiG-15bis@3.75=True, Yak-52@0.625=False,
+  MiG-15bis@2.0=False (out of range), unknown@5.0=False.
+- Real end-to-end build is not reproducible in the dev checkout (the presets phase runs
+  after `.miz` packing, which aborts earlier on missing community `published/` scripts);
+  the unit test exercises the exact failing code path.
+
+## Out of Scope
+
+- The promotion guard floor in `process_units` (still correct without per-aircraft context).
+- The `dcs-radio-specs.yaml` data (already accurate for the MiG-15bis).

--- a/.backlog/FIX-MIG15-PRIMARY-FREQ/tickets/01-spec-aware-primary-freq.md
+++ b/.backlog/FIX-MIG15-PRIMARY-FREQ/tickets/01-spec-aware-primary-freq.md
@@ -1,0 +1,27 @@
+# 01 — Spec-aware build-time primary-frequency check
+
+Status: 🔄 in-progress
+
+## Goal
+
+Stop the build from rejecting an aircraft whose genuine primary radio is HF (MiG-15bis
+RSI-6K, 3.75–5.0 MHz) while keeping the ADF-promotion guard (Yak-52 ARK-15M @ 0.625 MHz).
+
+## Changes
+
+- `presets_injector_worker.py`:
+  - import `validate_frequency`;
+  - add `_is_valid_primary_frequency_for_unit(unit_type, freq)` — floor OR
+    (`is_strict` AND in-spec);
+  - the `process_groups` safety net uses the new helper with `g.unit_type`.
+
+## Tests
+
+- `test_process_groups_hf_primary_on_strict_aircraft_does_not_stop` (MiG-15bis @ 3.75).
+- Existing `test_process_groups_stops_on_invalid_primary_frequency` (Yak-52 @ 0.625) stays green.
+
+## Done when
+
+- `poetry run pytest` green, coverage gate held.
+- `ruff check` / `ruff format --check` / `mypy` clean on the worker.
+- CHANGELOG entry + PATCH bump.

--- a/.backlog/README.md
+++ b/.backlog/README.md
@@ -12,6 +12,7 @@ lots are compacted into `.backlog/archive/<LOT-ID>.md`. Sequencing lives in
 
 | Lot | Status |
 |-----|--------|
+| [FIX-MIG15-PRIMARY-FREQ](FIX-MIG15-PRIMARY-FREQ/PRD.md) — build wrongly rejects the MiG-15bis HF primary frequency (RSI-6K 3.75 MHz, below the 30 MHz floor); the safety net is now spec-aware (`is_strict` + in-spec) while still catching ADF promotion (Yak-52 0.625 MHz). Reported by Tripack | 🔄 |
 | [FIX-EVENTHANDLER-UNITCATEGORY](FIX-EVENTHANDLER-UNITCATEGORY/PRD.md) — dynamic-slot airplane still ignored by the QRA unless `react_on_helicopters` true: `completeUnitFromName` populated `unitCategory` with `getCategory()` (Object.Category UNIT=1 collides with HELICOPTER), bypassing the #299 fix | ✅ |
 | [FEAT-LUA-BUILD-STAMP](FEAT-LUA-BUILD-STAMP/PRD.md) — single build stamp (`6.7.x+<sha>`) in the DCS log instead of 33 unreliable per-module versions; retires the hand-maintained `.Version` constants | ✅ |
 | [FIX-CTLD-REPACK-NIL-GROUP](FIX-CTLD-REPACK-NIL-GROUP/PRD.md) — CTLD F10 menu duplicated on dynamic-slot helo on a runtime FARP (`getUnitsInRepackRadius` nil `getGroup`) + analysis doc for the CTLD rewrite | ✅ |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Build wrongly rejected the MiG-15bis's HF primary radio frequency** (FIX-MIG15-PRIMARY-FREQ, reported by Tripack). After editing a MiG-15bis mission in the DCS Mission Editor and re-extracting, the build failed the radio-presets phase with *"Invalid primary radio frequency (below 30.0 MHz …): MiG-15 Template (3.75 MHz)"*. The build-time safety net applied a blanket 30 MHz floor — added (FIX-DYNSLOT-RADIO-UNITS) to stop an ADF channel (e.g. Yak-52 ARK-15M 0.625 MHz) being promoted to the primary radio — but the MiG-15bis legitimately has an HF primary: its only radio, the RSI-6K, operates at 3.75–5.0 MHz, and DCS itself writes and accepts `frequency: 3.75`. The safety net is now spec-aware: a sub-floor primary is accepted only when DCS strictly validates the aircraft (`dcs_rejects_on_load`) **and** the frequency is within its documented radio range — i.e. only the MiG-15bis-like case where DCS produced the value. The Yak-52 ADF-promotion guard (and the promotion guard in `process_units`) is unchanged.
+
 ## [6.7.5] — 2026-06-29
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.7.5"
+version = "6.7.6"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/presets_injector/presets_injector_worker.py
+++ b/src/python/veaf-tools/presets_injector/presets_injector_worker.py
@@ -21,6 +21,7 @@ from .radio_frequency_validator import (
     get_valid_ranges,
     is_strict,
     validate_frequencies,
+    validate_frequency,
     warn_invalid_channel_frequencies,
 )
 
@@ -36,10 +37,27 @@ def _is_valid_primary_frequency(freq_mhz: float) -> bool:
     """Whether *freq_mhz* may be a group's primary radio frequency.
 
     A primary radio is VHF/UHF/FM; anything below ``_MIN_PRIMARY_RADIO_MHZ`` is an
-    ADF/HF (kHz-range) channel that DCS rejects as a primary frequency. Single
-    source of truth for both the promotion guard and the build-time safety net.
+    ADF/HF (kHz-range) channel that DCS rejects as a primary frequency. Used by the
+    promotion guard, which has no per-aircraft context.
     """
     return freq_mhz >= _MIN_PRIMARY_RADIO_MHZ
+
+
+def _is_valid_primary_frequency_for_unit(unit_type: str | None, freq_mhz: float) -> bool:
+    """Whether *freq_mhz* may be *unit_type*'s primary radio frequency (build-time safety net).
+
+    Like ``_is_valid_primary_frequency`` but spec-aware: a sub-VHF frequency is still
+    valid when the aircraft's genuine primary radio is HF and DCS strictly validates it
+    (e.g. the MiG-15bis RSI-6K at 3.75–5.0 MHz). DCS itself writes and accepts that
+    frequency on extract, so the blanket floor would be a false positive. Aircraft DCS
+    does not strictly validate (Yak-52 ARK-15M, Ka-50 ARK-22…) keep the floor, so an ADF
+    channel mistakenly promoted to the primary is still caught.
+    """
+    if _is_valid_primary_frequency(freq_mhz):
+        return True
+    if unit_type is None:
+        return False
+    return is_strict(unit_type) and bool(validate_frequency(unit_type, freq_mhz))
 
 
 @dataclass
@@ -259,7 +277,7 @@ class PresetsInjectorWorker(GroupInjectorWorker):
             for g in self.groups.values()
             if g.human_pilot
             and isinstance((freq := g.group_dcs.get("frequency")), (int, float))
-            and not _is_valid_primary_frequency(freq)
+            and not _is_valid_primary_frequency_for_unit(g.unit_type, freq)
         ]
         if invalid_primary:
             details = ", ".join(f"{name} ({freq} MHz)" for name, freq in invalid_primary)

--- a/test/python/presets_injector/test_presets_injector_worker.py
+++ b/test/python/presets_injector/test_presets_injector_worker.py
@@ -372,6 +372,25 @@ class TestProcessGroups(unittest.TestCase):
         worker.presets_manager.get_radios_for.return_value = None
         worker.process_groups(silent=True)  # must not raise
 
+    def test_process_groups_hf_primary_on_strict_aircraft_does_not_stop(self) -> None:
+        # An aircraft whose genuine primary radio is HF (MiG-15bis RSI-6K, 3.75–5.0 MHz)
+        # has a sub-VHF primary frequency that DCS itself writes and accepts. The build
+        # must not flag it as invalid (FIX-MIG15-PRIMARY-FREQ false positive).
+        worker = _make_worker()
+        group = Group(
+            group_dcs={"units": [{"type": "MiG-15bis", "skill": "Client"}], "frequency": 3.75},
+            aircraft_type="plane",
+            country="USSR",
+            coalition="red",
+            human_pilot=True,
+            name="MiG-15 Template",
+            unit_type="MiG-15bis",
+        )
+        worker.groups = {"MiG-15 Template": group}
+        worker.presets_manager = MagicMock()
+        worker.presets_manager.get_radios_for.return_value = None
+        worker.process_groups(silent=True)  # must not raise
+
 
 class TestGenerateValidationReport(unittest.TestCase):
     """Tests for collect_freq_issues() and generate_validation_report()."""
@@ -484,45 +503,33 @@ class TestPresetRadioCompatibility(unittest.TestCase):
 
     @staticmethod
     def _group(unit_type: str) -> Group:
-        return Group(
-            group_dcs={}, aircraft_type="plane", country="USA", coalition="blue", unit_type=unit_type
-        )
+        return Group(group_dcs={}, aircraft_type="plane", country="USA", coalition="blue", unit_type=unit_type)
 
     def test_incompatible_preset_skipped(self) -> None:
         """A UHF preset is wholly incompatible with the Yak-52 (sub-MHz ARK-15M)."""
         worker = _make_worker()
-        self.assertFalse(
-            worker._preset_radio_compatible(self._group("Yak-52"), self._uhf_preset(243.0, 225.0))
-        )
+        self.assertFalse(worker._preset_radio_compatible(self._group("Yak-52"), self._uhf_preset(243.0, 225.0)))
 
     def test_compatible_preset_kept(self) -> None:
         """The same UHF preset fits an FA-18C, which has a UHF radio."""
         worker = _make_worker()
-        self.assertTrue(
-            worker._preset_radio_compatible(self._group("FA-18C_hornet"), self._uhf_preset(243.0, 225.0))
-        )
+        self.assertTrue(worker._preset_radio_compatible(self._group("FA-18C_hornet"), self._uhf_preset(243.0, 225.0)))
 
     def test_unknown_aircraft_treated_compatible(self) -> None:
         """An aircraft absent from the radio specs is not second-guessed."""
         worker = _make_worker()
-        self.assertTrue(
-            worker._preset_radio_compatible(self._group("NoSuchJet"), self._uhf_preset(243.0))
-        )
+        self.assertTrue(worker._preset_radio_compatible(self._group("NoSuchJet"), self._uhf_preset(243.0)))
 
     def test_mig15bis_uhf_preset_skipped(self) -> None:
         """MiG-15bis (HF RSI-6K, 3.75-5 MHz) is wholly incompatible with a UHF preset (C9 follow-up)."""
         worker = _make_worker()
-        self.assertFalse(
-            worker._preset_radio_compatible(self._group("MiG-15bis"), self._uhf_preset(243.0, 251.0))
-        )
+        self.assertFalse(worker._preset_radio_compatible(self._group("MiG-15bis"), self._uhf_preset(243.0, 251.0)))
 
     def test_partially_valid_preset_kept(self) -> None:
         """If at least one frequency is in range, the preset is kept."""
         worker = _make_worker()
         # Yak-52 ARK-15M range ~0.1-1.795 MHz: one in-range, one out-of-range.
-        self.assertTrue(
-            worker._preset_radio_compatible(self._group("Yak-52"), self._uhf_preset(0.5, 243.0))
-        )
+        self.assertTrue(worker._preset_radio_compatible(self._group("Yak-52"), self._uhf_preset(0.5, 243.0)))
 
 
 class TestDropOutOfRangeChannels(unittest.TestCase):


### PR DESCRIPTION
## Problem

Reported by **Tripack**: building a mission with a MiG-15bis fails the radio-presets phase with *"Invalid primary radio frequency (below 30.0 MHz …): MiG-15 Template (3.75 MHz), MiG-15 Template Red (3.75 MHz)"*. It only appears **after** editing the mission in the DCS Mission Editor and re-extracting — that is when DCS materialises `frequency: 3.75` into `dynamic-slot-templates.yaml`.

## Root cause

The build-time safety net in `PresetsInjectorWorker.process_groups` applied a blanket 30 MHz floor on every human group's primary `frequency`. That floor (FIX-DYNSLOT-RADIO-UNITS) exists to stop an **ADF** channel — e.g. the Yak-52 ARK-15M at 0.625 MHz — being promoted to the primary radio, a case DCS does reject.

But the **MiG-15bis** legitimately has an HF primary radio: its only radio, the RSI-6K, operates at **3.75–5.0 MHz** (`dcs-radio-specs.yaml`, `dcs_rejects_on_load: true`). DCS itself writes and accepts `frequency: 3.75`, so the floor is a false positive. Spec range alone can't tell the two apart (3.75 ∈ RSI-6K range, 0.625 ∈ ARK-15M range). The discriminator — verified across the whole spec DB — is that the **only** aircraft with both `dcs_rejects_on_load: true` and a sub-30 MHz radio is the MiG-15bis family, whose sub-30 radio *is* its genuine primary.

## Fix

Make the safety net spec-aware via `_is_valid_primary_frequency_for_unit(unit_type, freq)`:

- at/above the 30 MHz floor → valid (unchanged);
- below the floor → valid **only** when `is_strict(unit_type)` **and** `validate_frequency(unit_type, freq)`.

This accepts MiG-15bis @ 3.75 while still rejecting Yak-52 @ 0.625 (non-strict) and any unknown aircraft below the floor. The promotion guard in `process_units` is untouched.

## Tests

- New `test_process_groups_hf_primary_on_strict_aircraft_does_not_stop` (MiG-15bis @ 3.75 → no raise).
- Existing `test_process_groups_stops_on_invalid_primary_frequency` (Yak-52 @ 0.625 → still raises) stays green.
- Helper validated against Tripack's real data: `MiG-15bis@3.75=True`, `Yak-52@0.625=False`, `MiG-15bis@2.0=False`, `unknown@5.0=False`.

Full suite green, coverage 74.24% ≥ 73% gate; `ruff`/`mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make the build-time primary radio frequency check spec-aware so MiG-15bis missions with valid HF primary radios no longer fail the presets phase.

Bug Fixes:
- Allow MiG-15bis missions with a valid 3.75 MHz HF primary radio to pass the build-time radio-presets safety net instead of being incorrectly rejected.

Enhancements:
- Introduce a unit-aware primary frequency validator that applies the 30 MHz floor except for strictly validated aircraft whose primary HF frequency is within their documented radio range.

Build:
- Bump project version from 6.7.5 to 6.7.6 to release the MiG-15bis primary frequency fix.

Documentation:
- Document the MiG-15bis HF primary frequency fix in the changelog and backlog, including problem description, solution, and testing notes.

Tests:
- Add a unit test ensuring MiG-15bis groups with a 3.75 MHz primary frequency do not trigger the build-time safety net while existing Yak-52 guard tests remain valid.