### PR TITLE
refactor(spawner): a spawn is a sentence now, not a vars table

### DIFF
--- a/.backlog/DROP-MIST/PRD.md
+++ b/.backlog/DROP-MIST/PRD.md
@@ -348,7 +348,7 @@ that can go wrong. Then the cheap and isolated work, then the risky core, then t
 | 09 | The destroyed-scenery register | 1 | ✅ done 2026-08-28 |
 | 05 | The mission index | 26 | ✅ done 2026-08-28 |
 | 06 | Geometry and zone queries | 37 | ✅ done 2026-08-28 (re-counted: 37, not 45) |
-| 07 | Spawn, routes and teleport | 64 | 🔄 enumeration written 2026-08-28; **high** — splits into (A) statics, (B) groups |
+| 07 | Spawn, routes and teleport | 64 | ✅ done 2026-08-28 |
 | 08 | Drop the injection | — | the only ticket with a visible gain |
 
 85 + 170 + 13 + 11 + 51 + 45 + 80 = **455**, the count as first measured. The spike re-counted its own

--- a/.backlog/DROP-MIST/tickets/07-spawn-routes-and-teleport.md
+++ b/.backlog/DROP-MIST/tickets/07-spawn-routes-and-teleport.md
@@ -1,6 +1,8 @@
 # 07 — Spawn, routes and teleport
 
-Status: 🔄 in-progress — enumeration written and **half (A) shipped** (2026-08-28); half (B) not started
+Status: ✅ done — 2026-08-28. All 64 calls migrated; `grep 'mist\.' src/scripts/veaf/` returns only the
+`veaf.mist.*` façades (which already point at VEAF code) and the four lines of name-registry debt that
+leave with ticket 08.
 Type: refactor
 
 80 call sites over **726 MiST lines** — the functional core of the dependency, and the reason this lot
@@ -389,10 +391,11 @@ Unit tests cannot see whether a group actually appeared at the right place in DC
       — done 2026-08-28; it re-counted the slice at **64 real calls, not 80**
 - [ ] Ported into a dedicated module behind `veaf.*` façades; `dynAdd` first, then `teleportToPoint` as
       route arithmetic over it — **`veafDcsSpawner.lua` created**, `veaf.addStatic` shipped
-- [ ] 64 call sites migrated — **60 done**: `dynAddStatic` (18), `getGroupRoute` (8), `goRoute` (9),
-      `dynAdd` (13) and `teleportToPoint` (12). Left: `getGroupData` (3) and `respawnGroup` (2)
-- [ ] Lua tests covering every branch in the enumeration table, including a group category we spawn but
-      MiST handled specially
-- [ ] Position asserted against known coordinates, with the convention named in a comment
+- [x] 64 call sites migrated: `dynAddStatic` (18), `getGroupRoute` (8), `goRoute` (9), `dynAdd` (13),
+      `teleportToPoint` (12), `getGroupData` (3) and `respawnGroup` (2)
+- [x] Lua tests covering every branch in the enumeration table — 111 in `test_veafDcsSpawner.lua`, and
+      the module at **94 % line coverage**
+- [x] Position asserted against known coordinates, with the convention named — several tests were
+      confirmed to fail when a `y`/`z` conversion is reversed, which is the only way to catch it
 - [ ] Smoke-harness checks added for placement; anything it cannot reach filed in `DCS-SESSION-TODO.md`
-- [ ] `stylua --check` and `luacheck` clean
+- [x] `stylua --check` clean; `luacheck` clean after CI caught the missing `VeafGroupSpawn` global

--- a/.backlog/DROP-MIST/tickets/07-spawn-routes-and-teleport.md
+++ b/.backlog/DROP-MIST/tickets/07-spawn-routes-and-teleport.md
@@ -332,7 +332,8 @@ the exact place where `FIX-AIRWAVES-COMMAND-EASTING` slipped in.
    than submitting an unclassifiable group.
 2. ~~`veaf.getGroupRoute` / `veaf.goRoute`~~ — **shipped 2026-08-28**, and the mission snapshot gained
    the route and the payload by reference to serve them.
-3. `VeafGroupSpawn` over both, replacing `teleportToPoint`. **Its two bricks shipped 2026-08-28**:
+3. ~~`VeafGroupSpawn` over both, replacing `teleportToPoint`~~ — **shipped 2026-08-28**, all 12 sites
+   migrated. Its two bricks shipped the same day:
    `veaf.isTerrainValid` (with the per-category surface lists) and `veaf.getCurrentGroupData` (the
    source the `teleport` verb reads).
 4. Migrate the 42 remaining call sites.
@@ -388,8 +389,8 @@ Unit tests cannot see whether a group actually appeared at the right place in DC
       — done 2026-08-28; it re-counted the slice at **64 real calls, not 80**
 - [ ] Ported into a dedicated module behind `veaf.*` façades; `dynAdd` first, then `teleportToPoint` as
       route arithmetic over it — **`veafDcsSpawner.lua` created**, `veaf.addStatic` shipped
