### PR TITLE
refactor(spawner): VEAF creates its own groups, without MiST

### DIFF
--- a/.backlog/DROP-MIST/tickets/07-spawn-routes-and-teleport.md
+++ b/.backlog/DROP-MIST/tickets/07-spawn-routes-and-teleport.md
@@ -325,7 +325,8 @@ the exact place where `FIX-AIRWAVES-COMMAND-EASTING` slipped in.
 
 #### Order of work
 
-1. `veafDcsSpawner.addGroup` — the `dynAdd` port, the engine everything else sits on.
+1. ~~`veafDcsSpawner.addGroup`~~ — **shipped 2026-08-28**, and it refuses an unknown category rather
+   than submitting an unclassifiable group.
 2. ~~`veaf.getGroupRoute` / `veaf.goRoute`~~ — **shipped 2026-08-28**, and the mission snapshot gained
    the route and the payload by reference to serve them.
 3. `VeafGroupSpawn` over both, replacing `teleportToPoint`.
@@ -360,8 +361,8 @@ Unit tests cannot see whether a group actually appeared at the right place in DC
       — done 2026-08-28; it re-counted the slice at **64 real calls, not 80**
 - [ ] Ported into a dedicated module behind `veaf.*` façades; `dynAdd` first, then `teleportToPoint` as
       route arithmetic over it — **`veafDcsSpawner.lua` created**, `veaf.addStatic` shipped
-- [ ] 64 call sites migrated — **35 done**: all of `dynAddStatic` (18), `getGroupRoute` (8) and
-      `goRoute` (9)
+- [ ] 64 call sites migrated — **48 done**: `dynAddStatic` (18), `getGroupRoute` (8), `goRoute` (9)
+      and `dynAdd` (13). Left: `teleportToPoint` (12), `getGroupData` (3), `respawnGroup` (2)
 - [ ] Lua tests covering every branch in the enumeration table, including a group category we spawn but
       MiST handled specially
 - [ ] Position asserted against known coordinates, with the convention named in a comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,16 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and group on each call. And one dead guard went with it: a combat zone used to check whether MiST was
   loaded at all before reading a route, which a bundled function makes moot.
 
+- **VEAF creates its own groups**, the last big piece MiST held: every aircraft, ship and ground group
+  a VEAF command spawns now goes through `veafDcsSpawner` rather than `mist.dynAdd`. Behaviour is
+  unchanged, defaults included — the cruise speed and altitude an aircraft gets when the caller sets
+  none, the `Random` skill, the empty route without which DCS sends a new aircraft straight home.
+
+  **One thing it no longer does silently.** MiST accepted an unknown group category, left the type
+  empty and submitted the group anyway; a misspelling produced something DCS could not classify and
+  nobody was told. That is now refused, with the category named in the log. The spellings that *are*
+  accepted are unchanged, `PLANE` and `AIRPLANE` alike — VEAF uses both, for the same thing.
+
 ## [6.17.0] — 2026-08-26
 
 **Released.** This version consolidates the ten patch versions from **6.16.1 to 6.16.10**, whose detailed

