### PR TITLE
docs(tum-exploit): correct the server tier — the bridge is already in production

### DIFF
--- a/docs/exploration/TUM-EXPLOIT.md
+++ b/docs/exploration/TUM-EXPLOIT.md
@@ -83,7 +83,9 @@ interpolation of user-controlled strings.
 
 `veafAssist` is also the pattern to copy for the graceful part: it probes `net.dostring_in` once
 at initialisation and **disables the module with an explanatory message** rather than failing at
-the first call (`veafAssist.lua:211` and `:739`). Any future `a_*` consumer should do the same.
+the first call. Read its local `inEnv` helper and the `veafAssist.available` gate — named rather
+than numbered on purpose, since this note exists because line references and stale claims rot.
+Any future `a_*` consumer should do the same.
 
 TUM blocks its own init at `:30268` when `net.dostring_in` is absent — same idea.
 
@@ -93,7 +95,7 @@ TUM blocks its own init at `:30268` when `net.dostring_in` is absent — same id
 |------|-----------|--------|
 | 🟢 **Native** | **`Disposition.getSimpleZones`** (ground spawn) · **typed zone properties** `DCSEx.zones.getPropertyBoolean/Float/Int/Parse` (`:3257-3271`) | none — direct DCS API |
 | 🟡 **Robustness** | defensive fallback when the singleton is missing (✅ shipped) · inventory the *other* undocumented **singletons** (the author mentions "a few") — folded into the ticket-01 key dump | — |
-| 🔴 **Server** | `net.dostring_in` + `a_*` (HP, live briefing) · **JSON persistence** `DCSEx.io` + `net.lua2json` (`:1126-1177, 28016-28088`) · central clock-tick scheduler | **access already solved** — `MissionScripting.lua` unsanitize (not `autoexec.cfg`), in production via `veafAssist`. What remains: which `a_*` to use, SECREV fencing, server-only distribution |
+| 🔴 **Server** | `net.dostring_in` + `a_*` (HP, live briefing) · **JSON persistence** `DCSEx.io` + `net.lua2json` (`:1126-1177, 28016-28088`) · central clock-tick scheduler | **access already solved** — `MissionScripting.lua` unsanitizes `net`/`io` (not `autoexec.cfg`), in production via `veafAssist`. What remains: which `a_*` to use, SECREV fencing, server-only distribution |
 
 ## How this maps to the vision
 

--- a/docs/exploration/TUM-EXPLOIT.md
+++ b/docs/exploration/TUM-EXPLOIT.md
@@ -61,19 +61,39 @@ it may be what ED uses in their quick-action generator.
 | `:794`  | `a_out_picture(...)` | overlay image |
 | `:771`  | `a_load_mission(file)` | load another mission |
 
-Requires an `autoexec.cfg` that **unsanitizes `net`/`io`** (TUM blocks its own init at
-`:30268` if `net.dostring_in` is absent). This is a change to the **player's DCS install** →
-incompatible with a publicly distributed mission, but fine on **VEAF-controlled servers**.
-Also collides head-on with the SECREV "no arbitrary Lua execution" policy → strict argument
-fencing required (no interpolation of user-controlled strings).
+### Corrected 2026-08-05 — VEAF already does this, and two claims above were wrong
+
+This section was written as if the bridge were unexplored territory. **It is in production**:
+`veafAssist.lua` (shipped by `FEAT-ASSIST-CHECKLISTS`) reaches the trigger environment through
+`net.dostring_in("mission", …)` on every checklist step. Two corrections follow from what that
+lot measured in game, and they matter to whoever picks up this tier:
+
+- **The unsanitize is in `MissionScripting.lua`, not `autoexec.cfg`.** Same tweak STTS and the
+  VEAF dcs-bridge already require, so a VEAF-outfitted server has it. `autoexec.cfg` is the
+  wrong file and would send the next reader looking in the wrong place.
+- **There are 114 `a_*` functions, not the 5 sites listed above.** Measured from inside a
+  mission: `a_cockpit_highlight` is `nil` in the VEAF script environment, while
+  `net.dostring_in("mission", …)` reaches an environment holding all 114 — and, symmetrically,
+  holding no `veaf` and no `net`. The five rows above are TUM's *call sites*, not the surface.
+
+The distribution constraint stands: it is a change to the **player's DCS install** →
+incompatible with a publicly distributed mission, fine on **VEAF-controlled servers**. So does
+the SECREV collision with "no arbitrary Lua execution" → strict argument fencing, no
+interpolation of user-controlled strings.
+
+`veafAssist` is also the pattern to copy for the graceful part: it probes `net.dostring_in` once
+at initialisation and **disables the module with an explanatory message** rather than failing at
+the first call (`veafAssist.lua:211` and `:739`). Any future `a_*` consumer should do the same.
+
+TUM blocks its own init at `:30268` when `net.dostring_in` is absent — same idea.
 
 ## Borrowable techniques, by risk tier
 
 | Tier | Techniques | Prereq |
 |------|-----------|--------|
 | 🟢 **Native** | **`Disposition.getSimpleZones`** (ground spawn) · **typed zone properties** `DCSEx.zones.getPropertyBoolean/Float/Int/Parse` (`:3257-3271`) | none — direct DCS API |
