### PR TITLE
refactor(spawner): the terrain check and the live group reader are ours

### DIFF
--- a/.backlog/DROP-MIST/tickets/07-spawn-routes-and-teleport.md
+++ b/.backlog/DROP-MIST/tickets/07-spawn-routes-and-teleport.md
@@ -332,7 +332,9 @@ the exact place where `FIX-AIRWAVES-COMMAND-EASTING` slipped in.
    than submitting an unclassifiable group.
 2. ~~`veaf.getGroupRoute` / `veaf.goRoute`~~ — **shipped 2026-08-28**, and the mission snapshot gained
    the route and the payload by reference to serve them.
-3. `VeafGroupSpawn` over both, replacing `teleportToPoint`.
+3. `VeafGroupSpawn` over both, replacing `teleportToPoint`. **Its two bricks shipped 2026-08-28**:
+   `veaf.isTerrainValid` (with the per-category surface lists) and `veaf.getCurrentGroupData` (the
+   source the `teleport` verb reads).
 4. Migrate the 42 remaining call sites.
 
 ### `teleportToPoint`, read 2026-08-28 — what the chain has to carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,13 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   nobody was told. That is now refused, with the category named in the log. The spellings that *are*
   accepted are unchanged, `PLANE` and `AIRPLANE` alike — VEAF uses both, for the same thing.
 
+- **Two more pieces of MiST are VEAF's**, both needed by the spawn chain still to come: the terrain
+  check that keeps a ship off a hill and a convoy out of a lake, and the reader that describes a group
+  *as it stands right now* rather than as the Mission Editor drew it.
+
+  The terrain lists are unchanged, runways included for ground units — DCS reports a dam's surface as
+  `RUNWAY`, and excluding it would refuse a convoy the crossing it was drawn to take.
+
 ## [6.17.0] — 2026-08-26
 
 **Released.** This version consolidates the ten patch versions from **6.16.1 to 6.16.10**, whose detailed

--- a/src/scripts/veaf/veafDcsSpawner.lua
+++ b/src/scripts/veaf/veafDcsSpawner.lua
@@ -530,12 +530,157 @@ function veafDcsSpawner.addGroup(groupData)
   return group
 end
 
