### PR TITLE
fix(docs): stamp the version in the page footer too, not just the header

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,22 @@ on:
     tags:
       - "v*"           # → the versioned release + the "latest" alias
 
+  # Republish a version's documentation without moving its tag. Re-running the tag build would
+  # rebuild from the *tagged* commit — so a fix landed after the tag (e.g. the footer version
+  # stamper) would never reach the published pages. This path builds from the branch you pick and
+  # deploys under the version you name.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to (re)publish, e.g. 6.12.0. Leave empty to deploy the 'dev' alias."
+        required: false
+        type: string
+      set_latest:
+        description: "Also move the 'latest' alias (and the site default) to that version"
+        required: false
+        type: boolean
+        default: true
+
 jobs:
   deploy-docs:
     name: Build and deploy MkDocs
@@ -42,8 +58,18 @@ jobs:
       # version; the published site must state the version it was generated from. Stamped on this
       # throwaway checkout only — nothing is committed back (DOC-QUALITY-GATE). Run as a plain
       # script: it is stdlib-only, so it needs neither the project installed nor its deps.
+      # On a manual republish, the version being published is NOT the working tree's version:
+      # republishing 6.12.0 from a 6.12.1 tree would stamp 6.12.1 onto the 6.12.0 pages. Passed
+      # through an env var rather than interpolated into the shell — inputs are untrusted.
       - name: Stamp the shipped version into the docs headers
-        run: python veaf_build/docs_version_stamp.py
+        env:
+          FORCED_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ -n "$FORCED_VERSION" ]; then
+            python veaf_build/docs_version_stamp.py --version "$FORCED_VERSION"
+          else
+            python veaf_build/docs_version_stamp.py
+          fi
 
       - name: Configure git identity (required by mike)
         run: |
@@ -63,8 +89,27 @@ jobs:
             "https://x-access-token:${DOCS_DEPLOY_TOKEN}@github.com/VEAF/documentation.git"
           git fetch ext-docs gh-pages --depth=1 || true
 
+      # `github.event_name == 'push'` matters: without it, a manual republish of 6.12.0 run from
+      # `develop` would also redeploy the "dev" alias, which is not what was asked for.
       - name: Deploy docs (develop → alias "dev")
-        if: github.ref == 'refs/heads/develop'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        run: poetry run mike deploy --update-aliases --push --remote ext-docs dev
+
+      - name: Republish a version (manual)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          SET_LATEST: ${{ github.event.inputs.set_latest }}
+        run: |
+          if [ "$SET_LATEST" = "true" ]; then
+            poetry run mike deploy --update-aliases --push --remote ext-docs "$VERSION" latest
+            poetry run mike set-default --push --remote ext-docs latest
+          else
+            poetry run mike deploy --update-aliases --push --remote ext-docs "$VERSION"
+          fi
+
+      - name: Deploy the "dev" alias (manual, no version given)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.version == ''
         run: poetry run mike deploy --update-aliases --push --remote ext-docs dev
 
       # No step for a plain push to `master`: `mike deploy latest` would create a *version*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **A version's documentation can be republished without moving its tag** (DOC-STAMP-FOOTER). `Deploy Docs` gained a manual trigger taking a `version` (and whether to move `latest`). Re-running the tag build was not an option: it rebuilds from the **tagged commit**, so a fix landed after the tag — such as the footer stamper below — could never reach the published pages. The version entered is also the one stamped into the pages, since republishing 6.12.0 from a 6.12.1 tree would otherwise stamp 6.12.1 onto them. Documented in the developer guide (FR + EN).
