### PR TITLE
fix(mcp): scaffold_mission ignores hidden entries in the empty-folder guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Blank missions for 9 theatres** (FEAT-BLANK-MISSION-THEATRE-005): `theatre-defaults.yaml` (the per-theatre map-centre + bullseye the blank generator uses) is now extracted from the calibration missions in [VEAF/dcs-maps](https://github.com/VEAF/dcs-maps) `data/maps/*.miz` (MIT), parsed with our own `read_miz` — real values, not fabricated. `prepare --theatre` / `scaffold_mission(theatre=)` now cover Caucasus, Afghanistan, GermanyCW, MarianaIslands(+WWII), Normandy, PersianGulf, SinaiMap, Syria (the maps dcs-maps ships); the generator itself is unchanged.
 - **`veaf-tools mcp` subcommand** (FEAT-MCP-PLUGIN-001): launches the mission-editing MCP server on stdio from inside the shipped `veaf-tools` binary (no separate binary). First step toward packaging `veaf-mission-mcp` + the `veaf-mission-authoring` skill as a self-hosted Claude plugin.
 
+### Fixed
+- **`scaffold_mission` no longer refuses a folder that only holds hidden tooling entries** (found in real use): under Claude Code the working folder always has a `.claude/` (and often `.git/`), so the "must be empty" guard made in-place scaffolding impossible. It now ignores hidden entries (`.git`, `.claude`, `.gitignore`, …) and only blocks on non-hidden content (a likely-existing mission).
+
+### Added
+
 ## [6.9.1] — 2026-07-13
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.9.17"
+version = "6.9.18"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/src/python/veaf-tools/veaf_mission_mcp/scaffold.py
+++ b/src/python/veaf-tools/veaf_mission_mcp/scaffold.py
@@ -101,8 +101,9 @@ def scaffold_mission(
         ``{"folder", "template", "veaf_tools_version", "updater_asset"}``.
 
     Raises:
-        ValueError: when ``template`` is invalid, the folder is not empty, or the platform has no
-            updater asset.
+        ValueError: when ``template`` is invalid, the folder already has non-hidden content (a
+            likely-existing mission — hidden entries like ``.git``/``.claude`` are ignored), or the
+            platform has no updater asset.
         RuntimeError: when the updater or ``prepare`` exits non-zero, or the updater did not install
             ``veaf-tools`` / ``published/``.
     """
@@ -112,8 +113,15 @@ def scaffold_mission(
     tag = tag or _DEFAULT_TAG
     folder = Path(target_folder)
     folder.mkdir(parents=True, exist_ok=True)
-    if any(folder.iterdir()):
-        raise ValueError(f"Target folder is not empty: {folder} — scaffolding only initializes an empty folder.")
+    # Refuse to scaffold over existing content, but ignore hidden tooling entries — under Claude
+    # Code the working folder always has a `.claude/` (and often `.git/`), so "literally empty" is
+    # never true; blocking on those would make scaffolding unusable in-place.
+    non_hidden = [entry.name for entry in folder.iterdir() if not entry.name.startswith(".")]
+    if non_hidden:
+        raise ValueError(
+            f"Target folder already has content ({', '.join(sorted(non_hidden))}): {folder} — "
+            "scaffolding only initializes an otherwise-empty folder (hidden entries like .git/.claude are OK)."
+        )
 
     asset_name = platform_assets.release_updater_asset_name()
     if asset_name is None:

--- a/test/python/veaf_mission_mcp/test_scaffold.py
+++ b/test/python/veaf_mission_mcp/test_scaffold.py
@@ -104,15 +104,26 @@ class TestScaffoldMission:
         # The tag is also used to build the download URL.
         assert "published-v6.9.9" in recorder["downloads"][0]["url"]
 
-    def test_rejects_non_empty_folder_before_any_work(self, tmp_path: Path, recorder: dict[str, list[Any]]) -> None:
+    def test_rejects_folder_with_non_hidden_content(self, tmp_path: Path, recorder: dict[str, list[Any]]) -> None:
         target = tmp_path / "busy"
         target.mkdir()
         (target / "leftover.txt").write_text("x", encoding="utf-8")
 
-        with pytest.raises(ValueError, match="not empty"):
+        with pytest.raises(ValueError, match="already has content"):
             scaffold.scaffold_mission(str(target), template="standard")
 
         assert recorder["downloads"] == [] and recorder["runs"] == []
+
+    def test_hidden_only_folder_is_accepted(self, tmp_path: Path, recorder: dict[str, list[Any]]) -> None:
+        # Under Claude Code the working folder always has a .claude/ (often .git/): must not block.
+        target = tmp_path / "syria-mezzeh"
+        (target / ".claude").mkdir(parents=True)
+        (target / ".gitignore").write_text("x", encoding="utf-8")
+
+        result = scaffold.scaffold_mission(str(target), template="standard")
+
+        assert result["folder"] == str(target)
+        assert len(recorder["runs"]) == 2  # proceeded: updater + prepare ran
 
     def test_rejects_invalid_template_before_any_work(self, tmp_path: Path, recorder: dict[str, list[Any]]) -> None:
         with pytest.raises(ValueError, match="template"):


### PR DESCRIPTION
## Found in real use (David, authoring a mission via the MCP)

`scaffold_mission` refused any non-empty folder. But under Claude Code the working folder **always** has a `.claude/` (and usually `.git/`), so "must be empty" made in-place scaffolding impossible — David had to scaffold into a dedicated subfolder as a workaround.

## Fix
Root cause: the guard's real intent is "don't clobber an existing mission", not "be literally empty". It now **ignores hidden entries** (`.git`, `.claude`, `.gitignore`, …) and blocks only on **non-hidden content** (a likely-existing mission — still prevents clobber, since `mission.yaml`/`src` are visible).

## Tests
- Folder with only `.claude/` + `.gitignore` → **accepted** (proceeds).
- Folder with a visible file → refused (unchanged).
- Full-file suite green; ruff · mypy clean. Bump 6.9.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Relax scaffold_mission's empty-folder guard to allow in-place scaffolding when only hidden tooling entries are present, and bump the veaf-tools version.

Bug Fixes:
- Ensure scaffold_mission only rejects target folders that contain non-hidden content, allowing folders with hidden tooling entries like .git or .claude to be scaffolded.

Build:
- Bump veaf-tools package version from 6.9.17 to 6.9.18.

Documentation:
- Document the updated scaffold_mission behavior in the changelog, clarifying that hidden tooling entries no longer block scaffolding.

Tests:
- Add tests covering acceptance of folders containing only hidden entries and rejection of folders with visible content to validate the new scaffold_mission guard behavior.