+--- Terrain a group of this category may be put on, when the caller does not say.
+---
+--- Ported from `mist.teleportToPoint`, including the reason a runway is valid ground: DCS reports a
+--- dam's surface as `RUNWAY`, and a convoy refused a bridge crossing would be a visible regression.
+--- A category with no entry here accepts any surface, which is what MiST did.
+veafDcsSpawner.TERRAIN_BY_CATEGORY = {
+  ship = { "SHALLOW_WATER", "WATER" },
+  vehicle = { "LAND", "ROAD", "RUNWAY" },
+  ground_unit = { "LAND", "ROAD", "RUNWAY" },
+}
+
+--- Every surface a spawn accepts when nothing narrows it down.
+veafDcsSpawner.ANY_TERRAIN = { "LAND", "ROAD", "SHALLOW_WATER", "WATER", "RUNWAY" }
+
+--- Is this point on one of these surfaces?
+---
+--- Replaces `mist.isTerrainValid`. Accepts either coordinate shape — a vec3's `z` is the easting that
+--- `land.getSurfaceType` wants as `y`, which is the confusion `docs/agents/dcs-coordinates.md` exists
+--- for.
+---
+--- @param point table a vec2 (x, y) or a vec3 (x, y, z)
+--- @param surfaces table|string a surface name, or a list of them
+--- @return boolean
+function veafDcsSpawner.isTerrainValid(point, surfaces)
+  if type(point) ~= "table" or type(point.x) ~= "number" then
+    return false
+  end
+  local flat = { x = point.x, y = point.z or point.y }
+  if type(flat.y) ~= "number" then
+    return false
+  end
+
+  local wanted = surfaces
+  if type(wanted) == "string" then
+    wanted = { wanted }
+  end
+  if type(wanted) ~= "table" then
+    return false
+  end
+
+  local actual = land.getSurfaceType(flat)
+  for _, name in pairs(wanted) do
+    if type(name) == "string" and land.SurfaceType[string.upper(name)] == actual then
+      return true
+    end
+  end
+  return false
+end
+
+--- The surfaces a group of this category may stand on.
+--- @param category string|nil the group's category, in any spelling
+--- @return table a list of surface names
+function veafDcsSpawner.terrainForCategory(category)
+  if type(category) ~= "string" then
+    return veafDcsSpawner.ANY_TERRAIN
+  end
+  return veafDcsSpawner.TERRAIN_BY_CATEGORY[string.lower(category)] or veafDcsSpawner.ANY_TERRAIN
+end
+
+--- A group's definition as it stands **right now** — live positions, live ids, live units.
+---
+--- Replaces `mist.getCurrentGroupData`, the source the `teleport` verb reads (as opposed to `clone` and
+--- `respawn`, which read the editor definition). It starts from the editor record so that everything
+--- the running world does not expose — skill, payload, callsign — survives, then overwrites what the
+--- world knows better: the group id DCS assigned, its current category, and each live unit's position,
+--- heading, altitude and speed.
+---
+--- **Coordinates.** The result is the mission-table shape a spawn expects: `x` northing, `y` easting.
+--- The live position is a vec3, so its `z` becomes the record's `y`. Getting this backwards places the
+--- group somewhere else entirely, with no error.
+---
+--- @param groupName string
+--- @return table|nil the group data, or nil when neither a group nor a static answers to that name
+function veafDcsSpawner.getCurrentGroupData(groupName)
+  local record = veafMissionDb.getGroupRecord(groupName)
+  local group = Group.getByName(groupName)
+
+  if group and group:isExist() then
+    local data = veaf.deepCopy(record or {})
+    data.name = groupName
+    data.groupName = groupName
+    data.groupId = tonumber(group:getID())
+    data.category = group:getCategory()
+    -- getCategory answers a number; a spawn wants the editor's word for it.
+    if data.category == Group.Category.GROUND then
+      data.category = "vehicle"
+    elseif data.category == Group.Category.SHIP then
+      data.category = "ship"
+    end
+
+    data.units = {}
+    local liveUnits = group:getUnits() or {}
+    if #liveUnits == 0 then
+      veaf.loggers.get(veafDcsSpawner.Id):warn("getCurrentGroupData: group [%s] exists but has no units", veaf.p(groupName))
+    end
+    for index, unit in ipairs(liveUnits) do
+      local unitName = unit:getName()
+      local known = veafMissionDb.getUnitRecord(unitName)
+      local unitData = known and veaf.deepCopy(known) or {}
+      unitData.unitId = tonumber(unit:getID())
+      unitData.type = unit:getTypeName()
+      unitData.unitName = unitName
+      unitData.name = unitName
+
+      local position = unit:getPosition()
+      if position and position.p then
+        unitData.x = position.p.x
+        unitData.y = position.p.z
+        unitData.alt = position.p.y
+        unitData.point = { x = unitData.x, y = unitData.y }
+        if position.x then
+          unitData.heading = math.atan2(position.x.z, position.x.x)
+        end
+      end
+      local velocity = unit:getVelocity()
+      if velocity then
+        unitData.speed = veaf.vecMag(velocity)
+      end
+      data.units[index] = unitData
+    end
+    return data
+  end
+
+  -- A static answers to a name too, and carries a single unit.
+  local static = StaticObject.getByName(groupName)
+  if static and static:isExist() and record and record.units and record.units[1] then
+    local data = veaf.deepCopy(record)
+    local position = static:getPosition()
+    if position and position.p then
+      data.units[1].x = position.p.x
+      data.units[1].y = position.p.z
+      data.units[1].alt = position.p.y
+      if position.x then
+        data.units[1].heading = math.atan2(position.x.z, position.x.x)
+      end
+    end
+    return data
+  end
+
+  veaf.loggers.get(veafDcsSpawner.Id):debug("getCurrentGroupData: nothing alive named [%s]", veaf.p(groupName))
+  return nil
+end
+
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Framework façades. Callers use `veaf.*` and never name the implementation.
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 veaf.addStatic = veafDcsSpawner.addStatic
 veaf.addGroup = veafDcsSpawner.addGroup