+
 ### Fixed
 - **The docs version stamper also stamps the page footer** (DOC-STAMP-FOOTER). `LUA_API_REFERENCE` carries a version and a date **twice** — header and footer — and the first implementation stamped only the header, using `count=1`. The published 6.12.0 page therefore still advertised *"Généré pour : VEAF Mission Creation Tools v6.5.25"* and *"Juin 2026"* in its footer, which is exactly the stale-header defect the stamper was written to end. Found by reading the published page rather than trusting the local run. The footer pattern is anchored on the ASCII product name instead of the localised label, and both date lines are now stamped. A regression test asserts the pattern contains no control character: the first attempt wrote a literal backspace where a regex `` was intended, producing a pattern that silently matched nothing — invisible in the source and in a `sed` dump.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **The docs version stamper also stamps the page footer** (DOC-STAMP-FOOTER). `LUA_API_REFERENCE` carries a version and a date **twice** — header and footer — and the first implementation stamped only the header, using `count=1`. The published 6.12.0 page therefore still advertised *"Généré pour : VEAF Mission Creation Tools v6.5.25"* and *"Juin 2026"* in its footer, which is exactly the stale-header defect the stamper was written to end. Found by reading the published page rather than trusting the local run. The footer pattern is anchored on the ASCII product name instead of the localised label, and both date lines are now stamped. A regression test asserts the pattern contains no control character: the first attempt wrote a literal backspace where a regex `` was intended, producing a pattern that silently matched nothing — invisible in the source and in a `sed` dump.
+
 ## [6.12.0] — 2026-07-28
 
 ### Added

--- a/doc/developer/GUIDE.en.md
+++ b/doc/developer/GUIDE.en.md
@@ -500,6 +500,20 @@ A cross-page link then always targets `#coverage`, whatever language the reader 
 > readable range (`6.11.x`) and the deploy workflow replaces it with the shipped version
 > (`poetry run docs-stamp-version`).
 
+### Republishing an already-released version's documentation
+
+Re-running the tag build is not enough: it would rebuild from the **tagged commit**, so a fix that
+landed after the tag would never reach the pages. Use the `Deploy Docs` workflow's manual trigger:
+
+| Field | Value |
+|-------|-------|
+| branch | the one carrying the fix (`develop`) |
+| `version` | the version to republish, e.g. `6.12.0` |
+| `set_latest` | ticked if that version should remain the site's `latest` |
+
+The version you enter is also the one stamped into the pages — otherwise republishing 6.12.0 from a
+6.12.1 tree would stamp 6.12.1 onto them. Leaving `version` empty simply redeploys the `dev` alias.
+
 ### Releasing a new version
 
 Push a `published-v*` tag — the `Release` CI workflow does everything automatically:

--- a/doc/developer/GUIDE.md
+++ b/doc/developer/GUIDE.md
@@ -499,6 +499,21 @@ Un lien inter-page vise alors toujours `#coverage`, quelle que soit la langue du
 > garde un intervalle lisible (`6.11.x`) et le workflow de publication la remplace par la version
 > livrée (`poetry run docs-stamp-version`).
 
+### Republier la documentation d'une version déjà sortie
+
+Relancer le build du tag ne suffit pas : il reconstruirait depuis le **commit tagué**, donc sans
+un correctif arrivé après le tag. Utilisez le déclenchement manuel du workflow `Deploy Docs` :
+
+| Champ | Valeur |
+|-------|--------|
+| branche | celle qui contient le correctif (`develop`) |
+| `version` | la version à republier, par exemple `6.12.0` |
+| `set_latest` | coché si cette version doit rester la `latest` du site |
+
+La version saisie est aussi celle qui est tamponnée dans les pages — sans quoi republier la 6.12.0
+depuis un dépôt en 6.12.1 estampillerait les pages 6.12.1. Laisser `version` vide redéploie
+simplement l'alias `dev`.
+
 ---
 
 ### Publier une nouvelle version

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "veaf-mission-editor",
   "displayName": "VEAF Mission Editor",
   "description": "Author VEAF DCS missions from Claude Code — create, edit, validate and build a mission through the veaf-mission-mcp server, guided by the veaf-mission-authoring skill.",
