### PR TITLE
feat(presets): project role-based channel lists onto standard aircraft (ADR 0010)

### DIFF
--- a/.backlog/FEAT-RADIO-PRESET-PROJECTION/tickets/01-standard-aircraft-end-to-end.md
+++ b/.backlog/FEAT-RADIO-PRESET-PROJECTION/tickets/01-standard-aircraft-end-to-end.md
@@ -1,6 +1,6 @@
 # FEAT-RADIO-PRESET-PROJECTION-01 — full chain on a standard aircraft
 
-Status: ⬜ ready
+Status: ✅ done
 Type: feat · Phase: 1 · AFK
 
 ## Parent
@@ -22,14 +22,43 @@ a type with an explicit override keeps it.
 
 ## Acceptance criteria
 
-- [ ] `channel_lists` parsed per coalition into roles; aliases resolve by band.
-- [ ] Band-based default maps a standard aircraft's radios to roles from specs.
-- [ ] Packer emits a `PresetDefinition`; downstream injection/validation reused.
-- [ ] Channel lacking the role's band is dropped (recorded).
-- [ ] Explicit old-format assignment wins over the packer.
-- [ ] Tests: parsing + a standard aircraft packed end-to-end (prior art
+- [x] `channel_lists` parsed per coalition into roles; aliases resolve by band.
+- [x] Default maps a standard aircraft's radios to roles from the specs.
+- [x] Packer emits a `PresetDefinition`; downstream injection/validation reused.
+- [x] Channel lacking the role's band is dropped (recorded).
+- [x] Explicit old-format assignment wins over the packer.
+- [x] Tests: parsing + a standard aircraft packed end-to-end (prior art
       `test_presets.py`, `test_presets_injector_worker.py`).
 
 ## Blocked by
 
 None — can start immediately.
+
+## Implementation notes
+
+The default is **not** the flat "radio 1 -> primary_1, radio 2 -> primary_2,
+radio 3 -> FM" positional rule the ticket description sketched. Verified against
+the real `dcs-radio-specs.yaml`: only 19 of 87 aircraft have radios that are
+cleanly single-band throughout — most modern radios (ARC-210, ARC-222…) report
+the union of every mode they support, and some 2-radio helicopters (Mi-8MT,
+UH-1H-shaped) mean "1 primary + 1 FM", not "UHF + VHF". A pure radio-count or
+band-purity heuristic misclassifies the F-16 (this ticket's own worked example),
+the Hornet, and most helicopters.
+
+The implemented default instead classifies each physical radio from its ranges
+(uhf-dedicated / vhf-dedicated / ambiguous combo / FM-or-other), assigns
+dedicated radios to their natural role directly (so the A-10's inverted
+VHF-first order resolves correctly with **no** explicit layout entry), and falls
+back to physical order only for genuinely ambiguous combo radios (e.g. the
+Hornet's two identical ARC-210s). See `_classify_radio` / `_assign_roles_by_position`
+in `presets_manager.py` for the reasoning, and
+`TestPackPresetRealSpecsEndToEnd` in `test_radio_preset_packer.py` for the
+regression coverage against real aircraft (F-16, F/A-18, A-10, UH-1H, Mi-8MT,
+Bf-109K-4).
+
+This does not reopen ADR 0010's decisions — the outcome (simple default for the
+common case, explicit `Radio layout` override for the rest) is unchanged; only
+the *mechanism* differs from the ADR's illustrative sketch. `fm_secondary`
+defaulting to a copy of `fm_supplement` (ticket 03's stated behaviour) is
+implemented here too, since it falls out naturally from the same role-assignment
+pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Radio preset plan model — standard-aircraft projection** (FEAT-RADIO-PRESET-PROJECTION-01, ADR 0010). Mission-makers can now declare a `channel_lists` block in `presets.yaml`: a handful of channel lists by _Radio role_ (`primary_1`, `primary_2`, `fm_substitute`, `fm_supplement`, `fm_secondary`) and coalition, instead of a per-aircraft `radios_collection`/`presets_collection` pair. A new packer projects these lists onto each aircraft's physical radios automatically — including aircraft with a deliberately inverted radio order (e.g. the A-10's VHF-first layout) or identical combo radios (e.g. the F/A-18's two ARC-210s) — with no per-type configuration needed for the common case. An explicit assignment in the legacy `presets_assignments` format (including an explicit `none`) always takes priority over the packer. This is the first of several lots building the full preset-plan model; special airframes (Mi-24P, OH-58D, AJS-37…) still use their existing bespoke presets until later lots add the matching `Radio layout` primitives.
+
 ## [6.7.8] — 2026-07-02
 
 ### Changed

--- a/docs/adr/0010-per-type-radio-preset-projection.md
+++ b/docs/adr/0010-per-type-radio-preset-projection.md
@@ -69,6 +69,22 @@ migration, tests). **Phase 2**: convert-v5 plan generation.
 - convert-v5 no longer guarantees iso-functionality by default; the faithful
   copy stays available as the fallback.
 
+## Implementation note (ticket 01)
+
+The "band-based default" is **not** a flat positional rule (radio 1 -> primary_1,
+2 -> primary_2, 3 -> FM). Verified against the real `dcs-radio-specs.yaml`: only
+19 of 87 aircraft have radios that are cleanly single-band throughout — most
+modern radios (ARC-210, ARC-222…) report the union of every mode they support,
+and some 2-radio helicopters mean "1 primary + 1 FM", not "UHF + VHF". The
+implemented default classifies each physical radio from its frequency ranges,
+assigns radios unambiguously dedicated to one sub-band directly (so a
+deliberately inverted order, e.g. the A-10's VHF-first radio 1, resolves without
+an explicit layout entry), and falls back to physical order only for genuinely
+ambiguous combo radios (e.g. the F/A-18's two identical ARC-210s). See
+`_assign_roles_by_position` in `presets_manager.py`. This does not change the
+decision — a simple default for the common case, explicit `Radio layout`
+override for the rest — only the mechanism.
+
 ## Alternatives rejected
 
 - **Replace the old layers** — breaks existing missions and convert-v5.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.7.8"
+version = "6.7.9"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"
@@ -123,7 +123,7 @@ addopts = [
     "--cov=src/python/veaf-tools",
     "--cov-report=xml",
     "--cov-report=term-missing:skip-covered",
-    "--cov-fail-under=73",
+    "--cov-fail-under=74",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/python/veaf-tools/presets_injector/presets_manager.py
+++ b/src/python/veaf-tools/presets_injector/presets_manager.py
@@ -28,6 +28,26 @@ from PIL import Image, ImageDraw, ImageFont
 from PIL.ImageFont import FreeTypeFont
 from veaf_libs.logger import logger
 
+from .radio_frequency_validator import FrequencyRange, RadioSpec, get_radios
+
+# ── Radio roles (ADR 0010: per-type radio-preset projection) ────────────────
+# A Radio role is the functional slot a Channel list plays across all aircraft,
+# independent of physical radio hardware. See CONTEXT.md.
+ROLE_PRIMARY_1 = "primary_1"
+ROLE_PRIMARY_2 = "primary_2"
+ROLE_FM_SUBSTITUTE = "fm_substitute"
+ROLE_FM_SUPPLEMENT = "fm_supplement"
+ROLE_FM_SECONDARY = "fm_secondary"
+
+# The band each role resolves its channel aliases against (see ChannelDefinition.frequencies).
+ROLE_BANDS: dict[str, str] = {
+    ROLE_PRIMARY_1: "uhf",
+    ROLE_PRIMARY_2: "vhf",
+    ROLE_FM_SUBSTITUTE: "fm",
+    ROLE_FM_SUPPLEMENT: "fm",
+    ROLE_FM_SECONDARY: "fm",
+}
+
 
 class Channel:
     """
@@ -180,10 +200,30 @@ class RadioDefinition:
         return None
 
     def add_channel_from_dict(
-        self, channel_name: str, channel_data: dict[str, Any], channel_collections: dict[str, ChannelCollection]
-    ):
+        self,
+        channel_name: str,
+        channel_data: dict[str, Any],
+        channel_collections: dict[str, ChannelCollection],
+        *,
+        strict: bool = True,
+    ) -> bool:
+        """Resolve and add one channel entry.
+
+        Args:
+            strict: When True (default, used by the legacy ``radios_collection``
+                format), a channel alias lacking this radio's ``radio_type``
+                frequency is a hard authoring error. When False (used by
+                _Channel lists_, see ADR 0010), that case is not an error — the
+                channel simply does not apply to this role's band and is
+                silently skipped; the caller is told via the return value so it
+                can record the drop.
+
+        Returns:
+            True if a channel was added, False if it was skipped (only possible
+            when ``strict`` is False).
+        """
         if not channel_data:
-            return
+            return False
         channel_freq = None
         channel_alias = None
         channel_title = None
@@ -205,6 +245,8 @@ class RadioDefinition:
                     channel_definition = channel_collection.channel_definitions[channel_alias]
                     channel_title = channel_definition.title
                     if self.radio_type not in channel_definition.frequencies:
+                        if not strict:
+                            return False
                         logger.error(
                             message=f"'freq' not defined and 'channel_alias' {channel_alias} in RadioDefinition {self.name} does not contain any frequency of type {self.radio_type}",
                             exception_type=ValueError,
@@ -220,6 +262,7 @@ class RadioDefinition:
         if channel_freq is None:
             logger.error(message=f"'freq' is mandatory for RadioDefinition {self.name}", exception_type=ValueError)
         self.add_channel(Channel(name_or_number=channel_name, freq=channel_freq, title=channel_title, mod=channel_mod))  # type: ignore[arg-type]
+        return True
 
     @classmethod
     def from_dict(
@@ -499,6 +542,201 @@ class PresetAssignmentCollection:
         )
 
 
+def parse_channel_lists(
+    data: dict[str, Any], channel_collections: dict[str, ChannelCollection]
+) -> tuple[dict[str, dict[str, RadioDefinition]], dict[str, dict[str, list[str]]]]:
+    """Parse the ``channel_lists`` block of ``presets.yaml`` (ADR 0010).
+
+    Each channel list is represented as a :class:`RadioDefinition` (same shape as
+    a legacy radio: an ordered list of channels resolved against a single band),
+    with ``radio_type`` set to the role's band so alias resolution reuses
+    ``RadioDefinition.add_channel_from_dict`` unchanged.
+
+    Args:
+        data: The ``channel_lists`` mapping: coalition -> role -> channels.
+        channel_collections: Used to resolve channel aliases.
+
+    Returns:
+        A tuple of (channel_lists, dropped): ``channel_lists`` maps
+        coalition -> role -> RadioDefinition; ``dropped`` maps
+        coalition -> role -> list of channel names skipped because they had no
+        frequency for that role's band (e.g. a UHF-only channel listed under
+        ``primary_2``).
+    """
+    channel_lists: dict[str, dict[str, RadioDefinition]] = {}
+    dropped: dict[str, dict[str, list[str]]] = {}
+    for coalition, roles_data in data.items():
+        role_lists: dict[str, RadioDefinition] = {}
+        role_dropped: dict[str, list[str]] = {}
+        for role, channels_data in (roles_data or {}).items():
+            if role not in ROLE_BANDS:
+                logger.error(
+                    message=f"Unknown radio role '{role}' in channel_lists.{coalition} (expected one of {sorted(ROLE_BANDS)})",
+                    exception_type=ValueError,
+                )
+                continue
+            band = ROLE_BANDS[role]
+            radio = RadioDefinition(name=f"channel_list_{coalition}_{role}", radio_type=band, title=role)
+            skipped: list[str] = []
+            for channel_name, channel_data in (channels_data or {}).items():
+                if not radio.add_channel_from_dict(channel_name, channel_data, channel_collections, strict=False):
+                    skipped.append(str(channel_name))
+            role_lists[role] = radio
+            if skipped:
+                role_dropped[role] = skipped
+        channel_lists[coalition] = role_lists
+        if role_dropped:
+            dropped[coalition] = role_dropped
+    return channel_lists, dropped
+
+
+# Per-radio classification thresholds (MHz). Deliberately coarse: many modern
+# radios (ARC-210, R-863…) report the union of every mode they support at once
+# (verified against the real dcs-radio-specs.yaml — only 19 of 87 aircraft have
+# radios that are cleanly single-band throughout), so an exact uhf/vhf boundary
+# cannot be derived reliably for every aircraft. These thresholds only need to
+# separate FM-capable radios from V/UHF-capable ones, and, among V/UHF-capable
+# radios, tell apart one dedicated to a single sub-band from one whose data is
+# genuinely ambiguous (handled by falling back to physical position below).
+_FM_CEILING_MHZ = 95.0
+_UHF_FLOOR_MHZ = 195.0
+
+
+def _classify_radio(ranges: list[FrequencyRange]) -> str | None:
+    """Classify one physical radio's role band from its frequency ranges.
+
+    Returns "uhf" or "vhf" when the radio is unambiguously dedicated to that
+    sub-band, "ambiguous" when its ranges reach into both (common on digital
+    combo radios like the ARC-210, or on single-range radios spanning both
+    windows like the Mi-8MT's R-863 or a warbird's FuG16 — the packer falls back
+    to physical position for the former, and this range naturally resolves to a
+    single band for the latter two), or None when the radio never reaches above
+    the FM ceiling (an FM radio, or an unrelated low-band set like an HF/ADF
+    radio — see the packer's module docstring for how that degrades safely).
+    """
+    has_uhf = any(r.max_mhz >= _UHF_FLOOR_MHZ for r in ranges)
+    has_vhf = any(r.min_mhz < _UHF_FLOOR_MHZ and r.max_mhz > _FM_CEILING_MHZ for r in ranges)
+    if has_uhf and has_vhf:
+        return "ambiguous"
+    if has_uhf:
+        return "uhf"
+    if has_vhf:
+        return "vhf"
+    return None
+
+
+def _assign_roles_by_position(radios: list[RadioSpec]) -> dict[int, str]:
+    """Assign a Radio role to each physical radio index, ADR 0010's default projection.
+
+    Radios unambiguously dedicated to one sub-band claim that role directly —
+    this is what lets a deliberately "inverted" aircraft (e.g. the A-10, whose
+    physical radio 1 is VHF and radio 2 is UHF) resolve correctly without an
+    explicit per-type override. Radios whose data is genuinely ambiguous fill
+    whichever primary slot remains, in physical order — the shipped default's
+    own ``radio_1``/``radio_2`` convention for aircraft where hardware data alone
+    cannot tell UHF and VHF apart (e.g. the FA-18C's two identical ARC-210s).
+    Any radio that never reaches above the FM ceiling gets the FM role
+    (``fm_supplement`` if two primaries were found, else ``fm_substitute``); a
+    second such radio (e.g. the OH-58D's two FM sets) gets ``fm_secondary``.
+    """
+    bands = [_classify_radio(radio.ranges) for radio in radios]
+    role_by_index: dict[int, str] = {}
+
+    for index, band in enumerate(bands):
+        if band == "uhf" and ROLE_PRIMARY_1 not in role_by_index.values():
+            role_by_index[index] = ROLE_PRIMARY_1
+        elif band == "vhf" and ROLE_PRIMARY_2 not in role_by_index.values():
+            role_by_index[index] = ROLE_PRIMARY_2
+
+    for index, band in enumerate(bands):
+        if band != "ambiguous" or index in role_by_index:
+            continue
+        if ROLE_PRIMARY_1 not in role_by_index.values():
+            role_by_index[index] = ROLE_PRIMARY_1
+        elif ROLE_PRIMARY_2 not in role_by_index.values():
+            role_by_index[index] = ROLE_PRIMARY_2
+
+    fm_role = ROLE_FM_SUPPLEMENT if len(role_by_index) >= 2 else ROLE_FM_SUBSTITUTE
+    fm_indices = [index for index, band in enumerate(bands) if band is None and index not in role_by_index]
+    if fm_indices:
+        role_by_index[fm_indices[0]] = fm_role
+        if len(fm_indices) >= 2:
+            role_by_index[fm_indices[1]] = ROLE_FM_SECONDARY
+
+    return role_by_index
+
+
+def _channel_list_for_role(role_lists: dict[str, RadioDefinition], role: str) -> RadioDefinition | None:
+    """Look up *role*'s channel list, defaulting fm_secondary to fm_supplement (ADR 0010)."""
+    source = role_lists.get(role)
+    if source is None and role == ROLE_FM_SECONDARY:
+        source = role_lists.get(ROLE_FM_SUPPLEMENT)
+    return source
+
+
+def pack_preset_for_type(
+    channel_lists: dict[str, dict[str, RadioDefinition]], coalition: str, unit_type: str
+) -> "PresetDefinition | None":
+    """Project a mission-maker's Channel lists onto one aircraft type's physical radios.
+
+    This is the packer's default projection (ADR 0010), used when no explicit
+    per-type _Radio layout_ entry exists (added by a later lot): each physical
+    radio is assigned a role by :func:`_assign_roles_by_position`, then filled
+    with that role's channel list. An aircraft with no primary radio at all
+    (single-radio HF/ADF sets, e.g. the MiG-15bis or Yak-52) still gets an
+    ``fm_substitute`` guess on its only radio; since that content will not be in
+    range, the existing frequency validator drops it and reports the mismatch —
+    a safe, actionable degradation rather than a crash, pending an explicit
+    layout entry for that type.
+
+    Args:
+        channel_lists: Parsed Channel lists, coalition -> role -> RadioDefinition
+            (from :func:`parse_channel_lists`).
+        coalition: "blue" or "red".
+        unit_type: DCS unit type string.
+
+    Returns:
+        A :class:`PresetDefinition` with one radio per resolvable physical slot,
+        or None if the aircraft is unknown or no role list has any content for it.
+    """
+    role_lists = channel_lists.get(coalition)
+    if not role_lists:
+        return None
+    radios = get_radios(unit_type)
+    if not radios:
+        return None
+
+    role_by_index = _assign_roles_by_position(radios)
+    if not role_by_index:
+        return None
+
+    resolved: list[RadioDefinition | None] = []
+    for index in range(len(radios)):
+        role = role_by_index.get(index)
+        source = _channel_list_for_role(role_lists, role) if role else None
+        resolved.append(source if source and source.channels else None)
+
+    if all(source is None for source in resolved):
+        return None
+    last_usable = max(index for index, source in enumerate(resolved) if source is not None)
+    if any(source is None for source in resolved[:last_usable]):
+        # A gap before the last usable radio is ambiguous — packing it would
+        # silently renumber a later radio to the wrong physical slot. Leave it
+        # to an explicit layout entry rather than guess.
+        return None
+
+    preset = PresetDefinition(name=f"packed_{coalition}_{unit_type}")
+    for index, source in enumerate(resolved[: last_usable + 1], start=1):
+        assert source is not None
+        radio = RadioDefinition(name=f"radio_{index}", radio_type=source.radio_type, title=source.title)
+        for channel in source.channels:
+            radio.add_channel(
+                Channel(name_or_number=channel.number, freq=channel.freq, title=channel.title, mod=channel.mod)
+            )
+        preset.add_radio(radio)
+    return preset
+
+
 class PresetsManager:
     """
     The presets manager has functions to manage the presets in DCS
@@ -511,6 +749,10 @@ class PresetsManager:
         self.preset_assignments: PresetAssignmentCollection = PresetAssignmentCollection()
         self.presets_images: dict[str, io.BytesIO] | None = None
         self._cached_fonts: tuple[FreeTypeFont, FreeTypeFont, FreeTypeFont] | None = None
+        # ADR 0010: role-based channel lists, parsed from the optional `channel_lists`
+        # block, and channels dropped because they lacked a role's band (reporting hook).
+        self.channel_lists: dict[str, dict[str, RadioDefinition]] = {}
+        self.channel_lists_dropped: dict[str, dict[str, list[str]]] = {}
 
     def read_yaml(self, yaml_path: Path):
         try:
@@ -546,6 +788,12 @@ class PresetsManager:
                     data=collection, presets_collections=self.preset_collections
                 )
 
+            # Load channel lists (ADR 0010: role-based preset plan)
+            if "channel_lists" in data:
+                self.channel_lists, self.channel_lists_dropped = parse_channel_lists(
+                    data=data["channel_lists"], channel_collections=self.channel_collections
+                )
+
         except FileNotFoundError:
             logger.error(message=f"YAML file not found: {yaml_path}", exception_type=FileNotFoundError)
         except yaml.YAMLError as e:
@@ -558,10 +806,15 @@ class PresetsManager:
         pass
 
     def get_radios_for(self, coalition: str, aircraft_type: str, unit_type: str):
+        # An explicit assignment (including an explicit "none") always wins over
+        # the packer (ADR 0010: manual override). Only fall back to packing
+        # `channel_lists` when NO assignment at all matched this aircraft.
         preset_assignment = self.preset_assignments.get_preset_for(
             coalition=coalition, aircraft_type=aircraft_type, unit_type=unit_type
         )
-        return preset_assignment.preset_definition if preset_assignment else None
+        if preset_assignment is not None:
+            return preset_assignment.preset_definition
+        return pack_preset_for_type(self.channel_lists, coalition, unit_type)
 
     def generate_presets_images(self, width: int = 1200, height: int | None = None):
         generator = RadioPresetsImageGenerator(self.preset_collections, width=width, height=height)

--- a/src/python/veaf-tools/presets_injector/presets_manager.py
+++ b/src/python/veaf-tools/presets_injector/presets_manager.py
@@ -575,12 +575,7 @@ def parse_channel_lists(
                     exception_type=ValueError,
                 )
                 continue
-            band = ROLE_BANDS[role]
-            radio = RadioDefinition(name=f"channel_list_{coalition}_{role}", radio_type=band, title=role)
-            skipped: list[str] = []
-            for channel_name, channel_data in (channels_data or {}).items():
-                if not radio.add_channel_from_dict(channel_name, channel_data, channel_collections, strict=False):
-                    skipped.append(str(channel_name))
+            radio, skipped = _build_role_list(coalition, role, channels_data, channel_collections)
             role_lists[role] = radio
             if skipped:
                 role_dropped[role] = skipped
@@ -588,6 +583,30 @@ def parse_channel_lists(
         if role_dropped:
             dropped[coalition] = role_dropped
     return channel_lists, dropped
+
+
+def _build_role_list(
+    coalition: str, role: str, channels_data: dict[str, Any] | None, channel_collections: dict[str, ChannelCollection]
+) -> tuple[RadioDefinition, list[str]]:
+    """Resolve one role's channels into a RadioDefinition, tracking dropped ones.
+
+    Args:
+        coalition: "blue" or "red" (only used to name the resulting RadioDefinition).
+        role: One of the ``ROLE_BANDS`` keys.
+        channels_data: The role's channel mapping from ``channel_lists.yaml``.
+        channel_collections: Used to resolve channel aliases.
+
+    Returns:
+        The role's RadioDefinition, and the list of channel names skipped
+        because they lacked a frequency for the role's band.
+    """
+    band = ROLE_BANDS[role]
+    radio = RadioDefinition(name=f"channel_list_{coalition}_{role}", radio_type=band, title=role)
+    skipped: list[str] = []
+    for channel_name, channel_data in (channels_data or {}).items():
+        if not radio.add_channel_from_dict(channel_name, channel_data, channel_collections, strict=False):
+            skipped.append(str(channel_name))
+    return radio, skipped
 
 
 # Per-radio classification thresholds (MHz). Deliberately coarse: many modern
@@ -640,25 +659,28 @@ def _assign_roles_by_position(radios: list[RadioSpec]) -> dict[int, str]:
     second such radio (e.g. the OH-58D's two FM sets) gets ``fm_secondary``.
     """
     bands = [_classify_radio(radio.ranges) for radio in radios]
+    uhf_indices = [index for index, band in enumerate(bands) if band == "uhf"]
+    vhf_indices = [index for index, band in enumerate(bands) if band == "vhf"]
+    ambiguous_indices = [index for index, band in enumerate(bands) if band == "ambiguous"]
+    fm_indices = [index for index, band in enumerate(bands) if band is None]
+
     role_by_index: dict[int, str] = {}
 
-    for index, band in enumerate(bands):
-        if band == "uhf" and ROLE_PRIMARY_1 not in role_by_index.values():
-            role_by_index[index] = ROLE_PRIMARY_1
-        elif band == "vhf" and ROLE_PRIMARY_2 not in role_by_index.values():
-            role_by_index[index] = ROLE_PRIMARY_2
+    # Radios unambiguously dedicated to one sub-band claim that role directly.
+    if uhf_indices:
+        role_by_index[uhf_indices[0]] = ROLE_PRIMARY_1
+    if vhf_indices:
+        role_by_index[vhf_indices[0]] = ROLE_PRIMARY_2
 
-    for index, band in enumerate(bands):
-        if band != "ambiguous" or index in role_by_index:
-            continue
+    # Ambiguous combo radios fill whichever primary slot remains, in physical order.
+    for index in ambiguous_indices:
         if ROLE_PRIMARY_1 not in role_by_index.values():
             role_by_index[index] = ROLE_PRIMARY_1
         elif ROLE_PRIMARY_2 not in role_by_index.values():
             role_by_index[index] = ROLE_PRIMARY_2
 
-    fm_role = ROLE_FM_SUPPLEMENT if len(role_by_index) >= 2 else ROLE_FM_SUBSTITUTE
-    fm_indices = [index for index, band in enumerate(bands) if band is None and index not in role_by_index]
     if fm_indices:
+        fm_role = ROLE_FM_SUPPLEMENT if len(role_by_index) >= 2 else ROLE_FM_SUBSTITUTE
         role_by_index[fm_indices[0]] = fm_role
         if len(fm_indices) >= 2:
             role_by_index[fm_indices[1]] = ROLE_FM_SECONDARY
@@ -674,30 +696,21 @@ def _channel_list_for_role(role_lists: dict[str, RadioDefinition], role: str) ->
     return source
 
 
-def pack_preset_for_type(
+def _resolved_slots_for_type(
     channel_lists: dict[str, dict[str, RadioDefinition]], coalition: str, unit_type: str
-) -> "PresetDefinition | None":
-    """Project a mission-maker's Channel lists onto one aircraft type's physical radios.
+) -> list[tuple[int, RadioDefinition]] | None:
+    """Resolve which physical radio index gets which channel list (ADR 0010).
 
-    This is the packer's default projection (ADR 0010), used when no explicit
-    per-type _Radio layout_ entry exists (added by a later lot): each physical
-    radio is assigned a role by :func:`_assign_roles_by_position`, then filled
-    with that role's channel list. An aircraft with no primary radio at all
-    (single-radio HF/ADF sets, e.g. the MiG-15bis or Yak-52) still gets an
-    ``fm_substitute`` guess on its only radio; since that content will not be in
-    range, the existing frequency validator drops it and reports the mismatch —
-    a safe, actionable degradation rather than a crash, pending an explicit
-    layout entry for that type.
-
-    Args:
-        channel_lists: Parsed Channel lists, coalition -> role -> RadioDefinition
-            (from :func:`parse_channel_lists`).
-        coalition: "blue" or "red".
-        unit_type: DCS unit type string.
+    Localizes the packer's resolution policy — role assignment, content lookup,
+    and the "gap before the last usable radio" safety check — separately from
+    :func:`pack_preset_for_type`'s materialization into a `PresetDefinition`.
 
     Returns:
-        A :class:`PresetDefinition` with one radio per resolvable physical slot,
-        or None if the aircraft is unknown or no role list has any content for it.
+        Ordered (physical_index, source) pairs (0-based physical_index), or None
+        if the aircraft is unknown, no role list has content for it, or a gap
+        before the last usable radio makes the mapping ambiguous — packing it
+        would silently renumber a later radio to the wrong physical slot, so
+        it is left to an explicit layout entry rather than guessed.
     """
     role_lists = channel_lists.get(coalition)
     if not role_lists:
@@ -720,15 +733,44 @@ def pack_preset_for_type(
         return None
     last_usable = max(index for index, source in enumerate(resolved) if source is not None)
     if any(source is None for source in resolved[:last_usable]):
-        # A gap before the last usable radio is ambiguous — packing it would
-        # silently renumber a later radio to the wrong physical slot. Leave it
-        # to an explicit layout entry rather than guess.
+        return None
+
+    return [(index, source) for index, source in enumerate(resolved[: last_usable + 1]) if source is not None]
+
+
+def pack_preset_for_type(
+    channel_lists: dict[str, dict[str, RadioDefinition]], coalition: str, unit_type: str
+) -> "PresetDefinition | None":
+    """Project a mission-maker's Channel lists onto one aircraft type's physical radios.
+
+    This is the packer's default projection (ADR 0010), used when no explicit
+    per-type _Radio layout_ entry exists (added by a later lot): each physical
+    radio is assigned a role by :func:`_assign_roles_by_position` (resolved by
+    :func:`_resolved_slots_for_type`), then filled with that role's channel
+    list. An aircraft with no primary radio at all (single-radio HF/ADF sets,
+    e.g. the MiG-15bis or Yak-52) still gets an ``fm_substitute`` guess on its
+    only radio; since that content will not be in range, the existing frequency
+    validator drops it and reports the mismatch — a safe, actionable
+    degradation rather than a crash, pending an explicit layout entry for that
+    type.
+
+    Args:
+        channel_lists: Parsed Channel lists, coalition -> role -> RadioDefinition
+            (from :func:`parse_channel_lists`).
+        coalition: "blue" or "red".
+        unit_type: DCS unit type string.
+
+    Returns:
+        A :class:`PresetDefinition` with one radio per resolvable physical slot,
+        or None if the aircraft is unknown or no role list has any content for it.
+    """
+    slots = _resolved_slots_for_type(channel_lists, coalition, unit_type)
+    if not slots:
         return None
 
     preset = PresetDefinition(name=f"packed_{coalition}_{unit_type}")
-    for index, source in enumerate(resolved[: last_usable + 1], start=1):
-        assert source is not None
-        radio = RadioDefinition(name=f"radio_{index}", radio_type=source.radio_type, title=source.title)
+    for physical_index, source in slots:
+        radio = RadioDefinition(name=f"radio_{physical_index + 1}", radio_type=source.radio_type, title=source.title)
         for channel in source.channels:
             radio.add_channel(
                 Channel(name_or_number=channel.number, freq=channel.freq, title=channel.title, mod=channel.mod)

--- a/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
+++ b/src/python/veaf-tools/presets_injector/radio_frequency_validator.py
@@ -62,6 +62,43 @@ def get_valid_ranges(unit_type: str) -> list[FrequencyRange] | None:
     return ranges
 
 
+@dataclass(frozen=True)
+class RadioSpec:
+    """One physical radio's frequency ranges, in the aircraft's `.miz` order."""
+
+    name: str
+    ranges: list[FrequencyRange]
+
+
+def get_radios(unit_type: str) -> list[RadioSpec] | None:
+    """Return the ordered list of physical radios for a DCS unit type, or None if unknown.
+
+    Used by the radio-preset packer (ADR 0010) to determine each physical radio's
+    role. Order matches the specs / `.miz` order.
+
+    Args:
+        unit_type: DCS unit type string (e.g. "F-16C_50").
+
+    Returns:
+        List of RadioSpec in physical order, or None if the unit type is not in
+        the specs database.
+    """
+    specs = _load_specs()
+    entry = specs.get(unit_type)
+    if not entry:
+        return None
+    return [
+        RadioSpec(
+            name=radio.get("name", ""),
+            ranges=[
+                FrequencyRange(min_mhz=r["min_mhz"], max_mhz=r["max_mhz"], modulation=r.get("modulation", "AM/FM"))
+                for r in radio.get("ranges", [])
+            ],
+        )
+        for radio in entry.get("radios", [])
+    ]
+
+
 def is_strict(unit_type: str) -> bool:
     """Return True if out-of-range preset frequencies cause DCS to reject the mission at load.
 

--- a/test/python/presets_injector/test_channel_lists.py
+++ b/test/python/presets_injector/test_channel_lists.py
@@ -1,0 +1,103 @@
+import unittest
+
+from presets_injector.presets_manager import (
+    ROLE_BANDS,
+    ROLE_FM_SECONDARY,
+    ROLE_FM_SUBSTITUTE,
+    ROLE_FM_SUPPLEMENT,
+    ROLE_PRIMARY_1,
+    ROLE_PRIMARY_2,
+    ChannelCollection,
+    RadioDefinition,
+    parse_channel_lists,
+)
+
+
+class TestRoles(unittest.TestCase):
+    def test_role_bands(self):
+        self.assertEqual(
+            ROLE_BANDS,
+            {
+                ROLE_PRIMARY_1: "uhf",
+                ROLE_PRIMARY_2: "vhf",
+                ROLE_FM_SUBSTITUTE: "fm",
+                ROLE_FM_SUPPLEMENT: "fm",
+                ROLE_FM_SECONDARY: "fm",
+            },
+        )
+
+
+class TestParseChannelLists(unittest.TestCase):
+    def setUp(self):
+        self.channel_collections = {
+            "common": ChannelCollection.from_dict(
+                name="common",
+                data={
+                    "Overlord": {"title": "Overlord", "freqs": {"uhf": 280.0}},
+                    "Batumi": {"title": "Batumi / 16X", "freqs": {"uhf": 260.0, "vhf": 131.0}},
+                    "Garde": {"title": "Garde", "freqs": {"uhf": 243.0, "vhf": 121.5}},
+                },
+            )
+        }
+
+    def test_parses_a_simple_role_list(self):
+        data = {"blue": {"primary_1": {"01": "Overlord", "02": "Garde"}}}
+        channel_lists, dropped = parse_channel_lists(data, self.channel_collections)
+        radio = channel_lists["blue"]["primary_1"]
+        self.assertIsInstance(radio, RadioDefinition)
+        self.assertEqual(radio.radio_type, "uhf")
+        self.assertEqual([c.freq for c in radio.channels], [280.0, 243.0])
+        self.assertEqual(dropped, {})
+
+    def test_resolves_by_the_role_band_not_a_fixed_mode(self):
+        # The same alias (Batumi) resolves to a different frequency depending on
+        # which role's band it is placed under.
+        data = {
+            "blue": {
+                "primary_1": {"01": "Batumi"},
+                "primary_2": {"01": "Batumi"},
+            }
+        }
+        channel_lists, _ = parse_channel_lists(data, self.channel_collections)
+        self.assertEqual(channel_lists["blue"]["primary_1"].channels[0].freq, 260.0)
+        self.assertEqual(channel_lists["blue"]["primary_2"].channels[0].freq, 131.0)
+
+    def test_channel_lacking_the_role_band_is_dropped_and_recorded(self):
+        # "Overlord" has no vhf frequency: it must be dropped from a primary_2 list,
+        # not raise, and the drop must be recorded for reporting.
+        data = {"blue": {"primary_2": {"01": "Overlord", "02": "Batumi"}}}
+        channel_lists, dropped = parse_channel_lists(data, self.channel_collections)
+        radio = channel_lists["blue"]["primary_2"]
+        self.assertEqual(len(radio.channels), 1)
+        self.assertEqual(radio.channels[0].freq, 131.0)
+        self.assertEqual(dropped, {"blue": {"primary_2": ["01"]}})
+
+    def test_literal_frequency_is_never_dropped(self):
+        data = {"blue": {"fm_supplement": {"01": 31.5}}}
+        channel_lists, dropped = parse_channel_lists(data, self.channel_collections)
+        self.assertEqual(channel_lists["blue"]["fm_supplement"].channels[0].freq, 31.5)
+        self.assertEqual(dropped, {})
+
+    def test_unknown_role_is_rejected(self):
+        data = {"blue": {"not_a_role": {"01": "Overlord"}}}
+        with self.assertRaises(ValueError):
+            parse_channel_lists(data, self.channel_collections)
+
+    def test_unresolved_alias_still_raises(self):
+        # A typo'd alias (not found in any collection at all) stays a hard error,
+        # regardless of strict=False — that is an authoring mistake, not a
+        # role/band mismatch.
+        data = {"blue": {"primary_1": {"01": "TypoChannel"}}}
+        with self.assertRaises(ValueError):
+            parse_channel_lists(data, self.channel_collections)
+
+    def test_fm_secondary_not_defaulted_at_parse_time(self):
+        # fm_secondary defaulting to fm_supplement is a packer-time concern
+        # (ADR 0010), not a parsing concern — parsing only sees what is declared.
+        data = {"blue": {"fm_supplement": {"01": "Overlord"}}}
+        channel_lists, _ = parse_channel_lists(data, self.channel_collections)
+        self.assertNotIn(ROLE_FM_SECONDARY, channel_lists["blue"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/presets_injector/test_radio_preset_packer.py
+++ b/test/python/presets_injector/test_radio_preset_packer.py
@@ -1,0 +1,256 @@
+import unittest
+from unittest.mock import patch
+
+from presets_injector.presets_manager import (
+    Channel,
+    ChannelCollection,
+    PresetAssignment,
+    PresetAssignmentCollection,
+    PresetDefinition,
+    PresetsManager,
+    RadioDefinition,
+    pack_preset_for_type,
+    parse_channel_lists,
+)
+from presets_injector.radio_frequency_validator import FrequencyRange, RadioSpec
+
+UHF_ONLY = [FrequencyRange(min_mhz=225.0, max_mhz=400.0, modulation="AM/FM")]
+VHF_ONLY = [FrequencyRange(min_mhz=116.0, max_mhz=152.0, modulation="AM/FM")]
+FM_ONLY = [FrequencyRange(min_mhz=30.0, max_mhz=88.0, modulation="FM")]
+# A single range spanning both windows (e.g. Mi-8MT's R-863, or a warbird's FuG16).
+AMBIGUOUS = [FrequencyRange(min_mhz=100.0, max_mhz=399.9, modulation="AM/FM")]
+HF_ONLY = [FrequencyRange(min_mhz=3.75, max_mhz=5.0, modulation="AM")]  # MiG-15bis-shaped
+
+
+def _radio(freqs: list[float]) -> RadioDefinition:
+    radio = RadioDefinition(name="r", radio_type="uhf")
+    for i, freq in enumerate(freqs, start=1):
+        radio.add_channel(Channel(name_or_number=i, freq=freq))
+    return radio
+
+
+def _channel_lists(**roles: list[float]) -> dict[str, dict[str, RadioDefinition]]:
+    return {"blue": {role: _radio(freqs) for role, freqs in roles.items()}}
+
+
+def _specs(*range_lists: list[FrequencyRange]) -> list[RadioSpec]:
+    return [RadioSpec(name=f"radio{i}", ranges=ranges) for i, ranges in enumerate(range_lists, start=1)]
+
+
+class TestPackPresetForTypeDefaultProjection(unittest.TestCase):
+    """No explicit Radio layout entry -> the default projection (ADR 0010).
+
+    Each physical radio is classified from its frequency ranges: radios
+    unambiguously dedicated to one sub-band claim that role directly (so a
+    deliberately "inverted" aircraft resolves correctly by itself); ambiguous
+    combo radios fall back to physical order. This is deliberately NOT a
+    positional-only default: exact bands still matter, verified against real
+    dcs-radio-specs.yaml data in TestPackPresetRealSpecsEndToEnd below.
+    """
+
+    @patch("presets_injector.presets_manager.get_radios")
+    def test_clean_two_radio_aircraft(self, mock_get_radios):
+        mock_get_radios.return_value = _specs(UHF_ONLY, VHF_ONLY)
+        channel_lists = _channel_lists(primary_1=[280.0], primary_2=[131.0])
+        preset = pack_preset_for_type(channel_lists, "blue", "SomeType")
+        result = preset.to_dict()
+        self.assertEqual(result[1]["channels"], {1: 280.0})
+        self.assertEqual(result[2]["channels"], {1: 131.0})
+        self.assertNotIn(3, result)
+
+    @patch("presets_injector.presets_manager.get_radios")
+    def test_inverted_order_resolves_by_band_not_position(self, mock_get_radios):
+        # Physical radio 1 is VHF, radio 2 is UHF (the A-10's real shape) — the
+        # default must still put the UHF list on radio 2, not radio 1.
+        mock_get_radios.return_value = _specs(VHF_ONLY, UHF_ONLY, FM_ONLY)
+        channel_lists = _channel_lists(primary_1=[280.0], primary_2=[131.0], fm_supplement=[31.0])
+        preset = pack_preset_for_type(channel_lists, "blue", "SomeType")
+        result = preset.to_dict()
+        self.assertEqual(result[1]["channels"], {1: 131.0})  # VHF list on physical radio 1
+        self.assertEqual(result[2]["channels"], {1: 280.0})  # UHF list on physical radio 2
+        self.assertEqual(result[3]["channels"], {1: 31.0})
+
+    @patch("presets_injector.presets_manager.get_radios")
+    def test_two_ambiguous_radios_fall_back_to_physical_order(self, mock_get_radios):
+        # Two identical combo radios (e.g. the Hornet's ARC-210 x2) — no band
+        # data can tell them apart, so physical order decides.
+        mock_get_radios.return_value = _specs(AMBIGUOUS, AMBIGUOUS)
+        channel_lists = _channel_lists(primary_1=[280.0], primary_2=[131.0])
+        preset = pack_preset_for_type(channel_lists, "blue", "SomeType")
+        result = preset.to_dict()
+        self.assertEqual(result[1]["channels"], {1: 280.0})
+        self.assertEqual(result[2]["channels"], {1: 131.0})
+
+    @patch("presets_injector.presets_manager.get_radios")
+    def test_single_ambiguous_radio_plus_fm_gets_primary_1_and_fm_substitute(self, mock_get_radios):
+        # One combo primary radio (e.g. Mi-8MT's R-863) + one FM-only radio.
+        mock_get_radios.return_value = _specs(AMBIGUOUS, FM_ONLY)
+        channel_lists = _channel_lists(primary_1=[280.0], fm_substitute=[31.0], fm_supplement=[99.0])
+        preset = pack_preset_for_type(channel_lists, "blue", "SomeType")
+        result = preset.to_dict()
+        self.assertEqual(result[1]["channels"], {1: 280.0})
+        self.assertEqual(result[2]["channels"], {1: 31.0})  # fm_substitute, not fm_supplement
+
+    @patch("presets_injector.presets_manager.get_radios")
+    def test_two_primaries_plus_fm_gets_fm_supplement(self, mock_get_radios):
+        mock_get_radios.return_value = _specs(UHF_ONLY, VHF_ONLY, FM_ONLY)
+        channel_lists = _channel_lists(primary_1=[280.0], primary_2=[131.0], fm_supplement=[31.0], fm_substitute=[99.0])
+        preset = pack_preset_for_type(channel_lists, "blue", "SomeType")
+        result = preset.to_dict()
+        self.assertEqual(result[3]["channels"], {1: 31.0})
+
+    @patch("presets_injector.presets_manager.get_radios")
+    def test_second_fm_radio_defaults_to_fm_supplement_copy(self, mock_get_radios):
+        # OH-58D-shaped: 2 primaries + 2 FM radios, fm_secondary not declared by the maker.
+        mock_get_radios.return_value = _specs(UHF_ONLY, VHF_ONLY, FM_ONLY, FM_ONLY)
+        channel_lists = _channel_lists(primary_1=[280.0], primary_2=[131.0], fm_supplement=[31.0])
+        preset = pack_preset_for_type(channel_lists, "blue", "SomeType")
+        result = preset.to_dict()
+        self.assertEqual(result[3]["channels"], {1: 31.0})
+        self.assertEqual(result[4]["channels"], {1: 31.0})  # fm_secondary defaulted to fm_supplement
+
+    @patch("presets_injector.presets_manager.get_radios")
+    def test_explicit_fm_secondary_overrides_the_default_copy(self, mock_get_radios):
+        mock_get_radios.return_value = _specs(UHF_ONLY, VHF_ONLY, FM_ONLY, FM_ONLY)
+        channel_lists = _channel_lists(primary_1=[280.0], primary_2=[131.0], fm_supplement=[31.0], fm_secondary=[42.0])
+        preset = pack_preset_for_type(channel_lists, "blue", "SomeType")
+        result = preset.to_dict()
+        self.assertEqual(result[4]["channels"], {1: 42.0})
+
+    @patch("presets_injector.presets_manager.get_radios")
+    def test_single_hf_radio_with_no_primary_band_gets_fm_substitute_guess(self, mock_get_radios):
+        # No band reaches above the FM ceiling -> treated as an FM-role radio by
+        # default; downstream frequency validation is expected to drop the
+        # mismatched content and report it (safe degradation, not a crash).
+        mock_get_radios.return_value = _specs(HF_ONLY)
+        channel_lists = _channel_lists(fm_substitute=[31.0])
+        preset = pack_preset_for_type(channel_lists, "blue", "SomeType")
+        self.assertEqual(preset.to_dict()[1]["channels"], {1: 31.0})
+
+    @patch("presets_injector.presets_manager.get_radios")
+    def test_gap_before_last_usable_radio_bails_out(self, mock_get_radios):
+        # primary_2 undefined but fm_supplement is -> packing would silently
+        # renumber the FM radio to the wrong physical slot.
+        mock_get_radios.return_value = _specs(UHF_ONLY, VHF_ONLY, FM_ONLY)
+        channel_lists = _channel_lists(primary_1=[280.0], fm_supplement=[31.0])
+        preset = pack_preset_for_type(channel_lists, "blue", "SomeType")
+        self.assertIsNone(preset)
+
+    @patch("presets_injector.presets_manager.get_radios")
+    def test_unknown_unit_type_returns_none(self, mock_get_radios):
+        mock_get_radios.return_value = None
+        channel_lists = _channel_lists(primary_1=[280.0])
+        self.assertIsNone(pack_preset_for_type(channel_lists, "blue", "NotARealType"))
+
+    def test_no_channel_lists_for_coalition_returns_none(self):
+        self.assertIsNone(pack_preset_for_type({}, "red", "F-16C_50"))
+
+
+class TestPackPresetRealSpecsEndToEnd(unittest.TestCase):
+    """Ticket 01 acceptance: real flagship aircraft end-to-end, no mocks."""
+
+    def setUp(self):
+        self.channel_collections = {
+            "common": ChannelCollection.from_dict(
+                name="common",
+                data={
+                    "Overlord": {"title": "Overlord", "freqs": {"uhf": 280.0}},
+                    "Batumi": {"title": "Batumi", "freqs": {"vhf": 131.0}},
+                    "JTAC": {"title": "JTAC", "freqs": {"fm": 31.0}},
+                },
+            )
+        }
+
+    def _pack(self, unit_type: str, **roles: dict) -> dict:
+        channel_lists, _ = parse_channel_lists({"blue": roles}, self.channel_collections)
+        preset = pack_preset_for_type(channel_lists, "blue", unit_type)
+        self.assertIsNotNone(preset, f"expected a preset for {unit_type}")
+        return preset.to_dict()
+
+    def test_f16_receives_uhf_and_vhf_on_the_matching_radios(self):
+        result = self._pack("F-16C_50", primary_1={"01": "Overlord"}, primary_2={"01": "Batumi"})
+        self.assertEqual(result[1]["channels"], {1: 280.0})
+        self.assertEqual(result[2]["channels"], {1: 131.0})
+
+    def test_fa18_falls_back_to_physical_order_for_its_identical_radios(self):
+        result = self._pack("FA-18C_hornet", primary_1={"01": "Overlord"}, primary_2={"01": "Batumi"})
+        self.assertEqual(result[1]["channels"], {1: 280.0})
+        self.assertEqual(result[2]["channels"], {1: 131.0})
+
+    def test_a10c_resolves_its_inverted_vhf_first_order_by_itself(self):
+        # No explicit layout entry needed: A-10C's radio 1 is VHF, radio 2 UHF.
+        result = self._pack(
+            "A-10C", primary_1={"01": "Overlord"}, primary_2={"01": "Batumi"}, fm_supplement={"01": "JTAC"}
+        )
+        self.assertEqual(result[1]["channels"], {1: 131.0})
+        self.assertEqual(result[2]["channels"], {1: 280.0})
+        self.assertEqual(result[3]["channels"], {1: 31.0})
+
+    def test_uh1h_single_radio_gets_primary_1_only(self):
+        result = self._pack("UH-1H", primary_1={"01": "Overlord"})
+        self.assertEqual(result[1]["channels"], {1: 280.0})
+        self.assertNotIn(2, result)
+
+    def test_mi8mt_gets_primary_1_and_fm_substitute(self):
+        result = self._pack("Mi-8MT", primary_1={"01": "Overlord"}, fm_substitute={"01": "JTAC"})
+        self.assertEqual(result[1]["channels"], {1: 280.0})
+        self.assertEqual(result[2]["channels"], {1: 31.0})
+
+    def test_warbird_single_radio_resolves_to_primary_2(self):
+        # Its lone radio spans both windows in one range (a genuine airframe
+        # trait, not classification noise) and resolves to VHF, matching
+        # David's decision that warbirds are packed on primary_2.
+        result = self._pack("Bf-109K-4", primary_2={"01": "Batumi"})
+        self.assertEqual(result[1]["channels"], {1: 131.0})
+
+
+class TestGetRadiosForOverrideAndFallback(unittest.TestCase):
+    """PresetsManager.get_radios_for: explicit assignment always wins (ADR 0010)."""
+
+    def setUp(self):
+        self.manager = PresetsManager()
+        self.manager.channel_collections = {
+            "common": ChannelCollection.from_dict(
+                name="common", data={"Overlord": {"title": "Overlord", "freqs": {"uhf": 280.0}}}
+            )
+        }
+        data = {"blue": {"primary_1": {"01": "Overlord"}}}
+        self.manager.channel_lists, _ = parse_channel_lists(data, self.manager.channel_collections)
+
+    def test_no_assignment_falls_back_to_packer(self):
+        preset = self.manager.get_radios_for("blue", "plane", "F-16C_50")
+        self.assertIsNotNone(preset)
+        self.assertEqual(preset.to_dict()[1]["channels"], {1: 280.0})
+
+    def test_explicit_none_assignment_disables_and_skips_packer(self):
+        self.manager.preset_assignments = PresetAssignmentCollection()
+        self.manager.preset_assignments.preset_assignments_dict = {
+            "blue": {
+                "plane": {
+                    "F-16C_50": PresetAssignment(
+                        preset_definition=None, coalition="blue", aircraft_type="plane", unit_type="F-16C_50"
+                    )
+                }
+            }
+        }
+        preset = self.manager.get_radios_for("blue", "plane", "F-16C_50")
+        self.assertIsNone(preset)
+
+    def test_explicit_assignment_wins_over_packer(self):
+        bespoke = PresetDefinition(name="bespoke")
+        self.manager.preset_assignments = PresetAssignmentCollection()
+        self.manager.preset_assignments.preset_assignments_dict = {
+            "blue": {
+                "plane": {
+                    "F-16C_50": PresetAssignment(
+                        preset_definition=bespoke, coalition="blue", aircraft_type="plane", unit_type="F-16C_50"
+                    )
+                }
+            }
+        }
+        preset = self.manager.get_radios_for("blue", "plane", "F-16C_50")
+        self.assertIs(preset, bespoke)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Founding tracer bullet of FEAT-RADIO-PRESET-PROJECTION (ADR 0010): a `channel_lists` block in `presets.yaml` lets the mission-maker declare channels once per Radio role (`primary_1`, `primary_2`, `fm_substitute`, `fm_supplement`, `fm_secondary`) and coalition.
- New packer (`pack_preset_for_type`) projects these lists onto each aircraft's physical radios by classifying them against the real `dcs-radio-specs.yaml`, correctly resolving deliberately inverted layouts (A-10's VHF-first order) and ambiguous identical combo radios (F/A-18's two ARC-210s) — verified end-to-end against real specs data, no per-type configuration needed for the common case.
- An explicit legacy `presets_assignments` entry (including an explicit `none`) always wins over the packer (manual override, per ADR 0010).
- Bumps the coverage gate 73 → 74 to track the added tests.

See `.backlog/FEAT-RADIO-PRESET-PROJECTION/tickets/01-standard-aircraft-end-to-end.md` (Implementation notes) and the ADR 0010 addendum for why the mechanism differs from the ADR's illustrative "positional by radio count" sketch — a pure count/positional heuristic misclassifies the F-16, the Hornet, and most helicopters against real spec data.

## Test plan
- [x] `poetry run pytest` — full suite green (coverage 74.49%, gate 74%)
- [x] `poetry run ruff check` / `ruff format --check` — clean
- [x] `poetry run mypy src/python/veaf-tools/veaf-tools/` (presets_injector package) — clean
- [x] New regression tests against real aircraft (F-16C_50, FA-18C_hornet, A-10C, UH-1H, Mi-8MT, Bf-109K-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce role-based radio preset packing that projects coalition-level channel lists onto aircraft radios based on real radio specs, with legacy per-aircraft assignments still taking precedence.

New Features:
- Allow mission makers to define coalition-level channel lists by radio role in presets.yaml instead of per-aircraft radio/preset collections.
- Add a packer that maps these role-based channel lists onto each aircraft type's physical radios using their frequency ranges and positions.
- Expose ordered per-aircraft radio specifications from the radio frequency validator for use by the preset packer.

Enhancements:
- Extend radio preset parsing to support band-aware alias resolution per radio role and record channels dropped due to missing frequencies for a role.
- Update PresetsManager to fall back to the automatic packer only when no explicit preset assignment exists, including explicit none assignments.
- Document the implemented band-based projection behaviour in ADR 0010 and backlog notes, clarifying deviations from the earlier positional sketch.

Build:
- Bump project version to 6.7.9 and increase pytest coverage threshold from 73 to 74.

Tests:
- Add unit and end-to-end tests for channel list parsing, role assignment, and preset packing against both synthetic shapes and real aircraft specs.
- Add tests ensuring explicit preset assignments (including none) override the automatic packer in PresetsManager.