### PR TITLE
refactor(spawner): VEAF creates its own static objects, without MiST

### DIFF
--- a/.backlog/DROP-MIST/tickets/07-spawn-routes-and-teleport.md
+++ b/.backlog/DROP-MIST/tickets/07-spawn-routes-and-teleport.md
@@ -1,6 +1,6 @@
 # 07 — Spawn, routes and teleport
 
-Status: 🔄 in-progress — **the enumeration is written** (2026-08-28, below); implementation not started
+Status: 🔄 in-progress — enumeration written and **half (A) shipped** (2026-08-28); half (B) not started
 Type: refactor
 
 80 call sites over **726 MiST lines** — the functional core of the dependency, and the reason this lot
@@ -251,8 +251,8 @@ Unit tests cannot see whether a group actually appeared at the right place in DC
 - [x] The call-site → category → branch enumeration is written in this ticket **before** implementation
       — done 2026-08-28; it re-counted the slice at **64 real calls, not 80**
 - [ ] Ported into a dedicated module behind `veaf.*` façades; `dynAdd` first, then `teleportToPoint` as
-      route arithmetic over it
-- [ ] 64 call sites migrated
+      route arithmetic over it — **`veafDcsSpawner.lua` created**, `veaf.addStatic` shipped
+- [ ] 64 call sites migrated — **18 done** (all of `dynAddStatic`, half A)
 - [ ] Lua tests covering every branch in the enumeration table, including a group category we spawn but
       MiST handled specially
 - [ ] Position asserted against known coordinates, with the convention named in a comment

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -77,7 +77,7 @@ globals = {
   "veafNamedPoints", "veafQraManager", "veafRadio", "veafRecorder", "veafRemote",
   "veafSanctuary", "veafScheduler", "veafSecurity", "veafShortcuts",
   "veafSkynet", "veafSkynetMonitor",
-  "veafSpawn", "veafSpawnableAircraftsEditor",
+  "veafDcsSpawner", "veafSpawn", "veafSpawnableAircraftsEditor",
   "veafSunTimes", "veafTime", "veafTransportMission", "veafUnits",
   "veafWeather", "veafWeatherAtis", "veafWeatherData", "veafWeatherUnitSystem",
   "veafHoundElint", "veafServerHook",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,12 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   spawner a point with no easting (`FIX-AIRWAVES-COMMAND-EASTING`), and the tests that should have
   caught it were asserting a mock that answered a different coordinate shape than MiST ever did.
 
+- **VEAF creates its own static objects**, without MiST — every FARP, runway plot, tent, windsock,
+  outpost, tower, cargo drop and `-spawn static` now goes through `veafDcsSpawner`. Nothing changes in
+  a mission: the four behaviours that were easy to lose in the move are covered by tests, including the
+  **random heading** an object gets when none is set, without which every cargo drop would line up on
+  the same axis.
+
 ## [6.17.0] — 2026-08-26
 
 **Released.** This version consolidates the ten patch versions from **6.16.1 to 6.16.10**, whose detailed

--- a/doc/TESTING.en.md
+++ b/doc/TESTING.en.md
@@ -151,6 +151,7 @@ luaunit.assertIsTrue(ok, err)
 | `test_veafGeo_ported.lua` | Geometry ported off MiST: random point in a circle, units in a circular zone, heading, zone drawing |
 | `test_veafMissionDb.lua` | Mission snapshot, player roster, name registry, unit ids |
 | `test_veafMissionDb_scenery.lua` | Destroyed-scenery register: recording, zone lookup, event subscription |
+| `test_veafDcsSpawner.lua` | Runtime static creation: country, ids, shapes, random heading |
 | `test_veafInterpreter.lua` | Mark text tokenizer |
 | `test_veafTime.lua` | Time parsing, formatting, DCS time helpers |
 | `test_veafSecurity.lua` | Security levels, admin management |

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -151,6 +151,7 @@ luaunit.assertIsTrue(ok, err)
 | `test_veafGeo_ported.lua` | Géométrie portée depuis MiST : tirage dans un cercle, unités en zone circulaire, cap, dessin de zone |
 | `test_veafMissionDb.lua` | Instantané de la mission, liste des joueurs, registre des noms, identifiants |
 | `test_veafMissionDb_scenery.lua` | Registre des objets de décor détruits : enregistrement, recherche par zone, abonnement à l'événement |
+| `test_veafDcsSpawner.lua` | Création de statiques à l'exécution : pays, identifiants, formes, cap aléatoire |
 | `test_veafInterpreter.lua` | Tokeniseur de texte marqueur |
 | `test_veafTime.lua` | Parsing de temps, formatage, helpers temps DCS |
 | `test_veafSecurity.lua` | Niveaux de sécurité, gestion des admins |

--- a/src/scripts/veaf/veafDcsSpawner.lua
+++ b/src/scripts/veaf/veafDcsSpawner.lua
@@ -1,0 +1,297 @@
+------------------------------------------------------------------
+-- VEAF runtime spawner for DCS World
+-- By Zip (2026)
+--
+-- Features:
+-- ---------
+-- * Create static objects at runtime, without MiST
+--
+-- This module is the adapter over the DCS calls that put things into the running world --
+-- `coalition.addStaticObject` today, `coalition.addGroup` when DROP-MIST ticket 07's second half
+-- lands. It is deliberately *not* called veafSpawn-anything: `veafSpawn*` is the family that reads a
+-- mission maker's command, while this is what finally asks DCS for an object.
+------------------------------------------------------------------
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Global settings. Stores the script constants
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+--- Identifier. All output in DCS.log will start with this.
+veafDcsSpawner = {}
+
+--- Identifier. All output in the log will start with this.
+veafDcsSpawner.Id = "SPAWNER"
+
+-- trace level, specific to this module (uncomment for debugging)
+--veafDcsSpawner.LogLevel = "trace"
+
+veaf.loggers.new(veafDcsSpawner.Id, veafDcsSpawner.LogLevel)
+
+--- The shape a static type is drawn with, when its table does not say.
+---
+--- DCS needs `shape_name` for a structure, and a mission maker asking for one by type through
+--- `-spawn static` never supplies it. Ported verbatim from `mist.DBs.const.shapeNames` (124 entries):
+--- **93 of them are types VEAF's own 873-unit catalogue can resolve**, so they are reachable by
+--- command — `.Ammunition depot`, `Barracks 2`, `Cafe`, `Boiler-house A` and the like. The other 31
+--- only the Mission Editor can place; they are kept anyway rather than filtered, because a filtered
+--- copy would silently go stale the day the catalogue grows.
+---
+--- Objects that carry their own shape never reach this table: the FARP, the windsock and the runway
+--- cones all pass `shape_name` explicitly.
+veafDcsSpawner.SHAPE_NAMES = {
+  ["Landmine"] = "landmine",
+  ["FARP CP Blindage"] = "kp_ug",
+  ["Subsidiary structure C"] = "saray-c",
+  ["Barracks 2"] = "kazarma2",
+  ["Small house 2C"] = "dom2c",
+  ["Military staff"] = "aviashtab",
+  ["Tech hangar A"] = "ceh_ang_a",
+  ["Oil derrick"] = "neftevyshka",
+  ["Tech combine"] = "kombinat",
+  ["Garage B"] = "garage_b",
+  ["Airshow_Crowd"] = "Crowd1",
+  ["Hangar A"] = "angar_a",
+  ["Repair workshop"] = "tech",
+  ["Subsidiary structure D"] = "saray-d",
+  ["FARP Ammo Dump Coating"] = "SetkaKP",
+  ["Small house 1C area"] = "dom2c-all",
+  ["Tank 2"] = "airbase_tbilisi_tank_01",
+  ["Boiler-house A"] = "kotelnaya_a",
+  ["Workshop A"] = "tec_a",
+  ["Small werehouse 1"] = "s1",
+  ["Garage small B"] = "garagh-small-b",
+  ["Small werehouse 4"] = "s4",
+  ["Shop"] = "magazin",
+  ["Subsidiary structure B"] = "saray-b",
+  ["FARP Fuel Depot"] = "GSM Rus",
+  ["Coach cargo"] = "wagon-gruz",
+  ["Electric power box"] = "tr_budka",
+  ["Tank 3"] = "airbase_tbilisi_tank_02",
+  ["Red_Flag"] = "H-flag_R",
+  ["Container red 3"] = "konteiner_red3",
+  ["Garage A"] = "garage_a",
+  ["Hangar B"] = "angar_b",
+  ["Black_Tyre"] = "H-tyre_B",
+  ["Cafe"] = "stolovaya",
+  ["Restaurant 1"] = "restoran1",
+  ["Subsidiary structure A"] = "saray-a",
+  ["Container white"] = "konteiner_white",
+  ["Warehouse"] = "sklad",
+  ["Tank"] = "bak",
+  ["Railway crossing B"] = "pereezd_small",
+  ["Subsidiary structure F"] = "saray-f",
+  ["Farm A"] = "ferma_a",
+  ["Small werehouse 3"] = "s3",
+  ["Water tower A"] = "wodokachka_a",
+  ["Railway station"] = "r_vok_sd",
+  ["Coach a tank blue"] = "wagon-cisterna_blue",
+  ["Supermarket A"] = "uniwersam_a",
+  ["Coach a platform"] = "wagon-platforma",
+  ["Garage small A"] = "garagh-small-a",
+  ["TV tower"] = "tele_bash",
+  ["Comms tower M"] = "tele_bash_m",
+  ["Small house 1A"] = "domik1a",
+  ["Farm B"] = "ferma_b",
+  ["GeneratorF"] = "GeneratorF",
+  ["Cargo1"] = "ab-212_cargo",
+  ["Container red 2"] = "konteiner_red2",
+  ["Subsidiary structure E"] = "saray-e",
+  ["Coach a passenger"] = "wagon-pass",
+  ["Black_Tyre_WF"] = "H-tyre_B_WF",
+  ["Electric locomotive"] = "elektrowoz",
+  ["Shelter"] = "ukrytie",
+  ["Coach a tank yellow"] = "wagon-cisterna_yellow",
+  ["Railway crossing A"] = "pereezd_big",
+  [".Ammunition depot"] = "SkladC",
+  ["Small werehouse 2"] = "s2",
+  ["Windsock"] = "H-Windsock_RW",
+  ["Shelter B"] = "ukrytie_b",
+  ["Fuel tank"] = "toplivo-bak",
+  ["Locomotive"] = "teplowoz",
+  [".Command Center"] = "ComCenter",
+  ["Pump station"] = "nasos",
+  ["Black_Tyre_RF"] = "H-tyre_B_RF",
+  ["Coach cargo open"] = "wagon-gruz-otkr",
+  ["Subsidiary structure 3"] = "hozdomik3",
+  ["FARP Tent"] = "PalatkaB",
+  ["White_Tyre"] = "H-tyre_W",
+  ["Subsidiary structure G"] = "saray-g",
+  ["Container red 1"] = "konteiner_red1",
+  ["Small house 1B area"] = "domik1b-all",
+  ["Subsidiary structure 1"] = "hozdomik1",
+  ["Container brown"] = "konteiner_brown",
+  ["Small house 1B"] = "domik1b",
+  ["Subsidiary structure 2"] = "hozdomik2",
+  ["Chemical tank A"] = "him_bak_a",
+  ["WC"] = "WC",
+  ["Small house 1A area"] = "domik1a-all",
+  ["White_Flag"] = "H-Flag_W",
+  ["Airshow_Cone"] = "Comp_cone",
+  ["Bulk Cargo Ship Ivanov"] = "barge-1",
+  ["Bulk Cargo Ship Yakushev"] = "barge-2",
+  ["Outpost"] = "block",
+  ["Road outpost"] = "block-onroad",
+  ["Container camo"] = "bw_container_cargo",
+  ["Tech Hangar A"] = "ceh_ang_a",
+  ["Bunker 1"] = "dot",
+  ["Bunker 2"] = "dot2",
+  ["Tanker Elnya 160"] = "elnya",
+  ["F-shape barrier"] = "f_bar_cargo",
+  ["Helipad Single"] = "farp",
+  ["FARP_SINGLE_01"] = "farp",
+  ["FARP"] = "farps",
+  ["Invisible FARP"] = "invisiblefarp",
+  ["Fueltank"] = "fueltank_cargo",
+  ["Gate"] = "gate",
+  ["Armed house"] = "home1_a",
+  ["FARP Command Post"] = "kp-ug",
+  ["Watch Tower Armed"] = "ohr-vyshka",
+  ["Oiltank"] = "oiltank_cargo",
+  ["Pipes small"] = "pipes_small_cargo",
+  ["Pipes big"] = "pipes_big_cargo",
+  ["Oil platform"] = "plavbaza",
+  ["Tetrapod"] = "tetrapod_cargo",
+  ["Trunks long"] = "trunks_long_cargo",
+  ["Trunks small"] = "trunks_small_cargo",
+  ["Passenger liner"] = "yastrebow",
+  ["Passenger boat"] = "zwezdny",
+  ["Oil rig"] = "oil_platform",
+  ["Gas platform"] = "gas_platform",
+  ["Container 20ft"] = "container_20ft",
+  ["Container 40ft"] = "container_40ft",
+  ["Downed pilot"] = "cadaver",
+  ["Parachute"] = "parash",
+  ["Pilot F15 Parachute"] = "pilot_f15_parachute",
+  ["Pilot standing"] = "pilot_parashut",
+}
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Do not change anything below unless you know what you are doing!
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+--- Resolve a country given either its name or its id.
+---
+--- A name is matched case-insensitively with spaces turned into underscores, which is how
+--- `country.name` spells them (`"United States of America"` → `USA` is *not* one of these; the entry
+--- really is `"USA"`, while `"South Korea"` is `SOUTH_KOREA`). Returns the canonical name, or nil.
+---
+--- @param wanted string|number a country name or id
+--- @return string|nil the name as `country.name` spells it
+local function resolveCountry(wanted)
+  if wanted == nil then
+    return nil
+  end
+  if type(wanted) == "number" then
+    for countryId, countryName in pairs(country.name) do
+      if countryId == wanted then
+        return countryName
+      end
+    end
+    return nil
+  end
+  local normalised = string.upper(tostring(wanted):gsub("%s+", "_"))
+  for _, countryName in pairs(country.name) do
+    if tostring(countryName) == normalised then
+      return countryName
+    end
+  end
+  return nil
+end
+
+--- Create a static object in the running mission.
+---
+--- Replaces `mist.dynAddStatic`, and reproduces what its 18 VEAF call sites depend on. Four of those
+--- behaviours are load-bearing and easy to lose in a port, so they are named here:
+---
+---  * **The MiST wrapper form.** `veafSpawnAircraft` passes `{ country, groupName, units = { … } }`
+---    rather than a flat object. The first unit is flattened into the object, as MiST did.
+---  * **The random heading.** An object with no heading gets one at random. Nothing in
+---    `veafSpawnEffects` sets a heading, so defaulting to zero would line every cargo drop up on the
+---    same axis — visible in game, invisible to a test.
+---  * **`mass` forces the Cargos category**, whatever the caller said.
+---  * **`categoryStatic` is an alias for `category`**, which is the spelling `veafGrass` uses
+---    throughout for its FARP furniture.
+---
+--- **Coordinates.** A static's table is the mission-table shape: `x` is the northing and **`y` is the
+--- easting** — `veafSpawnGround.lua` writes `["y"] = spawnPosition.z`. See
+--- `docs/agents/dcs-coordinates.md`. Getting this wrong raises no error, it only misplaces the object.
+---
+--- @param objectData table the static's definition
+--- @return table|false the object as it was submitted, or false when it could not be created
+function veafDcsSpawner.addStatic(objectData)
+  if type(objectData) ~= "table" then
+    veaf.loggers.get(veafDcsSpawner.Id):error("addStatic: no object data")
+    return false
+  end
+  local object = veaf.deepCopy(objectData)
+
+  -- The MiST wrapper form: hoist the single unit's fields onto the object itself.
+  if object.units and object.units[1] then
+    for key, value in pairs(object.units[1]) do
+      object[key] = value
+    end
+  end
+
+  local countryName = resolveCountry(object.countryId or object.country)
+  if not countryName then
+    veaf.loggers.get(veafDcsSpawner.Id):error("addStatic: country not found: %s", veaf.p(object.countryId or object.country))
+    return false
+  end
+
+  if object.clone or not object.groupId then
+    object.groupId = veaf.getNextUnitId()
+  end
+  if object.clone or not object.unitId then
+    object.unitId = veaf.getNextUnitId()
+  end
+
+  object.name = object.name or object.unitName
+  if object.clone or not object.name then
+    object.name = string.format("%s static %s", countryName, veaf.getNextUnitId())
+  end
+
+  if object.dead == nil then
+    object.dead = false
+  end
+
+  if not object.heading then
+    object.heading = math.rad(math.random(360))
+  end
+
+  if object.categoryStatic then
+    object.category = object.categoryStatic
+  end
+  if object.mass then
+    object.category = "Cargos"
+  end
+
+  if object.shapeName then
+    object.shape_name = object.shapeName
+  end
+  if not object.shape_name and object.type then
+    object.shape_name = veafDcsSpawner.SHAPE_NAMES[object.type]
+  end
+
+  if type(object.x) ~= "number" or type(object.y) ~= "number" or type(object.type) ~= "string" then
+    veaf.loggers
+      .get(veafDcsSpawner.Id)
+      :error("addStatic: refusing an object with x=%s y=%s type=%s", veaf.p(object.x), veaf.p(object.y), veaf.p(object.type))
+    return false
+  end
+
+  coalition.addStaticObject(country.id[countryName], object)
+  veaf.loggers.get(veafDcsSpawner.Id):trace("addStatic: created [%s] of type [%s]", veaf.p(object.name), veaf.p(object.type))
+  return object
+end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Framework façades. Callers use `veaf.*` and never name the implementation.
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+veaf.addStatic = veafDcsSpawner.addStatic
+
+function veafDcsSpawner.initialize()
+  veaf.loggers.get(veafDcsSpawner.Id):info("Initializing module")
+end
+
+veaf.loggers.get(veafDcsSpawner.Id):info(veaf.loggers.get(veafDcsSpawner.Id):getVersionInfo())

--- a/src/scripts/veaf/veafGrass.lua
+++ b/src/scripts/veaf/veafGrass.lua
@@ -610,7 +610,7 @@ function veafGrass.buildGrassRunway(grassRunwayUnit, hiddenOnMFD)
   local leftOriginPlot = veaf.deepCopy(template)
   leftOriginPlot.x = leftOrigin.x
   leftOriginPlot.y = leftOrigin.y
-  mist.dynAddStatic(leftOriginPlot)
+  veaf.addStatic(leftOriginPlot)
 
   -- place plots
   for i = 1, nbPlots do
@@ -618,13 +618,13 @@ function veafGrass.buildGrassRunway(grassRunwayUnit, hiddenOnMFD)
     local leftPlot = veaf.deepCopy(template)
     leftPlot.x = runwayOrigin.x + i * space * math.cos(math.rad(angle))
     leftPlot.y = runwayOrigin.y + i * space * math.sin(math.rad(angle))
-    mist.dynAddStatic(leftPlot)
+    veaf.addStatic(leftPlot)
 
     -- right plot
     local rightPlot = veaf.deepCopy(template)
     rightPlot.x = leftOrigin.x + i * space * math.cos(math.rad(angle))
     rightPlot.y = leftOrigin.y + i * space * math.sin(math.rad(angle))
-    mist.dynAddStatic(rightPlot)
+    veaf.addStatic(rightPlot)
   end
 
   if endMarkers then
@@ -644,13 +644,13 @@ function veafGrass.buildGrassRunway(grassRunwayUnit, hiddenOnMFD)
     local leftPlot = veaf.deepCopy(template)
     leftPlot.x = runwayOrigin.x + (nbPlots + 1) * space * math.cos(math.rad(angle))
     leftPlot.y = runwayOrigin.y + (nbPlots + 1) * space * math.sin(math.rad(angle))
-    mist.dynAddStatic(leftPlot)
+    veaf.addStatic(leftPlot)
 
     -- right plot
     local rightPlot = veaf.deepCopy(template)
     rightPlot.x = leftOrigin.x + (nbPlots + 1) * space * math.cos(math.rad(angle))
     rightPlot.y = leftOrigin.y + (nbPlots + 1) * space * math.sin(math.rad(angle))
-    mist.dynAddStatic(rightPlot)
+    veaf.addStatic(rightPlot)
   end
 
   if tower then
@@ -670,7 +670,7 @@ function veafGrass.buildGrassRunway(grassRunwayUnit, hiddenOnMFD)
     local tower = veaf.deepCopy(template)
     tower.x = leftOrigin.x - 60 + (nbPlots + 1.2) * space * math.cos(math.rad(angle))
     tower.y = leftOrigin.y - 60 + (nbPlots + 1.2) * space * math.sin(math.rad(angle))
-    mist.dynAddStatic(tower)
+    veaf.addStatic(tower)
   end
 
   -- add the runway to the named points
@@ -1619,7 +1619,7 @@ function veafGrass.buildFarpUnits(farp, grassRunwayUnits, groupName, hiddenOnMFD
       tent["groupName"] = groupName
     end
 
-    mist.dynAddStatic(tent)
+    veaf.addStatic(tent)
     farpUnitNameCounter = farpUnitNameCounter + 1
   end
 
@@ -1642,7 +1642,7 @@ function veafGrass.buildFarpUnits(farp, grassRunwayUnits, groupName, hiddenOnMFD
     if groupName then
       markerUnit1["groupName"] = groupName
     end
-    mist.dynAddStatic(markerUnit1)
+    veaf.addStatic(markerUnit1)
     farpUnitNameCounter = farpUnitNameCounter + 1
     local markerUnit2 = {
       ["unitName"] = string.format("FARP %s unit #%d", farp.groupName, farpUnitNameCounter),
@@ -1660,7 +1660,7 @@ function veafGrass.buildFarpUnits(farp, grassRunwayUnits, groupName, hiddenOnMFD
     if groupName then
       markerUnit2["groupName"] = groupName
     end
-    mist.dynAddStatic(markerUnit2)
+    veaf.addStatic(markerUnit2)
     farpUnitNameCounter = farpUnitNameCounter + 1
   end
 
@@ -1707,7 +1707,7 @@ function veafGrass.buildFarpUnits(farp, grassRunwayUnits, groupName, hiddenOnMFD
     if groupName then
       otherUnit["groupName"] = groupName
     end
-    mist.dynAddStatic(otherUnit)
+    veaf.addStatic(otherUnit)
     farpUnitNameCounter = farpUnitNameCounter + 1
   end
 
@@ -1776,7 +1776,7 @@ function veafGrass.buildFarpUnits(farp, grassRunwayUnits, groupName, hiddenOnMFD
   if groupName then
     windsockUnit["groupName"] = groupName
   end
-  mist.dynAddStatic(windsockUnit)
+  veaf.addStatic(windsockUnit)
   farpUnitNameCounter = farpUnitNameCounter + 1
 
   -- on FARP unit, place a second windsock, at 90°
@@ -1798,7 +1798,7 @@ function veafGrass.buildFarpUnits(farp, grassRunwayUnits, groupName, hiddenOnMFD
     if groupName then
       windsockUnit["groupName"] = groupName
     end
-    mist.dynAddStatic(windsockUnit)
+    veaf.addStatic(windsockUnit)
     farpUnitNameCounter = farpUnitNameCounter + 1
   end
 

--- a/src/scripts/veaf/veafSpawnAircraft.lua
+++ b/src/scripts/veaf/veafSpawnAircraft.lua
@@ -184,7 +184,7 @@ function veafSpawn.spawnUnit(
   -- actually spawn the unit
   if unit.static or static then --if the unit was forced to spawn as a static it could still be an air or a naval unit so this check goes first
     veaf.loggers.get(veafSpawn.Id):trace("Spawning STATIC")
-    mist.dynAddStatic({ country = country, groupName = groupName, units = units, hiddenOnMFD = hiddenOnMFD })
+    veaf.addStatic({ country = country, groupName = groupName, units = units, hiddenOnMFD = hiddenOnMFD })
     --groupName = nil --statics do not have a group name, you must set groupName to nil to avoid other scripts interacting
   elseif unit.air then
     veaf.loggers.get(veafSpawn.Id):trace("Spawning AIRPLANE")

--- a/src/scripts/veaf/veafSpawnEffects.lua
+++ b/src/scripts/veaf/veafSpawnEffects.lua
@@ -134,7 +134,7 @@ function veafSpawn.doSpawnCargo(spawnSpot, radius, cargoType, country, weightBia
         hiddenOnMFD = hiddenOnMFD,
       }
 
-      mist.dynAddStatic(cargoTable)
+      veaf.addStatic(cargoTable)
 
       -- smoke the cargo if needed
       if cargoSmoke then
@@ -211,7 +211,7 @@ function veafSpawn.doSpawnStatic(spawnSpot, radius, staticCategory, staticType, 
       hiddenOnMFD = hiddenOnMFD,
     }
 
-    mist.dynAddStatic(staticTable)
+    veaf.addStatic(staticTable)
 
     -- smoke if needed
     if smoke then

--- a/src/scripts/veaf/veafSpawnGround.lua
+++ b/src/scripts/veaf/veafSpawnGround.lua
@@ -102,7 +102,7 @@ function veafSpawn.spawnFarp(
     ["unlimitedFuel"] = true,
     ["unlimitedMunitions"] = true,
   }
-  mist.dynAddStatic(_farpStatic)
+  veaf.addStatic(_farpStatic)
   local _spawnedFARP = StaticObject.getByName(name)
   veaf.loggers.get(veafSpawn.Id):trace("_spawnedFARP=%s", veaf.lp(_spawnedFARP))
 
@@ -180,7 +180,7 @@ function veafSpawn.spawnFob(spawnSpot, radius, name, country, fobtype, side, hdg
     heading = math.rad(hdg),
     country = _country,
   }
-  mist.dynAddStatic(_outpost)
+  veaf.addStatic(_outpost)
   local _fob = StaticObject.getByName(_outpost["name"])
 
   local _tower = {
@@ -194,7 +194,7 @@ function veafSpawn.spawnFob(spawnSpot, radius, name, country, fobtype, side, hdg
     heading = math.rad(_hdg),
     country = _country,
   }
-  mist.dynAddStatic(_tower)
+  veaf.addStatic(_tower)
 
   -- add the FOB to the named points
   local _namedPoint = _spawnPosition

--- a/test/lua/dcs_mocks.lua
+++ b/test/lua/dcs_mocks.lua
@@ -12,6 +12,7 @@ dcs_mocks.currentTime = 0
 dcs_mocks.zones = {}
 dcs_mocks.logs = {} -- captured log lines
 dcs_mocks.tasksSet = {} -- captured Controller:setTask calls, as { group = name, task = task }
+dcs_mocks.staticsAdded = {} -- captured coalition.addStaticObject calls, as { countryId, object }
 
 -- Registre des groupes, declare ICI et pas plus bas : `coalition.getGroups` le lit, et un local declare
 -- apres son usage laisse la fermeture capturer la globale — c'est-a-dire nil.
@@ -336,6 +337,12 @@ coalition = {
     return {}
   end,
   addGroup = function(...) end,
+  --- Records what was submitted, rather than discarding it: what a spawner hands DCS *is* the
+  --- behaviour under test, and asserting against a no-op stub asserts nothing.
+  --- Entries are `{ countryId = <id>, object = <the table submitted> }`. Cleared by dcs_mocks.reset().
+  addStaticObject = function(countryId, object)
+    table.insert(dcs_mocks.staticsAdded, { countryId = countryId, object = object })
+  end,
   getCountryCoalition = function(countryId)
     -- Russia (0) → RED, USA (2) → BLUE
     if countryId == 0 then
@@ -754,6 +761,7 @@ function dcs_mocks.reset()
   dcs_mocks.zones = {}
   dcs_mocks.logs = {}
   dcs_mocks.tasksSet = {}
+  dcs_mocks.staticsAdded = {}
   dcs_mocks.messages = {}
   dcs_mocks.cockpitCalls = {}
   dcs_mocks.cockpitArguments = {}

--- a/test/lua/test_veafDcsSpawner.lua
+++ b/test/lua/test_veafDcsSpawner.lua
@@ -1,0 +1,267 @@
+--- Tests for the runtime static spawner — DROP-MIST ticket 07, half (A).
+--
+-- This replaces `mist.dynAddStatic`, the call behind every static VEAF puts into a running mission:
+-- FARP furniture and runway plots (12 of the 18 call sites, all in veafGrass), the FARP itself, an
+-- outpost, a tower, cargo, a `-spawn static`, and a static aircraft.
+--
+-- What is asserted is what reaches `coalition.addStaticObject`, because that is the only thing DCS
+-- ever sees. The mock records the submission rather than discarding it.
+local _base = debug.getinfo(1, "S").source:match("^@(.+)[\\/]") or "."
+luaunit = dofile(_base .. "/luaunit.lua")
+dofile(_base .. "/dcs_mocks.lua")
+local src = _base .. "/../../src/scripts/veaf"
+dofile(src .. "/veaf.lua")
+dofile(src .. "/veafScheduler.lua")
+dofile(src .. "/veafMath.lua")
+dofile(src .. "/veafGeo.lua")
+dofile(src .. "/veafMissionDb.lua")
+dofile(src .. "/veafDcsSpawner.lua")
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+--- The last object submitted to DCS.
+local function submitted()
+  local entries = dcs_mocks.staticsAdded
+  return entries[#entries] and entries[#entries].object
+end
+
+local function countrySubmitted()
+  local entries = dcs_mocks.staticsAdded
+  return entries[#entries] and entries[#entries].countryId
+end
+
+--- Sentinel meaning "remove this field", since `{ name = nil }` creates no key at all and `pairs`
+--- would never see it — the default would quietly survive and the test would assert nothing.
+local NONE = {}
+
+--- A minimal valid static: mission-table shape, x northing and y easting.
+local function _static(overrides)
+  local object = { type = "outpost", country = "USA", x = 1000, y = 2000, name = "thing" }
+  for key, value in pairs(overrides or {}) do
+    if value == NONE then
+      object[key] = nil
+    else
+      object[key] = value
+    end
+  end
+  return object
+end
+
+-- ---------------------------------------------------------------------------
+-- TestVeafDcsSpawnerAddStatic
+-- ---------------------------------------------------------------------------
+TestVeafDcsSpawnerAddStatic = {}
+
+function TestVeafDcsSpawnerAddStatic:setUp()
+  dcs_mocks.reset()
+end
+
+function TestVeafDcsSpawnerAddStatic:test_a_valid_static_reaches_dcs()
+  local result = veafDcsSpawner.addStatic(_static())
+
+  luaunit.assertNotNil(result)
+  luaunit.assertEquals(#dcs_mocks.staticsAdded, 1)
+  luaunit.assertEquals(submitted().type, "outpost")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_the_coordinates_are_passed_through_untouched()
+  -- x is the northing, y the **easting** — the mission-table shape. veafSpawnGround writes
+  -- `["y"] = spawnPosition.z` on purpose, and a port that "fixes" it moves every static.
+  veafDcsSpawner.addStatic(_static({ x = 12345, y = -6789 }))
+
+  luaunit.assertEquals(submitted().x, 12345)
+  luaunit.assertEquals(submitted().y, -6789)
+  luaunit.assertNil(submitted().z, "a static's table has no z")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_the_country_is_resolved_to_its_id()
+  veafDcsSpawner.addStatic(_static({ country = "USA" }))
+
+  luaunit.assertEquals(countrySubmitted(), country.id.USA)
+end
+
+function TestVeafDcsSpawnerAddStatic:test_a_country_id_is_accepted_as_well_as_a_name()
+  veafDcsSpawner.addStatic(_static({ country = NONE, countryId = country.id.RUSSIA }))
+
+  luaunit.assertEquals(countrySubmitted(), country.id.RUSSIA)
+end
+
+function TestVeafDcsSpawnerAddStatic:test_a_country_name_is_matched_case_insensitively()
+  veafDcsSpawner.addStatic(_static({ country = "usa" }))
+
+  luaunit.assertEquals(countrySubmitted(), country.id.USA)
+end
+
+function TestVeafDcsSpawnerAddStatic:test_an_unknown_country_creates_nothing()
+  -- Loud, not silent: an object with no country cannot belong to anyone.
+  luaunit.assertFalse(veafDcsSpawner.addStatic(_static({ country = "Atlantis" })))
+  luaunit.assertEquals(#dcs_mocks.staticsAdded, 0)
+end
+
+function TestVeafDcsSpawnerAddStatic:test_a_static_without_coordinates_creates_nothing()
+  luaunit.assertFalse(veafDcsSpawner.addStatic(_static({ x = NONE })))
+  luaunit.assertFalse(veafDcsSpawner.addStatic(_static({ y = "over there" })))
+  luaunit.assertEquals(#dcs_mocks.staticsAdded, 0)
+end
+
+function TestVeafDcsSpawnerAddStatic:test_a_static_without_a_type_creates_nothing()
+  luaunit.assertFalse(veafDcsSpawner.addStatic(_static({ type = NONE })))
+  luaunit.assertEquals(#dcs_mocks.staticsAdded, 0)
+end
+
+function TestVeafDcsSpawnerAddStatic:test_the_caller_table_is_not_mutated()
+  -- The caller keeps its own table: veafGrass reuses a template across several plots.
+  local original = _static({ heading = NONE })
+
+  veafDcsSpawner.addStatic(original)
+
+  luaunit.assertNil(original.heading, "the caller's table must not gain a heading")
+  luaunit.assertNil(original.unitId, "nor an id")
+end
+
+-- ---------------------------------------------------------------------------
+-- The four behaviours the port had to preserve deliberately
+-- ---------------------------------------------------------------------------
+
+function TestVeafDcsSpawnerAddStatic:test_the_mist_wrapper_form_is_flattened()
+  -- veafSpawnAircraft:187 is the only site passing { country, groupName, units = { … } }.
+  veafDcsSpawner.addStatic({
+    country = "USA",
+    groupName = "static flight",
+    units = { [1] = { type = "outpost", x = 500, y = 600, name = "the unit" } },
+  })
+
+  luaunit.assertEquals(#dcs_mocks.staticsAdded, 1, "the wrapper form must still create the object")
+  luaunit.assertEquals(submitted().type, "outpost")
+  luaunit.assertEquals(submitted().x, 500)
+  luaunit.assertEquals(submitted().name, "the unit")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_a_static_with_no_heading_gets_a_random_one()
+  -- Nothing in veafSpawnEffects sets a heading. Defaulting to zero would line every cargo drop up on
+  -- the same axis — visible in game, invisible to a test that only checks the object exists.
+  dcs_mocks.setRandomSequence({ 0.5 })
+
+  veafDcsSpawner.addStatic(_static({ heading = NONE }))
+
+  luaunit.assertNotNil(submitted().heading)
+  luaunit.assertTrue(submitted().heading > 0, "a drawn heading, not zero")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_a_heading_that_was_given_is_kept()
+  veafDcsSpawner.addStatic(_static({ heading = 1.25 }))
+
+  luaunit.assertEquals(submitted().heading, 1.25)
+end
+
+function TestVeafDcsSpawnerAddStatic:test_mass_forces_the_cargo_category()
+  veafDcsSpawner.addStatic(_static({ category = "Fortifications", mass = 500 }))
+
+  luaunit.assertEquals(submitted().category, "Cargos", "mass overrides whatever the caller said")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_categoryStatic_is_an_alias_for_category()
+  -- The spelling veafGrass uses throughout for its FARP furniture.
+  veafDcsSpawner.addStatic(_static({ categoryStatic = "Fortifications" }))
+
+  luaunit.assertEquals(submitted().category, "Fortifications")
+end
+
+-- ---------------------------------------------------------------------------
+-- Shapes
+-- ---------------------------------------------------------------------------
+
+function TestVeafDcsSpawnerAddStatic:test_a_shape_given_explicitly_is_kept()
+  -- The FARP, the windsock and the runway cones all pass their own shape.
+  veafDcsSpawner.addStatic(_static({ shape_name = "invisiblefarp" }))
+
+  luaunit.assertEquals(submitted().shape_name, "invisiblefarp")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_shapeName_is_an_alias_for_shape_name()
+  veafDcsSpawner.addStatic(_static({ shapeName = "H-Windsock_RW" }))
+
+  luaunit.assertEquals(submitted().shape_name, "H-Windsock_RW")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_a_known_type_gets_its_shape_from_the_table()
+  -- The reason the 124-entry table is ported at all: `-spawn static, Cafe` supplies no shape, and 93
+  -- of the catalogue's types need one.
+  veafDcsSpawner.addStatic(_static({ type = "Cafe" }))
+
+  luaunit.assertEquals(submitted().shape_name, "stolovaya")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_an_unknown_type_is_submitted_without_a_shape()
+  -- "outpost" is not in the table, and MiST submitted it anyway.
+  veafDcsSpawner.addStatic(_static({ type = "outpost" }))
+
+  luaunit.assertEquals(#dcs_mocks.staticsAdded, 1)
+  luaunit.assertNil(submitted().shape_name)
+end
+
+function TestVeafDcsSpawnerAddStatic:test_the_shape_table_carries_the_whole_mist_set()
+  local count = 0
+  for _ in pairs(veafDcsSpawner.SHAPE_NAMES) do
+    count = count + 1
+  end
+
+  luaunit.assertEquals(count, 124, "the table is ported verbatim, not filtered")
+  luaunit.assertEquals(veafDcsSpawner.SHAPE_NAMES["FARP"], "farps")
+end
+
+-- ---------------------------------------------------------------------------
+-- Identity
+-- ---------------------------------------------------------------------------
+
+function TestVeafDcsSpawnerAddStatic:test_ids_are_allocated_when_absent()
+  veafDcsSpawner.addStatic(_static())
+
+  luaunit.assertNotNil(submitted().unitId)
+  luaunit.assertNotNil(submitted().groupId)
+  luaunit.assertTrue(submitted().unitId >= veafMissionDb.FIRST_UNIT_ID, "ids come from VEAF's own allocator")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_an_id_that_was_given_is_kept()
+  veafDcsSpawner.addStatic(_static({ unitId = 4242, groupId = 77 }))
+
+  luaunit.assertEquals(submitted().unitId, 4242)
+  luaunit.assertEquals(submitted().groupId, 77)
+end
+
+function TestVeafDcsSpawnerAddStatic:test_two_statics_never_share_a_unit_id()
+  veafDcsSpawner.addStatic(_static({ name = "one" }))
+  veafDcsSpawner.addStatic(_static({ name = "two" }))
+
+  luaunit.assertNotEquals(dcs_mocks.staticsAdded[1].object.unitId, dcs_mocks.staticsAdded[2].object.unitId)
+end
+
+function TestVeafDcsSpawnerAddStatic:test_a_nameless_static_is_named_after_its_country()
+  veafDcsSpawner.addStatic(_static({ name = NONE }))
+
+  luaunit.assertNotNil(submitted().name)
+  luaunit.assertStrContains(submitted().name, "USA")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_unitName_serves_as_the_name()
+  veafDcsSpawner.addStatic(_static({ name = NONE, unitName = "windsock 3" }))
+
+  luaunit.assertEquals(submitted().name, "windsock 3")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_dead_defaults_to_false_and_is_not_overwritten()
+  veafDcsSpawner.addStatic(_static())
+  luaunit.assertEquals(submitted().dead, false)
+
+  veafDcsSpawner.addStatic(_static({ dead = true }))
+  luaunit.assertEquals(submitted().dead, true, "a caller asking for a wreck must get one")
+end
+
+function TestVeafDcsSpawnerAddStatic:test_nothing_at_all_is_survivable()
+  luaunit.assertFalse(veafDcsSpawner.addStatic(nil))
+  luaunit.assertEquals(#dcs_mocks.staticsAdded, 0)
+end
+
+os.exit(luaunit.LuaUnit.run())

--- a/test/lua/test_veafGrass.lua
+++ b/test/lua/test_veafGrass.lua
@@ -8,6 +8,7 @@ dofile(src .. "/veafScheduler.lua")
 dofile(src .. "/veafMath.lua")
 dofile(src .. "/veafGeo.lua")
 dofile(src .. "/veafMissionDb.lua")
+dofile(src .. "/veafDcsSpawner.lua")
 dofile(src .. "/veafGrass.lua")
 
 -- ---------------------------------------------------------------------------

--- a/test/lua/test_veafSpawn.lua
+++ b/test/lua/test_veafSpawn.lua
@@ -8,6 +8,7 @@ dofile(src .. "/veafScheduler.lua")
 dofile(src .. "/veafMath.lua")
 dofile(src .. "/veafGeo.lua")
 dofile(src .. "/veafMissionDb.lua")
+dofile(src .. "/veafDcsSpawner.lua")
 -- The catalog, not just the runtime: FEAT-CONVOY-WAYPOINTS asserts on the *messages* a convoy command
 -- gives the player, and `veaf.t` hands back the bare key when the catalog was never loaded.
 dofile(src .. "/veafI18n.lua")
@@ -1095,13 +1096,13 @@ TestVeafSpawnGroundExactPlacement = {}
 function TestVeafSpawnGroundExactPlacement:setUp()
   dcs_mocks.reset()
   veaf.DO_NOT_EXPORT_JSON_FILES = true
-  self._savedDynAddStatic = mist.dynAddStatic
+  self._savedDynAddStatic = veaf.addStatic
   self._savedFindSpawnPoint = veaf.findSpawnPoint
   self._savedGetRandPoint = veaf.getRandomPointInCircle
   -- A static's mission-table position: x is the northing, y the easting. The runtime vec3 that
   -- built it had the easting in z — see docs/agents/dcs-coordinates.md.
   self.statics = {}
-  mist.dynAddStatic = function(template)
+  veaf.addStatic = function(template)
     table.insert(self.statics, { x = template.x, y = template.y })
     return self._savedDynAddStatic(template)
   end
@@ -1113,7 +1114,7 @@ function TestVeafSpawnGroundExactPlacement:setUp()
 end
 
 function TestVeafSpawnGroundExactPlacement:tearDown()
-  mist.dynAddStatic = self._savedDynAddStatic
+  veaf.addStatic = self._savedDynAddStatic
   veaf.findSpawnPoint = self._savedFindSpawnPoint
   veaf.getRandomPointInCircle = self._savedGetRandPoint
   dcs_mocks.reset()
@@ -1652,21 +1653,21 @@ function TestSecrev2CargoMass:setUp()
   dcs_mocks.reset()
   veaf.DO_NOT_EXPORT_JSON_FILES = true
   self._savedFind = veafUnits.findDcsUnit
-  self._savedDynAddStatic = mist.dynAddStatic
+  self._savedDynAddStatic = veaf.addStatic
   -- A descriptor with the bounds the wrong way round: the branch the finding is about.
   self.shared = { type = "veaf_test_cargo", name = "VEAF test cargo", desc = { minMass = 100, maxMass = 50 } }
   veafUnits.findDcsUnit = function(name)
     return self.shared
   end
   self.spawned = {}
-  mist.dynAddStatic = function(template)
+  veaf.addStatic = function(template)
     table.insert(self.spawned, template)
   end
 end
 
 function TestSecrev2CargoMass:tearDown()
   veafUnits.findDcsUnit = self._savedFind
-  mist.dynAddStatic = self._savedDynAddStatic
+  veaf.addStatic = self._savedDynAddStatic
 end
 
 function TestSecrev2CargoMass:test_the_shared_descriptor_is_left_untouched()

--- a/veaf_build/worker.py
+++ b/veaf_build/worker.py
@@ -100,6 +100,7 @@ LUA_BUNDLE_SCRIPTS: list[str] = [
     "veafMath.lua",
     "veafGeo.lua",
     "veafMissionDb.lua",
+    "veafDcsSpawner.lua",
     "veafI18n.lua",
     "dcsUnits.lua",
     "veafCacheManager.lua",


### PR DESCRIPTION
DROP-MIST **ticket 07, half (A)** — all 18 `mist.dynAddStatic` call sites.

That is every static VEAF puts into a running mission: FARP furniture and runway plots (12 of the 18, all in `veafGrass`), the FARP itself, an outpost, a tower, cargo, a `-spawn static`, and a static aircraft.

## Why a new module, and why that name

`veafSpawn*` is the family that reads a mission maker's command. **`veafDcsSpawner` is what finally asks DCS for an object** — `coalition.addStaticObject` today, `coalition.addGroup` when half (B) lands. Keeping the two apart is deliberate: naming it `veafSpawnSomething` is how `veafSpawnEffects` ended up holding five functions that are not effects (see `CHORE-RENAME-SPAWN-EFFECTS`, opened today for exactly that).

## Four behaviours that were easy to lose, each with a test proven to fail without it

| Behaviour | Why it matters |
|---|---|
| **Random heading** when none is given | Nothing in `veafSpawnEffects` sets a heading. Defaulting to zero would line **every cargo drop up on the same axis** — visible in game, invisible to a test that only checks the object exists |
| **The MiST wrapper form** `{ country, groupName, units = {…} }` | `veafSpawnAircraft:187` is the only site that uses it |
| **`mass` forces the `Cargos` category** | A no-op at our only site today, but a rule that has to be ported on purpose rather than discovered later |
| **`categoryStatic` aliases `category`** | The spelling `veafGrass` uses throughout for its FARP furniture |

Two of them were confirmed red by breaking the implementation (heading → 0, `mass` branch disabled).

## The shape table

Ported **verbatim**, 124 entries, not filtered. The number that justifies it: **93 of its keys are types VEAF's own 873-unit catalogue can resolve**, so a mission maker reaches them through `-spawn static` — `.Ammunition depot`, `Barracks 2`, `Cafe`, `Boiler-house A`… A filtered copy would go stale the day the catalogue grows. Objects that carry their own shape (the FARP, the windsock, the runway cones) never touch it.

## Coordinates

Passed through untouched, and asserted: `x` is the northing and **`y` the easting** — the mission-table shape `veafSpawnGround` writes on purpose (`["y"] = spawnPosition.z`). A port that "fixed" that would move every static in every mission, with no error anywhere.

## What the tests found on the way

Two suites captured statics by overriding `mist.dynAddStatic`; they now drive `veaf.addStatic`. And my own test helper had the classic Lua trap — `{ name = nil }` creates no key, so `pairs` never sees it and the default survives. Four tests were passing against a value they thought they had removed; a `NONE` sentinel fixes it.

## Checks

- Lua suite: **44 suites**, green — 26 new tests
- Python suite: **3921 passed**, so `test_lua_bundle_manifest` accepts the new module in the bundle order
- `stylua --check` clean, `docs-check` clean
- `.luacheckrc` global added; `luacheck` itself left to the CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace MiST static-object creation with a dedicated VEAF DCS spawner while preserving runtime behavior and validating the migration with comprehensive tests.

Enhancements:
- Add a dedicated VEAF DCS spawner for creating runtime static objects independently of MiST.
- Migrate all 18 VEAF static-object creation paths to the new spawner façade while preserving existing spawning behavior, identity handling, coordinates, categories, headings, and shape resolution.

Build:
- Include the new spawner module in the published script bundle.

Documentation:
- Document the new runtime static-spawner test suite in the testing guides.
- Record the removal of MiST from VEAF static-object creation in the changelog.

Tests:
- Add comprehensive coverage for static creation, including country resolution, coordinates, wrapper inputs, defaults, identity allocation, categories, headings, and shape handling.
- Update existing static-spawn tests and mocks to validate submissions through the VEAF façade and DCS static-object API.

Chores:
- Register the new spawner global for static analysis and update the DROP-MIST ticket progress.