### PR TITLE
test(backlog): the status gate had the defect it was built to remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **The backlog status gate no longer lets anything opt out in silence** (follow-up to the check added in #692, on Sourcery's two remarks). It had the very defect it was built to remove: a `Status:` line below the 15-line window it scanned read as *absent*, and an unrecognised icon in a scope-table cell made the row **invisible** — both skipped the comparison instead of failing it. The window is gone, a missing or unreadable status is now reported, and each of the three holes was verified by reopening it and watching the gate refuse. The reliable fix turned out to be neither mine nor the one suggested: reading **the column the table names `Status`** rather than "the last cell". Measured first — a positional rule produced **17 false positives**, because two lots end their table with a *depends on* column holding values like `01, 02` or `—`.
+
 ### Added
 - **A test that the three places a lot's status is written agree.** `.backlog/README.md` carries a row per lot, `<LOT>/PRD.md` a `Status:` header and usually a scope table, and each ticket its own header — and nothing checked they told the same story. That cost **four separate corrections in one day**, the last of them inside the very commit that called the pattern out and still left the index row on ⬜. Naming a pattern is not removing it. The rule is **agreement, not conformity**: several PRDs deliberately carry no scope table, so the test compares the sources that exist rather than imposing one shape. It found **14 drifts** on landing — `TOOLING-REPO-LINK-GATE` had all five tickets done and none of them ticked, `SECREV-2` four, and `REVIEW-SECURITY-LAYER`'s PRD still read `ready` while its index row said in-progress. All aligned, taking the **ticket file** as truth: it is the one edited on finishing the work, so it is the source that drifts last.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "veaf-mission-editor",
   "displayName": "VEAF Mission Editor",
   "description": "Author VEAF DCS missions from Claude Code — create, edit, validate and build a mission through the veaf-mission-mcp server, guided by the veaf-mission-authoring skill.",
-  "version": "6.13.56",
+  "version": "6.13.57",
   "author": {
     "name": "VEAF",
     "url": "https://www.veaf.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veaf-tools"
-version = "6.13.56"
+version = "6.13.57"
 description = "A set of tools that help set up and run dynamic DCS World missions"
 authors = ["VEAF <https://www.veaf.org>"]
 license = "ISC"

--- a/test/python/test_backlog_status_consistency.py
+++ b/test/python/test_backlog_status_consistency.py
@@ -6,8 +6,14 @@ Nothing checked that the three tell the same story, and on 2026-08-10 that cost 
 corrections in one day — the last of them inside the very commit that called the pattern out and
 still left the index row on ⬜.
 
-The rule is **agreement, not conformity**. Several PRDs deliberately carry no scope table; this
-compares the sources that exist rather than imposing one shape on every lot.
+The rule is **agreement, not conformity**. Six of the 23 active lots deliberately shape their PRD
+table differently (one has a *depends on* last column, not a status); this compares the sources that
+exist rather than imposing one shape.
+
+Two holes, closed after review: nothing may **silently opt out** of a check. A missing `Status:`
+line and an unrecognised icon both used to make a file or a row invisible, which is the failure mode
+this gate exists to remove — the same one that let a coverage rule pass while extracting zero names
+and a link checker compensate for a defect instead of reporting it.
 """
 
 from __future__ import annotations
@@ -25,21 +31,40 @@ _ICON = re.compile(f"[{STATUS_ICONS}]")
 #: `| [LOT-ID](LOT-ID/PRD.md) — prose … | ✅ |`
 _INDEX_ROW = re.compile(r"^\| \[([A-Z0-9-]+)\]\(")
 
-#: `| 02 | [title](tickets/02-slug.md) | ✅ |` — the trailing cell is the status.
-_SCOPE_ROW = re.compile(r"^\|\s*(\d{2})\s*\|.*\|\s*([" + STATUS_ICONS + r"])\s*\|\s*$")
+#: A data row of a scope table: its first cell is the ticket number.
+_TICKET_ROW = re.compile(r"^\|\s*(\d{2})\s*\|")
+
+#: A markdown table separator, e.g. `|---|:--:|---|`.
+_SEPARATOR = re.compile(r"^\|[\s:|-]+\|$")
 
 
-def _first_icon(text: str) -> str | None:
-    """Return the first status icon in *text*, or None."""
-    found = _ICON.search(text)
-    return found.group(0) if found else None
+def _cells(line: str) -> list[str]:
+    """Split a markdown table row into its trimmed cells."""
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def _sole_icon(text: str) -> str | None:
+    """Return the status icon *text* consists of, or None when it is anything else.
+
+    Deliberately strict: a cell holding an icon **plus** other words is not a status cell, and a cell
+    holding an unknown glyph is a typo rather than something to skip.
+    """
+    found = _ICON.findall(text)
+    if len(found) != 1 or _ICON.sub("", text).strip():
+        return None
+    return found[0]
 
 
 def _header_status(path: Path) -> str | None:
-    """Return the icon on a PRD's or ticket's `Status:` line, or None when it has none."""
-    for line in path.read_text(encoding="utf-8").split("\n")[:15]:
+    """Return the icon on a file's first `Status:` line, or None when it has none.
+
+    The whole file is scanned, not a window at the top: a header further down used to read as
+    *absent*, which skipped every comparison for that file instead of failing.
+    """
+    for line in path.read_text(encoding="utf-8").split("\n"):
         if line.startswith("Status:"):
-            return _first_icon(line)
+            found = _ICON.search(line)
+            return found.group(0) if found else None
     return None
 
 
@@ -50,9 +75,8 @@ def _index_statuses() -> dict[str, str | None]:
         match = _INDEX_ROW.match(line)
         if not match:
             continue
-        # The status is the last cell; the prose before it is free to contain icons of its own.
-        cells = line.rstrip().rstrip("|").rsplit("|", 1)
-        result[match.group(1)] = _first_icon(cells[-1]) if len(cells) > 1 else None
+        cells = _cells(line)
+        result[match.group(1)] = _sole_icon(cells[-1]) if cells else None
     return result
 
 
@@ -61,13 +85,39 @@ def _active_lots() -> list[Path]:
     return sorted(p for p in BACKLOG.iterdir() if p.is_dir() and p.name != "archive")
 
 
-def _scope_rows(prd: Path) -> dict[str, str]:
-    """Return the PRD scope table's `{ticket number: status icon}`, empty when it has no table."""
-    rows: dict[str, str] = {}
-    for line in prd.read_text(encoding="utf-8").split("\n"):
-        match = _SCOPE_ROW.match(line)
-        if match:
-            rows[match.group(1)] = match.group(2)
+def _status_column(lines: list[str]) -> int | None:
+    """Return the index of the column a PRD table names `Status`, or None when it has no such table.
+
+    Keying on the **header** rather than on "the last cell" is what makes this reliable:
+    `FEAT-ASSIST-AUTHORING` and `FEAT-ASSIST-CHECKLISTS` end their table with a *depends on* column
+    holding values like `01, 02` or `—`, which a positional rule reads as a broken status.
+    """
+    for index, line in enumerate(lines):
+        if not line.startswith("|") or _SEPARATOR.match(line):
+            continue
+        cells = _cells(line)
+        if any(cell.lower() == "status" for cell in cells):
+            return cells.index(next(c for c in cells if c.lower() == "status"))
+    return None
+
+
+def _scope_rows(prd: Path) -> dict[str, str | None]:
+    """Return `{ticket number: status icon}` from the PRD's scope table.
+
+    Empty when the PRD has no table naming a `Status` column. A cell whose content is not exactly one
+    known icon maps to ``None`` so it is **reported**, not skipped.
+    """
+    lines = prd.read_text(encoding="utf-8").split("\n")
+    column = _status_column(lines)
+    if column is None:
+        return {}
+    rows: dict[str, str | None] = {}
+    for line in lines:
+        match = _TICKET_ROW.match(line)
+        if not match:
+            continue
+        cells = _cells(line)
+        rows[match.group(1)] = _sole_icon(cells[column]) if column < len(cells) else None
     return rows
 
 
@@ -82,6 +132,43 @@ class TestEveryLotIsListed(unittest.TestCase):
         self.assertEqual(missing, [], f"lot directories with no PRD.md: {missing}")
 
 
+class TestNothingOptsOutSilently(unittest.TestCase):
+    """A file or row with no readable status must fail, not disappear from the comparisons."""
+
+    def test_every_prd_and_ticket_declares_a_known_status(self) -> None:
+        offenders = []
+        for lot in _active_lots():
+            paths = [lot / "PRD.md"]
+            if (lot / "tickets").is_dir():
+                paths += sorted((lot / "tickets").glob("*.md"))
+            for path in paths:
+                if not path.exists():
+                    continue
+                if _header_status(path) is None:
+                    offenders.append(path.relative_to(BACKLOG).as_posix())
+        self.assertEqual(
+            offenders,
+            [],
+            "no `Status:` line, or one carrying no known icon — these escape every check below:\n  "
+            + "\n  ".join(offenders),
+        )
+
+    def test_every_index_row_declares_a_known_status(self) -> None:
+        offenders = sorted(lot for lot, icon in _index_statuses().items() if icon is None)
+        self.assertEqual(offenders, [], f"index rows whose status cell is not a lone known icon: {offenders}")
+
+    def test_every_scope_row_declares_a_known_status(self) -> None:
+        offenders = []
+        for lot in _active_lots():
+            prd = lot / "PRD.md"
+            if not prd.exists():
+                continue
+            for number, icon in _scope_rows(prd).items():
+                if icon is None:
+                    offenders.append(f"{lot.name} row {number}")
+        self.assertEqual(offenders, [], f"scope rows whose Status cell is not a lone known icon: {offenders}")
+
+
 class TestTheIndexAgreesWithThePrd(unittest.TestCase):
     def test_the_row_and_the_prd_header_carry_the_same_status(self) -> None:
         index = _index_statuses()
@@ -91,7 +178,7 @@ class TestTheIndexAgreesWithThePrd(unittest.TestCase):
             if not prd.exists():
                 continue
             row, header = index.get(lot.name), _header_status(prd)
-            if row is not None and header is not None and row != header:
+            if row != header:
                 drift.append(f"{lot.name}: index row {row} vs PRD header {header}")
         self.assertEqual(drift, [], "the index and the PRD disagree:\n  " + "\n  ".join(drift))
 
@@ -106,25 +193,22 @@ class TestThePrdAgreesWithItsTickets(unittest.TestCase):
     def test_every_scope_row_matches_its_ticket(self) -> None:
         drift = []
         for lot in _active_lots():
-            prd = lot / "PRD.md"
-            tickets = lot / "tickets"
+            prd, tickets = lot / "PRD.md", lot / "tickets"
             if not prd.exists() or not tickets.is_dir():
                 continue
             rows = _scope_rows(prd)
             for ticket in sorted(tickets.glob("*.md")):
                 number = ticket.name[:2]
                 if number not in rows:
-                    continue  # a PRD without a scope table, or a ticket it does not list
-                declared = _header_status(ticket)
-                if declared is not None and declared != rows[number]:
-                    drift.append(f"{lot.name}/{ticket.name}: PRD row {rows[number]} vs ticket {declared}")
+                    continue  # a PRD with no Status column, or a ticket it does not list
+                if _header_status(ticket) != rows[number]:
+                    drift.append(f"{lot.name}/{ticket.name}: PRD row {rows[number]} vs ticket {_header_status(ticket)}")
         self.assertEqual(drift, [], "a PRD scope table is stale:\n  " + "\n  ".join(drift))
 
     def test_a_scope_row_names_a_ticket_that_exists(self) -> None:
         dangling = []
         for lot in _active_lots():
-            prd = lot / "PRD.md"
-            tickets = lot / "tickets"
+            prd, tickets = lot / "PRD.md", lot / "tickets"
             if not prd.exists():
                 continue
             present = {t.name[:2] for t in tickets.glob("*.md")} if tickets.is_dir() else set()
@@ -132,21 +216,6 @@ class TestThePrdAgreesWithItsTickets(unittest.TestCase):
                 if number not in present:
                     dangling.append(f"{lot.name}: scope row {number} has no ticket file")
         self.assertEqual(dangling, [], "\n  ".join(dangling))
-
-
-class TestTheVocabularyIsTheDocumentedOne(unittest.TestCase):
-    def test_no_status_line_invents_an_icon(self) -> None:
-        # `docs/agents/triage-labels.md` defines one vocabulary; a lot using anything else would slip
-        # past every check above, which only ever compares icons it recognises.
-        offenders = []
-        for lot in _active_lots():
-            for path in [lot / "PRD.md", *sorted((lot / "tickets").glob("*.md"))]:
-                if not path.exists():
-                    continue
-                for line in path.read_text(encoding="utf-8").split("\n")[:15]:
-                    if line.startswith("Status:") and _first_icon(line) is None:
-                        offenders.append(f"{path.relative_to(BACKLOG).as_posix()}: {line[:60]}")
-        self.assertEqual(offenders, [], "Status: lines with no known icon:\n  " + "\n  ".join(offenders))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sourcery's two remarks on #692 — both correct, and both the same shape as what that gate exists to catch: **something unrecognised was skipped instead of reported.**

| hole | consequence |
|---|---|
| a `Status:` line below the 15-line window I scanned | read as **absent** → every comparison for that file silently skipped |
| an unrecognised icon in a scope-table cell | row **invisible** to the regex → its status never compared |

## Both closed, and verified by reopening them

The window is gone — the whole file is scanned — and a missing or unreadable status is now an offender rather than a gap. Each hole was reopened to watch the gate refuse, which is the only evidence worth anything here:

```
Status: line 20 lines down    -> "PRD row ✅ vs ticket ⬜"        (read, not skipped)
typo'd ☑ in a scope row       -> "not a lone known icon: SECREV-2 row 02"
ticket with no Status: line   -> "these escape every check below: …/01-register…"
```

## The fix is neither mine nor the one suggested

Sourcery proposed broadening the row regex to *any* trailing cell, then asserting the icon. Measuring that first showed **17 false positives**: `FEAT-ASSIST-AUTHORING` and `FEAT-ASSIST-CHECKLISTS` end their table with a *depends on* column holding values like `01, 02` or `—`, and one of them puts the status **inside** that cell.

```
FEAT-ASSIST-AUTHORING row 03: trailing cell '01, 02'
FEAT-ASSIST-CHECKLISTS row 06: trailing cell '02 (**🧑 slice to review by a pilot**)'
```

*"The last cell is the status"* is not a convention of this repository. What **is** one: 17 of the 23 active lots head their table `| # | Ticket | Status |`.

So the column is found **by name**. That removes the positional guess entirely, catches a typo'd icon because the cell exists and its content is wrong, and leaves the six differently-shaped lots unchecked **by structure rather than by accident** — which is the distinction the whole gate turns on.

## Checks

`pytest` 2955 passed · `ruff check` + `ruff format --check` · `docs-check` — all green. The backlog files the probes touched were restored and verified byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten backlog status consistency checks so that missing or unreadable status declarations are reported instead of silently skipped.

Bug Fixes:
- Scan entire files for `Status:` headers instead of only the first 15 lines, ensuring all statuses participate in consistency checks.
- Treat scope table rows and index rows with non-recognised or non-lone status icons as offenders, preventing them from being skipped in comparisons.

Enhancements:
- Determine PRD scope table status cells by locating the column named `Status` in the header rather than assuming the last cell, supporting differently shaped tables.
- Refine table parsing helpers for index and scope rows to robustly extract ticket numbers and status cells, and simplify drift detection between PRDs and tickets.
- Add focused tests that assert every PRD, ticket, index row, and scope row declares a single known status icon and cannot opt out silently.

Build:
- Bump the project version to 6.13.57 in `pyproject.toml`.

Documentation:
- Document the tightened backlog status gate behaviour and its rationale in the changelog as a follow-up to the checks introduced in #692.