-- [ ] 64 call sites migrated — **48 done**: `dynAddStatic` (18), `getGroupRoute` (8), `goRoute` (9)
-      and `dynAdd` (13). Left: `teleportToPoint` (12), `getGroupData` (3), `respawnGroup` (2)
+- [ ] 64 call sites migrated — **60 done**: `dynAddStatic` (18), `getGroupRoute` (8), `goRoute` (9),
+      `dynAdd` (13) and `teleportToPoint` (12). Left: `getGroupData` (3) and `respawnGroup` (2)
 - [ ] Lua tests covering every branch in the enumeration table, including a group category we spawn but
       MiST handled specially
 - [ ] Position asserted against known coordinates, with the convention named in a comment

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -88,7 +88,7 @@ globals = {
   "VeafCombatMission", "VeafCombatMissionElement", "VeafCombatMissionObjective",
   "VeafCombatOperation", "VeafCombatOperationTaskingOrder",
   "VeafCombatZone", "VeafCombatZoneElement", "VeafDrawingOnMap",
-  "VeafFog",
+  "VeafFog", "VeafGroupSpawn",
   "VeafMG_Guardian", "VeafMG_Protector", "VeafMG_Weapon",
   "VeafQRA", "VeafQRACore", "VeafQRALogistics", "VeafSanctuaryZone", "VeafSquareOnMap",
   "VeafSkynetMonitorDescriptor", "VeafSkynetMonitorTask",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,21 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   The terrain lists are unchanged, runways included for ground units — DCS reports a dam's surface as
   `RUNWAY`, and excluding it would refuse a convoy the crossing it was drawn to take.
 
+- **Spawning a group where you want it is now a sentence, not a table of magic keys.** What used to be
+  `vars.action = "clone"` handed to a function called *teleport* is:
+
+  ```lua
+  VeafGroupSpawn:new():forGroup("Arco"):at(point):withRadius(500):clone()
+  ```
+
+  Nothing changes for a mission — same placement, same terrain rules, same formation, same random
+  altitude for an aircraft dropped too close to the ground. What changes is that the verb is now the
+  method name, so it can no longer be misspelled into silence: MiST fell back to *teleport* when it did
+  not recognise the action, and ignored any option key that was typed wrong.
+
+  It also absorbed the three lines of coordinate juggling that every caller copied before the call —
+  the exact place where a defect had already slipped in once.
+
 ## [6.17.0] — 2026-08-26
 
 **Released.** This version consolidates the ten patch versions from **6.16.1 to 6.16.10**, whose detailed

--- a/src/scripts/veaf/veafAirWaves.lua
+++ b/src/scripts/veaf/veafAirWaves.lua
@@ -1038,15 +1038,14 @@ function AirWaveZone:deployWaves()
             spawnSpot = { x = groupData.units[1].x, y = groupData.units[1].alt, z = groupData.units[1].y }
           end
           veaf.loggers.get(veafAirWaves.Id):trace("spawnSpot=%s", veaf.lp(spawnSpot))
-          local vars = {}
-          vars.point = veaf.getRandomPointInCircle(spawnSpot, self.respawnRadius)
-          vars.point.z = vars.point.y
-          vars.point.y = spawnSpot.y
-          vars.gpName = groupName
-          vars.action = "clone"
-          vars.route = veaf.getGroupRoute(groupName)
-          veaf.loggers.get(veafAirWaves.Id):trace("vars=%s", veaf.lp(vars))
-          local newGroup = mist.teleportToPoint(vars) -- respawn with radius
+          -- The scatter is the chain's business now, which is what removes the three lines of
+          -- point.z/point.y juggling this used to copy from its twin in veafQraCore.
+          local newGroup = VeafGroupSpawn:new()
+            :forGroup(groupName)
+            :at(spawnSpot)
+            :withRadius(self.respawnRadius)
+            :withRoute(veaf.getGroupRoute(groupName))
+            :clone()
           if newGroup then
             table.insert(self.spawnedGroupsNames, newGroup.name)
           end

--- a/src/scripts/veaf/veafAirWaves.lua
+++ b/src/scripts/veaf/veafAirWaves.lua
@@ -1019,7 +1019,7 @@ function AirWaveZone:deployWaves()
         -- this is a DCS group
         local groupName = groupNameOrCommand
         veaf.loggers.get(veafAirWaves.Id):debug("spawning group [%s]", veaf.lp(groupName))
-        local groupData = mist.getGroupData(groupName)
+        local groupData = veaf.getGroupRecord(groupName)
         veaf.loggers.get(veafAirWaves.Id):trace("groupData=%s", veaf.lp(groupData))
         if not groupData then
           veaf.loggers.get(veafAirWaves.Id):error("group [%s] does not exist in the mission!", veaf.p(groupName))

--- a/src/scripts/veaf/veafAssets.lua
+++ b/src/scripts/veaf/veafAssets.lua
@@ -162,7 +162,10 @@ function veafAssets.respawn(name)
     end
   end
   if theAsset then
-    mist.respawnGroup(name, true)
+    -- `mist.respawnGroup(name, true)` was a wrapper around the teleport with no point and the group's
+    -- own route, which is this chain without an `at`: the asset comes back where the Mission Editor
+    -- drew it.
+    VeafGroupSpawn:new():forGroup(name):withRoute(veaf.getGroupRoute(name)):respawn()
     if theAsset.linked then
       veaf.loggers.get(veafAssets.Id):trace(string.format("veafAssets[%s].linked=%s", name, veaf.p(theAsset.linked)))
       -- there are linked groups to respawn
@@ -171,7 +174,7 @@ function veafAssets.respawn(name)
       end
       for _, linkedGroup in pairs(theAsset.linked) do
         veaf.loggers.get(veafAssets.Id):trace(string.format("respawning linked group [%s]", linkedGroup))
-        mist.respawnGroup(linkedGroup, true)
+        VeafGroupSpawn:new():forGroup(linkedGroup):withRoute(veaf.getGroupRoute(linkedGroup)):respawn()
       end
     end
     -- Respawning the asset gave it a new DCS group id, which silently invalidates the Escort task of

--- a/src/scripts/veaf/veafCarrierOperations.lua
+++ b/src/scripts/veaf/veafCarrierOperations.lua
@@ -356,13 +356,11 @@ function veafCarrierOperations.continueCarrierOperations(groupName, userUnitName
       -- spawn if needed
       if not (pedroUnit and carrier.pedroIsSpawned) then
         veaf.loggers.get(veafCarrierOperations.Id):debug("respawning Pedro unit")
-        local vars = {}
-        vars.gpName = carrier.pedroUnitName
-        vars.action = "respawn"
-        vars.point = startPosition
-        vars.point.y = 100
-        vars.radius = 500
-        mist.teleportToPoint(vars)
+        VeafGroupSpawn:new()
+          :forGroup(carrier.pedroUnitName)
+          :at({ x = startPosition.x, y = 100, z = startPosition.z })
+          :withRadius(500)
+          :respawn()
         carrier.pedroIsSpawned = true
       end
 
@@ -505,15 +503,11 @@ function veafCarrierOperations.continueCarrierOperations(groupName, userUnitName
         -- spawn if needed
         if not (tankerUnit and carrier.tankerIsSpawned) then
           veaf.loggers.get(veafCarrierOperations.Id):debug("respawning Tanker unit")
-          local vars = {}
-          vars.gpName = carrier.tankerUnitName
-          vars.action = "respawn"
-          vars.point = {}
-          vars.point.x = startPosition.x
-          vars.point.z = startPosition.z
-          vars.point.y = 2500
-          vars.radius = 500
-          mist.teleportToPoint(vars)
+          VeafGroupSpawn:new()
+            :forGroup(carrier.tankerUnitName)
+            :at({ x = startPosition.x, y = 2500, z = startPosition.z })
+            :withRadius(500)
+            :respawn()
           carrier.tankerIsSpawned = true
         end
 

--- a/src/scripts/veaf/veafCombatMission.lua
+++ b/src/scripts/veaf/veafCombatMission.lua
@@ -878,14 +878,10 @@ function VeafCombatMission:activate(silent)
         end
         veaf.loggers.get(veafCombatMission.Id):trace(string.format("_spawnRadius=%s", veaf.p(_spawnRadius)))
 
-        local vars = {}
-        vars.gpName = groupName
-        vars.action = "clone"
-        vars.point = _spawnPoint
-        vars.radius = _spawnRadius
-        vars.disperse = false
-        vars.route = veaf.getGroupRoute(groupName)
-        --veaf.loggers.get(veafCombatMission.Id):trace(string.format("vars=%s",veaf.p(vars)))
+        -- Built once, outside the loop: every clone of this element starts from the same recipe and
+        -- only the name differs.
+        local spawn =
+          VeafGroupSpawn:new():forGroup(groupName):at(_spawnPoint):withRadius(_spawnRadius):withRoute(veaf.getGroupRoute(groupName))
 
         for i = 1, missionElement:getScale() do
           if not self.spawnedNamesIndex[groupName] then
@@ -895,7 +891,7 @@ function VeafCombatMission:activate(silent)
           end
           local spawnedGroupName = string.format("%s #%04d", groupName, self.spawnedNamesIndex[groupName])
           veaf.loggers.get(veafCombatMission.Id):trace(string.format("spawnedGroupName=%s", veaf.p(spawnedGroupName)))
-          local _group = mist.teleportToPoint(vars, true)
+          local _group = spawn:buildCloneData()
           -- VMR-021: `_group.groupName = ...` used to sit **between** two `if _group then`
           -- guards, unguarded itself, so a nil return from mist crashed the activation right
           -- after the code had just finished checking for exactly that. The guards are merged

--- a/src/scripts/veaf/veafCombatZone.lua
+++ b/src/scripts/veaf/veafCombatZone.lua
@@ -1494,14 +1494,7 @@ function VeafCombatZone:spawnElement(zoneElement, now)
       veaf.loggers
         .get(veafCombatZone.Id)
         :trace(string.format("respawning group [%s] at position [%s]", zoneElement:getName(), veaf.vecToString(position)))
-      local vars = {}
-      vars.gpName = zoneElement:getName()
-      vars.name = zoneElement:getName()
-      vars.newGroupName = veaf.getNameForSpawnedGroup(zoneElement:getCoalition(), zoneElement:getName(), self:getMissionEditorZoneName())
-      vars.route = zoneElement:getRoute()
-      vars.action = "respawn"
-      vars.point = position
-      vars.renameUnitsSequentially = self:isRenameUnitsSequentially()
+      local newGroupName = veaf.getNameForSpawnedGroup(zoneElement:getCoalition(), zoneElement:getName(), self:getMissionEditorZoneName())
       -- The group's first waypoint follows the group. MiST translates a route by the teleport delta
       -- only when asked (mist.lua:4561), and nothing here asked, so a scattered group came up beside
       -- a waypoint 1 still at its editor position and drove back to it before starting its leg.
@@ -1515,12 +1508,18 @@ function VeafCombatZone:spawnElement(zoneElement, now)
       -- measures it against the mission table's unit 1, while the element's position comes from the
       -- first unit the zone happened to meet (see buildGroupElement), so a group whose units were not
       -- met in editor order carries a delta of its own intra-group spacing.
-      vars.offsetWP1 = true
-      local newGroup = mist.teleportToPoint(vars)
+      local newGroup = VeafGroupSpawn:new()
+        :forGroup(zoneElement:getName())
+        :named(newGroupName)
+        :at(position)
+        :withRoute(zoneElement:getRoute())
+        :renamingUnitsSequentially(self:isRenameUnitsSequentially())
+        :offsettingFirstWaypoint()
+        :respawn()
       if type(newGroup) == "table" then
         veaf.loggers
           .get(veafCombatZone.Id)
-          :trace(string.format("[%s]:activate() - mist.teleportToPoint([%s])", self:getMissionEditorZoneName(), zoneElement:getName()))
+          :trace(string.format("[%s]:activate() - VeafGroupSpawn([%s])", self:getMissionEditorZoneName(), zoneElement:getName()))
         self:addSpawnedGroup(newGroup.name)
         -- resolveAlarmState, not getAlarmState: the state is decided here, from the group's nature,
         -- unless its unit name stated one. A single default served the convoys of #290 and silenced
@@ -1529,9 +1528,7 @@ function VeafCombatZone:spawnElement(zoneElement, now)
       else
         veaf.loggers
           .get(veafCombatZone.Id)
-          :trace(
-            string.format("[%s]:activate() - mist.teleportToPoint([%s]) failed", self:getMissionEditorZoneName(), zoneElement:getName())
-          )
+          :trace(string.format("[%s]:activate() - VeafGroupSpawn([%s]) failed", self:getMissionEditorZoneName(), zoneElement:getName()))
       end
     elseif zoneElement:getVeafCommand() then
       veaf.loggers

--- a/src/scripts/veaf/veafDcsSpawner.lua
+++ b/src/scripts/veaf/veafDcsSpawner.lua
@@ -687,6 +687,280 @@ function veafDcsSpawner.getCurrentGroupData(groupName)
 end
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- VeafGroupSpawn — putting a group somewhere, with the verb in the method name
+--
+-- This replaces `mist.teleportToPoint`, whose interface was a table called `vars` carrying a string
+-- called `action`. That string was not a parameter: it chose between **three different verbs**, and an
+-- unnamed second argument chose a fourth. A misspelling silently fell through to "teleport", and a
+-- misspelled key did nothing at all.
+--
+--   VeafGroupSpawn:new():forGroup("Arco"):at(point):withRadius(500):clone()
+--
+-- The terminal method is the verb, so it cannot be misspelled without failing, and an unfinished chain
+-- creates nothing rather than guessing. Chaining rather than an options table because the repository
+-- already speaks it — 150 chainable `:setXxx` methods — and because `:withRadus(500)` fails loudly
+-- where `{ radus = 500 }` is a silent zero.
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+VeafGroupSpawn = {}
+
+--- How many times a valid-terrain draw is attempted before giving up. MiST's number.
+VeafGroupSpawn.TERRAIN_ATTEMPTS = 100
+
+--- Altitude bands an aircraft is dropped into when the requested point is too close to the ground,
+--- in metres above terrain. MiST's numbers, and the randomness is deliberate: a wave of respawned
+--- aircraft all at one altitude looks wrong from the cockpit.
+VeafGroupSpawn.ALTITUDE_BANDS = {
+  plane = { 300, 9000 },
+  helicopter = { 200, 3000 },
+}
+
+--- How far above the ground a requested altitude has to be before it is taken at face value.
+VeafGroupSpawn.MINIMUM_CLEARANCE_METRES = 10
+
+function VeafGroupSpawn:new()
+  local instance = {}
+  setmetatable(instance, self)
+  self.__index = self
+  instance.groupName = nil
+  instance.groupData = nil
+  instance.point = nil
+  instance.radius = 0
+  instance.route = nil
+  instance.newGroupName = nil
+  instance.dispersion = nil
+  instance.renameUnits = false
+  instance.terrain = nil
+  instance.anyTerrain = false
+  instance.offsetFirstWaypoint = false
+  return instance
+end
+
+--- The group to spawn from, by name.
+function VeafGroupSpawn:forGroup(groupName)
+  self.groupName = groupName
+  return self
+end
+
+--- A group definition supplied by the caller, instead of one read from the mission.
+--- `veafMove` uses this for its AFAC, which it builds rather than looks up.
+function VeafGroupSpawn:withGroupData(groupData)
+  self.groupData = groupData
+  return self
+end
+
+--- Where to put it. A vec3 whose `y` is the altitude.
+function VeafGroupSpawn:at(point)
+  self.point = point
+  return self
+end
+
+--- Scatter the group's origin anywhere within this radius of the point.
+function VeafGroupSpawn:withRadius(radius)
+  self.radius = radius or 0
+  return self
+end
+
+--- The route the spawned group flies or drives. Without one, the group's own is used.
+function VeafGroupSpawn:withRoute(route)
+  self.route = route
+  return self
+end
+
+--- Name the new group. Only a clone or a respawn can be renamed.
+function VeafGroupSpawn:named(newGroupName)
+  self.newGroupName = newGroupName
+  return self
+end
+
+--- Spread the units of the group over this radius, instead of keeping their formation.
+function VeafGroupSpawn:disperseOver(radius)
+  self.dispersion = radius
+  return self
+end
+
+--- Rename each unit after its group and its id, rather than keeping the editor names.
+function VeafGroupSpawn:renamingUnitsSequentially(enabled)
+  self.renameUnits = enabled ~= false
+  return self
+end
+
+--- Accept any surface, skipping the terrain check entirely.
+function VeafGroupSpawn:onAnyTerrain()
+  self.anyTerrain = true
+  return self
+end
+
+--- Accept only these surfaces, instead of the ones the group's category implies.
+function VeafGroupSpawn:onTerrain(surfaces)
+  self.terrain = surfaces
+  return self
+end
+
+--- Move the route's first waypoint by the same offset as the group.
+function VeafGroupSpawn:offsettingFirstWaypoint(enabled)
+  self.offsetFirstWaypoint = enabled ~= false
+  return self
+end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- The verbs
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+--- Create a **new** group from an editor group's definition, with new ids and names.
+function VeafGroupSpawn:clone()
+  return self:_spawn("clone", false)
+end
+
+--- Put **the same** group back where the Mission Editor drew it.
+function VeafGroupSpawn:respawn()
+  return self:_spawn("respawn", false)
+end
+
+--- Move the group **as it is right now**, keeping its live state.
+function VeafGroupSpawn:teleport()
+  return self:_spawn("teleport", false)
+end
+
+--- Build what a clone would submit, and create nothing. Replaces MiST's unnamed `prepareOnly` boolean;
+--- all three VEAF sites that passed it were cloning.
+function VeafGroupSpawn:buildCloneData()
+  return self:_spawn("clone", true)
+end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- The engine
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+--- The group definition a verb starts from.
+function VeafGroupSpawn:_sourceData(verb)
+  if self.groupData then
+    return veaf.deepCopy(self.groupData)
+  end
+  if not self.groupName then
+    return nil
+  end
+  if verb == "teleport" then
+    return veaf.getCurrentGroupData(self.groupName)
+  end
+  -- clone and respawn both read the editor definition; only clone asks for a new identity.
+  local record = veafMissionDb.getGroupRecord(self.groupName)
+  return record and veaf.deepCopy(record) or nil
+end
+
+--- A point in the circle whose terrain suits this group, and the offset to reach it.
+function VeafGroupSpawn:_drawOrigin(data)
+  local first = data.units[1]
+  if not self.point or self.radius < 0 then
+    return { x = 0, y = 0 }, nil
+  end
+
+  local surfaces = self.terrain or veafDcsSpawner.terrainForCategory(data.category)
+  for _ = 1, VeafGroupSpawn.TERRAIN_ATTEMPTS do
+    local candidate = veaf.getRandomPointInCircle(self.point, self.radius)
+    if self.anyTerrain or veafDcsSpawner.isTerrainValid(candidate, surfaces) then
+      return { x = candidate.x - first.x, y = candidate.y - first.y }, candidate
+    end
+  end
+
+  veaf.loggers
+    .get(veafDcsSpawner.Id)
+    :error("no point within %sm of the requested spot is valid terrain for [%s]", veaf.p(self.radius), veaf.p(self.groupName))
+  return nil, nil
+end
+
+--- The altitude an aircraft unit gets at this spot.
+function VeafGroupSpawn:_altitudeFor(category, unit)
+  local band = VeafGroupSpawn.ALTITUDE_BANDS[category]
+  if not band then
+    return unit.alt
+  end
+  local ground = land.getHeight({ x = unit.x, y = unit.y })
+  -- A requested altitude is taken at face value only when it clears the terrain; otherwise the
+  -- aircraft would be spawned inside a hill.
+  if self.point and self.point.z and self.point.y and self.point.y > ground + VeafGroupSpawn.MINIMUM_CLEARANCE_METRES then
+    return self.point.y
+  end
+  return ground + math.random(band[1], band[2])
+end
+
+--- Run the verb.
+--- @param verb string clone, respawn or teleport
+--- @param buildOnly boolean true to return the data without creating anything
+--- @return table|false|nil what was created, the data when building only, or false
+function VeafGroupSpawn:_spawn(verb, buildOnly)
+  local data = self:_sourceData(verb)
+  if not data then
+    veaf.loggers.get(veafDcsSpawner.Id):info("cannot %s [%s]: no group data", verb, veaf.p(self.groupName))
+    return false
+  end
+  if type(data.units) ~= "table" or not data.units[1] then
+    veaf.loggers.get(veafDcsSpawner.Id):warn("cannot %s [%s]: it has no units", verb, veaf.p(self.groupName))
+    return false
+  end
+
+  -- A record from the mission database names its group `groupName`; a spawn wants `name`.
+  data.name = self.newGroupName or data.name or data.groupName
+  data.groupName = data.name
+  if verb == "clone" then
+    -- New identity: drop the ids so the spawner allocates fresh ones.
+    data.groupId = nil
+    for _, unit in pairs(data.units) do
+      unit.unitId = nil
+    end
+  end
+
+  if self.renameUnits then
+    for index, unit in pairs(data.units) do
+      unit.unitName = string.format("%s #%d", data.name, unit.unitId or index)
+      unit.name = unit.unitName
+    end
+  end
+
+  local offset, origin = self:_drawOrigin(data)
+  if not offset then
+    return false
+  end
+
+  for index, unit in pairs(data.units) do
+    if self.dispersion and index > 1 then
+      local spread = veaf.getRandomPointInCircle(origin or { x = unit.x, y = 0, z = unit.y }, self.dispersion)
+      unit.x, unit.y = spread.x, spread.y
+    elseif self.dispersion and origin then
+      unit.x, unit.y = origin.x, origin.y
+    else
+      unit.x, unit.y = unit.x + offset.x, unit.y + offset.y
+    end
+    if self.point then
+      unit.alt = self:_altitudeFor(data.category, unit) or unit.alt
+    end
+  end
+
+  -- A start time already past means "now"; one still ahead keeps whatever is left of it.
+  if data.start_time and data.start_time ~= 0 and verb ~= "teleport" then
+    local elapsed = timer.getAbsTime() - timer.getTime0()
+    data.start_time = elapsed > data.start_time and 0 or data.start_time - elapsed
+  end
+
+  local route = self.route or (self.groupName and veaf.getGroupRoute(self.groupName)) or nil
+  if route then
+    route = veaf.deepCopy(route)
+    if self.offsetFirstWaypoint and route[1] and route[1].x then
+      route[1].x, route[1].y = route[1].x + offset.x, route[1].y + offset.y
+    end
+    data.route = { points = route }
+  end
+
+  if buildOnly then
+    return data
+  end
+  if type(data.category) == "string" and string.lower(data.category) == "static" then
+    return veaf.addStatic(data)
+  end
+  return veaf.addGroup(data)
+end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Framework façades. Callers use `veaf.*` and never name the implementation.
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/src/scripts/veaf/veafDcsSpawner.lua
+++ b/src/scripts/veaf/veafDcsSpawner.lua
@@ -899,6 +899,18 @@ function VeafGroupSpawn:_spawn(verb, buildOnly)
     return false
   end
 
+  -- Every unit needs a position to be moved from. MiST assumed one and raised an arithmetic error on
+  -- nil, which in DCS means the whole script stops; saying so and creating nothing is the same outcome
+  -- for the group and a far better one for the mission.
+  for index, unit in pairs(data.units) do
+    if type(unit.x) ~= "number" or type(unit.y) ~= "number" then
+      veaf.loggers
+        .get(veafDcsSpawner.Id)
+        :error("cannot %s [%s]: unit %s has no position", verb, veaf.p(self.groupName), veaf.p(unit.name or index))
+      return false
+    end
+  end
+
   -- A record from the mission database names its group `groupName`; a spawn wants `name`.
   data.name = self.newGroupName or data.name or data.groupName
   data.groupName = data.name

--- a/src/scripts/veaf/veafMove.lua
+++ b/src/scripts/veaf/veafMove.lua
@@ -613,8 +613,7 @@ function veafMove.moveTanker(eventPos, groupName, speed, alt, hdg, distance, tel
   -- teleport if the option is set
   if teleport then
     veaf.loggers.get(veafMove.Id):debug("Teleport the tanker")
-    local vars = { groupName = groupName, point = teleportPoint, action = "teleport" }
-    local grp = mist.teleportToPoint(vars)
+    local grp = VeafGroupSpawn:new():forGroup(groupName):at(teleportPoint):teleport()
     unitGroup = Group.getByName(groupName)
 
     veafMove.teleportEscort(groupName, movePoint, teleportPoint)
@@ -828,8 +827,7 @@ function veafMove.teleportEscort(escorted_groupName, movePoint, teleportPoint)
   task_escort.params.groupId = escortedId --assign the new groupID within the old escort mission, only necessary after teleporting as the tanker's ID will have changed
 
   veaf.loggers.get(veafMove.Id):debug("Teleport the escort")
-  local vars_escort = { groupName = groupName_escort, point = teleportPoint_escort, action = "teleport" }
-  mist.teleportToPoint(vars_escort)
+  VeafGroupSpawn:new():forGroup(groupName_escort):at(teleportPoint_escort):teleport()
   local unitGroup_escort = Group.getByName(groupName_escort)
 
   veafMove.replaceMission(unitGroup_escort, EscortData)
@@ -1019,11 +1017,13 @@ function veafMove.moveAfac(eventPos, groupName, speed, alt, heading, immortal)
 
     --teleport the group south of the requested location
     veaf.loggers.get(veafMove.Id):trace("AFAC " .. groupName .. " teleported")
-    local vars = { groupName = groupName, point = teleportPosition, action = "teleport" }
+    -- A dynamically spawned AFAC is not in the mission, so its definition is supplied rather than
+    -- looked up — and with it comes `onAnyTerrain`, since a JTAC may sit anywhere its operator put it.
+    local spawn = VeafGroupSpawn:new():forGroup(groupName):at(teleportPosition)
     if isDynamicallySpawned then
-      vars = { groupName = groupName, groupData = afacData, anyTerrain = true, point = teleportPosition, action = "teleport" }
+      spawn = spawn:withGroupData(afacData):onAnyTerrain()
     end
-    local grp = mist.teleportToPoint(vars)
+    local grp = spawn:teleport()
     unitGroup = Group.getByName(groupName) --refresh group class after respawn, not necessary but safer considering at least the groupId changes
 
     --necessary delay for the following code to not be ignored

--- a/src/scripts/veaf/veafQraCore.lua
+++ b/src/scripts/veaf/veafQraCore.lua
@@ -1020,14 +1020,12 @@ function VeafQRACore:deploy(nbUnitsInZone)
           else
             spawnSpot = group:getUnit(1):getPoint()
           end
-          local vars = {}
-          vars.point = veaf.getRandomPointInCircle(spawnSpot, self.respawnRadius)
-          vars.point.z = vars.point.y
-          vars.point.y = spawnSpot.y
-          vars.gpName = groupName
-          vars.action = "clone"
-          vars.route = veaf.getGroupRoute(groupName)
-          local newGroup = mist.teleportToPoint(vars) -- respawn with radius
+          local newGroup = VeafGroupSpawn:new()
+            :forGroup(groupName)
+            :at(spawnSpot)
+            :withRadius(self.respawnRadius)
+            :withRoute(veaf.getGroupRoute(groupName))
+            :clone()
           if newGroup then
             table.insert(self.spawnedGroupsNames, newGroup.name)
           end

--- a/src/scripts/veaf/veafSpawnAircraft.lua
+++ b/src/scripts/veaf/veafSpawnAircraft.lua
@@ -635,19 +635,9 @@ function veafSpawn.spawnAFAC(spawnSpot, name, country, altitude, speed, hdg, fre
   }
 
   -- (re)spawn group
-  local vars = {}
-  vars.gpName = groupName
-  vars.name = groupName
-  --vars.groupData = _template:getGroupData()
-  --replace the callsign to prevent interractions
-  vars.route = newRoute
-  vars.action = "clone"
-  vars.point = teleportSpot
-  vars.newGroupName = newGroupName
-
-  local newGroup = mist.teleportToPoint(vars, true)
+  local newGroup = VeafGroupSpawn:new():forGroup(groupName):named(newGroupName):at(teleportSpot):withRoute(newRoute):buildCloneData()
   if not newGroup then
-    veaf.loggers.get(veafSpawn.Id):error("cannot respawn group %s", veaf.p(vars.name))
+    veaf.loggers.get(veafSpawn.Id):error("cannot respawn group %s", veaf.p(groupName))
     return nil
   end
   if country and #country > 0 then
@@ -1121,18 +1111,9 @@ function veafSpawn.spawnCombatAirPatrol(
   veaf.loggers.get(veafSpawn.Id):debug("indexed newGroupName=%s", newGroupName)
 
   -- (re)spawn group
-  local vars = {}
-  vars.gpName = chosenTemplateName
-  vars.name = chosenTemplateName
-  --vars.groupData = _template:getGroupData()
-  vars.route = newRoute
-  vars.action = "clone"
-  vars.point = position
-  vars.newGroupName = newGroupName
-
-  local newGroup = mist.teleportToPoint(vars, true)
+  local newGroup = VeafGroupSpawn:new():forGroup(chosenTemplateName):named(newGroupName):at(position):withRoute(newRoute):buildCloneData()
   if not newGroup then
-    veaf.loggers.get(veafSpawn.Id):error("cannot respawn group %s", veaf.p(vars.name))
+    veaf.loggers.get(veafSpawn.Id):error("cannot respawn group %s", veaf.p(chosenTemplateName))
     return nil
   end
   if country and #country > 0 then

--- a/src/scripts/veaf/veafSpawnEffects.lua
+++ b/src/scripts/veaf/veafSpawnEffects.lua
@@ -469,8 +469,7 @@ end
 --- teleport group
 function veafSpawn.teleport(spawnSpot, name, silent)
   veaf.loggers.get(veafSpawn.Id):debug("teleport(name = " .. name .. ")")
-  local vars = { groupName = name, point = spawnSpot, action = "teleport" }
-  local grp = mist.teleportToPoint(vars)
+  local grp = VeafGroupSpawn:new():forGroup(name):at(spawnSpot):teleport()
   if not silent then
     if grp then
       trigger.action.outText(veaf.t("spawn.teleported", name), 5)

--- a/test/lua/dcs_mocks.lua
+++ b/test/lua/dcs_mocks.lua
@@ -7,6 +7,7 @@
 -- ---------------------------------------------------------------------------
 dcs_mocks = {}
 dcs_mocks.currentTime = 0
+dcs_mocks.missionStart = 0 -- what timer.getTime0 answers
 --- Trigger zones visible to trigger.misc.getZone, keyed by name:
 --- { point = { x, y, z }, radius = <metres> }. Empty unless a suite calls dcs_mocks.addZone.
 dcs_mocks.zones = {}
@@ -63,6 +64,11 @@ timer = {
   end,
   getAbsTime = function()
     return dcs_mocks.currentTime
+  end,
+  --- Mission start, in absolute time. A spawn subtracts it from getAbsTime to know how much of a
+  --- group's editor start_time is left.
+  getTime0 = function()
+    return dcs_mocks.missionStart or 0
   end,
   --- Record a task and hand back an id. **It does not run**, and `setTime` does not run it
   --- either: a suite that merely advances the clock must keep behaving as it did when this

--- a/test/lua/test_veafAssets.lua
+++ b/test/lua/test_veafAssets.lua
@@ -178,9 +178,26 @@ function TestVeafAssetsOps:test_dispose_not_found()
 end
 
 function TestVeafAssetsOps:test_respawn_found()
-  -- mist.respawnGroup is mocked as a no-op
+  -- This used to end on assertTrue(true), because `mist.respawnGroup` was a no-op stub and there was
+  -- nothing to look at. The respawn runs VEAF's own spawn chain now, so the group it puts back is
+  -- observable: what reaches DCS is the assertion.
+  env.mission.coalition.blue.country = {
+    [1] = {
+      name = "USA",
+      id = country.id.USA,
+      plane = {
+        group = {
+          { name = "testTanker", groupId = 12, units = { { name = "testTanker-1", unitId = 8, type = "KC-135", x = 1000, y = 2000 } } },
+        },
+      },
+    },
+  }
+  veafMissionDb.buildSnapshot()
+
   veafAssets.respawn("testTanker")
-  luaunit.assertTrue(true)
+
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 1, "the asset must actually be put back")
+  luaunit.assertEquals(dcs_mocks.groupsAdded[1].group.name, "testTanker")
 end
 
 function TestVeafAssetsOps:test_respawn_not_found()

--- a/test/lua/test_veafCombatZone.lua
+++ b/test/lua/test_veafCombatZone.lua
@@ -2037,17 +2037,20 @@ function TestVeafCombatZoneRenameOption:setUp()
   self.el:setCoalition(coalition.side.RED)
   self.el:setDcsGroup(true)
 
-  self._teleport = mist.teleportToPoint
-  self.vars = nil
+  self._spawnImpl = VeafGroupSpawn._spawn
+  self.spawn = nil
   local this = self
-  mist.teleportToPoint = function(vars)
-    this.vars = vars
-    return nil -- a nil return keeps spawnElement on its "nothing came back" path, which is enough here
+  -- The recipe the chain built, captured instead of MiST's `vars` table. A nil return keeps
+  -- spawnElement on its "nothing came back" path, which is enough here.
+  VeafGroupSpawn._spawn = function(spawn, verb)
+    this.spawn = spawn
+    this.verb = verb
+    return nil
   end
 end
 
 function TestVeafCombatZoneRenameOption:tearDown()
-  mist.teleportToPoint = self._teleport
+  VeafGroupSpawn._spawn = self._spawnImpl
 end
 
 function TestVeafCombatZoneRenameOption:test_the_default_is_todays_behaviour()
@@ -2064,14 +2067,14 @@ end
 -- The one that matters: the value reaches MiST.
 function TestVeafCombatZoneRenameOption:test_a_spawn_asks_mist_to_rename_by_default()
   self.z:spawnElement(self.el, true)
-  luaunit.assertNotNil(self.vars, "mist.teleportToPoint must have been called")
-  luaunit.assertTrue(self.vars.renameUnitsSequentially)
+  luaunit.assertNotNil(self.spawn, "the spawn chain must have been run")
+  luaunit.assertTrue(self.spawn.renameUnits)
 end
 
 function TestVeafCombatZoneRenameOption:test_a_zone_that_declined_renaming_says_so_to_mist()
   self.z:setRenameUnitsSequentially(false)
   self.z:spawnElement(self.el, true)
-  luaunit.assertFalse(self.vars.renameUnitsSequentially)
+  luaunit.assertFalse(self.spawn.renameUnits)
 end
 
 -- A static object goes down the same branch, so the setting has to reach it too.
@@ -2080,7 +2083,7 @@ function TestVeafCombatZoneRenameOption:test_a_static_element_honours_the_settin
   self.el:setDcsStatic(true)
   self.z:setRenameUnitsSequentially(false)
   self.z:spawnElement(self.el, true)
-  luaunit.assertFalse(self.vars.renameUnitsSequentially)
+  luaunit.assertFalse(self.spawn.renameUnits)
 end
 
 -- Zones are independent: this is a per-zone setting, not a global debug switch, precisely so that
@@ -2202,32 +2205,35 @@ function TestVeafCombatZoneSpawnRouteOffset:setUp()
   self.el:setCoalition(coalition.side.RED)
   self.el:setDcsGroup(true)
 
-  self._teleport = mist.teleportToPoint
-  self.vars = nil
+  self._spawnImpl = VeafGroupSpawn._spawn
+  self.spawn = nil
   local this = self
-  mist.teleportToPoint = function(vars)
-    this.vars = vars
+  VeafGroupSpawn._spawn = function(spawn, verb)
+    this.spawn = spawn
+    this.verb = verb
     return nil
   end
 end
 
 function TestVeafCombatZoneSpawnRouteOffset:tearDown()
-  mist.teleportToPoint = self._teleport
+  VeafGroupSpawn._spawn = self._spawnImpl
 end
 
 function TestVeafCombatZoneSpawnRouteOffset:test_a_spawn_asks_mist_to_move_waypoint_1()
   self.z:spawnElement(self.el, true)
-  luaunit.assertNotNil(self.vars, "mist.teleportToPoint must have been called")
-  luaunit.assertTrue(self.vars.offsetWP1)
+  luaunit.assertNotNil(self.spawn, "the spawn chain must have been run")
+  luaunit.assertTrue(self.spawn.offsetFirstWaypoint)
 end
 
--- The decision, pinned. `offsetRoute` would translate every waypoint of a track the mission maker
--- drew on the terrain, and differently on each activation; if someone sets it later it should be
--- because they meant to, not because this line drifted.
-function TestVeafCombatZoneSpawnRouteOffset:test_the_rest_of_the_route_is_left_where_it_was_drawn()
-  self.z:spawnElement(self.el, true)
-  luaunit.assertNil(self.vars.offsetRoute)
-  luaunit.assertNil(self.vars.initTasks, "initTasks would delete every waypoint past the first")
+-- The decision, pinned — and pinned differently since the chain replaced MiST's `vars`. Asserting
+-- `assertNil(self.spawn.offsetWholeRoute)` would pass whatever happened, because the chain has no such
+-- field: a test that cannot fail is not a test. What is asserted instead is the reason the risk is
+-- gone — the chain offers **no way** to translate the whole route or to truncate it, so `offsetRoute`
+-- and `initTasks` cannot drift back in without someone adding a method for them on purpose.
+function TestVeafCombatZoneSpawnRouteOffset:test_the_whole_route_cannot_be_moved_at_all()
+  luaunit.assertNil(VeafGroupSpawn.offsettingWholeRoute, "translating a drawn track is not on offer")
+  luaunit.assertNil(VeafGroupSpawn.initialisingTasks, "truncating a route past waypoint 1 is not on offer")
+  luaunit.assertNotNil(VeafGroupSpawn.offsettingFirstWaypoint, "moving waypoint 1 is, and is what a zone asks for")
 end
 
 -- Unconditional on purpose. The delta is not only the dispersion: MiST measures it against the
@@ -2236,13 +2242,13 @@ end
 function TestVeafCombatZoneSpawnRouteOffset:test_a_group_with_no_dispersion_still_asks_for_the_offset()
   self.el:setSpawnRadius(0)
   self.z:spawnElement(self.el, true)
-  luaunit.assertTrue(self.vars.offsetWP1)
+  luaunit.assertTrue(self.spawn.offsetFirstWaypoint)
 end
 
 function TestVeafCombatZoneSpawnRouteOffset:test_a_dispersed_group_asks_for_the_offset()
   self.el:setSpawnRadius(50)
   self.z:spawnElement(self.el, true)
-  luaunit.assertTrue(self.vars.offsetWP1)
+  luaunit.assertTrue(self.spawn.offsetFirstWaypoint)
 end
 
 -- A static goes down the same branch. It has no route to speak of, but the var must not be
@@ -2251,17 +2257,17 @@ function TestVeafCombatZoneSpawnRouteOffset:test_a_static_element_takes_the_same
   self.el:setDcsGroup(false)
   self.el:setDcsStatic(true)
   self.z:spawnElement(self.el, true)
-  luaunit.assertTrue(self.vars.offsetWP1)
+  luaunit.assertTrue(self.spawn.offsetFirstWaypoint)
 end
 
 -- The vars this lot did not touch must still arrive: this call site is the single place a combat zone
 -- respawns anything, and a fix that dropped one of them would be silent.
 function TestVeafCombatZoneSpawnRouteOffset:test_the_neighbouring_vars_are_untouched()
   self.z:spawnElement(self.el, true)
-  luaunit.assertEquals(self.vars.gpName, "OFFSETZONE-CONVOY")
-  luaunit.assertEquals(self.vars.action, "respawn")
-  luaunit.assertNotNil(self.vars.point)
-  luaunit.assertTrue(self.vars.renameUnitsSequentially)
+  luaunit.assertEquals(self.spawn.groupName, "OFFSETZONE-CONVOY")
+  luaunit.assertEquals(self.verb, "respawn")
+  luaunit.assertNotNil(self.spawn.point)
+  luaunit.assertTrue(self.spawn.renameUnits)
 end
 
 -- ============================================================================
@@ -2289,7 +2295,7 @@ function TestVeafCombatZoneSceneryAwareSpawn:setUp()
   self.el:setCoalition(coalition.side.RED)
   self.el:setDcsGroup(true)
 
-  self._teleport = mist.teleportToPoint
+  self._spawnImpl = VeafGroupSpawn._spawn
   self._savedDisposition = Disposition
   self._savedGetSurfaceType = land.getSurfaceType
   self._savedGetRandPoint = veaf.getRandomPointInCircle
@@ -2297,16 +2303,17 @@ function TestVeafCombatZoneSceneryAwareSpawn:setUp()
   Disposition = nil
   veaf.doNotAvoidScenery = false
 
-  self.vars = nil
+  self.spawn = nil
   local this = self
-  mist.teleportToPoint = function(vars)
-    this.vars = vars
+  VeafGroupSpawn._spawn = function(spawn, verb)
+    this.spawn = spawn
+    this.verb = verb
     return nil
   end
 end
 
 function TestVeafCombatZoneSceneryAwareSpawn:tearDown()
-  mist.teleportToPoint = self._teleport
+  VeafGroupSpawn._spawn = self._spawnImpl
   Disposition = self._savedDisposition
   land.getSurfaceType = self._savedGetSurfaceType
   veaf.getRandomPointInCircle = self._savedGetRandPoint
@@ -2342,8 +2349,8 @@ function TestVeafCombatZoneSceneryAwareSpawn:test_a_water_candidate_is_skipped()
   self.el:setSpawnRadius(1000)
   self:_jitter({ 100, 700 }, { 100 })
   self.z:spawnElement(self.el, true)
-  luaunit.assertNotNil(self.vars)
-  luaunit.assertEquals(self.vars.point.x, 700, "the water candidate must not become the element's position")
+  luaunit.assertNotNil(self.spawn)
+  luaunit.assertEquals(self.spawn.point.x, 700, "the water candidate must not become the element's position")
 end
 
 function TestVeafCombatZoneSceneryAwareSpawn:test_a_scenery_aware_point_is_used()
@@ -2355,8 +2362,8 @@ function TestVeafCombatZoneSceneryAwareSpawn:test_a_scenery_aware_point_is_used(
   }
   self:_jitter({ 100 })
   self.z:spawnElement(self.el, true)
-  luaunit.assertEquals(self.vars.point.x, 420)
-  luaunit.assertEquals(self.vars.point.z, 77)
+  luaunit.assertEquals(self.spawn.point.x, 420)
+  luaunit.assertEquals(self.spawn.point.z, 77)
 end
 
 -- The whole point of ticket 02's asymmetry with ticket 01. An unplaceable element still spawns.
@@ -2364,9 +2371,9 @@ function TestVeafCombatZoneSceneryAwareSpawn:test_no_acceptable_point_falls_back
   self.el:setSpawnRadius(1000)
   self:_allWater()
   self.z:spawnElement(self.el, true)
-  luaunit.assertNotNil(self.vars, "an unplaceable element must still be spawned, not skipped")
-  luaunit.assertEquals(self.vars.point.x, 0)
-  luaunit.assertEquals(self.vars.point.z, 0)
+  luaunit.assertNotNil(self.spawn, "an unplaceable element must still be spawned, not skipped")
+  luaunit.assertEquals(self.spawn.point.x, 0)
+  luaunit.assertEquals(self.spawn.point.z, 0)
 end
 
 -- The vertical is the element's declared one, not the terrain height the search writes. That is
@@ -2375,7 +2382,7 @@ function TestVeafCombatZoneSceneryAwareSpawn:test_the_declared_altitude_is_kept(
   self.el:setSpawnRadius(1000)
   self:_jitter({ 700 })
   self.z:spawnElement(self.el, true)
-  luaunit.assertEquals(self.vars.point.y, 12)
+  luaunit.assertEquals(self.spawn.point.y, 12)
 end
 
 function TestVeafCombatZoneSceneryAwareSpawn:test_a_zero_radius_never_consults_the_singleton()
@@ -2389,8 +2396,8 @@ function TestVeafCombatZoneSceneryAwareSpawn:test_a_zero_radius_never_consults_t
   }
   self.z:spawnElement(self.el, true)
   luaunit.assertFalse(asked, "a zero radius means exactly here")
-  luaunit.assertEquals(self.vars.point.x, 0)
-  luaunit.assertEquals(self.vars.point.z, 0)
+  luaunit.assertEquals(self.spawn.point.x, 0)
+  luaunit.assertEquals(self.spawn.point.z, 0)
 end
 
 -- ============================================================================

--- a/test/lua/test_veafDcsSpawner.lua
+++ b/test/lua/test_veafDcsSpawner.lua
@@ -965,4 +965,243 @@ function TestVeafDcsSpawnerCurrentGroupData:test_a_unit_whose_id_moved_does_not_
   luaunit.assertNil(veafDcsSpawner.getCurrentGroupData("Arco").units[1].payload)
 end
 
+-- ---------------------------------------------------------------------------
+-- TestVeafGroupSpawnChain
+-- ---------------------------------------------------------------------------
+-- Replaces `mist.teleportToPoint`, whose interface was a table called `vars` carrying a string called
+-- `action`. That string chose between three verbs and an unnamed boolean chose a fourth; a misspelling
+-- fell through to "teleport" and a misspelled key did nothing at all.
+TestVeafGroupSpawnChain = {}
+
+function TestVeafGroupSpawnChain:setUp()
+  dcs_mocks.reset()
+  land.getHeight = function()
+    return 0
+  end
+  land.getSurfaceType = function()
+    return land.SurfaceType.LAND
+  end
+  env.mission.coalition.blue.country = {
+    [1] = {
+      name = "USA",
+      id = country.id.USA,
+      vehicle = {
+        group = {
+          {
+            name = "Convoy",
+            groupId = 7,
+            units = { { name = "Convoy-1", unitId = 3, type = "M-1 Abrams", x = 1000, y = 2000, skill = "High" } },
+          },
+        },
+      },
+    },
+  }
+  veafMissionDb.buildSnapshot()
+end
+
+local function spawned()
+  local entries = dcs_mocks.groupsAdded
+  return entries[#entries] and entries[#entries].group
+end
+
+-- The verbs -----------------------------------------------------------------------------------
+
+function TestVeafGroupSpawnChain:test_a_clone_creates_a_group()
+  local result = VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 5000, y = 0, z = 6000 }):clone()
+
+  luaunit.assertNotNil(result)
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 1)
+end
+
+function TestVeafGroupSpawnChain:test_a_clone_asks_for_new_ids()
+  -- A new identity is the whole difference between cloning and respawning.
+  VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 5000, y = 0, z = 6000 }):clone()
+
+  luaunit.assertNotEquals(spawned().groupId, 7, "the editor's group id must not be reused")
+  luaunit.assertNotEquals(spawned().units[1].unitId, 3)
+end
+
+function TestVeafGroupSpawnChain:test_a_respawn_keeps_the_editor_identity()
+  VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 5000, y = 0, z = 6000 }):respawn()
+
+  luaunit.assertEquals(spawned().groupId, 7)
+  luaunit.assertEquals(spawned().units[1].unitId, 3)
+end
+
+function TestVeafGroupSpawnChain:test_building_only_creates_nothing()
+  -- Replaces MiST's unnamed second argument. All three sites that passed it were cloning.
+  local data = VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 5000, y = 0, z = 6000 }):buildCloneData()
+
+  luaunit.assertNotNil(data, "the data still comes back")
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 0, "but nothing was created")
+end
+
+function TestVeafGroupSpawnChain:test_an_unfinished_chain_creates_nothing()
+  -- MiST fell through to "tele" when the action was unrecognised. Here the verb is the method, so
+  -- there is no unrecognised action to fall through from.
+  VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 1, y = 0, z = 2 })
+
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 0)
+end
+
+function TestVeafGroupSpawnChain:test_a_verb_cannot_be_misspelled_into_silence()
+  -- The property the chain buys: a wrong verb is a nil method call, not a silent default.
+  luaunit.assertNil(VeafGroupSpawn.clown)
+  luaunit.assertNotNil(VeafGroupSpawn.clone)
+end
+
+-- Placement -----------------------------------------------------------------------------------
+
+function TestVeafGroupSpawnChain:test_the_group_lands_at_the_point_asked_for()
+  dcs_mocks.setRandomSequence({ 0 }) -- a zero draw puts the origin exactly on the point
+
+  VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 5000, y = 0, z = 6000 }):withRadius(100):respawn()
+
+  luaunit.assertEquals(spawned().units[1].x, 5000)
+  luaunit.assertEquals(spawned().units[1].y, 6000, "the point's z is the unit's y — the easting")
+end
+
+function TestVeafGroupSpawnChain:test_the_whole_group_keeps_its_formation()
+  -- One offset for everyone: the draw places unit 1 and the others follow, or a convoy would arrive
+  -- as a heap.
+  env.mission.coalition.blue.country[1].vehicle.group[1].units[2] =
+    { name = "Convoy-2", unitId = 4, type = "M-1 Abrams", x = 1050, y = 2000 }
+  veafMissionDb.buildSnapshot()
+  dcs_mocks.setRandomSequence({ 0 })
+
+  VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 5000, y = 0, z = 6000 }):withRadius(100):respawn()
+
+  local units = spawned().units
+  luaunit.assertEquals(units[2].x - units[1].x, 50, "the 50 m spacing must survive the move")
+end
+
+function TestVeafGroupSpawnChain:test_terrain_the_group_cannot_use_is_refused()
+  -- A convoy on water: a hundred draws, none valid, and nothing is created rather than a group
+  -- dropped in a lake.
+  land.getSurfaceType = function()
+    return land.SurfaceType.WATER
+  end
+
+  local result = VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 5000, y = 0, z = 6000 }):withRadius(500):respawn()
+
+  luaunit.assertFalse(result)
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 0)
+end
+
+function TestVeafGroupSpawnChain:test_any_terrain_skips_the_check()
+  -- What veafMove uses for a dynamically spawned AFAC.
+  land.getSurfaceType = function()
+    return land.SurfaceType.WATER
+  end
+
+  local result = VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 5000, y = 0, z = 6000 }):withRadius(500):onAnyTerrain():respawn()
+
+  luaunit.assertNotNil(result)
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 1)
+end
+
+function TestVeafGroupSpawnChain:test_an_explicit_terrain_list_overrides_the_category_one()
+  land.getSurfaceType = function()
+    return land.SurfaceType.WATER
+  end
+
+  local result = VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 5000, y = 0, z = 6000 }):withRadius(500):onTerrain({ "WATER" }):respawn()
+
+  luaunit.assertNotNil(result, "a caller naming its surfaces means it")
+end
+
+-- Naming and renaming -----------------------------------------------------------------------------
+
+function TestVeafGroupSpawnChain:test_a_new_name_is_used()
+  VeafGroupSpawn:new():forGroup("Convoy"):named("Convoy #0001"):at({ x = 1, y = 0, z = 2 }):respawn()
+
+  luaunit.assertEquals(spawned().name, "Convoy #0001")
+end
+
+function TestVeafGroupSpawnChain:test_units_can_be_renamed_after_their_group()
+  VeafGroupSpawn:new():forGroup("Convoy"):named("Alpha"):at({ x = 1, y = 0, z = 2 }):renamingUnitsSequentially():respawn()
+
+  luaunit.assertStrContains(spawned().units[1].name, "Alpha")
+end
+
+function TestVeafGroupSpawnChain:test_renaming_is_off_unless_asked()
+  VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 1, y = 0, z = 2 }):respawn()
+
+  luaunit.assertEquals(spawned().units[1].name, "Convoy-1")
+end
+
+function TestVeafGroupSpawnChain:test_renaming_can_be_declined_explicitly()
+  -- veafCombatZone passes a boolean through, so false has to mean false.
+  VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 1, y = 0, z = 2 }):renamingUnitsSequentially(false):respawn()
+
+  luaunit.assertEquals(spawned().units[1].name, "Convoy-1")
+end
+
+-- Routes ---------------------------------------------------------------------------------------
+
+function TestVeafGroupSpawnChain:test_a_route_that_was_given_is_used()
+  VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 1, y = 0, z = 2 }):withRoute({ { x = 9, y = 9 } }):respawn()
+
+  luaunit.assertNotNil(spawned().route)
+  luaunit.assertEquals(#spawned().route.points, 1)
+end
+
+function TestVeafGroupSpawnChain:test_the_first_waypoint_follows_the_group_when_asked()
+  -- FIX-COMBATZONE-SPAWN-ROUTE-OFFSET: without this a displaced group drove back to a waypoint 1
+  -- still at its editor position.
+  dcs_mocks.setRandomSequence({ 0 })
+
+  VeafGroupSpawn:new()
+    :forGroup("Convoy")
+    :at({ x = 5000, y = 0, z = 6000 })
+    :withRoute({ { x = 1000, y = 2000 } })
+    :offsettingFirstWaypoint()
+    :respawn()
+
+  luaunit.assertEquals(spawned().route.points[1].x, 5000, "waypoint 1 moved with the group")
+end
+
+function TestVeafGroupSpawnChain:test_the_first_waypoint_stays_put_by_default()
+  dcs_mocks.setRandomSequence({ 0 })
+
+  VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 5000, y = 0, z = 6000 }):withRoute({ { x = 1000, y = 2000 } }):respawn()
+
+  luaunit.assertEquals(spawned().route.points[1].x, 1000)
+end
+
+-- Sources ---------------------------------------------------------------------------------------
+
+function TestVeafGroupSpawnChain:test_a_caller_may_supply_the_group_definition()
+  -- veafMove does this for a dynamically spawned AFAC, which is not in the mission at all.
+  local result = VeafGroupSpawn:new()
+    :forGroup("NotInTheMission")
+    :withGroupData({
+      country = "USA",
+      category = "GROUND_UNIT",
+      name = "AFAC",
+      units = { { type = "Hummer", x = 1, y = 2 } },
+    })
+    :at({ x = 10, y = 0, z = 20 })
+    :teleport()
+
+  luaunit.assertNotNil(result)
+  luaunit.assertEquals(spawned().name, "AFAC")
+end
+
+function TestVeafGroupSpawnChain:test_an_unknown_group_creates_nothing()
+  luaunit.assertFalse(VeafGroupSpawn:new():forGroup("Nobody"):at({ x = 1, y = 0, z = 2 }):respawn())
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 0)
+end
+
+function TestVeafGroupSpawnChain:test_a_chain_with_no_group_at_all_creates_nothing()
+  luaunit.assertFalse(VeafGroupSpawn:new():at({ x = 1, y = 0, z = 2 }):respawn())
+end
+
+function TestVeafGroupSpawnChain:test_a_group_with_no_units_creates_nothing()
+  env.mission.coalition.blue.country[1].vehicle.group[1].units = {}
+  veafMissionDb.buildSnapshot()
+
+  luaunit.assertFalse(VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 1, y = 0, z = 2 }):respawn())
+end
+
 os.exit(luaunit.LuaUnit.run())