-| 🟡 **Robustness** | defensive fallback when the singleton is missing · inventory the *other* undocumented functions (the author mentions "a few") | — |
-| 🔴 **Server** | `net.dostring_in` + `a_*` (HP, live briefing) · **JSON persistence** `DCSEx.io` + `net.lua2json` (`:1126-1177, 28016-28088`) · central clock-tick scheduler | `autoexec.cfg` unsanitize, SECREV fencing |
+| 🟡 **Robustness** | defensive fallback when the singleton is missing (✅ shipped) · inventory the *other* undocumented **singletons** (the author mentions "a few") — folded into the ticket-01 key dump | — |
+| 🔴 **Server** | `net.dostring_in` + `a_*` (HP, live briefing) · **JSON persistence** `DCSEx.io` + `net.lua2json` (`:1126-1177, 28016-28088`) · central clock-tick scheduler | **access already solved** — `MissionScripting.lua` unsanitize (not `autoexec.cfg`), in production via `veafAssist`. What remains: which `a_*` to use, SECREV fencing, server-only distribution |
 
 ## How this maps to the vision
 
@@ -94,6 +114,9 @@ fencing required (no interpolation of user-controlled strings).
     downstream. Validating and retrying makes those spawns work, so the change is an improvement even
     where `Disposition` is missing.
 - 🔴 **Server tier** feeds the campaign branch directly: JSON persistence is a near-blueprint
-  for `PERSISTENCE`; live HP/briefing for `DYNAMIC-CAMPAIGN` / `AI-GAMEMASTER`.
+  for `PERSISTENCE`; live HP/briefing for `DYNAMIC-CAMPAIGN` / `AI-GAMEMASTER`. **Closer than
+  this note originally implied** — the access mechanism is not a prerequisite to build but a
+  shipped, exercised one (see the correction above), so a `PERSISTENCE` lot starts at "which
+  internals, fenced how" rather than at "can we get in at all".
 - **Do not patch TUM's 30k lines in place** — extract the patterns into VEAF modules;
   depending on the upstream file creates a merge-debt on every TUM bump.


### PR DESCRIPTION
Doc-only, one file: [`docs/exploration/TUM-EXPLOIT.md`](docs/exploration/TUM-EXPLOIT.md).

## Why

The note describes TUM's 🔴 server tier — `net.dostring_in` plus the undocumented `a_*` internals —
as unexplored ground sitting behind a prerequisite we have not met. **It is neither.**
`veafAssist.lua`, shipped by `FEAT-ASSIST-CHECKLISTS`, crosses that exact bridge on every guided
checklist step. Found while taking stock of what TUM/SMS has actually landed.

Two claims in the note are wrong, and each would send the next reader of that tier somewhere useless:

| The note said | Measured reality |
|---|---|
| Requires an **`autoexec.cfg`** that unsanitizes `net`/`io` | It is **`MissionScripting.lua`** — the same tweak STTS and the VEAF dcs-bridge already require, so a VEAF-outfitted server has it. Someone following the old text edits a file that has nothing to do with it. |
| Five `a_*` internals, listed by TUM call site | **114** `a_*` functions. From inside a mission, `a_cockpit_highlight` is `nil` in the VEAF script environment while `net.dostring_in("mission", …)` reaches an environment holding all 114 — and, symmetrically, holding no `veaf` and no `net`. TUM's five rows are its own call sites, not the surface. |

That 114 measurement previously existed **only as a comment in `veafAssist.lua`**. Worth writing down
for a second reason: it is easy to confuse with the unrelated 114 in
`DCS-COCKPIT-ASSISTANCE-API.md`, which counts the F-14B's cockpit *arguments* — same number,
different subject.

## What changed

- The server-tier section gains a dated correction block with both fixes and the evidence.
- The tier table's prereq column no longer says "`autoexec.cfg` unsanitize" but **"access already
  solved"**, and names what actually remains: which internals to use, SECREV fencing, server-only
  distribution.
- The vision section now says a `PERSISTENCE` lot starts at *"which internals, fenced how"* rather
  than at *"can we get in at all"* — the practical point of the whole correction.
- Points at `veafAssist`'s graceful-degradation pattern (`veafAssist.lua:211` and `:739`: probe
  `net.dostring_in` once at init, disable the module with an explanatory message rather than failing
  at the first call) as the thing to copy for any future `a_*` consumer.
- The 🟡 row marks the defensive fallback shipped and notes the "other undocumented functions" sweep
  is folded into `FEAT-SCENERY-AWARE-SPAWN` ticket 01's key dump.

**Unchanged, because both still stand:** the distribution constraint (a change to the *player's*
install, so incompatible with a publicly distributed mission, fine on VEAF servers) and the head-on
collision with the SECREV "no arbitrary Lua execution" policy.

`docs-check`: no defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the current production use and correct prerequisites of the TUM server-tier exploit path.

Documentation:
- Update TUM server-tier documentation to note that `net.dostring_in` + `a_*` access is already exercised in production via `veafAssist` and to correct that the unsanitization lives in `MissionScripting.lua`, not `autoexec.cfg`.
- Clarify that there are 114 `a_*` internals beyond the previously listed call sites and document the separation between mission and VEAF script environments.
- Adjust the risk-tier table and vision narrative so the server tier focuses on choosing and fencing internals and server-only distribution rather than treating access as an open prerequisite, and highlight `veafAssist`'s graceful-degradation pattern and existing robustness work.