--- a/src/scripts/veaf/veafCasMission.lua
+++ b/src/scripts/veaf/veafCasMission.lua
@@ -1036,7 +1036,7 @@ function veafCasMission.generateCasMission(spawnSpot, size, defense, armor, spac
   end
 
   -- actually spawn groups
-  mist.dynAdd({ country = country, category = "GROUND_UNIT", name = veafCasMission.casGroupName, hidden = false, units = dcsUnits })
+  veaf.addGroup({ country = country, category = "GROUND_UNIT", name = veafCasMission.casGroupName, hidden = false, units = dcsUnits })
 
   -- set AI options
   local controller = Group.getByName(veafCasMission.casGroupName):getController()

--- a/src/scripts/veaf/veafCombatMission.lua
+++ b/src/scripts/veaf/veafCombatMission.lua
@@ -921,7 +921,7 @@ function VeafCombatMission:activate(silent)
             end
           end
           veaf.loggers.get(veafCombatMission.Id):trace(string.format("_group=%s", veaf.p(_group)))
-          local _spawnedGroup = mist.dynAdd(_group)
+          local _spawnedGroup = veaf.addGroup(_group)
           if _spawnedGroup then
             veaf.loggers.get(veafCombatMission.Id):trace(string.format("_spawnedGroup.name=%s", veaf.p(_spawnedGroup.name)))
             local _dcsSpawnedGroup = Group.getByName(_spawnedGroup.name)

--- a/src/scripts/veaf/veafDcsSpawner.lua
+++ b/src/scripts/veaf/veafDcsSpawner.lua
@@ -361,11 +361,181 @@ function veafDcsSpawner.goRoute(groupOrName, route)
   return true
 end
 
+--- Category names DCS accepts for a group, and the spellings VEAF actually passes.
+---
+--- MiST tolerated four aliases and our call sites use two of them: `veafSpawnAircraft` passes `"PLANE"`
+--- where `veafSpawnCore` passes `"AIRPLANE"`, for the same thing. A port accepting only the canonical
+--- spelling would break the first one **silently**, because an unresolved category leaves the group
+--- type nil and the group is submitted anyway.
+veafDcsSpawner.GROUP_CATEGORIES = {
+  GROUND_UNIT = "GROUND_UNIT",
+  VEHICLE = "GROUND_UNIT",
+  GROUND = "GROUND_UNIT",
+  AIRPLANE = "AIRPLANE",
+  PLANE = "AIRPLANE",
+  HELICOPTER = "HELICOPTER",
+  SHIP = "SHIP",
+  BUILDING = "BUILDING",
+}
+
+--- Default cruise settings per aircraft category, applied to a unit that carries none.
+--- MiST's numbers, kept as they are: a spawned aircraft that suddenly cruises at a different speed or
+--- altitude is a behaviour change a mission maker would notice before any test would.
+veafDcsSpawner.AIRCRAFT_DEFAULTS = {
+  AIRPLANE = { speed = 150, alt = 2000 },
+  HELICOPTER = { speed = 60, alt = 500 },
+}
+
+--- Resolve a group category name or id to the spelling DCS wants.
+--- @param wanted string|number
+--- @return string|nil
+local function resolveCategory(wanted)
+  if type(wanted) == "number" then
+    for name, id in pairs(Unit.Category) do
+      if id == wanted then
+        return veafDcsSpawner.GROUP_CATEGORIES[name]
+      end
+    end
+    return nil
+  end
+  if type(wanted) ~= "string" then
+    return nil
+  end
+  return veafDcsSpawner.GROUP_CATEGORIES[string.upper(wanted)]
+end
+
+--- Create a group in the running mission.
+---
+--- Replaces `mist.dynAdd`. What it fills in for a caller who left it out is behaviour, not tidying, so
+--- each default is reproduced deliberately:
+---
+---  * a **group id** and a **unit id** per unit, from VEAF's own allocator;
+---  * a **group name**, and a unit name per unit built from it (`"<group> unit<N>"`);
+---  * `skill` = `"Random"`;
+---  * for aircraft only: `alt_type` = `RADIO`, and the cruise speed and altitude above — plus the
+---    **payload read from the mission**, which is why the snapshot carries it: `veafSpawnCore` builds
+---    `AIRPLANE` groups with no payload field at all;
+---  * for ground units: `playerCanDrive` = true;
+---  * an empty route for an aircraft that has none, or DCS sends it straight home.
+---
+--- **Coordinates.** A unit's table is the mission-table shape: `x` northing, `y` easting. See
+--- `docs/agents/dcs-coordinates.md`.
+---
+--- @param groupData table the group definition
+--- @return table|false the group as submitted, or false when it could not be created
+function veafDcsSpawner.addGroup(groupData)
+  if type(groupData) ~= "table" then
+    veaf.loggers.get(veafDcsSpawner.Id):error("addGroup: no group data")
+    return false
+  end
+  local group = veaf.deepCopy(groupData)
+
+  local countryName = resolveCountry(group.countryId or group.country)
+  if not countryName then
+    veaf.loggers.get(veafDcsSpawner.Id):error("addGroup: country not found: %s", veaf.p(group.countryId or group.country))
+    return false
+  end
+
+  local category = resolveCategory(group.category)
+  if not category then
+    -- Loud, where MiST was silent: it left the type nil and submitted the group anyway, so a misspelled
+    -- category produced a group DCS could not classify and nobody was told.
+    veaf.loggers.get(veafDcsSpawner.Id):error("addGroup: unknown category: %s", veaf.p(group.category))
+    return false
+  end
+
+  if type(group.units) ~= "table" or not group.units[1] then
+    veaf.loggers.get(veafDcsSpawner.Id):error("addGroup: a group needs at least one unit")
+    return false
+  end
+
+  group.groupId = group.groupId or veaf.getNextUnitId()
+  group.name = group.groupName or group.name
+  if not group.name then
+    group.name = string.format("%s %s %s", countryName, string.lower(category), group.groupId)
+  end
+
+  if group.hidden == nil then
+    group.hidden = false
+  end
+  if group.visible == nil then
+    group.visible = false
+  end
+  if type(group.start_time) ~= "number" then
+    group.start_time = group.startTime and veaf.round(group.startTime, 0) or 0
+  end
+
+  for index, unit in ipairs(group.units) do
+    unit.unitId = unit.unitId or veaf.getNextUnitId()
+    unit.name = unit.unitName or unit.name or string.format("%s unit%d", group.name, index)
+    unit.skill = unit.skill or "Random"
+
+    if category == "AIRPLANE" or category == "HELICOPTER" then
+      local defaults = veafDcsSpawner.AIRCRAFT_DEFAULTS[category]
+      if unit.alt_type ~= "BARO" then
+        unit.alt_type = "RADIO"
+      end
+      unit.speed = unit.speed or defaults.speed
+      if not unit.alt then
+        unit.alt = defaults.alt
+        unit.alt_type = "RADIO"
+        unit.speed = defaults.speed
+      end
+      if not unit.payload then
+        -- The loadout of the editor unit this one is modelled on. Held by reference in the snapshot,
+        -- exactly as MiST's getPayload returned it.
+        local record = veafMissionDb.getUnitRecord(unit.unitName or unit.name)
+        unit.payload = record and record.payload or nil
+      end
+    elseif category == "GROUND_UNIT" then
+      if unit.playerCanDrive == nil then
+        unit.playerCanDrive = true
+      end
+    end
+  end
+
+  -- A route given as a bare list of points is wrapped; an aircraft with no route at all gets an empty
+  -- one, without which DCS sends it home the moment it spawns.
+  if group.route and not group.route.points and group.route[1] then
+    group.route = { points = group.route }
+  elseif not group.route and (category == "AIRPLANE" or category == "HELICOPTER") then
+    group.route = { points = { {} } }
+  end
+
+  -- Tasks that name the group or its first unit have to point at the ids just allocated.
+  if group.route and group.route.points then
+    for _, point in pairs(group.route.points) do
+      local tasks = point.task and point.task.params and point.task.params.tasks
+      for _, task in pairs(tasks or {}) do
+        local action = task.params and task.params.action
+        if action and action.id == "EPLRS" then
+          action.params.groupId = group.groupId
+        elseif action and (action.id == "ActivateBeacon" or action.id == "ActivateICLS") then
+          action.params.unitId = group.units[1].unitId
+        end
+      end
+    end
+  end
+
+  -- DCS reads the country and category from the call, not from the table, and chokes on VEAF's own
+  -- bookkeeping fields.
+  group.groupName, group.category, group.country, group.countryId, group.startTime = nil, nil, nil, nil, nil
+  group.tasks = {}
+  for _, unit in ipairs(group.units) do
+    unit.unitName = nil
+  end
+
+  coalition.addGroup(country.id[countryName], Unit.Category[category], group)
+  veaf.loggers.get(veafDcsSpawner.Id):trace("addGroup: created [%s] with %d unit(s)", veaf.p(group.name), #group.units)
+  return group
+end
+
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Framework façades. Callers use `veaf.*` and never name the implementation.
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 veaf.addStatic = veafDcsSpawner.addStatic
+veaf.addGroup = veafDcsSpawner.addGroup
 veaf.getGroupRoute = veafDcsSpawner.getGroupRoute
 veaf.goRoute = veafDcsSpawner.goRoute
 

--- a/src/scripts/veaf/veafGrass.lua
+++ b/src/scripts/veaf/veafGrass.lua
@@ -1471,14 +1471,14 @@ end
 -- nothing CTLD about it — and CTLD 2 keeps its equivalent private, rightly so.
 --
 -- @param point vec3 : where to put it
--- @param country : the FARP's country (name or id, as mist.dynAdd accepts)
+-- @param country : the FARP's country (name or id, as veaf.addGroup accepts)
 -- @param displayName string : shown in the unit name, so a pilot reading the F10 map
 --                             sees the channel
 -- @return Group or nil
 ------------------------------------------------------------------------------
 function veafGrass.spawnTacanCarrierUnit(point, country, displayName)
   local groupName = string.format("VEAF TACAN carrier - %s", displayName)
-  local spawned = mist.dynAdd({
+  local spawned = veaf.addGroup({
     country = country,
     category = "GROUND_UNIT",
     groupName = groupName,
@@ -1887,7 +1887,7 @@ function veafGrass.buildFarpUnits(farp, grassRunwayUnits, groupName, hiddenOnMFD
     farpUnitNameCounter = farpUnitNameCounter + 1
   end
 
-  mist.dynAdd(farpEscortGroup)
+  veaf.addGroup(farpEscortGroup)
 
   -- add the FARP to the named points
   local farpNamedPoint = {

--- a/src/scripts/veaf/veafMissionDb.lua
+++ b/src/scripts/veaf/veafMissionDb.lua
@@ -377,11 +377,12 @@ end
 --- This replaces `veafSpawnAircraft`'s hand-deletion of `mist.DBs.unitsByName[x]` and
 --- `groupsByName[x]`, which existed so a dead AFAC's callsign could be reused.
 ---
---- **It still performs that deletion**, and has to, until ticket 07: the code that refuses a name it
---- has seen before is `mist.dynAdd`, and it reads MiST's tables, not ours. Freeing the name here
---- without freeing it there would leave the AFAC unable to respawn under its own callsign — a
---- regression a pilot would notice, traded for a grep that is one line cleaner. The two lines go when
---- ticket 08 drops the injection, and this comment goes with them.
+--- **It still performs that deletion.** Ticket 07 ported `dynAdd`, and the port reaches no
+--- name-uniqueness test at all: `clone` is never passed to it directly — every VEAF `clone` goes
+--- through the teleport path, which is still MiST's. So MiST is still the thing that would refuse a
+--- name it has seen, and freeing the name here without freeing it there would leave the AFAC unable to
+--- respawn under its own callsign. The two lines go with the teleport port, and this comment with
+--- them.
 ---
 --- @param name string
 --- @return boolean true when the name was released somewhere

--- a/src/scripts/veaf/veafSpawnAircraft.lua
+++ b/src/scripts/veaf/veafSpawnAircraft.lua
@@ -188,13 +188,13 @@ function veafSpawn.spawnUnit(
     --groupName = nil --statics do not have a group name, you must set groupName to nil to avoid other scripts interacting
   elseif unit.air then
     veaf.loggers.get(veafSpawn.Id):trace("Spawning AIRPLANE")
-    mist.dynAdd({ country = country, category = "PLANE", groupName = groupName, units = units, hiddenOnMFD = hiddenOnMFD })
+    veaf.addGroup({ country = country, category = "PLANE", groupName = groupName, units = units, hiddenOnMFD = hiddenOnMFD })
   elseif unit.naval then
     veaf.loggers.get(veafSpawn.Id):trace("Spawning SHIP")
-    mist.dynAdd({ country = country, category = "SHIP", groupName = groupName, units = units, hiddenOnMFD = hiddenOnMFD })
+    veaf.addGroup({ country = country, category = "SHIP", groupName = groupName, units = units, hiddenOnMFD = hiddenOnMFD })
   else
     veaf.loggers.get(veafSpawn.Id):trace("Spawning GROUND_UNIT")
-    mist.dynAdd({ country = country, category = "GROUND_UNIT", groupName = groupName, units = units, hiddenOnMFD = hiddenOnMFD })
+    veaf.addGroup({ country = country, category = "GROUND_UNIT", groupName = groupName, units = units, hiddenOnMFD = hiddenOnMFD })
   end
 
   if role == "jtac" and not static then
@@ -678,7 +678,7 @@ function veafSpawn.spawnAFAC(spawnSpot, name, country, altitude, speed, hdg, fre
   unit.alt = teleportSpot.alt
 
   veaf.loggers.get(veafSpawn.Id):trace("newGroup=%s", veaf.lp(newGroup, nil, { "route", "payload" }))
-  local _spawnedGroup = mist.dynAdd(newGroup)
+  local _spawnedGroup = veaf.addGroup(newGroup)
 
   if _spawnedGroup then
     veaf.loggers.get(veafSpawn.Id):trace("_spawnedGroup=%s", veaf.lp(_spawnedGroup, nil, { "route", "payload" }))
@@ -1160,14 +1160,14 @@ function veafSpawn.spawnCombatAirPatrol(
     veaf.loggers.get(veafSpawn.Id):debug("indexed spawnedUnitName=%s", spawnedUnitName)
   end
 
-  veaf.loggers.get(veafSpawn.Id):trace("before mist.dynAdd, newGroup=%s", veaf.lp(newGroup, nil, { "route", "payload" }))
-  local _spawnedGroup = mist.dynAdd(newGroup)
+  veaf.loggers.get(veafSpawn.Id):trace("before addGroup, newGroup=%s", veaf.lp(newGroup, nil, { "route", "payload" }))
+  local _spawnedGroup = veaf.addGroup(newGroup)
   if not _spawnedGroup then
     veaf.loggers.get(veafSpawn.Id):error("cannot spawn group %s", veaf.p(newGroup.name))
     return nil
   end
-  veaf.loggers.get(veafSpawn.Id):debug("after mist.dynAdd, _spawnedGroup.name=%s", _spawnedGroup.name)
-  veaf.loggers.get(veafSpawn.Id):trace("after mist.dynAdd, _spawnedGroup=%s", veaf.lp(_spawnedGroup, nil, { "route", "payload" }))
+  veaf.loggers.get(veafSpawn.Id):debug("after addGroup, _spawnedGroup.name=%s", _spawnedGroup.name)
+  veaf.loggers.get(veafSpawn.Id):trace("after addGroup, _spawnedGroup=%s", veaf.lp(_spawnedGroup, nil, { "route", "payload" }))
 
   local _dcsSpawnedGroup = Group.getByName(_spawnedGroup.name)
   veaf.loggers

--- a/src/scripts/veaf/veafSpawnCore.lua
+++ b/src/scripts/veaf/veafSpawnCore.lua
@@ -789,11 +789,18 @@ function veafSpawn.doSpawnGroup(
 
   -- actually spawn the group
   if group.naval then
-    mist.dynAdd({ country = country, category = "SHIP", name = groupName, hidden = false, units = units, hiddenOnMFD = hiddenOnMFD })
+    veaf.addGroup({ country = country, category = "SHIP", name = groupName, hidden = false, units = units, hiddenOnMFD = hiddenOnMFD })
   elseif group.air then
-    mist.dynAdd({ country = country, category = "AIRPLANE", name = groupName, hidden = false, units = units, hiddenOnMFD = hiddenOnMFD })
+    veaf.addGroup({ country = country, category = "AIRPLANE", name = groupName, hidden = false, units = units, hiddenOnMFD = hiddenOnMFD })
   else
-    mist.dynAdd({ country = country, category = "GROUND_UNIT", name = groupName, hidden = false, units = units, hiddenOnMFD = hiddenOnMFD })
+    veaf.addGroup({
+      country = country,
+      category = "GROUND_UNIT",
+      name = groupName,
+      hidden = false,
+      units = units,
+      hiddenOnMFD = hiddenOnMFD,
+    })
   end
 
   if not silent then

--- a/src/scripts/veaf/veafSpawnGround.lua
+++ b/src/scripts/veaf/veafSpawnGround.lua
@@ -378,7 +378,14 @@ function veafSpawn._createDcsUnits(country, units, groupName, hiddenOnMFD, hasDe
   end
 
   -- actually spawn groups
-  mist.dynAdd({ country = country, category = "GROUND_UNIT", name = groupName, hidden = false, units = dcsUnits, hiddenOnMFD = hiddenOnMFD })
+  veaf.addGroup({
+    country = country,
+    category = "GROUND_UNIT",
+    name = groupName,
+    hidden = false,
+    units = dcsUnits,
+    hiddenOnMFD = hiddenOnMFD,
+  })
 end
 
 --- Spawns a dynamic infantry group

--- a/test/lua/dcs_mocks.lua
+++ b/test/lua/dcs_mocks.lua
@@ -13,6 +13,7 @@ dcs_mocks.zones = {}
 dcs_mocks.logs = {} -- captured log lines
 dcs_mocks.tasksSet = {} -- captured Controller:setTask calls, as { group = name, task = task }
 dcs_mocks.staticsAdded = {} -- captured coalition.addStaticObject calls, as { countryId, object }
+dcs_mocks.groupsAdded = {} -- captured coalition.addGroup calls, as { countryId, categoryId, group }
 
 -- Registre des groupes, declare ICI et pas plus bas : `coalition.getGroups` le lit, et un local declare
 -- apres son usage laisse la fermeture capturer la globale — c'est-a-dire nil.
@@ -336,7 +337,11 @@ coalition = {
   getPlayers = function(side)
     return {}
   end,
-  addGroup = function(...) end,
+  --- Records what was submitted, for the same reason addStaticObject does.
+  --- Entries are `{ countryId, categoryId, group }`. Cleared by dcs_mocks.reset().
+  addGroup = function(countryId, categoryId, group)
+    table.insert(dcs_mocks.groupsAdded, { countryId = countryId, categoryId = categoryId, group = group })
+  end,
   --- Records what was submitted, rather than discarding it: what a spawner hands DCS *is* the
   --- behaviour under test, and asserting against a no-op stub asserts nothing.
   --- Entries are `{ countryId = <id>, object = <the table submitted> }`. Cleared by dcs_mocks.reset().
@@ -762,6 +767,7 @@ function dcs_mocks.reset()
   dcs_mocks.logs = {}
   dcs_mocks.tasksSet = {}
   dcs_mocks.staticsAdded = {}
+  dcs_mocks.groupsAdded = {}
   dcs_mocks.messages = {}
   dcs_mocks.cockpitCalls = {}
   dcs_mocks.cockpitArguments = {}

--- a/test/lua/test_veafDcsSpawner.lua
+++ b/test/lua/test_veafDcsSpawner.lua
@@ -394,4 +394,295 @@ function TestVeafDcsSpawnerRoutes:test_goRoute_copies_the_route_it_is_given()
   luaunit.assertEquals(dcs_mocks.tasksSet[#dcs_mocks.tasksSet].task.params.route.points[1].x, 1)
 end
 
+-- ---------------------------------------------------------------------------
+-- TestVeafDcsSpawnerAddGroup
+-- ---------------------------------------------------------------------------
+-- Replaces `mist.dynAdd`, which was a **no-op stub** in these mocks and which no test ever overrode.
+-- The 13 call sites it serves were therefore never exercised; the branches below come from the
+-- call-site enumeration in DROP-MIST ticket 07.
+TestVeafDcsSpawnerAddGroup = {}
+
+function TestVeafDcsSpawnerAddGroup:setUp()
+  dcs_mocks.reset()
+end
+
+local function _group(overrides)
+  local group = {
+    country = "USA",
+    category = "GROUND_UNIT",
+    name = "a group",
+    units = { { type = "M-1 Abrams", x = 100, y = 200 } },
+  }
+  for key, value in pairs(overrides or {}) do
+    if value == NONE then
+      group[key] = nil
+    else
+      group[key] = value
+    end
+  end
+  return group
+end
+
+local function submittedGroup()
+  local entries = dcs_mocks.groupsAdded
+  return entries[#entries] and entries[#entries].group
+end
+
+local function submittedCategory()
+  local entries = dcs_mocks.groupsAdded
+  return entries[#entries] and entries[#entries].categoryId
+end
+
+function TestVeafDcsSpawnerAddGroup:test_a_valid_group_reaches_dcs()
+  luaunit.assertNotNil(veafDcsSpawner.addGroup(_group()))
+
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 1)
+  luaunit.assertEquals(submittedGroup().name, "a group")
+end
+
+-- The categories the enumeration found, including the two spellings of the same thing -------------
+
+function TestVeafDcsSpawnerAddGroup:test_ground_units()
+  veafDcsSpawner.addGroup(_group({ category = "GROUND_UNIT" }))
+
+  luaunit.assertEquals(submittedCategory(), Unit.Category.GROUND_UNIT)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_airplane_spelled_AIRPLANE()
+  -- veafSpawnCore.lua:794
+  veafDcsSpawner.addGroup(_group({ category = "AIRPLANE" }))
+
+  luaunit.assertEquals(submittedCategory(), Unit.Category.AIRPLANE)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_airplane_spelled_PLANE()
+  -- veafSpawnAircraft.lua:191 passes this spelling for the same thing. MiST mapped it; a port that
+  -- only accepted the canonical name would break that site and say nothing.
+  veafDcsSpawner.addGroup(_group({ category = "PLANE" }))
+
+  luaunit.assertEquals(submittedCategory(), Unit.Category.AIRPLANE)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_ship()
+  veafDcsSpawner.addGroup(_group({ category = "SHIP" }))
+
+  luaunit.assertEquals(submittedCategory(), Unit.Category.SHIP)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_helicopter()
+  -- Never a literal at a call site, but it arrives through the three sites that pass a group table
+  -- built from a template.
+  veafDcsSpawner.addGroup(_group({ category = "HELICOPTER" }))
+
+  luaunit.assertEquals(submittedCategory(), Unit.Category.HELICOPTER)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_the_ground_aliases_are_accepted()
+  for _, spelling in ipairs({ "VEHICLE", "GROUND", "ground_unit" }) do
+    dcs_mocks.reset()
+    veafDcsSpawner.addGroup(_group({ category = spelling }))
+    luaunit.assertEquals(submittedCategory(), Unit.Category.GROUND_UNIT, spelling .. " must resolve to ground")
+  end
+end
+
+function TestVeafDcsSpawnerAddGroup:test_an_unknown_category_creates_nothing_and_says_so()
+  -- MiST left the type nil and submitted the group anyway, so a typo produced a group DCS could not
+  -- classify and nobody was told.
+  luaunit.assertFalse(veafDcsSpawner.addGroup(_group({ category = "SUBMARINE" })))
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 0)
+end
+
+-- What it fills in --------------------------------------------------------------------------------
+
+function TestVeafDcsSpawnerAddGroup:test_ids_are_allocated()
+  veafDcsSpawner.addGroup(_group())
+
+  luaunit.assertNotNil(submittedGroup().groupId)
+  luaunit.assertNotNil(submittedGroup().units[1].unitId)
+  luaunit.assertTrue(submittedGroup().groupId >= veafMissionDb.FIRST_UNIT_ID)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_given_ids_are_kept()
+  veafDcsSpawner.addGroup(_group({ groupId = 11, units = { { type = "M-1 Abrams", x = 1, y = 2, unitId = 22 } } }))
+
+  luaunit.assertEquals(submittedGroup().groupId, 11)
+  luaunit.assertEquals(submittedGroup().units[1].unitId, 22)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_a_unit_with_no_name_is_named_after_its_group()
+  veafDcsSpawner.addGroup(_group({ name = "Convoy" }))
+
+  luaunit.assertEquals(submittedGroup().units[1].name, "Convoy unit1")
+end
+
+function TestVeafDcsSpawnerAddGroup:test_groupName_is_accepted_as_the_name()
+  veafDcsSpawner.addGroup(_group({ name = NONE, groupName = "from groupName" }))
+
+  luaunit.assertEquals(submittedGroup().name, "from groupName")
+end
+
+function TestVeafDcsSpawnerAddGroup:test_skill_defaults_to_random()
+  veafDcsSpawner.addGroup(_group())
+
+  luaunit.assertEquals(submittedGroup().units[1].skill, "Random")
+end
+
+function TestVeafDcsSpawnerAddGroup:test_a_ground_unit_can_be_driven_by_a_player()
+  veafDcsSpawner.addGroup(_group())
+
+  luaunit.assertTrue(submittedGroup().units[1].playerCanDrive)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_startTime_is_rounded_into_start_time()
+  veafDcsSpawner.addGroup(_group({ startTime = 12.7 }))
+
+  luaunit.assertEquals(submittedGroup().start_time, 13)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_start_time_defaults_to_zero()
+  veafDcsSpawner.addGroup(_group())
+
+  luaunit.assertEquals(submittedGroup().start_time, 0)
+end
+
+-- Aircraft ----------------------------------------------------------------------------------------
+
+function TestVeafDcsSpawnerAddGroup:test_an_airplane_gets_its_cruise_defaults()
+  veafDcsSpawner.addGroup(_group({ category = "AIRPLANE", units = { { type = "F-16C_50", x = 1, y = 2 } } }))
+
+  luaunit.assertEquals(submittedGroup().units[1].speed, 150)
+  luaunit.assertEquals(submittedGroup().units[1].alt, 2000)
+  luaunit.assertEquals(submittedGroup().units[1].alt_type, "RADIO")
+end
+
+function TestVeafDcsSpawnerAddGroup:test_a_helicopter_gets_slower_and_lower_defaults()
+  veafDcsSpawner.addGroup(_group({ category = "HELICOPTER", units = { { type = "UH-1H", x = 1, y = 2 } } }))
+
+  luaunit.assertEquals(submittedGroup().units[1].speed, 60)
+  luaunit.assertEquals(submittedGroup().units[1].alt, 500)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_a_baro_altitude_is_left_alone()
+  veafDcsSpawner.addGroup(_group({
+    category = "AIRPLANE",
+    units = { { type = "F-16C_50", x = 1, y = 2, alt = 9000, alt_type = "BARO" } },
+  }))
+
+  luaunit.assertEquals(submittedGroup().units[1].alt_type, "BARO", "a caller asking for barometric altitude means it")
+  luaunit.assertEquals(submittedGroup().units[1].alt, 9000)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_an_aircraft_with_no_route_gets_an_empty_one()
+  -- Without it DCS sends the aircraft home the moment it spawns.
+  veafDcsSpawner.addGroup(_group({ category = "AIRPLANE", units = { { type = "F-16C_50", x = 1, y = 2 } } }))
+
+  luaunit.assertNotNil(submittedGroup().route)
+  luaunit.assertNotNil(submittedGroup().route.points)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_a_ground_group_with_no_route_gets_none_invented()
+  veafDcsSpawner.addGroup(_group())
+
+  luaunit.assertNil(submittedGroup().route)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_a_bare_list_of_points_is_wrapped_into_a_route()
+  veafDcsSpawner.addGroup(_group({ route = { { x = 1, y = 2 }, { x = 3, y = 4 } } }))
+
+  luaunit.assertNotNil(submittedGroup().route.points)
+  luaunit.assertEquals(#submittedGroup().route.points, 2)
+end
+
+-- The payload, which is why the snapshot carries it ------------------------------------------------
+
+function TestVeafDcsSpawnerAddGroup:test_an_aircraft_without_a_payload_gets_the_editor_one()
+  env.mission.coalition.blue.country = {
+    [1] = {
+      name = "USA",
+      id = country.id.USA,
+      plane = {
+        group = { { name = "Template", groupId = 7, units = { { name = "Template-1", unitId = 3, payload = { fuel = 5000 } } } } },
+      },
+    },
+  }
+  veafMissionDb.buildSnapshot()
+
+  veafDcsSpawner.addGroup(_group({
+    category = "AIRPLANE",
+    units = { { type = "F-16C_50", x = 1, y = 2, unitName = "Template-1" } },
+  }))
+
+  luaunit.assertNotNil(submittedGroup().units[1].payload, "the loadout must come from the mission")
+  luaunit.assertEquals(submittedGroup().units[1].payload.fuel, 5000)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_a_payload_that_was_given_is_kept()
+  veafDcsSpawner.addGroup(_group({
+    category = "AIRPLANE",
+    units = { { type = "F-16C_50", x = 1, y = 2, payload = { fuel = 1 } } },
+  }))
+
+  luaunit.assertEquals(submittedGroup().units[1].payload.fuel, 1)
+end
+
+-- Tasks that name the ids just allocated -----------------------------------------------------------
+
+function TestVeafDcsSpawnerAddGroup:test_an_eplrs_task_points_at_the_new_group_id()
+  local group = _group({
+    route = { points = { { task = { params = { tasks = { { params = { action = { id = "EPLRS", params = { groupId = 999 } } } } } } } } } },
+  })
+
+  veafDcsSpawner.addGroup(group)
+
+  local action = submittedGroup().route.points[1].task.params.tasks[1].params.action
+  luaunit.assertEquals(action.params.groupId, submittedGroup().groupId)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_a_beacon_task_points_at_the_new_unit_id()
+  local group = _group({
+    route = {
+      points = { { task = { params = { tasks = { { params = { action = { id = "ActivateBeacon", params = { unitId = 999 } } } } } } } } },
+    },
+  })
+
+  veafDcsSpawner.addGroup(group)
+
+  local action = submittedGroup().route.points[1].task.params.tasks[1].params.action
+  luaunit.assertEquals(action.params.unitId, submittedGroup().units[1].unitId)
+end
+
+-- Refusals and hygiene -----------------------------------------------------------------------------
+
+function TestVeafDcsSpawnerAddGroup:test_a_group_with_no_units_creates_nothing()
+  luaunit.assertFalse(veafDcsSpawner.addGroup(_group({ units = {} })))
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 0)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_an_unknown_country_creates_nothing()
+  luaunit.assertFalse(veafDcsSpawner.addGroup(_group({ country = "Atlantis" })))
+end
+
+function TestVeafDcsSpawnerAddGroup:test_nothing_at_all_is_survivable()
+  luaunit.assertFalse(veafDcsSpawner.addGroup(nil))
+end
+
+function TestVeafDcsSpawnerAddGroup:test_the_bookkeeping_fields_are_stripped()
+  -- DCS reads country and category from the call arguments and chokes on them in the table.
+  veafDcsSpawner.addGroup(_group({ groupName = "x", startTime = 5 }))
+
+  luaunit.assertNil(submittedGroup().category)
+  luaunit.assertNil(submittedGroup().country)
+  luaunit.assertNil(submittedGroup().groupName)
+  luaunit.assertNil(submittedGroup().units[1].unitName)
+end
+
+function TestVeafDcsSpawnerAddGroup:test_the_caller_table_is_not_mutated()
+  local original = _group()
+
+  veafDcsSpawner.addGroup(original)
+
+  luaunit.assertEquals(original.category, "GROUND_UNIT", "the caller keeps its own table")
+  luaunit.assertNil(original.groupId)
+end
+
 os.exit(luaunit.LuaUnit.run())


### PR DESCRIPTION
DROP-MIST **ticket 07**: the `dynAdd` port, 13 call sites. With the statics (#838) and the routes (#839), the ticket is at **48 of its 64 calls** — `teleportToPoint` is what remains.

## Behaviour unchanged, and the defaults *are* the behaviour

What `dynAdd` fills in for a caller who left it out is not tidying, it is what a mission maker sees:

| Default | Why it matters |
|---|---|
| cruise **150 kn at 2000** (plane), **60 at 500** (helicopter) | a spawned aircraft that suddenly cruises differently is a visible change |
| `skill = "Random"` | |
| `playerCanDrive` on a ground unit | |
| an **empty route** for an aircraft that has none | without it DCS sends the aircraft home the moment it spawns |
| ids for the group and every unit | from VEAF's allocator, not MiST's counter |

Each has a test.

## One thing it no longer does silently

MiST accepted an **unknown category**, left the group type nil, and submitted the group anyway — so a misspelling produced something DCS could not classify and nobody was told. That is now refused, with the category named in the log.

The spellings that *are* accepted are unchanged: **`PLANE` and `AIRPLANE` both**, because VEAF passes both for the same thing (`veafSpawnAircraft:191` vs `veafSpawnCore:794`), along with `VEHICLE` / `GROUND` for ground units. A port taking only the canonical name would have broken the first site in silence — that test was confirmed to fail when the alias is removed.

## The payload

Comes from the mission snapshot, which is why #839 put it there: `veafSpawnCore` builds `AIRPLANE` groups with **no payload field at all**, and `dynAdd` filled it from the mission on every such spawn.

## The same coverage hole, a third time

`mist.dynAdd` was a **no-op stub** in `dcs_mocks` that no test ever overrode — like `dynAddStatic` and `getRandPointInCircle` before it. None of these 13 call sites was exercised by anything.

**31 tests** now cover the branches the ticket's enumeration listed: the four categories actually reached plus the aliases, an unknown category refused, every default, the route wrapped or invented, the payload found and the payload kept, the `EPLRS` and `ActivateBeacon` tasks repointed at the freshly allocated ids, and the bookkeeping fields stripped before submission.

## Checks

- Lua suite: 44 suites green — `veafDcsSpawner.lua` at **96.83 %** line coverage
- Lua coverage overall **77.69 %**, gate at 76
- `stylua --check` clean, `docs-check` clean
- `luacheck` left to the CI gate

Also corrected: a comment in `veafMissionDb` claimed the MiST name-table deletion could go once ticket 07 landed. It cannot yet — the port reaches no name-uniqueness test, because `clone` is never passed to `dynAdd` directly; every VEAF clone goes through the teleport path, which is still MiST's. The comment now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace MiST dynamic group creation with VEAF's own spawner while preserving existing spawn behavior and adding validation for invalid categories.

New Features:
- Add VEAF-native dynamic group spawning for aircraft, helicopters, ships, and ground units through the `veaf.addGroup` interface.
- Preserve dynamic-spawn behavior including category aliases, defaults, routes, payloads, allocated identifiers, and task references while rejecting unknown categories.

Bug Fixes:
- Prevent invalid group categories from being submitted silently as unclassifiable DCS groups.

Enhancements:
- Migrate the remaining `mist.dynAdd` group-spawn call sites to VEAF's spawner and clarify the remaining MiST dependency in mission database cleanup.

Documentation:
- Document the new VEAF group-spawning behavior and update DROP-MIST ticket progress.

Tests:
- Add comprehensive coverage for group categories, defaults, routes, payload handling, task identifiers, validation, and submission bookkeeping.