--- a/test/lua/test_veafDcsSpawner.lua
+++ b/test/lua/test_veafDcsSpawner.lua
@@ -1204,4 +1204,14 @@ function TestVeafGroupSpawnChain:test_a_group_with_no_units_creates_nothing()
   luaunit.assertFalse(VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 1, y = 0, z = 2 }):respawn())
 end
 
+function TestVeafGroupSpawnChain:test_a_unit_with_no_position_creates_nothing()
+  -- MiST raised an arithmetic error on nil here, and in DCS a raised error stops the whole script.
+  -- Refusing says the same thing about the group and leaves the mission running.
+  env.mission.coalition.blue.country[1].vehicle.group[1].units[1].x = nil
+  veafMissionDb.buildSnapshot()
+
+  luaunit.assertFalse(VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 1, y = 0, z = 2 }):respawn())
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 0)
+end
+
 os.exit(luaunit.LuaUnit.run())


### PR DESCRIPTION
DROP-MIST **ticket 07**: `VeafGroupSpawn` replaces `mist.teleportToPoint`, and all **12** call sites with it. The ticket is at **60 of its 64 calls** — `getGroupData` and `respawnGroup` are what is left.

## Before and after, on a real call site

```lua
-- veafQraCore.lua, before
local vars = {}
vars.point = veaf.getRandomPointInCircle(spawnSpot, self.respawnRadius)
vars.point.z = vars.point.y
vars.point.y = spawnSpot.y
vars.gpName = groupName
vars.action = "clone"
vars.route = veaf.getGroupRoute(groupName)
local newGroup = mist.teleportToPoint(vars)

-- after
local newGroup = VeafGroupSpawn:new()
  :forGroup(groupName)
  :at(spawnSpot)
  :withRadius(self.respawnRadius)
  :withRoute(veaf.getGroupRoute(groupName))
  :clone()
```