-  "version": "6.12.0",
+  "version": "6.12.1",
   "author": {
     "name": "VEAF",
     "url": "https://www.veaf.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.12.0"
+version = "6.12.1"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/test/python/veaf_build/test_docs_version_stamp.py
+++ b/test/python/veaf_build/test_docs_version_stamp.py
@@ -106,6 +106,12 @@ class TestFooter:
         assert out.count("**Dernière mise à jour :** Juillet 2026") == 2
         assert "Juin 2026" not in out
 
+    def test_underscore_is_not_treated_as_part_of_a_version(self):
+        # `\w` would have matched "v6.5.25_local"; no version we publish carries an underscore.
+        text = _FR_HEADER + _FR_FOOTER.replace("v6.5.25", "v6.5.25_local")
+        out = stamp_text(text, "6.12.0", date(2026, 7, 28), french=True)
+        assert "v6.5.25_local" in out
+
     def test_document_version_is_left_alone(self):
         # "**Version du document :** 1.0" is the page's own revision, not the product version.
         out = stamp_text(_FR_HEADER + _FR_FOOTER, "6.12.0", date(2026, 7, 28), french=True)
@@ -116,7 +122,7 @@ class TestFooter:
         # producing a pattern that silently matched nothing.
         from veaf_build.docs_version_stamp import _GENERATED_FOR_LINE
 
-        assert all(ord(c) >= 32 for c in _GENERATED_FOR_LINE.pattern)
+        assert all(c.isprintable() for c in _GENERATED_FOR_LINE.pattern)
 
 
 class TestStamp:

--- a/test/python/veaf_build/test_docs_version_stamp.py
+++ b/test/python/veaf_build/test_docs_version_stamp.py
@@ -136,3 +136,10 @@ class TestStamp:
     def test_missing_page_is_skipped(self, tmp_path: Path):
         (tmp_path / "pyproject.toml").write_text('version = "6.11.9"\n', encoding="utf-8")
         assert stamp(tmp_path, today=date(2026, 7, 28)) == []
+
+    def test_explicit_version_overrides_pyproject(self, repo: Path):
+        # Republishing an older version's docs: the tree says 6.11.9, the pages must say 6.12.0.
+        stamp(repo, today=date(2026, 7, 28), version="6.12.0")
+        text = (repo / STAMPED_PAGES[0]).read_text(encoding="utf-8")
+        assert "générée pour la 6.12.0" in text
+        assert "6.11.9" not in text

--- a/test/python/veaf_build/test_docs_version_stamp.py
+++ b/test/python/veaf_build/test_docs_version_stamp.py
@@ -71,6 +71,54 @@ class TestStampText:
         assert "**Version :** générée pour la 6.11.9" in out
 
 
+# The page repeats a version and a date in its footer. The first pass stamped only the header,
+# which shipped a 6.12.0 page still advertising v6.5.25 — caught by reading the published site.
+_FR_FOOTER = """
+---
+
+**Version du document :** 1.0
+**Dernière mise à jour :** Juin 2026
+**Généré pour :** VEAF Mission Creation Tools v6.5.25
+"""
+
+_EN_FOOTER = """
+---
+
+**Document Version:** 1.0
+**Last Updated:** June 2026
+**Generated for:** VEAF Mission Creation Tools v6.5.25
+"""
+
+
+class TestFooter:
+    def test_footer_version_is_stamped(self):
+        out = stamp_text(_FR_HEADER + _FR_FOOTER, "6.12.0", date(2026, 7, 28), french=True)
+        assert "**Généré pour :** VEAF Mission Creation Tools v6.12.0" in out
+        assert "v6.5.25" not in out
+
+    def test_footer_version_is_stamped_in_english(self):
+        out = stamp_text(_EN_HEADER + _EN_FOOTER, "6.12.0", date(2026, 7, 28), french=False)
+        assert "**Generated for:** VEAF Mission Creation Tools v6.12.0" in out
+        assert "v6.5.25" not in out
+
+    def test_both_date_lines_are_stamped(self):
+        out = stamp_text(_FR_HEADER + _FR_FOOTER, "6.12.0", date(2026, 7, 28), french=True)
+        assert out.count("**Dernière mise à jour :** Juillet 2026") == 2
+        assert "Juin 2026" not in out
+
+    def test_document_version_is_left_alone(self):
+        # "**Version du document :** 1.0" is the page's own revision, not the product version.
+        out = stamp_text(_FR_HEADER + _FR_FOOTER, "6.12.0", date(2026, 7, 28), french=True)
+        assert "**Version du document :** 1.0" in out
+
+    def test_pattern_carries_no_control_character(self):
+        # The first attempt wrote a literal backspace (\\x08) where a regex \\b was intended,
+        # producing a pattern that silently matched nothing.
+        from veaf_build.docs_version_stamp import _GENERATED_FOR_LINE
+
+        assert all(ord(c) >= 32 for c in _GENERATED_FOR_LINE.pattern)
+
+
 class TestStamp:
     def test_writes_both_pages(self, repo: Path):
         assert sorted(stamp(repo, today=date(2026, 7, 28))) == sorted(STAMPED_PAGES)

--- a/veaf_build/docs_version_stamp.py
+++ b/veaf_build/docs_version_stamp.py
@@ -30,7 +30,8 @@ _UPDATED_LINE = re.compile(r"^(\*\*(?:Dernière mise à jour|Last Updated)\s*:?\
 #: pass and caught by reading the published 6.12.0 page, which still advertised v6.5.25 there.
 #: Anchored on the ASCII product name rather than the localised label: one occurrence per page,
 #: and no accented literal to get wrong.
-_GENERATED_FOR_LINE = re.compile(r"^(\*\*[^*]+\*\*\s*VEAF Mission Creation Tools v)\d[\w.+-]*\s*$", re.MULTILINE)
+#: `\w` would also admit underscores, which no version we publish contains.
+_GENERATED_FOR_LINE = re.compile(r"^(\*\*[^*]+\*\*\s*VEAF Mission Creation Tools v)\d[0-9A-Za-z.+-]*\s*$", re.MULTILINE)
 _PYPROJECT_VERSION = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
 
 _FR_MONTHS = {

--- a/veaf_build/docs_version_stamp.py
+++ b/veaf_build/docs_version_stamp.py
@@ -26,6 +26,11 @@ STAMPED_PAGES: tuple[str, ...] = ("doc/LUA_API_REFERENCE.md", "doc/LUA_API_REFER
 
 _VERSION_LINE = re.compile(r"^(\*\*Version\s*:?\*\*)\s*.+$", re.MULTILINE)
 _UPDATED_LINE = re.compile(r"^(\*\*(?:Dernière mise à jour|Last Updated)\s*:?\*\*)\s*.+$", re.MULTILINE)
+#: The page repeats a version in its footer ("Généré pour : … v6.5.25"). Missed on the first
+#: pass and caught by reading the published 6.12.0 page, which still advertised v6.5.25 there.
+#: Anchored on the ASCII product name rather than the localised label: one occurrence per page,
+#: and no accented literal to get wrong.
+_GENERATED_FOR_LINE = re.compile(r"^(\*\*[^*]+\*\*\s*VEAF Mission Creation Tools v)\d[\w.+-]*\s*$", re.MULTILINE)
 _PYPROJECT_VERSION = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
 
 _FR_MONTHS = {
@@ -81,7 +86,9 @@ def stamp_text(text: str, version: str, today: date, french: bool) -> str:
         version_value = f"generated for {version}"
         updated_value = f"{today:%B} {today.year}"
     text = _VERSION_LINE.sub(lambda m: f"{m.group(1)} {version_value}", text, count=1)
-    return _UPDATED_LINE.sub(lambda m: f"{m.group(1)} {updated_value}", text, count=1)
+    # No count here: the header and the footer both carry a date, and both must reflect the build.
+    text = _UPDATED_LINE.sub(lambda m: f"{m.group(1)} {updated_value}", text)
+    return _GENERATED_FOR_LINE.sub(lambda m: f"{m.group(1)}{version}", text)
 
 
 def stamp(repo_root: Path, check_only: bool = False, today: date | None = None) -> list[str]:

--- a/veaf_build/docs_version_stamp.py
+++ b/veaf_build/docs_version_stamp.py
@@ -91,18 +91,27 @@ def stamp_text(text: str, version: str, today: date, french: bool) -> str:
     return _GENERATED_FOR_LINE.sub(lambda m: f"{m.group(1)}{version}", text)
 
 
-def stamp(repo_root: Path, check_only: bool = False, today: date | None = None) -> list[str]:
+def stamp(
+    repo_root: Path,
+    check_only: bool = False,
+    today: date | None = None,
+    version: str | None = None,
+) -> list[str]:
     """Stamp every page in :data:`STAMPED_PAGES`.
 
     Args:
         repo_root: Repository root holding ``pyproject.toml`` and ``doc/``.
         check_only: When True, report what would change without writing.
         today: Date to stamp; defaults to today.
+        version: Version to stamp. Defaults to the one in ``pyproject.toml`` — pass it explicitly
+            when **republishing an older version's documentation**, where the working tree's
+            version is not the one being published (republishing 6.12.0 from a 6.12.1 tree would
+            otherwise stamp 6.12.1 onto the 6.12.0 pages).
 
     Returns:
         The relative paths whose header changed (or would change).
     """
-    version = read_version(repo_root / "pyproject.toml")
+    version = version or read_version(repo_root / "pyproject.toml")
     when = today or date.today()
     changed: list[str] = []
     for rel in STAMPED_PAGES:
@@ -131,9 +140,13 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Stamp the shipped version into the docs headers.")
     parser.add_argument("--repo-root", type=Path, default=_REPO_ROOT)
     parser.add_argument("--check", action="store_true", help="Report, do not write; exit 1 if stale.")
+    parser.add_argument(
+        "--version",
+        help="Version to stamp instead of pyproject's — use when republishing an older version's docs.",
+    )
     args = parser.parse_args(argv)
 
-    changed = stamp(args.repo_root, check_only=args.check)
+    changed = stamp(args.repo_root, check_only=args.check, version=args.version)
     if not changed:
         print("docs-stamp-version: headers already up to date.")
         return 0


### PR DESCRIPTION
Found by reading the **published** 6.12.0 page instead of trusting the local run.

## The defect

`LUA_API_REFERENCE` carries a version and a date **twice** — header and footer — and the stamper
I shipped in #643 handled only the header, using `count=1`. So the freshly published 6.12.0 page
still says, at the bottom:

```
**Dernière mise à jour :** Juin 2026
**Généré pour :** VEAF Mission Creation Tools v6.5.25
```

That is precisely the stale-header defect the stamper exists to eliminate — half-fixed is a fair
description of the first version.

## The fix

- The footer pattern is anchored on the **ASCII product name** (`VEAF Mission Creation Tools v…`) rather than the localised label: one occurrence per page, and no accented literal to get wrong.
- Both date lines are stamped now (the `count=1` is gone from that substitution).
- Left alone, as before: the page's own `**Version du document :** 1.0`, and the per-module `**Version :** 1.56.2` / `datamine-…` lines.

## A note on how it was found, because it is the interesting part

My first attempt at the footer pattern silently matched **nothing**. The cause: I wrote a literal
**backspace** (`0x08`) where a regex `\b` was intended. It is invisible in the source, invisible in
a `sed` dump, and `Edit` refused to match the line for reasons that looked like an encoding problem
— I first blamed Unicode normalisation of the `é`, checked it, and was wrong. Only dumping the
compiled pattern's `repr()` showed the `\x08`.

Hence the last test: `test_pattern_carries_no_control_character`, asserting every character in the
pattern is printable. A pattern that matches nothing is worse than a missing feature, because the
run reports success.

## Tests

Five new tests on the footer: version stamped FR and EN, both date lines stamped, the document's own
version untouched, and the control-character guard. `16 passed` on the stamper.

## Worth deciding: republish the 6.12.0 documentation?

The 6.12.0 doc is already deployed with the stale footer. Re-running `Deploy Docs` on the existing
`v6.12.0` tag after this merge would republish that version's pages with the footer corrected —
your call, since it touches an already-published release. Nothing else about 6.12.0 is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix documentation version stamping to correctly update both header and footer metadata and bump the package patch version.

Bug Fixes:
- Ensure the docs version stamper also updates the footer's product version and dates, preventing stale version information on published pages.

Enhancements:
- Anchor the footer version-matching pattern on the ASCII product name to make stamping robust across localised labels and avoid accented-character issues.

Build:
- Bump the project version from 6.12.0 to 6.12.1 to reflect the documentation stamping fix.

Documentation:
- Document the footer-stamping fix and its underlying issue in the unreleased section of the changelog.

Tests:
- Add regression tests covering footer version stamping in French and English, stamping of both date lines, preservation of the document-version field, and guarding against control characters in the regex pattern.