+veaf.isTerrainValid = veafDcsSpawner.isTerrainValid
+veaf.getCurrentGroupData = veafDcsSpawner.getCurrentGroupData
 veaf.getGroupRoute = veafDcsSpawner.getGroupRoute
 veaf.goRoute = veafDcsSpawner.goRoute
 

--- a/test/lua/test_veafDcsSpawner.lua
+++ b/test/lua/test_veafDcsSpawner.lua
@@ -685,4 +685,193 @@ function TestVeafDcsSpawnerAddGroup:test_the_caller_table_is_not_mutated()
   luaunit.assertNil(original.groupId)
 end
 
+-- ---------------------------------------------------------------------------
+-- TestVeafDcsSpawnerTerrain
+-- ---------------------------------------------------------------------------
+-- `isTerrainValid` is what stops a ship spawning on a hill and a convoy in a lake: the teleport draws
+-- up to a hundred random points and keeps the first this accepts.
+TestVeafDcsSpawnerTerrain = {}
+
+function TestVeafDcsSpawnerTerrain:setUp()
+  dcs_mocks.reset()
+  self._surface = land.getSurfaceType
+end
+
+function TestVeafDcsSpawnerTerrain:tearDown()
+  land.getSurfaceType = self._surface
+end
+
+function TestVeafDcsSpawnerTerrain:_surfaceIs(name)
+  land.getSurfaceType = function()
+    return land.SurfaceType[name]
+  end
+end
+
+function TestVeafDcsSpawnerTerrain:test_a_matching_surface_is_valid()
+  self:_surfaceIs("LAND")
+
+  luaunit.assertTrue(veafDcsSpawner.isTerrainValid({ x = 1, y = 2 }, { "LAND", "ROAD" }))
+end
+
+function TestVeafDcsSpawnerTerrain:test_a_surface_not_in_the_list_is_not()
+  self:_surfaceIs("WATER")
+
+  luaunit.assertFalse(veafDcsSpawner.isTerrainValid({ x = 1, y = 2 }, { "LAND", "ROAD" }))
+end
+
+function TestVeafDcsSpawnerTerrain:test_a_single_surface_name_is_accepted()
+  self:_surfaceIs("WATER")
+
+  luaunit.assertTrue(veafDcsSpawner.isTerrainValid({ x = 1, y = 2 }, "WATER"))
+end
+
+function TestVeafDcsSpawnerTerrain:test_the_name_is_matched_whatever_its_case()
+  self:_surfaceIs("SHALLOW_WATER")
+
+  luaunit.assertTrue(veafDcsSpawner.isTerrainValid({ x = 1, y = 2 }, { "shallow_water" }))
+end
+
+function TestVeafDcsSpawnerTerrain:test_a_vec3_is_read_with_z_as_the_easting()
+  -- The trap this whole module is careful about: land.getSurfaceType wants a vec2 whose `y` is the
+  -- easting, and a vec3 carries that in `z`. Reading `y` instead asks about a completely different
+  -- place, and answers without complaining.
+  local asked
+  land.getSurfaceType = function(point)
+    asked = point
+    return land.SurfaceType.LAND
+  end
+
+  veafDcsSpawner.isTerrainValid({ x = 10, y = 9999, z = 20 }, { "LAND" })
+
+  luaunit.assertEquals(asked.x, 10)
+  luaunit.assertEquals(asked.y, 20, "the vec3's z is the easting, not its y")
+end
+
+function TestVeafDcsSpawnerTerrain:test_nonsense_is_not_valid_terrain()
+  self:_surfaceIs("LAND")
+
+  luaunit.assertFalse(veafDcsSpawner.isTerrainValid(nil, { "LAND" }))
+  luaunit.assertFalse(veafDcsSpawner.isTerrainValid({ x = 1 }, { "LAND" }))
+  luaunit.assertFalse(veafDcsSpawner.isTerrainValid({ x = 1, y = 2 }, nil))
+end
+
+function TestVeafDcsSpawnerTerrain:test_a_ship_belongs_on_water()
+  luaunit.assertEquals(veafDcsSpawner.terrainForCategory("ship"), { "SHALLOW_WATER", "WATER" })
+end
+
+function TestVeafDcsSpawnerTerrain:test_a_vehicle_may_stand_on_a_runway()
+  -- Deliberate, and inherited: DCS reports a dam's surface as RUNWAY, so excluding it would refuse a
+  -- convoy the crossing it was drawn to take.
+  local surfaces = veafDcsSpawner.terrainForCategory("vehicle")
+
+  luaunit.assertEquals(surfaces, { "LAND", "ROAD", "RUNWAY" })
+end
+
+function TestVeafDcsSpawnerTerrain:test_an_unknown_category_accepts_anything()
+  luaunit.assertEquals(veafDcsSpawner.terrainForCategory("plane"), veafDcsSpawner.ANY_TERRAIN)
+  luaunit.assertEquals(veafDcsSpawner.terrainForCategory(nil), veafDcsSpawner.ANY_TERRAIN)
+end
+
+-- ---------------------------------------------------------------------------
+-- TestVeafDcsSpawnerCurrentGroupData
+-- ---------------------------------------------------------------------------
+-- The source the `teleport` verb reads: the group as it stands right now, rather than as the Mission
+-- Editor drew it. Five of the thirteen teleport call sites ask for it.
+TestVeafDcsSpawnerCurrentGroupData = {}
+
+function TestVeafDcsSpawnerCurrentGroupData:setUp()
+  dcs_mocks.reset()
+end
+
+--- An editor record for the group, so the fields the running world does not expose have somewhere to
+--- come from — skill and payload above all.
+function TestVeafDcsSpawnerCurrentGroupData:_editorGroup()
+  env.mission.coalition.blue.country = {
+    [1] = {
+      name = "USA",
+      id = country.id.USA,
+      plane = {
+        group = {
+          {
+            name = "Arco",
+            groupId = 7,
+            units = { { name = "Arco-1", unitId = 3, type = "KC-135", skill = "High", payload = { fuel = 90000 } } },
+          },
+        },
+      },
+    },
+  }
+  veafMissionDb.buildSnapshot()
+end
+
+--- A live group at a position, with a heading and a speed.
+function TestVeafDcsSpawnerCurrentGroupData:_liveGroup(x, alt, z)
+  dcs_mocks.addUnit("Arco-1", {
+    _id = 4242,
+    getTypeName = function()
+      return "KC-135"
+    end,
+    getPosition = function()
+      return { p = { x = x, y = alt, z = z }, x = { x = 1, y = 0, z = 0 } }
+    end,
+    getVelocity = function()
+      return { x = 100, y = 0, z = 0 }
+    end,
+  })
+  dcs_mocks.addGroup("Arco", {
+    _id = 99,
+    getUnits = function()
+      return { Unit.getByName("Arco-1") }
+    end,
+  })
+end
+
+function TestVeafDcsSpawnerCurrentGroupData:test_the_live_position_wins_over_the_editor_one()
+  self:_editorGroup()
+  self:_liveGroup(5000, 7000, 6000)
+
+  local data = veafDcsSpawner.getCurrentGroupData("Arco")
+
+  luaunit.assertNotNil(data)
+  luaunit.assertEquals(data.units[1].x, 5000)
+  luaunit.assertEquals(data.units[1].y, 6000, "the live vec3's z is the record's y — the easting")
+  luaunit.assertEquals(data.units[1].alt, 7000)
+end
+
+function TestVeafDcsSpawnerCurrentGroupData:test_the_live_group_id_is_used()
+  self:_editorGroup()
+  self:_liveGroup(1, 2, 3)
+
+  luaunit.assertEquals(veafDcsSpawner.getCurrentGroupData("Arco").groupId, 99, "DCS's id, not the editor's 7")
+end
+
+function TestVeafDcsSpawnerCurrentGroupData:test_what_the_world_does_not_expose_survives_from_the_editor()
+  -- The whole reason this starts from the record rather than from the live group.
+  self:_editorGroup()
+  self:_liveGroup(1, 2, 3)
+
+  local unit = veafDcsSpawner.getCurrentGroupData("Arco").units[1]
+
+  luaunit.assertEquals(unit.skill, "High")
+  luaunit.assertNotNil(unit.payload)
+  luaunit.assertEquals(unit.payload.fuel, 90000)
+end
+
+function TestVeafDcsSpawnerCurrentGroupData:test_the_speed_comes_from_the_velocity()
+  self:_editorGroup()
+  self:_liveGroup(1, 2, 3)
+
+  luaunit.assertAlmostEquals(veafDcsSpawner.getCurrentGroupData("Arco").units[1].speed, 100, 0.001)
+end
+
+function TestVeafDcsSpawnerCurrentGroupData:test_a_group_that_is_not_alive_returns_nil()
+  self:_editorGroup()
+
+  luaunit.assertNil(veafDcsSpawner.getCurrentGroupData("Arco"), "the editor knowing it is not enough")
+end
+
+function TestVeafDcsSpawnerCurrentGroupData:test_an_unknown_name_returns_nil()
+  luaunit.assertNil(veafDcsSpawner.getCurrentGroupData("Nobody"))
+end
+
 os.exit(luaunit.LuaUnit.run())