## Why chaining

David's call, after comparing an options table and positional arguments on that same site. An options table is the closest Lua has to Python's keyword arguments and **keeps `vars`'s worst property**: nobody validates the keys, so `{ radus = 500 }` is a silent zero radius. Chaining is what the repository already speaks — **150 chainable `:setXxx` methods** — and `:withRadus(500)` fails loudly.

## What the table was hiding

Not a parameter object: **three verbs behind a string**, plus a fourth behind an unnamed boolean.

| was | is |
|---|---|
| `vars.action = "clone"` | `:clone()` |
| `vars.action = "respawn"` | `:respawn()` |
| `vars.action = "teleport"` | `:teleport()` |
| `teleportToPoint(vars, true)` | `:buildCloneData()` |

A misspelled action **fell through to teleport**. A misspelled verb is now a nil method call, and an unfinished chain creates nothing — both asserted.

`withRadius` also absorbed the three lines of `point.z = point.y` juggling every caller copied — the exact place `FIX-AIRWAVES-COMMAND-EASTING` slipped in.

## Behaviour unchanged

Same per-category terrain rules, the single offset that keeps a group in formation, the random altitude band for an aircraft dropped too close to the ground, the start time made relative to now. Each has a test; **three were confirmed to fail** when the behaviour they name is broken (the formation offset, the point drawn, the terrain refusal).

