### PR TITLE
chore(release): 6.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.11.0] — 2026-07-26
+
 ### Added
 - **A QRA can be declared without being armed** (FEAT-ACTIVATION-CONTROLS). New `active_at_start` key on a `modules.QRA.definitions[]` entry (default `true`, so nothing changes for existing missions). With `false`, the generated builder chain stops before `:start()`: the QRA is still registered under its name, so a `qra.start` radio command — or a script — arms it later. Until then it is inert (its birth-event handler returns early while its enemy-unit cache is unset). Previously every QRA was armed at mission load and `active_at_start` was silently ignored there (it is a *combat-zone* key). Reported by Tripack.
 - **A combat zone can be told never to auto-complete** (FEAT-ACTIVATION-CONTROLS). New `completable` key on a `modules.COMBATZONE.combat_zones[]` entry (default `true`), mapping to the runtime's existing `:setCompletable(false)`, which stops the zone from scheduling its completion watchdog. This is what a zone holding **only BLUE units** needs: completion is decided on the *red* unit count alone (`nbUnitsR == 0` — the blue count is computed but never used), so such a zone activated and then deactivated itself on its first check, about a minute later. Reported by Tripack. Making the enemy coalition itself configurable remains open.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,56 +1,78 @@
-# VEAF Mission Creation Tools — 6.10.0
+# VEAF Mission Creation Tools — 6.11.0
 
-Première version **stable et officielle** de la ligne v6. Elle remplace la v5 et
-devient la version installée par défaut (`published-latest`).
+Cette version répond à trois retours de **Tripack** : les **noms d'aérodromes** étaient
+faux dans nos données, et il manquait un moyen de **choisir quand** une QRA ou une zone de
+combat s'active. Aucune mission existante n'a besoin d'être retouchée.
 
-## 🚀 Une nouvelle chaîne de création de missions
+## 🛫 Les noms d'aérodromes sont enfin les bons
 
-La v6 décrit une mission de façon **déclarative** dans un simple `mission.yaml`, puis
-la construit :
+Le build refusait des `airport_link` de QRA parfaitement valides — Tiyas, Marj Ruhayyil,
+Al-Dumayr… — en les déclarant « aérodrome inconnu ». **Merci à Tripack** de l'avoir
+signalé : ses noms étaient corrects depuis le début, c'est notre table qui était fausse.
 
