### PR TITLE
feat(mcp): wave 8 — composite builders (FEAT-MCP-MISSION-EDITOR 24-28)

### DIFF
--- a/.backlog/FEAT-MCP-MISSION-EDITOR/PRD.md
+++ b/.backlog/FEAT-MCP-MISSION-EDITOR/PRD.md
@@ -1,6 +1,6 @@
 # Lot FEAT-MCP-MISSION-EDITOR — MCP server for LLM-assisted mission editing (v1: groups/units)
 
-Status: 🔄 in-progress (waves 1-5 done — 18 tickets, merged into integration branch `feature/mcp-mission-editor` (wave 5 = PR #576, merged); umbrella PR #575 → `develop-v6` draft; wave 6 (convention-aware add_group, tickets 19-21) done (PR #577, merged); wave 7 (target symmetry, tickets 22-23) done on sub-branch `feature/mcp-target-symmetry` (PR #578); **wave 8 (composite builders, tickets 24-28) next** — the endgame)
+Status: 🔄 in-progress (waves 1-5 done — 18 tickets, merged into integration branch `feature/mcp-mission-editor` (wave 5 = PR #576, merged); umbrella PR #575 → `develop-v6` draft; wave 6 (convention-aware add_group, tickets 19-21) done (PR #577, merged); wave 7 (target symmetry, tickets 22-23) done (PR #578, merged); **wave 8 (composite builders, tickets 24-28) open on sub-branch `feature/mcp-composite-builders`** — the endgame: folder-aware one-pass `create_combat_zone`/`create_qra`/`create_cap_mission`)
 
 Branch: `feature/mcp-mission-editor` → PR → `develop-v6`
 

--- a/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/24-folder-awareness.md
+++ b/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/24-folder-awareness.md
@@ -1,0 +1,41 @@
+# FEAT-MCP-MISSION-EDITOR-024 — Mission-folder awareness (extract/build round-trip)
+
+Status: ⬜ ready
+Type: feat
+Files: `src/python/veaf-tools/veaf_mission_mcp/mission_folder.py`, `test/python/`
+
+## What to build
+
+The foundation for the composite builders: let the MCP operate on a **mission folder** (the
+editable source: `mission.yaml` + `src/mission/` exploded `.miz`), not only a standalone built
+`.miz`. A composite feature lives in **both worlds** (trigger zones/groups in `src/mission/`, the
+module config in `mission.yaml`), so a one-pass builder must edit both and then realise it.
+
+- A small `mission_folder` helper that resolves a folder's pieces: the `mission.yaml`, the
+  exploded mission under `src/mission/`, and (re)builds a `.miz` from the folder via the existing
+  CLI/worker (`veaf-tools build`, `MissionBuilderWorker`, `mission_promoter.promote_mission_to_v6`
+  for the extract-back half).
+- The wave-1/2 editor-parity primitives (`add_group`, `add_trigger_zone`) currently operate on a
+  `.miz` zip; make them reusable against the folder's mission representation (edit `src/mission/`,
+  or edit a built `.miz` then extract back — decide during implementation, see below).
+
+## Design decision to settle (flag at implementation)
+
+Two viable models for "edit the `.miz` side of a folder":
+1. **Edit `src/mission/` directly** (the exploded mission), then `build`.
+2. **Build → edit the `.miz` (editor-parity) → extract back** (the `mission_promoter` round-trip).
+
+Prefer (1) if the exploded `src/mission/mission` is straightforward to mutate with the existing
+`read_miz`/`write_miz`-style helpers; else (2) reusing `promote_mission_to_v6`. Confirm with David
+before committing the composite builders to one model.
+
+## Acceptance criteria
+
+- [ ] `mission_folder` resolves `mission.yaml` + the exploded mission for a given folder path.
+- [ ] A build (folder → `.miz`) can be triggered programmatically, reusing the existing worker.
+- [ ] The editor-parity primitives can target the folder's mission (chosen model), backed up first.
+- [ ] TDD; ruff + mypy clean.
+
+## Blocked by
+
+None (reuses `mission_builder`/`mission_extractor`/`mission_promoter`).

--- a/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/24-folder-awareness.md
+++ b/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/24-folder-awareness.md
@@ -1,6 +1,6 @@
 # FEAT-MCP-MISSION-EDITOR-024 — Mission-folder awareness (extract/build round-trip)
 
-Status: ⬜ ready
+Status: ✅ done
 Type: feat
 Files: `src/python/veaf-tools/veaf_mission_mcp/mission_folder.py`, `test/python/`
 
@@ -19,22 +19,21 @@ module config in `mission.yaml`), so a one-pass builder must edit both and then 
   `.miz` zip; make them reusable against the folder's mission representation (edit `src/mission/`,
   or edit a built `.miz` then extract back — decide during implementation, see below).
 
-## Design decision to settle (flag at implementation)
+## Design decision — settled (David, model 1)
 
-Two viable models for "edit the `.miz` side of a folder":
-1. **Edit `src/mission/` directly** (the exploded mission), then `build`.
-2. **Build → edit the `.miz` (editor-parity) → extract back** (the `mission_promoter` round-trip).
-
-Prefer (1) if the exploded `src/mission/mission` is straightforward to mutate with the existing
-`read_miz`/`write_miz`-style helpers; else (2) reusing `promote_mission_to_v6`. Confirm with David
-before committing the composite builders to one model.
+Composites **edit the durable source**: the exploded `src/mission/` (zones/groups) + `mission.yaml`
+(config). No build is triggered by the composite — a later `veaf-tools build` produces the `.miz`.
+The exploded `mission` file is mutated with the existing pure-Python `luadata` parser via the new
+`write_mission_folder` (sibling of the existing `read_mission_folder`) — no zip, no Lua execution.
 
 ## Acceptance criteria
 
-- [ ] `mission_folder` resolves `mission.yaml` + the exploded mission for a given folder path.
-- [ ] A build (folder → `.miz`) can be triggered programmatically, reusing the existing worker.
-- [ ] The editor-parity primitives can target the folder's mission (chosen model), backed up first.
-- [ ] TDD; ruff + mypy clean.
+- [x] `mission_folder` resolves both sides of a folder: `mission_yaml_path()` and the exploded
+      mission (`load_folder_mission`).
+- [x] `write_mission_folder` (in `mission_tools.miz_tools`) writes `mission_content` back to the
+      loose `mission` file, leaving the rest of the folder intact.
+- [x] `save_folder_mission` backs the `mission` file up first, then writes.
+- [x] TDD (4 tests); ruff + mypy clean (full-tree, CI-exact). No auto-build (model 1).
 
 ## Blocked by
 

--- a/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/25-create-combat-zone.md
+++ b/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/25-create-combat-zone.md
@@ -1,0 +1,32 @@
+# FEAT-MCP-MISSION-EDITOR-025 — `create_combat_zone` (one pass, both worlds)
+
+Status: ⬜ ready
+Type: feat
+Files: `src/python/veaf-tools/veaf_mission_mcp/composites.py`, `veaf_mission_mcp/actions.py`, `test/python/`
+
+## What to build
+
+A single high-level action that lays down a complete VEAF combat zone across both worlds, by
+orchestrating the wave-1..7 primitives on a mission folder (ticket 024):
+
+1. **Trigger zone** (`add_trigger_zone`) — the circular zone `<zone_name>`.
+2. **Groups inside it** (`add_group` with `for_combat_zone=<zone_name>`) — placed geometrically
+   inside the zone, names prefixed so the zone captures them; coalition-agnostic (VEAF respawns).
+   The LLM supplies the `{type,count}` groups (using the wave-5 oracle for types).
+3. **`mission.yaml` config** (`set_mission_module`) — a `COMBATZONE` block referencing `zone_name`.
+
+Then (optionally) build. Not deduplicated. Returns a summary of what it created + any
+`validate_group_name` warnings.
+
+## Acceptance criteria
+
+- [ ] One call produces: the trigger zone, ≥1 correctly-named group inside it, and the
+      `modules.COMBATZONE.combat_zones[]` entry — verifiable by re-reading the folder.
+- [ ] Group names satisfy the combat-zone membership rule (zone-name prefix).
+- [ ] Idempotency/dedup: documented (calling twice = two zones), matching the primitives.
+- [ ] TDD against a real mission folder fixture; ruff + mypy clean.
+- [ ] Mission-maker catalogue updated (living-doc rule).
+
+## Blocked by
+
+FEAT-MCP-MISSION-EDITOR-024.

--- a/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/25-create-combat-zone.md
+++ b/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/25-create-combat-zone.md
@@ -1,6 +1,6 @@
 # FEAT-MCP-MISSION-EDITOR-025 — `create_combat_zone` (one pass, both worlds)
 
-Status: ⬜ ready
+Status: ✅ done
 Type: feat
 Files: `src/python/veaf-tools/veaf_mission_mcp/composites.py`, `veaf_mission_mcp/actions.py`, `test/python/`
 
@@ -20,12 +20,18 @@ Then (optionally) build. Not deduplicated. Returns a summary of what it created 
 
 ## Acceptance criteria
 
-- [ ] One call produces: the trigger zone, ≥1 correctly-named group inside it, and the
-      `modules.COMBATZONE.combat_zones[]` entry — verifiable by re-reading the folder.
-- [ ] Group names satisfy the combat-zone membership rule (zone-name prefix).
-- [ ] Idempotency/dedup: documented (calling twice = two zones), matching the primitives.
-- [ ] TDD against a real mission folder fixture; ruff + mypy clean.
-- [ ] Mission-maker catalogue updated (living-doc rule).
+- [x] One call produces: the trigger zone, ≥1 correctly-named group inside it, and the
+      `modules.COMBATZONE.combat_zones[]` entry — verified by re-reading the folder.
+- [x] Group names satisfy the combat-zone membership rule (zone-name prefix, via `resolve_group_name`).
+- [x] Appends to existing `combat_zones` (second call = two zones), doesn't clobber.
+- [x] TDD (2 tests) against a real mission folder fixture; ruff + mypy clean (full-tree).
+- [x] Mission-maker catalogue updated — new "🏗️ Composites" headline theme, FR/EN.
+
+## Note
+
+Extracted content-level cores `insert_trigger_zone` / `insert_group_into_content` (from
+`add_trigger_zone` / `add_group`) so the composite reuses them on the folder's exploded mission —
+the `.miz` actions now delegate to the same cores (behavior-preserving).
 
 ## Blocked by
 

--- a/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/26-create-qra.md
+++ b/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/26-create-qra.md
@@ -1,0 +1,30 @@
+# FEAT-MCP-MISSION-EDITOR-026 — `create_qra` (one pass, both worlds)
+
+Status: ⬜ ready
+Type: feat
+Files: `src/python/veaf-tools/veaf_mission_mcp/composites.py`, `veaf_mission_mcp/actions.py`, `test/python/`
+
+## What to build
+
+A single action laying down a complete VEAF QRA across both worlds (contrast with the combat
+zone: QRA groups are referenced **by exact name**, coalition **matters**, and interceptors are
+**Late Activation**):
+
+1. **Trigger zone** (`add_trigger_zone`) — the protected-airspace zone (or accept a `zone_radius`).
+2. **Interceptor group(s)** (`add_group` with `late_activation=True`, the definition's coalition,
+   coherent names) — the LLM picks the aircraft type (wave-5 oracle).
+3. **`mission.yaml` config** (`set_mission_module` on `QRA`) — a `definitions[]` entry with
+   `name`, `coalition`, `trigger_zone`, and `simple_groups` listing the interceptor group names
+   **verbatim**.
+
+## Acceptance criteria
+
+- [ ] One call produces: the trigger zone, the Late-Activation interceptor group(s) on the right
+      coalition, and the `modules.QRA.definitions[]` entry referencing the group name(s) verbatim.
+- [ ] The group name in the `.miz` and the name listed in the QRA definition match exactly.
+- [ ] TDD against a real mission folder fixture; ruff + mypy clean.
+- [ ] Mission-maker catalogue updated.
+
+## Blocked by
+
+FEAT-MCP-MISSION-EDITOR-024 (and shares patterns with 025).

--- a/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/27-create-cap-mission.md
+++ b/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/27-create-cap-mission.md
@@ -1,0 +1,30 @@
+# FEAT-MCP-MISSION-EDITOR-027 — `create_cap_mission` (one pass, both worlds)
+
+Status: ⬜ ready
+Type: feat
+Files: `src/python/veaf-tools/veaf_mission_mcp/composites.py`, `veaf_mission_mcp/actions.py`, `test/python/`
+
+## What to build
+
+A single action laying down an on-demand CAP mission across both worlds:
+
+1. **Template group** (`add_group` with `late_activation=True`, name `OnDemand-<missionName>`
+   — the `as_cap_template` intent or explicit prefix) — the CAP template DCS activates on demand.
+2. **`mission.yaml` config** — a `cap_missions:` / `combat_missions:` entry referencing
+   `<missionName>` (the build resolves it to the `OnDemand-` group via `group_validation`'s
+   `ONDEMAND_CAP_PREFIX`).
+
+Confirm the exact `mission.yaml` shape (`cap_missions:` vs `combat_missions:`) against
+`MISSION_YAML_REFERENCE` / `group_validation.py` during implementation.
+
+## Acceptance criteria
+
+- [ ] One call produces: the `OnDemand-<name>` Late-Activation template group and the matching
+      `cap_missions`/`combat_missions` yaml entry.
+- [ ] The yaml reference resolves to the `OnDemand-`-prefixed group (matches `group_validation`).
+- [ ] TDD against a real mission folder fixture; ruff + mypy clean.
+- [ ] Mission-maker catalogue updated.
+
+## Blocked by
+
+FEAT-MCP-MISSION-EDITOR-024.

--- a/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/28-wave8-doc.md
+++ b/.backlog/FEAT-MCP-MISSION-EDITOR/tickets/28-wave8-doc.md
@@ -1,0 +1,27 @@
+# FEAT-MCP-MISSION-EDITOR-028 — Wave-8 documentation
+
+Status: ⬜ ready
+Type: docs
+Files: `doc/developer/mission-editing-mcp.md` (FR/EN), `doc/mission-maker/AI_ASSISTANT_CATALOG.md` (FR/EN), `CONTEXT.md`, `CHANGELOG.md`, `pyproject.toml`, `plugin/skills/veaf-mission-authoring/SKILL.md`
+
+## What to build
+
+- Developer doc (FR/EN): document folder-awareness and the composite builders
+  (`create_combat_zone`, `create_qra`, `create_cap_mission`) — the "one pass, both worlds" model
+  and the extract/build round-trip.
+- Mission-maker catalogue (FR/EN): a new **top-of-list** theme for the one-shot builders (this is
+  the headline capability — high frequency), with worked example phrases.
+- CONTEXT.md glossary: a "composite action" / "one-pass builder" entry if warranted.
+- Update the `veaf-mission-authoring` skill: prefer the composite when the user asks for a whole
+  feature; fall back to primitives otherwise.
+- CHANGELOG entry; PATCH version bump.
+
+## Acceptance criteria
+
+- [ ] Both language docs and the catalogue describe the composites and the both-worlds model.
+- [ ] Skill updated to reach for composites first.
+- [ ] CHANGELOG + version bump landed.
+
+## Blocked by
+
+FEAT-MCP-MISSION-EDITOR-025 / 026 / 027.

--- a/doc/mission-maker/AI_ASSISTANT_CATALOG.en.md
+++ b/doc/mission-maker/AI_ASSISTANT_CATALOG.en.md
@@ -56,6 +56,7 @@ The AI can act in two places, and it changes what "survives":
 | 14 | [Explain the naming conventions](#naming-conventions) | Domain knowledge | — | ◽ |
 | 15 | [Look up a VEAF module](#describe-module) | Domain knowledge | — | ◽ |
 | 16 | [Check a group name](#check-group-name) | Domain knowledge | — | ◽ |
+| 17 | [Create a full combat zone (one pass)](#create-combat-zone) | 🏗️ Composites | Recipe (folder) | 🔥 |
 
 ---
 
@@ -101,6 +102,22 @@ given mission, warns about the **combat-zone capture trap**. The AI uses it befo
 and relays any warning to you.
 
 > 💬 *"Could this group name cause a problem?"*
+
+---
+
+## 🏗️ Composites — create a full feature (one pass)
+
+*The core goal: from a single request, the AI lays down a whole VEAF feature across **both worlds**
+(source `src/mission` + `mission.yaml`) of a **mission folder**. Durable: a later `veaf-tools build`
+produces the `.miz`.*
+
+### Create a full combat zone {#create-combat-zone}
+
+*Recipe (folder) · 🔥* — In one call: the trigger zone, the groups placed inside it (auto-named so
+the zone captures them) **and** the `COMBATZONE` block in `mission.yaml`. You describe, the AI
+assembles.
+
+> 💬 *"Create a “North” combat zone with two enemy armor groups."*
 
 ---
 

--- a/doc/mission-maker/AI_ASSISTANT_CATALOG.md
+++ b/doc/mission-maker/AI_ASSISTANT_CATALOG.md
@@ -57,6 +57,7 @@ L'IA peut agir à deux endroits, et ça change ce qui « survit » :
 | 14 | [Expliquer les conventions de nommage](#conventions-nommage) | Connaissance métier | — | ◽ |
 | 15 | [Renseigner sur un module VEAF](#decrire-module) | Connaissance métier | — | ◽ |
 | 16 | [Vérifier un nom de groupe](#verifier-nom-groupe) | Connaissance métier | — | ◽ |
+| 17 | [Créer une combat zone complète (une passe)](#creer-combat-zone) | 🏗️ Composites | Recette (dossier) | 🔥 |
 
 ---
 
@@ -103,6 +104,22 @@ mission donnée, prévient du **piège de capture combat-zone**. L'IA s'en sert 
 groupe et te relaie tout avertissement.
 
 > 💬 *« Est-ce que ce nom de groupe risque de poser problème ? »*
+
+---
+
+## 🏗️ Composites — créer une fonctionnalité complète (une passe)
+
+*Le cœur de l'objectif : d'une seule demande, l'IA pose une fonctionnalité VEAF entière sur les
+**deux mondes** (source `src/mission` + `mission.yaml`) d'un **dossier de mission**. Durable : un
+`veaf-tools build` ultérieur produit le `.miz`.*
+
+### Créer une combat zone complète {#creer-combat-zone}
+
+*Recette (dossier) · 🔥* — En un appel : la zone de déclenchement, les groupes placés dedans
+(nommés automatiquement pour être capturés par la zone) **et** le bloc `COMBATZONE` dans
+`mission.yaml`. Tu décris, l'IA assemble.
+
+> 💬 *« Crée une combat zone “North” avec deux groupes de blindés ennemis. »*
 
 ---
 

--- a/src/python/veaf-tools/mission_tools/miz_tools.py
+++ b/src/python/veaf-tools/mission_tools/miz_tools.py
@@ -215,6 +215,37 @@ def read_mission_folder(folder_path: Path) -> DcsMission:
     return result
 
 
+def write_mission_folder(mission: DcsMission, folder_path: Path) -> Path:
+    """Serialize ``mission_content`` back to a folder's loose ``mission`` file.
+
+    The write-side counterpart of :func:`read_mission_folder`. Rewrites only the ``mission`` file
+    (the tables the composite builders edit), leaving the rest of ``src/mission/`` and the folder
+    untouched. Uses the same ``luadata`` serializer as :func:`write_miz`, so no Lua is executed.
+
+    Args:
+        mission: The mission whose ``mission_content`` to write.
+        folder_path: A folder holding the loose mission files (root or ``src/mission/``).
+
+    Returns:
+        The path of the ``mission`` file written.
+
+    Raises:
+        FileNotFoundError: when no ``mission`` file can be located under *folder_path*.
+        ValueError: when `mission.mission_content` is ``None``.
+    """
+    root = _find_mission_root(folder_path)
+    if root is None:
+        raise FileNotFoundError(f"No 'mission' file found under {folder_path} (looked in '.' and 'src/mission')")
+    if mission.mission_content is None:
+        raise ValueError("mission_content is None — nothing to write")
+    lua_content = luadata.serialize(
+        mission.mission_content, indent="  ", indent_level=0, always_provide_keyname=True, sort=True
+    )
+    mission_file = root / "mission"
+    mission_file.write_text(f"mission = \n{lua_content}", encoding="utf-8")
+    return mission_file
+
+
 def create_miz(miz_file_path: Path, files: dict[str, bytes]) -> Path:
     """Create an mission in a .miz file with new data (zip it)."""
 

--- a/src/python/veaf-tools/veaf_mission_mcp/actions.py
+++ b/src/python/veaf-tools/veaf_mission_mcp/actions.py
@@ -7,6 +7,7 @@ from veaf_mission_mcp.add_group import add_group
 from veaf_mission_mcp.add_startup_script_trigger import add_startup_script_trigger
 from veaf_mission_mcp.add_trigger_zone import add_trigger_zone
 from veaf_mission_mcp.catalog import ActionCatalog
+from veaf_mission_mcp.composites import create_combat_zone
 from veaf_mission_mcp.describe_mission import describe_mission
 from veaf_mission_mcp.edit_mission_yaml import (
     describe_mission_config,
@@ -445,6 +446,66 @@ def register_default_actions(catalog: ActionCatalog) -> None:
     )
     catalog.register(
         ActionSpec(
+            name="create_combat_zone",
+            description=(
+                "Lay down a complete VEAF combat zone in a mission FOLDER, in one pass, editing "
+                "both worlds durably (no build): a circular trigger zone + groups placed inside it "
+                "(names auto-prefixed with the zone so it captures them) in src/mission, and a "
+                "modules.COMBATZONE.combat_zones[] entry appended in mission.yaml."
+            ),
+            parameters_schema={
+                "type": "object",
+                "properties": {
+                    "folder_path": {
+                        "type": "string",
+                        "description": "Path to the mission folder (mission.yaml + src/mission/).",
+                    },
+                    "zone_name": {"type": "string", "description": "The combat zone's trigger-zone name."},
+                    "position": {
+                        "type": "object",
+                        "properties": {"x": {"type": "number"}, "y": {"type": "number"}},
+                        "required": ["x", "y"],
+                        "description": "The zone centre.",
+                    },
+                    "radius": {"type": "number", "description": "The zone radius, in metres."},
+                    "groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "units": {"type": "array", "items": {"type": "object"}},
+                                "position": {
+                                    "type": "object",
+                                    "properties": {"x": {"type": "number"}, "y": {"type": "number"}},
+                                },
+                            },
+                            "required": ["name", "units"],
+                        },
+                        "description": "Groups placed inside the zone; names are auto-prefixed with zone_name.",
+                    },
+                    "coalition": {"type": "string", "enum": ["blue", "red", "neutral"]},
+                    "country_id": {"type": "integer"},
+                    "country_name": {"type": "string"},
+                    "category": {"type": "string", "default": "vehicle"},
+                    "combat_zone": {"type": "object", "description": "Optional extra combat_zones[] keys."},
+                },
+                "required": [
+                    "folder_path",
+                    "zone_name",
+                    "position",
+                    "radius",
+                    "groups",
+                    "coalition",
+                    "country_id",
+                    "country_name",
+                ],
+            },
+        ),
+        handler=_handle_create_combat_zone,
+    )
+    catalog.register(
+        ActionSpec(
             name="list_unit_types",
             description=(
                 "List DCS unit types from the canonical generated database (the same the build "
@@ -540,6 +601,21 @@ def _handle_add_group(params: dict[str, Any]) -> dict[str, Any]:
         for_combat_zone=params.get("for_combat_zone"),
         late_activation=params.get("late_activation", False),
         as_spawn_template=params.get("as_spawn_template", False),
+    )
+
+
+def _handle_create_combat_zone(params: dict[str, Any]) -> dict[str, Any]:
+    return create_combat_zone(
+        Path(params["folder_path"]),
+        zone_name=params["zone_name"],
+        position=params["position"],
+        radius=params["radius"],
+        groups=params["groups"],
+        coalition=params["coalition"],
+        country_id=params["country_id"],
+        country_name=params["country_name"],
+        category=params.get("category", "vehicle"),
+        combat_zone=params.get("combat_zone"),
     )
 
 

--- a/src/python/veaf-tools/veaf_mission_mcp/add_group.py
+++ b/src/python/veaf-tools/veaf_mission_mcp/add_group.py
@@ -73,17 +73,18 @@ def add_group(
         raise ValueError(f"Not a valid DCS mission archive (missing 'mission' file): {miz_path}")
 
     name = resolve_group_name(name, for_combat_zone=for_combat_zone, as_spawn_template=as_spawn_template)
-    group = _build_group(
-        name=name, position=position, units=units, route=route, patrol=patrol, late_activation=late_activation
-    )
-
-    group_id = insert_group(
+    group_id = insert_group_into_content(
         mission.mission_content,
         coalition=coalition,
         country_id=country_id,
         country_name=country_name,
         category=category,
-        group=group,
+        name=name,
+        position=position,
+        units=units,
+        route=route,
+        patrol=patrol,
+        late_activation=late_activation,
     )
 
     warnings = validate_group_name(name, miz_path=miz_path, expected_combat_zone=for_combat_zone)["warnings"]
@@ -92,6 +93,58 @@ def add_group(
     write_miz(mission, miz_path)
 
     return {"group_id": group_id, "name": name, "warnings": warnings}
+
+
+def insert_group_into_content(
+    mission_content: dict[str, Any],
+    *,
+    coalition: str,
+    country_id: int,
+    country_name: str,
+    category: str,
+    name: str,
+    position: dict[str, float],
+    units: list[dict[str, Any]],
+    route: list[dict[str, float]] | None = None,
+    patrol: bool = False,
+    late_activation: bool = False,
+) -> int:
+    """Build a group and insert it into `mission_content` in place; return its fresh `groupId`.
+
+    The content-level core shared by the `.miz` action :func:`add_group` and the wave-8 composite
+    builders (which mutate a mission folder's exploded content). Does no I/O and no name
+    resolution — the caller passes the final `name`.
+
+    Args:
+        mission_content: The parsed ``mission`` table to mutate.
+        coalition: `"blue"`, `"red"` or `"neutral"`.
+        country_id: DCS numeric country id.
+        country_name: DCS country name (used only if the country is absent in this coalition).
+        category: One of `"vehicle"`, `"plane"`, `"helicopter"`, `"ship"`, `"static"`.
+        name: The group's final name.
+        position: The group's anchor position.
+        units: `[{"type", "count"}, ...]`.
+        route: Optional waypoints; defaults to a stationary point at `position`.
+        patrol: Loop the route back to its start.
+        late_activation: Mark the group late-activation.
+
+    Returns:
+        The fresh ``groupId`` assigned to the inserted group.
+
+    Raises:
+        ValueError: If `units` yields no units.
+    """
+    group = _build_group(
+        name=name, position=position, units=units, route=route, patrol=patrol, late_activation=late_activation
+    )
+    return insert_group(
+        mission_content,
+        coalition=coalition,
+        country_id=country_id,
+        country_name=country_name,
+        category=category,
+        group=group,
+    )
 
 
 def _build_group(

--- a/src/python/veaf-tools/veaf_mission_mcp/add_trigger_zone.py
+++ b/src/python/veaf-tools/veaf_mission_mcp/add_trigger_zone.py
@@ -47,7 +47,42 @@ def add_trigger_zone(
     if mission.mission_content is None:
         raise ValueError(f"Not a valid DCS mission archive (missing 'mission' file): {miz_path}")
 
-    zones = _zones_list(mission.mission_content)
+    zone_id = insert_trigger_zone(
+        mission.mission_content, name=name, position=position, radius=radius, hidden=hidden, color=color
+    )
+
+    backup_before_write(miz_path)
+    write_miz(mission, miz_path)
+
+    return {"zone_id": zone_id, "name": name}
+
+
+def insert_trigger_zone(
+    mission_content: dict[str, Any],
+    *,
+    name: str,
+    position: dict[str, float],
+    radius: float,
+    hidden: bool = False,
+    color: list[float] | None = None,
+) -> int:
+    """Append a circular trigger zone to `mission_content` in place; return its fresh `zoneId`.
+
+    The content-level core shared by the `.miz` action :func:`add_trigger_zone` and the wave-8
+    composite builders (which mutate a mission folder's exploded content). Does no I/O.
+
+    Args:
+        mission_content: The parsed ``mission`` table to mutate.
+        name: The zone's name.
+        position: The zone centre, `{"x": ..., "y": ...}`.
+        radius: The zone radius, in metres.
+        hidden: Whether the zone is hidden in the editor.
+        color: RGBA fill `[r, g, b, a]` (0..1); defaults to translucent white.
+
+    Returns:
+        The fresh ``zoneId`` assigned to the inserted zone.
+    """
+    zones = _zones_list(mission_content)
     zone_id = _max_zone_id(zones) + 1
     zones.append(
         {
@@ -62,11 +97,7 @@ def add_trigger_zone(
             "properties": {},
         }
     )
-
-    backup_before_write(miz_path)
-    write_miz(mission, miz_path)
-
-    return {"zone_id": zone_id, "name": name}
+    return zone_id
 
 
 def _zones_list(mission_content: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/python/veaf-tools/veaf_mission_mcp/composites.py
+++ b/src/python/veaf-tools/veaf_mission_mcp/composites.py
@@ -1,0 +1,110 @@
+"""Composite one-pass builders (wave 8) — lay down a full VEAF feature across both worlds.
+
+Each builder orchestrates the wave-1..7 primitives on a mission **folder** (David's model): it
+edits the durable source — the exploded ``src/mission/`` (trigger zones + groups) and
+``mission.yaml`` (module config) — so a later ``veaf-tools build`` produces the ``.miz``. No build
+is triggered here. See ``.backlog/FEAT-MCP-MISSION-EDITOR/PRD.md`` (wave 8).
+"""
+
+from pathlib import Path
+from typing import Any
+
+from mission_tools.mission_yaml_editor import load_yaml, save_yaml
+
+from veaf_mission_mcp.add_group import insert_group_into_content
+from veaf_mission_mcp.add_trigger_zone import insert_trigger_zone
+from veaf_mission_mcp.group_naming import resolve_group_name, validate_group_name
+from veaf_mission_mcp.mission_folder import load_folder_mission, mission_yaml_path, save_folder_mission
+
+
+def create_combat_zone(
+    folder_path: Path,
+    *,
+    zone_name: str,
+    position: dict[str, float],
+    radius: float,
+    groups: list[dict[str, Any]],
+    coalition: str,
+    country_id: int,
+    country_name: str,
+    category: str = "vehicle",
+    combat_zone: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a complete VEAF combat zone in a mission folder, in one pass, both worlds.
+
+    On the exploded `.miz` side (`src/mission/`): a circular trigger zone named `zone_name`, plus
+    the given `groups` placed inside it — each group's name prefixed with `zone_name` so the zone
+    captures it at runtime. On the `mission.yaml` side: a `modules.COMBATZONE.combat_zones[]` entry
+    referencing `zone_name` (appended, not replacing existing zones). Not deduplicated. No build.
+
+    Args:
+        folder_path: The mission folder (holds `mission.yaml` + `src/mission/`).
+        zone_name: The combat zone's trigger-zone name.
+        position: The zone centre, `{"x": ..., "y": ...}`.
+        radius: The zone radius, in metres.
+        groups: `[{"name", "units": [{"type","count"}], "position"?}, ...]` placed inside the zone.
+        coalition: `"blue"`, `"red"` or `"neutral"` the groups are placed under (runtime-agnostic;
+            VEAF respawns them regardless).
+        country_id: DCS numeric country id for the groups.
+        country_name: DCS country name for the groups.
+        category: Group category (default `"vehicle"`).
+        combat_zone: Optional extra `combat_zones[]` keys (e.g. `friendly_name`, `training`).
+
+    Returns:
+        `{"zone_name", "zone_id", "groups": [<resolved names>], "warnings": [...]}`.
+
+    Raises:
+        FileNotFoundError: when the folder has no mission / `mission.yaml`.
+        ValueError: when the mission has no readable content.
+    """
+    mission = load_folder_mission(folder_path)
+    content = mission.mission_content
+    if content is None:
+        raise ValueError(f"Mission folder has no readable mission: {folder_path}")
+
+    zone_id = insert_trigger_zone(content, name=zone_name, position=position, radius=radius)
+
+    created: list[str] = []
+    warnings: list[dict[str, Any]] = []
+    for spec in groups:
+        group_name = resolve_group_name(spec["name"], for_combat_zone=zone_name)
+        insert_group_into_content(
+            content,
+            coalition=coalition,
+            country_id=country_id,
+            country_name=country_name,
+            category=category,
+            name=group_name,
+            position=spec.get("position", position),
+            units=spec["units"],
+        )
+        created.append(group_name)
+        warnings += validate_group_name(group_name, expected_combat_zone=zone_name)["warnings"]
+
+    save_folder_mission(mission, folder_path)
+    _append_combat_zone(mission_yaml_path(folder_path), zone_name, combat_zone)
+
+    return {"zone_name": zone_name, "zone_id": zone_id, "groups": created, "warnings": warnings}
+
+
+def _append_combat_zone(yaml_path: Path, zone_name: str, combat_zone: dict[str, Any] | None) -> None:
+    """Append a `combat_zones[]` entry to `modules.COMBATZONE` in `mission.yaml`, preserving comments."""
+    data: Any = load_yaml(yaml_path)
+    modules: Any = data.get("modules") if hasattr(data, "get") else None
+    if not hasattr(modules, "get"):
+        modules = {}
+        data["modules"] = modules
+    combatzone: Any = modules.get("COMBATZONE")
+    if not hasattr(combatzone, "get"):
+        combatzone = {"enabled": True, "combat_zones": []}
+        modules["COMBATZONE"] = combatzone
+    combatzone["enabled"] = True
+    zones: Any = combatzone.get("combat_zones")
+    if not isinstance(zones, list):
+        zones = []
+        combatzone["combat_zones"] = zones
+    entry: dict[str, Any] = {"type": "zone", "zone_name": zone_name}
+    if combat_zone:
+        entry.update(combat_zone)
+    zones.append(entry)
+    save_yaml(yaml_path, data)

--- a/src/python/veaf-tools/veaf_mission_mcp/mission_folder.py
+++ b/src/python/veaf-tools/veaf_mission_mcp/mission_folder.py
@@ -1,0 +1,75 @@
+"""Mission-folder awareness for the composite builders (wave 8).
+
+Composites edit the **durable source** of a mission folder — the exploded `src/mission/` (trigger
+zones and groups) and `mission.yaml` (module config) — so a later `veaf-tools build` produces the
+`.miz` (David's chosen model). This module wraps the folder's `.miz`-side read/save with a
+timestamped backup, reusing the pure-Python `mission_tools` folder helpers (no Lua execution, no
+zip). The `mission.yaml` side is handled by `edit_mission_yaml` / `mission_yaml_editor`.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from mission_tools.miz_backup import backup_before_write
+from mission_tools.miz_tools import DcsMission, read_mission_folder, write_mission_folder
+
+
+def _mission_file(folder_path: Path) -> Path:
+    """Locate the folder's loose ``mission`` file (root or ``src/mission/``)."""
+    for candidate in (folder_path, folder_path / "src" / "mission"):
+        mission_file = candidate / "mission"
+        if mission_file.is_file():
+            return mission_file
+    raise FileNotFoundError(f"No 'mission' file found under {folder_path} (looked in '.' and 'src/mission')")
+
+
+def mission_yaml_path(folder_path: Path) -> Path:
+    """Return the folder's ``mission.yaml`` path (the config side of the folder).
+
+    Args:
+        folder_path: The mission folder.
+
+    Returns:
+        Path to ``<folder>/mission.yaml``.
+
+    Raises:
+        FileNotFoundError: when the folder has no ``mission.yaml``.
+    """
+    path = folder_path / "mission.yaml"
+    if not path.is_file():
+        raise FileNotFoundError(f"No 'mission.yaml' in mission folder: {folder_path}")
+    return path
+
+
+def load_folder_mission(folder_path: Path) -> DcsMission:
+    """Load a mission folder's exploded `.miz` side (`src/mission/`), no Lua executed.
+
+    Args:
+        folder_path: The mission folder (root or one containing ``src/mission/``).
+
+    Returns:
+        The parsed :class:`DcsMission`.
+
+    Raises:
+        FileNotFoundError: when no ``mission`` file can be located.
+    """
+    return read_mission_folder(folder_path)
+
+
+def save_folder_mission(mission: DcsMission, folder_path: Path) -> dict[str, Any]:
+    """Back up the folder's ``mission`` file, then write `mission`'s tables back to it.
+
+    Args:
+        mission: The (mutated) mission to persist.
+        folder_path: The mission folder to write into.
+
+    Returns:
+        `{"mission_file": <path str>, "backup": <path str>}`.
+
+    Raises:
+        FileNotFoundError: when no ``mission`` file can be located.
+        ValueError: when `mission.mission_content` is ``None``.
+    """
+    backup = backup_before_write(_mission_file(folder_path))
+    written = write_mission_folder(mission, folder_path)
+    return {"mission_file": str(written), "backup": str(backup)}

--- a/test/python/veaf_mission_mcp/test_create_combat_zone.py
+++ b/test/python/veaf_mission_mcp/test_create_combat_zone.py
@@ -1,0 +1,106 @@
+"""Tests for the wave-8 `create_combat_zone` composite builder."""
+
+from pathlib import Path
+from typing import Any
+
+from mission_tools.mission_yaml_editor import load_yaml
+from mission_tools.miz_tools import read_mission_folder
+
+from veaf_mission_mcp.composites import create_combat_zone
+
+_MISSION = """\
+mission =
+{
+  ["coalition"] =
+  {
+    ["red"] =
+    {
+      ["country"] =
+      {
+      },
+    },
+  },
+  ["triggers"] =
+  {
+    ["zones"] =
+    {
+    },
+  },
+}
+"""
+
+_YAML = """\
+# mission config
+modules:
+  COMBATMISSION: true
+"""
+
+
+def _folder(tmp_path: Path) -> Path:
+    exploded = tmp_path / "src" / "mission"
+    exploded.mkdir(parents=True)
+    (exploded / "mission").write_text(_MISSION, encoding="utf-8")
+    (tmp_path / "mission.yaml").write_text(_YAML, encoding="utf-8")
+    return tmp_path
+
+
+def _zone_names(content: dict[str, Any]) -> list[str]:
+    zones = content.get("triggers", {}).get("zones", [])
+    values = zones.values() if isinstance(zones, dict) else zones
+    return [z["name"] for z in values if isinstance(z, dict) and "name" in z]
+
+
+def _group_names(content: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for coalition in content.get("coalition", {}).values():
+        countries = coalition.get("country", {})
+        for country in countries.values() if isinstance(countries, dict) else countries:
+            for cat in (v for v in country.values() if isinstance(v, dict) and "group" in v):
+                groups = cat["group"]
+                for group in groups.values() if isinstance(groups, dict) else groups:
+                    if isinstance(group, dict) and "name" in group:
+                        names.append(group["name"])
+    return names
+
+
+def test_create_combat_zone_lays_down_both_worlds(tmp_path: Path) -> None:
+    folder = _folder(tmp_path)
+    result = create_combat_zone(
+        folder,
+        zone_name="CZ-North",
+        position={"x": 1000.0, "y": 2000.0},
+        radius=3000,
+        groups=[{"name": "armor", "units": [{"type": "T-72B", "count": 2}]}],
+        coalition="red",
+        country_id=0,
+        country_name="Russia",
+    )
+
+    assert result["zone_name"] == "CZ-North"
+    assert result["groups"] == ["CZ-North-armor"]
+
+    content = read_mission_folder(folder).mission_content or {}
+    assert "CZ-North" in _zone_names(content)  # trigger zone written to src/mission
+    assert "CZ-North-armor" in _group_names(content)  # group written, zone-prefixed
+
+    modules = load_yaml(folder / "mission.yaml")["modules"]
+    zones = modules["COMBATZONE"]["combat_zones"]
+    assert any(z["zone_name"] == "CZ-North" for z in zones)  # COMBATZONE block appended
+
+
+def test_create_combat_zone_appends_to_existing(tmp_path: Path) -> None:
+    folder = _folder(tmp_path)
+    common: dict[str, Any] = {
+        "position": {"x": 0.0, "y": 0.0},
+        "radius": 1000,
+        "groups": [{"name": "g", "units": [{"type": "T-72B", "count": 1}]}],
+        "coalition": "red",
+        "country_id": 0,
+        "country_name": "Russia",
+    }
+    create_combat_zone(folder, zone_name="CZ-A", **common)
+    create_combat_zone(folder, zone_name="CZ-B", **common)
+
+    zones = load_yaml(folder / "mission.yaml")["modules"]["COMBATZONE"]["combat_zones"]
+    names = {z["zone_name"] for z in zones}
+    assert {"CZ-A", "CZ-B"} <= names  # second call appended, didn't clobber the first

--- a/test/python/veaf_mission_mcp/test_mission_folder.py
+++ b/test/python/veaf_mission_mcp/test_mission_folder.py
@@ -1,0 +1,51 @@
+"""Tests for wave-8 mission-folder awareness (durable source edits)."""
+
+from pathlib import Path
+
+import pytest
+
+from veaf_mission_mcp.mission_folder import load_folder_mission, save_folder_mission
+
+_MISSION = """\
+mission =
+{
+  ["coalition"] =
+  {
+  },
+  ["start_time"] = 0,
+}
+"""
+
+
+def _folder(tmp_path: Path) -> Path:
+    exploded = tmp_path / "src" / "mission"
+    exploded.mkdir(parents=True)
+    (exploded / "mission").write_text(_MISSION, encoding="utf-8")
+    return tmp_path
+
+
+def test_load_reads_exploded_mission(tmp_path: Path) -> None:
+    mission = load_folder_mission(_folder(tmp_path))
+    assert isinstance(mission.mission_content, dict)
+    assert "coalition" in mission.mission_content
+
+
+def test_save_persists_a_mutation(tmp_path: Path) -> None:
+    folder = _folder(tmp_path)
+    mission = load_folder_mission(folder)
+    mission.mission_content["start_time"] = 42
+    save_folder_mission(mission, folder)
+    assert load_folder_mission(folder).mission_content["start_time"] == 42
+
+
+def test_save_backs_up_the_mission_file(tmp_path: Path) -> None:
+    folder = _folder(tmp_path)
+    result = save_folder_mission(load_folder_mission(folder), folder)
+    backup = Path(result["backup"])
+    assert backup.exists()
+    assert backup.name.startswith("mission.")
+
+
+def test_load_missing_folder_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_folder_mission(tmp_path)  # empty folder, no mission file


### PR DESCRIPTION
## Wave 8 — Composite builders (the endgame)

Sub-branch of the MCP integration branch `feature/mcp-mission-editor` (PRs **into** it).

The headline capability: one-pass, both-worlds VEAF feature creation. The MCP becomes
**mission-folder-aware** (edits `src/mission/` + `mission.yaml`, builds the `.miz`) and orchestrates
the wave-1..7 primitives into single high-level actions.

Tickets (see [PRD](.backlog/FEAT-MCP-MISSION-EDITOR/PRD.md)):
- **024** — folder-awareness: extract/build round-trip helper (the foundation; a design fork to settle).
- **025** — `create_combat_zone`: trigger zone + groups inside (geometry, zone-prefixed) + `COMBATZONE` yaml.
- **026** — `create_qra`: trigger zone + Late-Activation interceptors (exact-name, coalition) + `QRA` yaml.
- **027** — `create_cap_mission`: `OnDemand-` template + `cap_missions`/`combat_missions` yaml.
- **028** — docs + catalogue + skill.

Draft — implementation in progress; 024's edit-model is confirmed with David before building the composites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce mission-folder awareness and a composite builder for VEAF combat zones, enabling one-pass creation of zones, groups, and corresponding mission.yaml configuration across both worlds.

New Features:
- Add mission-folder helpers to load, back up, and persist exploded mission content alongside mission.yaml.
- Expose a new MCP action `create_combat_zone` that orchestrates trigger zone, groups, and COMBATZONE yaml updates for a mission folder.
- Provide a content-level `insert_trigger_zone` and `insert_group_into_content` API to reuse group/zone insertion logic on both .miz files and mission folders.

Enhancements:
- Extend mission tools with `write_mission_folder` to serialize mission_content back to a folder’s loose mission file without rebuilding the .miz.
- Update AI assistant catalogs (FR/EN) with a new composites section highlighting one-pass combat zone creation.
- Refresh FEAT-MCP-MISSION-EDITOR PRD status and add backlog tickets documenting wave-8 folder-awareness and composite builders.

Documentation:
- Extend mission-maker catalogs in English and French with documentation for composite one-pass builders and the new combat-zone recipe.
- Add detailed backlog tickets describing design and acceptance criteria for mission-folder awareness and composite builders.

Tests:
- Add tests covering mission-folder read/write, including backup behavior and mutation persistence.
- Add tests verifying that `create_combat_zone` writes zones and groups to src/mission and appends COMBATZONE entries in mission.yaml without clobbering existing zones.