### PR DESCRIPTION
DROP-MIST **ticket 07**: the two bricks the spawn chain needs before it can replace `teleportToPoint`.

## `isTerrainValid`

What stops a ship spawning on a hill and a convoy in a lake: the teleport draws up to a hundred random points in the circle and keeps the first this accepts.

The per-category surface lists are unchanged, **runways included for ground units** — DCS reports a dam's surface as `RUNWAY`, so excluding it would refuse a convoy the crossing it was drawn to take. That reason was a VEAF comment from 2023 sitting in the middle of MiST; it is now a named test.

## `getCurrentGroupData`

The source the **`teleport`** verb reads, as opposed to `clone` and `respawn` which read the editor definition. Five of the thirteen call sites need it.

It starts from the mission record so that what the running world does not expose — **skill, payload, callsign** — survives, then overwrites what the world knows better: the id DCS assigned, the current category, and each live unit's position, heading, altitude and speed.

## The coordinate trap, twice

Both functions cross the boundary this module keeps meeting: a live position is a **vec3 whose `z` is the easting**, while a mission table calls that **`y`**. `land.getSurfaceType` wants the vec2 form.

Two tests were confirmed to fail when either conversion is reversed — which is the only way to catch it, since getting it wrong places things somewhere else entirely and raises nothing.

## Checks

- Lua suite: 44 suites green, **84 tests** in `test_veafDcsSpawner.lua`
- `stylua --check` clean, `docs-check` clean
- `luacheck` left to the CI gate

What remains for the ticket: the `VeafGroupSpawn` chain itself, and the 12 `teleportToPoint` call sites it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Provide the terrain and live-state data primitives required to replace teleport-based spawning with the new spawn chain.

New Features:
- Add terrain validation and category-based surface selection for spawn locations.
- Add live group data retrieval that combines mission metadata with current DCS group and unit state.

Bug Fixes:
- Preserve correct coordinate conversion between DCS vec3 positions and mission-table coordinates when validating terrain and reading live units.
- Allow ground units to use runway surfaces, including crossings that DCS reports as runways.

Enhancements:
- Expose the new terrain and live group readers through the VEAF façade for future spawn-chain migration.

Documentation:
- Document the shipped spawn-chain building blocks and their terrain behavior in the changelog and ticket backlog.

Tests:
- Add coverage for terrain matching, category defaults, coordinate conversion, live identifiers, current positions, retained editor metadata, speed, and missing entities.