-- **Migrer depuis la v5** — `convert-v5` reprend une mission v5 existante et produit son
-  équivalent v6, presets radio et données de spawn compris.
-- **Partir d'un modèle** — `prepare --template` pose un dossier de mission prêt à remplir.
-- **Valider puis construire** — `validate` vérifie la cohérence (références, fréquences,
-  types d'unités) et `build` assemble le `.miz` jouable.
-- **Presets radio & kneeboards** — projection des presets par type d'appareil, planchettes
-  générées automatiquement.
+En cause : cette table nom→identifiant était extraite des **balises radio** des cartes.
+Elle contenait donc des noms de VOR ou de NDB au lieu de noms d'aérodromes, et ignorait
+toutes les bases sans balise. Elle est désormais construite depuis **DCS lui-même**, ce
+qui donne le nom exact reconnu en jeu.
 
-## 🤖 Créer une mission avec un assistant IA
+- **7 cartes couvertes**, 657 terrains : Caucase, Syrie, Golfe Persique, Normandie,
+  Mariannes, Sinaï, Allemagne guerre froide.
+- **Hélistations incluses** : elles sont utilisables pour une QRA ou un spawn.
+- Vaut aussi pour les **entrepôts** (`warehouses.yaml`), qui utilisent la même table.
 
-La v6 ouvre un **serveur MCP** livré comme **plugin Claude** : un assistant IA construit
-une mission VEAF **de bout en bout**, du dossier vide au `.miz` jouable, en langage naturel.
+## 🎛️ Choisir quand une QRA ou une zone s'active
 
-- **Partir de zéro** — carte blanche prête à remplir pour le théâtre choisi (Caucasus,
-  Syria, Persian Gulf, Normandy, Marianas, Sinaï, Germany CW, Afghanistan).
-- **Placer par la géographie réelle** — « à 10 km au nord de Kobuleti », « près de Batumi ».
-- **Poser des éléments VEAF** — combat zones, QRA, CAP ; l'assistant connaît les conventions
-  de nommage et privilégie les **raccourcis de spawn** (`#command`, ex. `-samLR`).
-- **Gérer les bases** — « Mezzeh est bleu » colore l'aérodrome et active ses slots dynamiques.
+Deux nouvelles clés dans `mission.yaml`, toutes deux demandées par **Tripack** :
 
-## 🛠️ Runtime DCS
+- **QRA en sommeil** — `active_at_start: false` déclare une QRA **sans l'armer** : elle
+  attend une commande radio `qra.start` ou un appel de script. *(Jusqu'ici toute QRA était
+  armée au chargement de la mission ; la clé était ignorée sans avertissement.)*
+- **Zone qui ne s'éteint pas** — `completable: false` empêche une zone de combat de se
+  terminer d'elle-même. Indispensable pour une zone **sans unité rouge** : la fin de partie
+  se décidant sur le seul décompte des rouges, une telle zone s'activait puis se
+  désactivait toute seule au bout d'une minute environ — exactement le symptôme rapporté.
 
-- **Pagination automatique** des menus radio F10 (fini le débordement de la limite des 10).
-- **Combat zones** : regroupement et préfixe de menu radio pilotables depuis le YAML.
-- **QRA / slots dynamiques** : réactions correctes sur les appareils en slot dynamique.
-- **Server hook** déployable par simple copie (flags OFF par défaut) — **à redéployer**.
+## 🗺️ Aider à collecter les données d'une carte
 
-## 🌍 Multi-théâtres & multi-plateformes
+Les cartes que personne n'a encore relevées peuvent maintenant l'être **par n'importe
+qui**, sans outil de développement : un nouveau **kit de capture** est publié à chaque
+version, avec les programmes, une mission prête pour chaque carte connue et une procédure
+pas-à-pas.
 
-- Conversion de coordonnées et **placement géographique sur les 14 théâtres DCS**.
-- Binaires standalone **Linux / macOS** en plus de Windows.
+- Téléchargez `veaf-map-capture-kit-<version>.zip` dans les fichiers de cette version.
+- Fonctionne aussi sur **n'importe quelle carte** via une mission créée dans l'éditeur DCS.
+- Chaque relevé renvoyé enrichit la table pour toute la communauté.
 
-## ⚠️ Notes de migration pour les mission makers
+**Cartes déjà relevées :**
 
-- Une mission **v5** se convertit avec `convert-v5` (ne pas éditer un dossier v6 à la main
-  comme en v5).
-- Le **server hook** doit être redéployé (nouveau contrat de callbacks).
-- `MISSILEGUARDIAN` n'est plus activé par le tier `full` — il est désormais **opt-in**.
-- L'**AJS-37** rompt l'iso-fonctionnalité des presets radio (agencement dédié Viggen).
+- [x] Caucase
+- [x] Syrie
+- [x] Golfe Persique
+- [x] Normandie
+- [x] Mariannes
+- [x] Sinaï
+- [x] Allemagne guerre froide
+
+**Cartes qui restent à relever — si vous en possédez une, votre aide est bienvenue :**
+
+- [ ] Nevada (NTTR)
+- [ ] La Manche
+- [ ] Atlantique Sud (Malouines)
+- [ ] Kola
+- [ ] Afghanistan
+- [ ] Irak
+- [ ] Mariannes 1944
+
+## 🖥️ Serveurs
+
+- **Liste de pilotes partagée retrouvée** : sur un serveur de production, plus aucun pilote
+  n'était reconnu (administrateur compris) et toute commande `/…` faisait planter le hook.
+  Le fichier partagé est de nouveau lu au bon endroit, un fichier absent est signalé
+  clairement au lieu de tout interrompre, et un pilote inconnu se voit refuser la commande
+  proprement. **Hook à redéployer.**
 
 ## 🙏 Remerciements
 
-Merci à tous les **mission makers** et **mission programmers** de la VEAF qui ont essuyé
-les plâtres de la v6 et fait remonter retours, tests et correctifs — avec une pensée
-spéciale pour **Dup**, **Flogas**, **Reaper** et **Tripack**. Merci également à **Mitch**
-pour les données dcs-maps.
+Merci à **Tripack**, dont les retours sur les QRA et les zones de combat sont à l'origine
+de l'essentiel de cette version, et à tous les **mission makers** de la VEAF qui
+continuent de faire remonter ce qui coince.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "veaf-mission-editor",
   "displayName": "VEAF Mission Editor",
   "description": "Author VEAF DCS missions from Claude Code — create, edit, validate and build a mission through the veaf-mission-mcp server, guided by the veaf-mission-authoring skill.",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "author": {
     "name": "VEAF",
     "url": "https://www.veaf.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.10.2"
+version = "6.11.0"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"


### PR DESCRIPTION
Release consolidation for **6.11.0**. No functional code — only the release paperwork.

## What this PR does

- **`RELEASE_NOTES.md`** — rewritten for mission makers (the release workflow publishes it *as-is* from the tagged commit). Internal noise filtered out: CI gitleaks licensing and the `main`→`master` workflow rename are in the CHANGELOG but not in the notes.
- **`CHANGELOG.md`** — `[Unreleased]` closed as `[6.11.0] — 2026-07-26`, a fresh empty `[Unreleased]` kept on top.
- **Version** — `6.10.2` → `6.11.0` in `pyproject.toml` **and** the plugin manifest (kept in lockstep, `test_plugin_version.py` enforces it).
- **Roadmap** — deliberately untouched: both lots in this release were reactive (Tripack's reports), not planned roadmap items.

## Why MINOR and not PATCH

The release carries real new capability, not just fixes: two new `mission.yaml` keys (`active_at_start` on a QRA, `completable` on a combat zone), two new `veaf-tools` commands (`capture-map`, `inject-bridge`), and a new release asset (the map-capture kit). The `6.10.2` sitting in `pyproject.toml` was only the sum of my working PATCH bumps.

## Compatibility

**No breaking change.** Both new keys default to the previous behaviour, and the airdrome-name fix only makes the build *accept* values it was wrongly rejecting. Mission makers have nothing to rewrite.

One operational note is called out in the release notes: the **server hook must be redeployed** (shared pilots-list fix).

## After merge

The tag is pushed by hand — it triggers `release.yml`, which builds and publishes the GitHub Release (including the new `veaf-map-capture-kit-6.11.0.zip` asset):

```bash
git checkout develop-v6 && git pull origin develop-v6
git tag published-v6.11.0 && git push origin published-v6.11.0
```

Then `develop-v6` → `master` for the stable milestone (15 commits pending there), as agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the 6.11.0 release by updating release notes, changelog, and version metadata.

Enhancements:
- Add a 6.11.0 entry to CHANGELOG.md and roll over the Unreleased section for future changes.
- Bump project and plugin manifest versions from 6.10.x to 6.11.0 to align published artifacts with the new release.

Documentation:
- Rewrite RELEASE_NOTES.md for 6.11.0 with mission-maker focused explanations of the new QRA/zone controls, corrected airdrome data, map capture kit, and server hook behaviour.