## A hollow assertion found on the way

The combat-zone tests captured MiST's `vars` and asserted on its keys. Converted to capture the built recipe — but one of them became `assertNil` on keys the chain does not have, **which can never fail**. It now asserts what really makes the risk impossible: the chain offers no method to translate a whole route or truncate it, so `offsetRoute` and `initTasks` cannot drift back without someone adding one on purpose.

## Checks

- Lua suite: 44 suites green, **110 tests** in `test_veafDcsSpawner.lua`
- `stylua --check` clean, `docs-check` clean
- `luacheck` left to the CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace MiST-based group spawning with the validated VeafGroupSpawn API while preserving mission behavior and completing the DROP-MIST migration.

Bug Fixes:
- Prevent invalid or incomplete spawn requests from silently defaulting to teleport or failing through malformed parameters.
- Preserve group placement, terrain validation, formation offsets, aircraft altitude handling, and relative start-time behavior while migrating spawning operations.

Enhancements:
- Replace MiST group teleport and respawn calls with the validated, chainable VeafGroupSpawn API across all call sites.
- Centralize group cloning, respawning, teleporting, route handling, naming, terrain selection, dispersion, and coordinate conversion behind VeafGroupSpawn.
- Allow dynamically constructed group data to be spawned without requiring a mission-database record.
- Complete DROP-MIST ticket 07 by migrating all 64 identified spawn, route, and teleport call sites.

Build:
- Register VeafGroupSpawn as a recognized Lua global for static analysis.

Documentation:
- Document the new sentence-style group spawning API and its behavior in the changelog.
- Mark DROP-MIST ticket 07 and its migration checklist as complete.

Tests:
- Add comprehensive VeafGroupSpawn coverage for verbs, placement, terrain rules, naming, routes, supplied group data, and invalid input.
- Update asset and combat-zone tests to validate spawn recipes and observable group creation rather than MiST parameter tables.