### PR TITLE
feat(logs): veaf-logs, a reader for DCS logs

### DIFF
--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -37,9 +37,15 @@ jobs:
       - name: Install Poetry
         run: pip install poetry
 
+      # veaf-logs is a Qt application: its tests run headless (QT_QPA_PLATFORM=offscreen,
+      # set by their conftest), but the offscreen plugin still links against these.
+      - name: Install the Qt runtime libraries
+        run: sudo apt-get update && sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3
+
       - name: Install dependencies
         # Install runtime + dev deps; exclude only the 'build' group (pyinstaller)
-        # --all-extras installs lupa (lua extra) needed by miz_tools / luadata
+        # --all-extras installs lupa (lua extra) needed by miz_tools / luadata,
+        # and PySide6 (logs extra) needed by veaf-logs
         run: poetry install --without build --all-extras
 
       # The whole Python tree, not just the shipped package: test/python/ was under no gate at all,
@@ -108,3 +114,46 @@ jobs:
           cd smoke
           ../dist/veaf-tools generate-config --output .
           test -s mission.yaml
+
+  # ---------------------------------------------------------------------------
+  # Does the veaf-logs executable start?
+  #
+  # Same blind spot as above, and it has already bitten: the first build of this
+  # binary died instantly because its entry point used a relative import, which
+  # resolves fine from the checkout and not at all from a PyInstaller bundle. The
+  # window is the product here, so "it opens one and reads a log" is the test.
+  # ---------------------------------------------------------------------------
+  veaf-logs-exe-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install the Qt runtime libraries
+        run: sudo apt-get update && sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies (including PyInstaller)
+        run: poetry install --with build --all-extras
+
+      - name: Build the veaf-logs executable
+        run: poetry run pyinstaller veaf-logs.spec --noconfirm
+
+      # A window has no --help to walk, so we hand it a real log and check that it
+      # is still alive a few seconds later. A bundle whose imports are broken dies
+      # at once, which is exactly what this catches.
+      - name: The executable opens a log and keeps running
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          cat > smoke.log <<'LOG'
+          2026-08-31 11:50:40.872 ERROR   APP (Main): Corrupt damage model.
+          LOG
+          timeout 20 ./dist/veaf-logs smoke.log && code=$? || code=$?
+          # 124 is what `timeout` returns when it had to stop a healthy process.
+          test "$code" = "124" || { echo "veaf-logs exited on its own (code $code)"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,12 @@ jobs:
       - name: Build release package
         run: poetry run veaf-build build --version ${{ steps.version.outputs.version }}
 
+      # veaf-logs has its own recipe: it bundles Qt and nothing of the mission
+      # build chain, and keeping it out of veaf-tools.exe spares that binary
+      # some forty megabytes for a window most of its users never open.
+      - name: Build the veaf-logs executable
+        run: poetry run pyinstaller veaf-logs.spec --noconfirm
+
       - name: Publish to GitHub
         shell: bash
         run: |
@@ -66,6 +72,13 @@ jobs:
           poetry run veaf-build publish --version "${{ steps.version.outputs.version }}" --ci --force $FLAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload veaf-logs to the release
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.version.outputs.tag }}"             "dist/veaf-logs.exe#veaf-logs-${{ steps.version.outputs.version }}.exe" --clobber
 
       # Only a real release advances the floating published-latest tag; a pre-release leaves
       # production users on the previous stable (they opt in with --tag published-v<version>).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`veaf-logs`, a reader for DCS logs.** A DCS log buries what matters under noise nobody can act on.
+  This one knows our scripts and hides the rest — on a real session log, it takes 2,710 severe lines
+  down to **362**.
+
+  Three things it does that a general-purpose log viewer structurally cannot. **A stack trace stays
+  with its error**: filtering on errors no longer hides the `stack traceback` that explains them.
+  **The level shown is the real one** — DCS logs all Lua as `INFO SCRIPTING`, so a `VEAF|W|` warning
+  arrives labelled INFO; this reads it from the prefix, and filtering on WARNING finally surfaces
+  VEAF, CTLD and CSAR warnings. And **ED's harmless errors are hidden by family** — corrupt damage
+  models, negative payload weights, missing taxi routes, IC failures — each one switchable, with a
+  running count of what is hidden, so the filter is never silent.
+
+  Every level, source and noise family also has a third state besides shown and hidden: **context**,
+  which keeps a category only around the lines that matter, the way `grep -C` does. Each one carries
+  its own span. A complete filter set saves as a **profile**; three ship with the tool.
+
+  It reads a **119 MB server log in 8.6 seconds using 37 MB of memory**, indexing in the background
+  while you already read and filter the first lines. It never holds the log open — on Windows that
+  would stop DCS from rotating its own `dcs.log` at launch.
+
+  Shipped as a separate `veaf-logs.exe` asset. Its Qt dependency is optional (`--extras logs`), so
+  `veaf-tools.exe` neither grows nor changes. Documented in `doc/mission-maker/LOGS.md`.
+
 ### Fixed
 
 - **A FARP's escort could be parked through a building, or in a wood.** The clear-ground search added in

--- a/doc/mission-maker/LOGS.en.md
+++ b/doc/mission-maker/LOGS.en.md
@@ -1,0 +1,163 @@
+# veaf-logs — reading DCS logs
+
+`veaf-logs` opens a DCS log and shows only what matters. It knows the VEAF, CTLD,
+CSAR, AIEN and Skynet scripts, recognises Eagle Dynamics' harmless errors, and
+follows the file live while the mission runs.
+
+## Running it
+
+From the executable shipped with the release:
+
+```
+veaf-logs.exe
+```
+
+With no argument it reopens the last session's files, falling back to the current
+`dcs.log` (`Saved Games\DCS\Logs\dcs.log`). You can also pass it a path, or drop a
+file onto it.
+
+From the sources:
+
+```
+poetry install --all-extras
+poetry run veaf-logs
+```
+
+The window needs PySide6, declared as an optional dependency (`--all-extras`, or
+`--extras logs`). Nothing else in `veaf-tools` requires it.
+
+## The three states
+
+Every level, source and noise family cycles through three states on click:
+
+| | |
+|---|---|
+| ✓ | shown |
+| ◐ | **context** — shown only around a kept line |
+| ✕ | hidden |
+
+Context mode is what makes a log readable. Setting `INFO` to ◐ with ±3 lines
+keeps only errors and warnings, surrounded by what explains them. Each category
+can have its own span: the `±` field appears beside it as soon as it switches to
+◐, and leaving that field empty falls back to the shared value set at the top of
+the panel.
+
+On a real session log, dropping the ED noise takes 2,710 severe lines down to 362.
+
+## Profiles
+
+The dropdown at the top holds a complete filter set — category states, search
+criteria, context spans. Three profiles ship with the tool:
+
+- **Tout** — no filter at all, the way out when you have lost yourself;
+- **Lecture** — ED noise hidden;
+- **Diagnostic** — errors and warnings, with three lines of context.
+
+`Enregistrer…` saves a profile; the shipped ones can be neither edited nor
+deleted. As soon as a filter changes, the dropdown falls back to "Session
+courante": a saved profile never moves unless you ask it to.
+
+## Search
+
+Three modes, chosen from the dropdown:
+
+| Mode | `.` | `*` `?` | Example |
+|---|---|---|---|
+| Texte | literal | literal | `CSAR.lua` |
+| Jokers | literal | wildcards | `No taxiroad*Batumi*` |
+| Regex | wildcard | quantifiers | `VEAF\|[WE]\|` |
+
+`≠` inverts the criterion, `Aa` makes it case-sensitive. **Ajouter au filtre**
+stacks the current criterion: filters combine, and show up as chips you can
+remove with one click.
+
+Search covers the line **and** the stack trace under it: looking for a symbol
+that only appears in the trace brings back the error that produced it.
+
+## What it understands of the log
+
+**Stack traces stay with their error.** A `Mission script error` followed by its
+`stack traceback` forms a single entry, so filtering on errors no longer hides
+the explanation. The line then carries a `[+3]` marker, and the detail shows at
+the bottom when you select it.
+
+**The level shown is the real one.** DCS logs all Lua as `INFO SCRIPTING`,
+including a `VEAF|W|` that is a warning. `veaf-logs` reads it from the prefix:
+filtering on WARNING does bring up VEAF, CTLD and CSAR warnings.
+
+**Archives open directly.** The `.zip` files in `Saved Games\DCS\Logs` also carry
+the memory dump, the mission and the dxdiag report: the log is picked for you.
+
+**The log is never locked.** On Windows a file held open cannot be renamed — and
+that is exactly what DCS does to its `dcs.log` on every launch. `veaf-logs` opens
+and closes on each read, so it never keeps the game from starting.
+
+## Large logs
+
+The text is not held in memory: only a compact index is, and lines are decoded as
+they are displayed. On a 119 MB server log (991,392 lines):
+
+| | |
+|---|---|
+| First lines readable | 0.3 s |
+| Full indexing | 8.6 s, in the background |
+| Memory | 37 MB |
+| Search | 0.65 s |
+
+Indexing carries on while you read and filter; a progress bar shows up with a
+button to stop it — whatever is already indexed stays usable.
+
+## Shortcuts
+
+| | |
+|---|---|
+| `Ctrl+D` | open the current `dcs.log` |
+| `Ctrl+O` | open a file |
+| `Ctrl+W` | close the tab |
+| `Ctrl+F` | search |
+| `F` | follow the end of the file / pause |
+| `Ctrl+R` | show everything |
+| `Ctrl+S` | save the profile |
+| `F5` | reload the rule catalogue |
+
+## Adding your own rules
+
+Recognised sources, colours and noise families all live in one file,
+`veaf_logs/rules.json`, which the **Règles** menu opens and reloads (`F5`)
+without leaving the application.
+
+A script of your own takes one entry:
+
+```json
+{
+  "id": "monscript",
+  "label": "MonScript",
+  "color": "#ff8800",
+  "match": "^MONSCRIPT\\|(?P<lvl>[A-Z])\\|",
+  "level_group": "lvl",
+  "level_map": {"D": "DEBUG", "I": "INFO", "W": "WARNING", "E": "ERROR"}
+}
+```
+
+A noise family to drop:
+
+```json
+{
+  "id": "mon_bruit",
+  "label": "Short label shown",
+  "help": "Sentence shown as a tooltip.",
+  "default_hidden": true,
+  "match": "the pattern to hide",
+  "regex": true
+}
+```
+
+Patterns are matched against bytes to keep indexing fast, so they must stay
+ASCII. The number of noise families is capped at 64.
+
+## Where the settings live
+
+| | |
+|---|---|
+| Session (open files, filters, geometry) | `%APPDATA%\veaf-logs\session.json` |
+| Profiles | `%APPDATA%\veaf-logs\profiles.json` |

--- a/doc/mission-maker/LOGS.md
+++ b/doc/mission-maker/LOGS.md
@@ -1,0 +1,172 @@
+# veaf-logs — lire les journaux de DCS
+
+`veaf-logs` ouvre un journal DCS et n'en montre que ce qui compte. Il connaît les
+scripts VEAF, CTLD, CSAR, AIEN et Skynet, sait reconnaître les erreurs d'Eagle
+Dynamics sans conséquence, et suit le fichier en direct pendant que la mission
+tourne.
+
+## Lancer
+
+Depuis l'exécutable téléchargé avec la release :
+
+```
+veaf-logs.exe
+```
+
+Sans argument, il rouvre les fichiers de la dernière session ; à défaut, le
+`dcs.log` courant (`Saved Games\DCS\Logs\dcs.log`). On peut aussi lui passer un
+chemin, ou faire glisser un fichier dessus.
+
+Depuis les sources :
+
+```
+poetry install --all-extras
+poetry run veaf-logs
+```
+
+L'interface graphique demande PySide6, déclaré en dépendance optionnelle
+(`--all-extras`, ou `--extras logs`). Le reste de `veaf-tools` n'en a pas besoin.
+
+## Les trois états
+
+Chaque niveau, chaque source et chaque famille de bruit se règle d'un clic, en
+faisant défiler trois états :
+
+| | |
+|---|---|
+| ✓ | affiché |
+| ◐ | **contexte** — affiché seulement autour d'une ligne retenue |
+| ✕ | masqué |
+
+Le mode contexte est ce qui rend un journal lisible. Mettre `INFO` en ◐ avec
+±3 lignes ne garde que les erreurs et les avertissements, entourés de ce qui les
+explique. Chaque catégorie peut avoir sa propre portée : le champ `±` apparaît à
+sa droite dès qu'elle passe en ◐, et laisser le champ vide reprend la valeur
+commune réglée en haut du panneau.
+
+Sur un journal de session réel, écarter le bruit ED ramène 2 710 lignes de niveau
+grave à 362.
+
+## Profils
+
+La liste déroulante en haut retient un jeu de filtres complet — états des
+catégories, critères de recherche, portées du contexte. Trois profils sont
+fournis :
+
+- **Tout** — aucun filtre, la porte de sortie quand on s'est perdu ;
+- **Lecture** — le bruit ED masqué ;
+- **Diagnostic** — erreurs et avertissements, avec trois lignes de contexte.
+
+`Enregistrer…` crée un profil ; les profils fournis ne sont ni modifiables ni
+supprimables. Dès qu'un filtre change, la liste repasse sur « Session courante » :
+un profil enregistré ne bouge jamais sans qu'on le demande.
+
+## Recherche
+
+Trois modes, au choix dans la liste déroulante :
+
+| Mode | `.` | `*` `?` | Exemple |
+|---|---|---|---|
+| Texte | littéral | littéraux | `CSAR.lua` |
+| Jokers | littéral | jokers | `No taxiroad*Batumi*` |
+| Regex | joker | quantificateurs | `VEAF\|[WE]\|` |
+
+`≠` inverse le critère, `Aa` respecte la casse. **Ajouter au filtre** empile le
+critère courant : les filtres se cumulent et s'affichent en pastilles retirables
+d'un clic.
+
+La recherche porte sur la ligne **et** sur la trace de pile qui la suit :
+chercher un symbole présent uniquement dans la trace ramène l'erreur qui l'a
+produite.
+
+## Ce qu'il comprend du journal
+
+**Les traces de pile restent avec leur erreur.** Un `Mission script error` suivi
+de son `stack traceback` forme une seule entrée : filtrer sur les erreurs ne fait
+plus disparaître l'explication. La ligne porte alors un `[+3]`, et le détail
+s'affiche en bas quand on la sélectionne.
+
+**Le niveau affiché est le niveau réel.** DCS journalise tout le Lua en
+`INFO SCRIPTING`, y compris un `VEAF|W|` qui est un avertissement. `veaf-logs` le
+lit dans le préfixe : filtrer sur WARNING fait bien remonter les avertissements
+VEAF, CTLD ou CSAR.
+
+**Les archives s'ouvrent directement.** Les `.zip` de `Saved Games\DCS\Logs`
+contiennent aussi le vidage mémoire, la mission et le rapport dxdiag : le journal
+est choisi tout seul.
+
+**Le journal n'est jamais verrouillé.** Sous Windows, un fichier maintenu ouvert
+ne peut pas être renommé — et c'est ce que DCS fait de son `dcs.log` à chaque
+lancement. `veaf-logs` ouvre et referme à chaque lecture : il n'empêche jamais le
+jeu de démarrer.
+
+## Gros journaux
+
+Le texte n'est pas chargé en mémoire : seul un index compact l'est, et les lignes
+sont décodées à l'affichage. Sur un journal de serveur de 119 Mo (991 392 lignes) :
+
+| | |
+|---|---|
+| Premières lignes lisibles | 0,3 s |
+| Indexation complète | 8,6 s, en tâche de fond |
+| Mémoire | 37 Mo |
+| Recherche | 0,65 s |
+
+L'indexation se poursuit pendant qu'on lit et qu'on filtre ; une barre de
+progression apparaît, avec un bouton pour l'interrompre — ce qui est déjà indexé
+reste utilisable.
+
+## Raccourcis
+
+| | |
+|---|---|
+| `Ctrl+D` | ouvrir le `dcs.log` courant |
+| `Ctrl+O` | ouvrir un fichier |
+| `Ctrl+W` | fermer l'onglet |
+| `Ctrl+F` | chercher |
+| `F` | suivre la fin du fichier / mettre en pause |
+| `Ctrl+R` | tout afficher |
+| `Ctrl+S` | enregistrer le profil |
+| `F5` | recharger le catalogue de règles |
+
+## Ajouter ses propres règles
+
+Les sources reconnues, les couleurs et les familles de bruit vivent dans un seul
+fichier, `veaf_logs/rules.json`, que le menu **Règles** ouvre et recharge (`F5`)
+sans quitter l'application.
+
+Un script maison tient en une entrée :
+
+```json
+{
+  "id": "monscript",
+  "label": "MonScript",
+  "color": "#ff8800",
+  "match": "^MONSCRIPT\\|(?P<lvl>[A-Z])\\|",
+  "level_group": "lvl",
+  "level_map": {"D": "DEBUG", "I": "INFO", "W": "WARNING", "E": "ERROR"}
+}
+```
+
+Une famille de bruit à écarter :
+
+```json
+{
+  "id": "mon_bruit",
+  "label": "Libellé court affiché",
+  "help": "Phrase d'explication montrée en infobulle.",
+  "default_hidden": true,
+  "match": "le motif à masquer",
+  "regex": true
+}
+```
+
+Les motifs sont appliqués sur des octets pour que l'indexation reste rapide : ils
+doivent rester en ASCII. Le nombre de familles de bruit est plafonné à 64.
+
+## Où sont rangés les réglages
+
+| | |
+|---|---|
+| Session (fichiers ouverts, filtres, géométrie) | `%APPDATA%\veaf-logs\session.json` |
+| Profils | `%APPDATA%\veaf-logs\profiles.json` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
     - Migration Guide: mission-maker/MIGRATION_GUIDE.md
     - Adopt a third-party mission: mission-maker/CONVERT_OTHER.md
     - Foothold moulinette: mission-maker/FOOTHOLD.md
+    - Read the DCS logs: mission-maker/LOGS.md
     - AI assistant — install: mission-maker/AI_ASSISTANT_INSTALL.md
     - AI assistant — action catalogue: mission-maker/AI_ASSISTANT_CATALOG.md
     - Aliases: ALIASES.md

--- a/poetry.lock
+++ b/poetry.lock
@@ -2090,6 +2090,25 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pyside6-essentials"
+version = "6.11.2"
+description = "Python bindings for the Qt cross-platform application and UI framework (Essentials)"
+optional = true
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+markers = "python_version <= \"3.14\" and extra == \"logs\""
+files = [
+    {file = "pyside6_essentials-6.11.2-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:77795c145202e65a78d88f7cd409d186e3ba23d159bdb3ba2dcd159ae5e5f0d9"},
+    {file = "pyside6_essentials-6.11.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:aaf9f25f0f324874085fa5b26a610318db8a8e243cf85bb3e5400595191c7778"},
+    {file = "pyside6_essentials-6.11.2-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:d3ec6e1885c46e57f16364f38ea8040ffc5dc0b18341058f608fede3ba930567"},
+    {file = "pyside6_essentials-6.11.2-cp310-abi3-win_amd64.whl", hash = "sha256:c8a29def77032773a30879f7f24415b5395ad08592d147c170824ef4c735dfc1"},
+    {file = "pyside6_essentials-6.11.2-cp310-abi3-win_arm64.whl", hash = "sha256:fadd75c5c20800d64dd0a586ea8cb337c5e630aa2246df0e5105738afa46e02c"},
+]
+
+[package.dependencies]
+shiboken6 = "6.11.2"
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
@@ -2566,6 +2585,22 @@ files = [
 ]
 
 [[package]]
+name = "shiboken6"
+version = "6.11.2"
+description = "Python/C++ bindings helper module"
+optional = true
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+markers = "python_version <= \"3.14\" and extra == \"logs\""
+files = [
+    {file = "shiboken6-6.11.2-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:53659683b1f7a08e9f87eff9b1065f1ceb7110cd7a4bc09fdf5efe43d286604d"},
+    {file = "shiboken6-6.11.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:7a7a0a72a9ed26c9bf77d42246b1c736486befb8f31aa2fb29957ea4cdd1c1c2"},
+    {file = "shiboken6-6.11.2-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:4bbbd6fa4d7cff5ec5e12bc4c10e1d845fa30c89457ecb13cc64f7bddb77f6f9"},
+    {file = "shiboken6-6.11.2-cp310-abi3-win_amd64.whl", hash = "sha256:6ab0eba1c904455df621f9a6df3ca2bb896bab8670572d2bc4e37804ae91f19a"},
+    {file = "shiboken6-6.11.2-cp310-abi3-win_arm64.whl", hash = "sha256:97c49432488df958f0308736f3d15b6915d8826fc380af17bb4b9ec5c4a5e81b"},
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -2825,7 +2860,10 @@ files = [
 [package.extras]
 test = ["pytest", "pytest-cov"]
 
+[extras]
+logs = ["PySide6-Essentials"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "09493297c2f152a0d88b3be6b5df1102127e658b06dd0ba25466737a32a89ea8"
+content-hash = "d15a8526174508119be551c24d5238a925ea1f7c6624dcfef4b76c82b8133274"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,11 @@ packages = [
     {include = "veaf_build"},
     {include = "veaf_tools", from = "src/python/veaf-tools"},
     {include = "veaf_mission_mcp", from = "src/python/veaf-tools"},
+    {include = "veaf_logs", from = "src/python/veaf-tools"},
+]
+include = [
+    # Le catalogue de regles de veaf-logs est une donnee du package, pas du code.
+    { path = "src/python/veaf-tools/veaf_logs/rules.json", format = ["sdist", "wheel"] },
 ]
 
 [tool.poetry.dependencies]
@@ -27,6 +32,14 @@ InquirerPy = ">=0.3,<1"
 requests = ">=2.28,<3"
 mcp = "^2.0.0"
 "ruamel.yaml" = ">=0.18,<1.0"
+# Interface graphique de veaf-logs uniquement. Optionnelle : elle pese plus de
+# 200 Mo installee, et rien d'autre dans veaf-tools n'en depend.
+# python = "<3.15" : la borne haute que le paquet declare lui-meme. Sans elle,
+# la resolution echoue, `^3.11` allant jusqu'a 4.0. Meme raison que pyinstaller.
+PySide6-Essentials = { version = ">=6.6", optional = true, python = "<3.15" }
+
+[tool.poetry.extras]
+logs = ["PySide6-Essentials"]
 
 [tool.poetry.scripts]
 veaf-build = "veaf_build:main"
@@ -39,6 +52,7 @@ check-vendored = "veaf_build.vendored_check_cli:main"
 docs-check = "veaf_build.docs_check:main"
 docs-stamp-version = "veaf_build.docs_version_stamp:main"
 veaf-mission-mcp = "veaf_mission_mcp.server:main"
+veaf-logs = "veaf_logs.ui.main_window:main"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.4"

--- a/src/python/veaf-tools/veaf_logs/__init__.py
+++ b/src/python/veaf-tools/veaf_logs/__init__.py
@@ -1,0 +1,15 @@
+"""veaf-logs : lecture et suivi des journaux de DCS World.
+
+L'organisation suit le chemin d'une ligne de journal :
+
+* `buffer`   lit les octets du fichier, sans le charger ni le verrouiller ;
+* `store`    les decoupe en entrees et les classe, dans un index compact ;
+* `rules`    porte le catalogue (`rules.json`) qui dit comment classer ;
+* `parser`   decrit la forme d'une entree et les motifs partages ;
+* `filters`  choisit les entrees a montrer : recherche, tri-etat, contexte ;
+* `tailer`   ouvre un journal et repere sa rotation ;
+* `profiles` et `session` conservent les reglages entre deux lancements ;
+* `ui`       affiche tout cela.
+
+Documentation d'usage : `doc/mission-maker/LOGS.md`.
+"""

--- a/src/python/veaf-tools/veaf_logs/__main__.py
+++ b/src/python/veaf-tools/veaf_logs/__main__.py
@@ -1,0 +1,10 @@
+"""Point d'entree : `python -m veaf_logs [fichier...]`."""
+
+from __future__ import annotations
+
+import sys
+
+from veaf_logs.ui.main_window import run
+
+if __name__ == "__main__":
+    raise SystemExit(run(sys.argv))

--- a/src/python/veaf-tools/veaf_logs/buffer.py
+++ b/src/python/veaf-tools/veaf_logs/buffer.py
@@ -1,0 +1,85 @@
+"""Acces aux octets d'un journal, sans le charger ni le verrouiller.
+
+Deux contraintes se croisent ici.
+
+La premiere est la taille : un journal de serveur peut depasser la centaine de
+mega-octets, et le garder en memoire coute plusieurs fois sa taille. On ne lit
+donc que les portions demandees.
+
+La seconde a decide de l'implementation. Sous Windows, tant qu'un processus
+garde un descripteur ouvert sur un fichier — projection memoire ou simple
+`open()` — plus personne ne peut le renommer. Or c'est exactement ce que fait
+DCS au lancement : il renomme `dcs.log` en `.old` avant d'en creer un neuf.
+Un visualiseur qui garde le journal ouvert empecherait donc le jeu de demarrer
+normalement. On ouvre et on referme a chaque lecture ; le surcout est de
+quelques microsecondes, sans commune mesure avec le risque.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class Buffer:
+    """Sequence d'octets adressable, dont la taille peut croitre."""
+
+    def size(self) -> int:
+        raise NotImplementedError
+
+    def slice(self, start: int, length: int) -> bytes:
+        raise NotImplementedError
+
+    def refresh(self) -> int:
+        """Reprend en compte ce qui a ete ecrit depuis. Rend la taille."""
+        return self.size()
+
+    def close(self) -> None:
+        pass
+
+
+class BytesBuffer(Buffer):
+    """Contenu deja en memoire : archive extraite, ou test."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def size(self) -> int:
+        return len(self._data)
+
+    def slice(self, start: int, length: int) -> bytes:
+        return self._data[start : start + length]
+
+
+class FileBuffer(Buffer):
+    """Fichier lu a la demande, jamais maintenu ouvert.
+
+    Voir l'en-tete du module : conserver le descripteur empecherait DCS de
+    faire tourner son journal.
+    """
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self._size = 0
+        self.refresh()
+
+    def size(self) -> int:
+        return self._size
+
+    def slice(self, start: int, length: int) -> bytes:
+        if length <= 0:
+            return b""
+        try:
+            with open(self.path, "rb") as handle:
+                handle.seek(start)
+                return handle.read(length)
+        except OSError:
+            # Le fichier vient de disparaitre : l'appelant le constatera au
+            # prochain controle de rotation.
+            return b""
+
+    def refresh(self) -> int:
+        try:
+            self._size = self.path.stat().st_size
+        except OSError:
+            self._size = 0
+        return self._size

--- a/src/python/veaf-tools/veaf_logs/filters.py
+++ b/src/python/veaf-tools/veaf_logs/filters.py
@@ -1,0 +1,423 @@
+"""Filtrage et recherche.
+
+Trois modes de recherche au choix de l'utilisateur :
+
+* `PLAIN`  texte simple, sous-chaine ;
+* `GLOB`   jokers `*` (n'importe quelle suite), `?` (un caractere), `.` litteral ;
+* `REGEX`  expression reguliere complete.
+
+Chaque categorie du panneau lateral (niveau, source, famille de bruit) a trois
+etats plutot que deux :
+
+* `ON`       ses lignes sont affichees ;
+* `OFF`      ses lignes sont masquees ;
+* `CONTEXT`  ses lignes n'apparaissent qu'au voisinage d'une ligne retenue,
+             comme le `-C` de grep. C'est ce qui permet de ne garder que les
+             erreurs tout en voyant ce qui les entoure.
+
+L'evaluation travaille sur des masques binaires (`bytearray`, un octet par
+entree) plutot qu'entree par entree : sur un journal d'un million de lignes,
+c'est ce qui separe une reponse immediate d'une attente de plusieurs secondes.
+"""
+
+from __future__ import annotations
+
+import re
+from array import array
+from bisect import bisect_left, bisect_right
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class Mode(StrEnum):
+    PLAIN = "plain"
+    GLOB = "glob"
+    REGEX = "regex"
+
+    @property
+    def label(self) -> str:
+        return {"plain": "Texte", "glob": "Jokers", "regex": "Regex"}[self.value]
+
+
+class State(StrEnum):
+    ON = "on"
+    OFF = "off"
+    CONTEXT = "context"
+
+    @property
+    def label(self) -> str:
+        return {"on": "affiche", "off": "masque", "context": "contexte"}[self.value]
+
+
+class PatternError(ValueError):
+    """Motif invalide : regex mal formee. Remonte a l'interface pour affichage."""
+
+
+DEFAULT_CONTEXT_LINES = 3
+
+
+def glob_to_regex(pattern: str) -> str:
+    r"""Traduit un motif a jokers en expression reguliere.
+
+    `*` et `?` sont les jokers ; tout le reste, `.` compris, est litteral. On
+    n'utilise pas `fnmatch.translate` parce qu'il ancre le motif aux deux bouts
+    (il compare des noms de fichiers entiers) alors qu'on cherche une
+    sous-chaine dans une ligne de journal.
+
+    >>> glob_to_regex("VEAF*error")
+    'VEAF.*error'
+    >>> glob_to_regex("v1.?")
+    'v1\\..'
+    """
+    out = []
+    for char in pattern:
+        if char == "*":
+            out.append(".*")
+        elif char == "?":
+            out.append(".")
+        else:
+            out.append(re.escape(char))
+    return "".join(out)
+
+
+def pattern_source(pattern: str, mode: Mode) -> str:
+    mode = Mode(mode)
+    if mode is Mode.PLAIN:
+        return re.escape(pattern)
+    if mode is Mode.GLOB:
+        return glob_to_regex(pattern)
+    return pattern
+
+
+def compile_pattern(pattern: str, mode: Mode, case_sensitive: bool = False) -> re.Pattern | None:
+    """Compile un motif selon le mode. Rend None si le motif est vide."""
+    if not pattern:
+        return None
+    flags = 0 if case_sensitive else re.IGNORECASE
+    try:
+        return re.compile(pattern_source(pattern, mode), flags)
+    except re.error as exc:
+        raise PatternError(str(exc)) from exc
+
+
+def compile_pattern_bytes(pattern: str, mode: Mode, case_sensitive: bool = False) -> re.Pattern | None:
+    """Version octets du meme motif, pour chercher dans le fichier projete.
+
+    Les journaux DCS sont de l'ASCII ; `IGNORECASE` ne vaut donc que pour
+    l'ASCII, ce qui est sans consequence ici.
+    """
+    if not pattern:
+        return None
+    flags = 0 if case_sensitive else re.IGNORECASE
+    try:
+        return re.compile(pattern_source(pattern, mode).encode("utf-8"), flags)
+    except (re.error, UnicodeEncodeError) as exc:
+        raise PatternError(str(exc)) from exc
+
+
+@dataclass(slots=True)
+class TextFilter:
+    """Un critere textuel unique."""
+
+    pattern: str = ""
+    mode: Mode = Mode.PLAIN
+    case_sensitive: bool = False
+    invert: bool = False
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        # `Mode` est une `StrEnum` : Qt la rend telle quelle depuis
+        # `currentData()`, donc on peut recevoir une chaine la ou le code
+        # compare avec `is`.
+        if not isinstance(self.mode, Mode):
+            self.mode = Mode(self.mode)
+
+    def compiled(self) -> re.Pattern | None:
+        return compile_pattern(self.pattern, self.mode, self.case_sensitive)
+
+    def compiled_bytes(self) -> re.Pattern | None:
+        return compile_pattern_bytes(self.pattern, self.mode, self.case_sensitive)
+
+    def describe(self) -> str:
+        prefix = "sans " if self.invert else ""
+        return f"{prefix}{self.mode.label} : {self.pattern}"
+
+    def to_dict(self) -> dict:
+        return {
+            "pattern": self.pattern,
+            "mode": self.mode.value,
+            "case_sensitive": self.case_sensitive,
+            "invert": self.invert,
+            "enabled": self.enabled,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> TextFilter:
+        return cls(
+            pattern=raw["pattern"],
+            mode=Mode(raw.get("mode", "plain")),
+            case_sensitive=bool(raw.get("case_sensitive", False)),
+            invert=bool(raw.get("invert", False)),
+            enabled=bool(raw.get("enabled", True)),
+        )
+
+
+@dataclass
+class FilterSet:
+    """Etat complet du filtrage.
+
+    Les dictionnaires ne contiennent que les categories dont l'etat n'est pas
+    `ON` : une categorie inconnue — un niveau qui apparait en cours de suivi —
+    est donc affichee par defaut, sans qu'on ait eu a la prevoir.
+    """
+
+    levels: dict[str, State] = field(default_factory=dict)
+    sources: dict[str, State] = field(default_factory=dict)
+    noise: dict[str, State] = field(default_factory=dict)
+    text_filters: list[TextFilter] = field(default_factory=list)
+
+    # Portee du contexte : une valeur par defaut, et des surcharges par
+    # categorie, indexees `"<famille>:<cle>"` — par exemple `"levels:INFO"`.
+    # Voir les tarifs d'une categorie donnee par `span_for()`.
+    context_lines: int = DEFAULT_CONTEXT_LINES
+    context_spans: dict[str, int] = field(default_factory=dict)
+
+    # -- consultation -----------------------------------------------------
+
+    def set_state(self, kind: str, key: str, state: State) -> None:
+        table = getattr(self, kind)
+        if state is State.ON:
+            table.pop(key, None)
+        else:
+            table[key] = state
+
+    @staticmethod
+    def span_key(kind: str, key: str) -> str:
+        return f"{kind}:{key}"
+
+    def span_for(self, kind: str, key: str) -> int:
+        """Portee du contexte pour une categorie, sa surcharge ou le defaut."""
+        return self.context_spans.get(self.span_key(kind, key), self.context_lines)
+
+    def set_span(self, kind: str, key: str, span: int | None) -> None:
+        """Fixe une portee propre a une categorie ; `None` rend au defaut."""
+        composite = self.span_key(kind, key)
+        if span is None or span == self.context_lines:
+            self.context_spans.pop(composite, None)
+        else:
+            self.context_spans[composite] = max(0, int(span))
+
+    @property
+    def uses_context(self) -> bool:
+        return any(
+            state is State.CONTEXT for table in (self.levels, self.sources, self.noise) for state in table.values()
+        )
+
+    @property
+    def is_empty(self) -> bool:
+        """Aucun critere : le balayage peut etre court-circuite."""
+        return (
+            not self.levels
+            and not self.sources
+            and not self.noise
+            and not [f for f in self.text_filters if f.enabled and f.pattern]
+        )
+
+    # -- persistance ------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        return {
+            "levels": {key: state.value for key, state in self.levels.items()},
+            "sources": {key: state.value for key, state in self.sources.items()},
+            "noise": {key: state.value for key, state in self.noise.items()},
+            "text_filters": [item.to_dict() for item in self.text_filters],
+            "context_lines": self.context_lines,
+            "context_spans": dict(self.context_spans),
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> FilterSet:
+        def states(name: str) -> dict[str, State]:
+            out: dict[str, State] = {}
+            for key, value in (raw.get(name) or {}).items():
+                try:
+                    state = State(value)
+                except ValueError:
+                    continue
+                if state is not State.ON:
+                    out[key] = state
+            return out
+
+        filters = []
+        for item in raw.get("text_filters") or []:
+            try:
+                filters.append(TextFilter.from_dict(item))
+            except (KeyError, ValueError):
+                continue
+        return cls(
+            levels=states("levels"),
+            sources=states("sources"),
+            noise=states("noise"),
+            text_filters=filters,
+            context_lines=int(raw.get("context_lines", DEFAULT_CONTEXT_LINES)),
+            context_spans={
+                str(key): max(0, int(value))
+                for key, value in (raw.get("context_spans") or {}).items()
+                if isinstance(value, (int, float)) and not isinstance(value, bool)
+            },
+        )
+
+    def copy(self) -> FilterSet:
+        return FilterSet.from_dict(self.to_dict())
+
+
+def evaluate(store, filters: FilterSet) -> list[int]:
+    """Indices des entrees visibles, dans l'ordre du journal.
+
+    Deroulement : on classe d'abord chaque entree en retenue / exclue / de
+    contexte selon ses categories, puis on applique les criteres textuels aux
+    seules entrees retenues — une ligne de contexte n'a pas a contenir le texte
+    cherche, sinon elle n'apporterait rien — et on ajoute enfin le voisinage.
+    """
+    total = len(store)
+    if not total:
+        return []
+    if filters.is_empty:
+        return list(range(total))
+
+    kept, spans = _classify(store, filters)
+    for text_filter in filters.text_filters:
+        if not text_filter.enabled or not text_filter.pattern:
+            continue
+        _apply_text(store, kept, text_filter)
+
+    if any(spans):
+        _add_context(kept, spans)
+
+    return [index for index, visible in enumerate(kept) if visible]
+
+
+def _classify(store, filters: FilterSet) -> tuple[bytearray, array]:
+    """Repartit les entrees entre retenues et candidates au contexte.
+
+    Le second tableau donne, pour chaque entree de contexte, sa portee en
+    lignes — 0 signifiant qu'elle n'est pas du contexte. Quand plusieurs
+    categories d'une meme entree sont en contexte avec des portees differentes,
+    la plus large gagne : on a demande a voir loin sur au moins un critere.
+    """
+    total = len(store)
+    kept = bytearray(total)
+    spans = array("i", bytes(4 * total))
+
+    level_states = filters.levels
+    source_states = filters.sources
+    noise_states = filters.noise
+    if not level_states and not source_states and not noise_states:
+        return bytearray(b"" * total), spans
+
+    for index in range(total):
+        state = State.ON
+        span = 0
+
+        if level_states:
+            key = store.level_of(index)
+            state = _worse(state, level_states.get(key, State.ON))
+            if state is State.CONTEXT:
+                span = max(span, filters.span_for("levels", key))
+        if state is not State.OFF and source_states:
+            key = store.source_of(index)
+            found = source_states.get(key, State.ON)
+            state = _worse(state, found)
+            if found is State.CONTEXT:
+                span = max(span, filters.span_for("sources", key))
+        if state is not State.OFF and noise_states:
+            for family in store.noise_of(index):
+                found = noise_states.get(family, State.ON)
+                state = _worse(state, found)
+                if found is State.CONTEXT:
+                    span = max(span, filters.span_for("noise", family))
+                if state is State.OFF:
+                    break
+
+        if state is State.ON:
+            kept[index] = 1
+        elif state is State.CONTEXT and span > 0:
+            spans[index] = span
+    return kept, spans
+
+
+def _worse(current: State, candidate: State) -> State:
+    """`OFF` l'emporte sur `CONTEXT`, qui l'emporte sur `ON`."""
+    if current is State.OFF or candidate is State.OFF:
+        return State.OFF
+    if current is State.CONTEXT or candidate is State.CONTEXT:
+        return State.CONTEXT
+    return State.ON
+
+
+def _apply_text(store, kept: bytearray, text_filter: TextFilter) -> None:
+    """Restreint `kept` aux entrees qui satisfont un critere textuel.
+
+    Le journal est balaye par blocs, et chaque position trouvee est ramenee a
+    son entree. Comme les entrees couvrent le fichier sans trou, une
+    correspondance situee dans une trace de pile designe bien l'erreur qui la
+    porte.
+    """
+    pattern = text_filter.compiled_bytes()
+    if pattern is None:
+        return
+
+    found = bytearray(len(kept))
+    offsets = store.offsets
+    for first, base, data in store.iter_blocks():
+        for match in pattern.finditer(data):
+            index = bisect_right(offsets, base + match.start(), first) - 1
+            if index >= 0:
+                found[index] = 1
+
+    if text_filter.invert:
+        for index, hit in enumerate(found):
+            if hit:
+                kept[index] = 0
+    else:
+        for index, hit in enumerate(found):
+            if not hit:
+                kept[index] = 0
+
+
+def _add_context(kept: bytearray, spans: array) -> None:
+    """Ajoute les entrees de contexte assez proches d'une entree retenue.
+
+    On cherche, pour chaque entree de contexte, s'il existe une entree retenue
+    a portee — plutot que de balayer le voisinage de chaque entree retenue.
+    Avec des portees larges et beaucoup de lignes retenues, la seconde approche
+    reparcourt sans cesse les memes intervalles.
+    """
+    anchors = [index for index, visible in enumerate(kept) if visible]
+    if not anchors:
+        return
+
+    for index, span in enumerate(spans):
+        if not span:
+            continue
+        position = bisect_left(anchors, index)
+        # Ancre la plus proche, avant ou apres.
+        if position < len(anchors) and anchors[position] - index <= span:
+            kept[index] = 1
+        elif position and index - anchors[position - 1] <= span:
+            kept[index] = 1
+
+
+def highlight_patterns(filters: FilterSet) -> list[re.Pattern]:
+    """Motifs positifs seuls : ce sont eux qu'on surligne dans le message."""
+    out = []
+    for text_filter in filters.text_filters:
+        if not text_filter.enabled or text_filter.invert or not text_filter.pattern:
+            continue
+        try:
+            pattern = text_filter.compiled()
+        except PatternError:
+            continue
+        if pattern is not None:
+            out.append(pattern)
+    return out

--- a/src/python/veaf-tools/veaf_logs/parser.py
+++ b/src/python/veaf-tools/veaf_logs/parser.py
@@ -1,0 +1,68 @@
+"""Forme d'une ligne de journal DCS.
+
+Une ligne standard se presente ainsi :
+
+    2026-08-31 11:50:40.872 ERROR   DX11BACKEND (20628): Unknown DLSS preset 'L'
+    |__ horodatage ______| |level| |_ subsystem _| |thr| |_______ message ______|
+
+Certaines lignes n'ont pas d'en-tete : les traces de pile Lua qui suivent une
+erreur de script, le vidage des informations processeur au demarrage. Elles sont
+rattachees a la ligne precedente (`Entry.continuations`) au lieu de flotter
+seules, sans quoi un filtre sur ERROR fait disparaitre la trace qui explique
+l'erreur.
+
+Ce module ne contient que la description : le decoupage effectif est fait par
+`store`, qui recompile ces motifs en octets pour indexer sans decoder.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# En-tete DCS. Le sous-systeme peut contenir '::' (MissionScripting::initialize)
+# et le thread vaut 'Main' ou un identifiant numerique. Le ': ' final est parfois
+# reduit a ':' quand le message est vide.
+#
+# Les motifs sont exposes sous forme de chaines : `store` les recompile en
+# octets pour indexer sans decoder. Une seule definition, deux emplois.
+HEADER_PATTERN = (
+    r"^(?P<date>\d{4}-\d{2}-\d{2}) (?P<time>\d{2}:\d{2}:\d{2}\.\d+) +"
+    r"(?P<level>[A-Z][A-Z_]*) +"
+    r"(?P<subsystem>[A-Za-z_][A-Za-z0-9_:]*)? *"
+    r"\((?P<thread>[^)]*)\): ?(?P<message>.*)$"
+)
+
+# Ligne d'ouverture inseree par DCS en tete de fichier.
+LOG_OPENED_PATTERN = r"^=== Log (?P<what>opened|closed) UTC (?P<stamp>.+)$"
+
+LEVELS = ("ALERT", "ERROR", "ERROR_ONCE", "WARNING", "INFO", "DEBUG", "TRACE", "UNKNOWN")
+
+
+@dataclass(slots=True)
+class Entry:
+    """Une entree du journal : une ligne d'en-tete et ses eventuelles suites."""
+
+    lineno: int
+    raw: str
+    timestamp: str = ""
+    level: str = "UNKNOWN"
+    subsystem: str = ""
+    thread: str = ""
+    message: str = ""
+    source: str = ""  # id de source du catalogue ("veaf", "ctld", ...)
+    source_label: str = ""  # libelle affichable ("VEAF", "CTLD", ...)
+    module: str = ""  # sous-module d'un script ("GRASS" pour VEAF-GRASS)
+    noise: tuple[str, ...] = ()  # ids des familles de bruit qui correspondent
+    continuations: list[str] = field(default_factory=list)
+
+    @property
+    def text(self) -> str:
+        """Ligne complete, suites comprises. C'est ce sur quoi porte la recherche."""
+        if not self.continuations:
+            return self.raw
+        return "\n".join((self.raw, *self.continuations))
+
+    @property
+    def time_only(self) -> str:
+        """Heure sans la date, pour la colonne du tableau."""
+        return self.timestamp[11:] if len(self.timestamp) > 11 else self.timestamp

--- a/src/python/veaf-tools/veaf_logs/profiles.py
+++ b/src/python/veaf-tools/veaf_logs/profiles.py
@@ -1,0 +1,134 @@
+"""Profils de configuration.
+
+Un profil est un jeu de filtres nomme : etats des niveaux, des sources et des
+familles de bruit, criteres textuels cumules, nombre de lignes de contexte.
+Il se choisit dans une liste deroulante, sans passer par un fichier.
+
+Trois profils sont fournis d'office et ne peuvent etre ni modifies ni
+supprimes ; ils servent de point de depart et de porte de sortie quand on s'est
+perdu dans ses filtres.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from .filters import FilterSet, State
+
+PROFILES_VERSION = 1
+DEFAULT_PROFILE = "Session courante"
+
+
+def default_profiles_path() -> Path:
+    base = os.environ.get("APPDATA") or os.path.expanduser("~/.config")
+    return Path(base) / "veaf_logs" / "profiles.json"
+
+
+def builtin_profiles(rules) -> dict[str, FilterSet]:
+    """Profils fournis, calcules depuis le catalogue courant."""
+    bruit_masque = {family: State.OFF for family in rules.default_hidden_noise()}
+
+    tout = FilterSet()
+
+    lecture = FilterSet(noise=dict(bruit_masque))
+
+    # Ne garder que ce qui reclame une action, en laissant quelques lignes
+    # alentour pour comprendre le contexte de l'erreur.
+    diagnostic = FilterSet(
+        levels={
+            "INFO": State.CONTEXT,
+            "DEBUG": State.CONTEXT,
+            "TRACE": State.CONTEXT,
+        },
+        noise=dict(bruit_masque),
+        context_lines=3,
+    )
+
+    return {
+        "Tout": tout,
+        "Lecture (sans le bruit ED)": lecture,
+        "Diagnostic (erreurs + contexte)": diagnostic,
+    }
+
+
+class ProfileStore:
+    """Profils fournis et profils de l'utilisateur, dans un meme espace de noms."""
+
+    def __init__(self, rules, path: Path | None = None) -> None:
+        self.path = path or default_profiles_path()
+        self.builtin = builtin_profiles(rules)
+        self.user: dict[str, FilterSet] = {}
+        self.load()
+
+    # -- consultation -----------------------------------------------------
+
+    def names(self) -> list[str]:
+        """Profils fournis d'abord, puis ceux de l'utilisateur par ordre alphabetique."""
+        return list(self.builtin) + sorted(self.user)
+
+    def is_builtin(self, name: str) -> bool:
+        return name in self.builtin
+
+    def get(self, name: str) -> FilterSet | None:
+        found = self.builtin.get(name) or self.user.get(name)
+        # On rend une copie : modifier les filtres courants ne doit pas
+        # reecrire le profil dont ils proviennent.
+        return found.copy() if found is not None else None
+
+    # -- modification -----------------------------------------------------
+
+    def save_profile(self, name: str, filters: FilterSet) -> None:
+        """Enregistre ou remplace un profil utilisateur."""
+        name = name.strip()
+        if not name:
+            raise ValueError("un profil doit avoir un nom")
+        if name in self.builtin:
+            raise ValueError(f"« {name} » est un profil fourni, choisis un autre nom")
+        self.user[name] = filters.copy()
+        self.save()
+
+    def delete(self, name: str) -> None:
+        if name in self.builtin:
+            raise ValueError(f"« {name} » est un profil fourni, il ne peut pas etre supprime")
+        self.user.pop(name, None)
+        self.save()
+
+    def rename(self, old: str, new: str) -> None:
+        if old in self.builtin:
+            raise ValueError(f"« {old} » est un profil fourni, il ne peut pas etre renomme")
+        filters = self.user.pop(old, None)
+        if filters is None:
+            return
+        self.user[new.strip()] = filters
+        self.save()
+
+    # -- persistance ------------------------------------------------------
+
+    def load(self) -> None:
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            # Fichier absent ou illisible : on repart des seuls profils fournis
+            # plutot que d'empecher le lancement.
+            self.user = {}
+            return
+        if payload.get("version") != PROFILES_VERSION:
+            self.user = {}
+            return
+        self.user = {
+            name: FilterSet.from_dict(raw)
+            for name, raw in (payload.get("profiles") or {}).items()
+            if name not in self.builtin
+        }
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": PROFILES_VERSION,
+            "profiles": {name: filters.to_dict() for name, filters in self.user.items()},
+        }
+        temporary = self.path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        temporary.replace(self.path)

--- a/src/python/veaf-tools/veaf_logs/rules.json
+++ b/src/python/veaf-tools/veaf_logs/rules.json
@@ -1,0 +1,285 @@
+{
+  "$schema_version": 1,
+  "$comment": [
+    "Catalogue de regles pour veaf-logs. Editable a la main : l'application le",
+    "recharge a chaud (menu Regles > Recharger) et l'exportateur klogg s'en sert",
+    "comme source unique.",
+    "",
+    "sources[]  : identification de l'emetteur d'une ligne (script Lua ou",
+    "             sous-systeme DCS natif). La premiere source dont un motif",
+    "             correspond gagne, dans l'ordre du fichier.",
+    "noise[]    : familles de bruit ED. Chaque famille est activable/desactivable",
+    "             independamment dans l'interface. 'default_hidden' dit si elle",
+    "             est masquee au demarrage.",
+    "levels{}   : couleurs par niveau, appliquees par-dessus la teinte de source."
+  ],
+
+  "sources": [
+    {
+      "id": "veaf",
+      "label": "VEAF",
+      "color": "#4aa3ff",
+      "match": "^VEAF(-[A-Z0-9]+)?\\|(?P<lvl>[A-Z])\\|",
+      "level_group": "lvl",
+      "level_map": {"T": "TRACE", "D": "DEBUG", "I": "INFO", "W": "WARNING", "E": "ERROR"},
+      "module_pattern": "^VEAF-([A-Z0-9]+)\\|"
+    },
+    {
+      "id": "veaf-dynamicloader",
+      "label": "VEAF",
+      "color": "#4aa3ff",
+      "match": "^VEAF-DYNAMICLOADER:"
+    },
+    {
+      "id": "ctld",
+      "label": "CTLD",
+      "color": "#3ecf8e",
+      "match": "^\\[CTLD\\]\\[(?P<lvl>[A-Z]+)\\]",
+      "level_group": "lvl"
+    },
+    {
+      "id": "csar",
+      "label": "CSAR",
+      "color": "#f0883e",
+      "match": "^\\s*(?P<lvl>[TDIWE]) - CSAR - ",
+      "level_group": "lvl",
+      "level_map": {"T": "TRACE", "D": "DEBUG", "I": "INFO", "W": "WARNING", "E": "ERROR"}
+    },
+    {
+      "id": "aien",
+      "label": "AIEN",
+      "color": "#c778dd",
+      "match": "^AIEN\\|(?P<lvl>[A-Z])\\|",
+      "level_group": "lvl",
+      "level_map": {"T": "TRACE", "D": "DEBUG", "I": "INFO", "W": "WARNING", "E": "ERROR"}
+    },
+    {
+      "id": "skynet",
+      "label": "Skynet",
+      "color": "#d29922",
+      "match": "(SKYNET|skynet)"
+    },
+    {
+      "id": "slmod",
+      "label": "Slmod",
+      "color": "#a5a5a5",
+      "match": "^(Slmod:|Loading SLMOD|MissionScripting\\.lua SLMOD)"
+    },
+    {
+      "id": "mist",
+      "label": "MIST",
+      "color": "#e06c9f",
+      "match": "\\bMIST\\b"
+    },
+    {
+      "id": "moose",
+      "label": "MOOSE",
+      "color": "#7ec8e3",
+      "match": "\\bMOOSE\\b"
+    },
+    {
+      "id": "dcs-bridge",
+      "label": "dcs-bridge",
+      "color": "#8b949e",
+      "match": "^\\[dcs-(bridge|fiddle-server)\\]"
+    },
+    {
+      "id": "grpc",
+      "label": "DCS-gRPC",
+      "color": "#8b949e",
+      "match": "(DCS-gRPC|grpc\\.lua)"
+    },
+    {
+      "id": "srs",
+      "label": "SRS",
+      "color": "#8b949e",
+      "match": "^(SRS|STTS)\\b"
+    },
+    {
+      "id": "lua",
+      "label": "Lua",
+      "color": "#ffb347",
+      "match": "^(Mission script error|stack traceback)"
+    }
+  ],
+
+  "subsystem_families": {
+    "$comment": "Regroupement des sous-systemes DCS natifs, pour le panneau lateral.",
+    "Moteur": ["APP", "DCS", "EDCORE", "Dispatcher", "SECURITYCONTROL", "LOG", "INTER"],
+    "Graphismes": ["DX11BACKEND", "GRAPHICSCORE", "VISUALIZER", "RENDERER", "ENLIGHT",
+                   "BACKENDCOMMON", "EDOBJECTS"],
+    "Terrain": ["TERRAIN", "EDTERRAIN4", "EDTERRAINGRAPHICS41", "SCENE", "WEATHER"],
+    "Monde": ["WORLDGENERAL", "WORLD", "WorldPlugIns", "FLIGHT", "wInfo", "COCKPITBASE"],
+    "Son": ["SOUND", "ED_SOUND", "SOUNDER"],
+    "Reseau": ["ASYNCNET", "NET", "MULTIPLAYER"],
+    "Scripts": ["SCRIPTING", "Scripting", "MissionScripting", "LuaHooks",
+                "MissionScripting::initialize"]
+  },
+
+  "noise": [
+    {
+      "id": "damage_model",
+      "label": "Modeles de degats corrompus",
+      "help": "Modules tiers dont le modele de degats n'est pas au format attendu. Cosmetique.",
+      "default_hidden": true,
+      "match": "Corrupt damage model\\.",
+      "regex": true
+    },
+    {
+      "id": "invalid_unit_module",
+      "label": "Modules d'unites absents",
+      "help": "Modules payants non installes, references par un pack d'unites. Sans effet.",
+      "default_hidden": true,
+      "match": "(Invalid Unit Module:|MISMATCH DESCRIPTOR TYPE)",
+      "regex": true
+    },
+    {
+      "id": "payload_weight",
+      "label": "Poids / trainee negatifs d'emport",
+      "help": "Erreurs de fiches d'armement ED sur les modules Heatblur et CoreMods.",
+      "default_hidden": true,
+      "match": "negative (weight|drag) of payload",
+      "regex": true
+    },
+    {
+      "id": "property_record",
+      "label": "Segments 3D non declares",
+      "help": "Segments de modele 3D non declares. Bruit constant au chargement.",
+      "default_hidden": true,
+      "match": "No property record for (segment|cell)",
+      "regex": true
+    },
+    {
+      "id": "duplicate_skipped",
+      "label": "Messages dupliques ignores",
+      "help": "Compte-rendu du deduplicateur interne de DCS.",
+      "default_hidden": true,
+      "match": "duplicate message\\(s\\) skipped\\.",
+      "regex": true
+    },
+    {
+      "id": "dlss_preset",
+      "label": "Preset DLSS inconnu",
+      "help": "DCS demande un preset DLSS que le pilote ne connait pas et retombe sur C.",
+      "default_hidden": true,
+      "match": "Unknown DLSS preset",
+      "regex": true
+    },
+    {
+      "id": "sound_source",
+      "label": "Sources sonores introuvables",
+      "help": "source_add / invalid source_params : prototypes de son absents. Inaudible.",
+      "default_hidden": true,
+      "match": "(source_add\\(host:|invalid source_params\\()",
+      "regex": true
+    },
+    {
+      "id": "render_target",
+      "label": "Cibles de rendu introuvables",
+      "help": "ERROR_ONCE du backend DX11 au demarrage de l'interface.",
+      "default_hidden": true,
+      "match": "((render target|texture) '[^']*' not found)",
+      "regex": true
+    },
+    {
+      "id": "renderer_callback",
+      "label": "Rappel graphique en double",
+      "help": "Rappel graphique enregistre deux fois au chargement d'une mission.",
+      "default_hidden": true,
+      "match": "already registered Renderer callback",
+      "regex": true
+    },
+    {
+      "id": "scene_alive",
+      "label": "Scene fermee avec objets vivants",
+      "help": "Objets encore references a la destruction d'une scene. Sans consequence.",
+      "default_hidden": true,
+      "match": "Scene was removed with \\d+ alive objects",
+      "regex": true
+    },
+    {
+      "id": "degenerate_triangle",
+      "label": "Triangles degeneres (collision)",
+      "help": "Triangles plats dans les modeles de collision du terrain.",
+      "default_hidden": true,
+      "match": "Removed degenerate triangle in collision",
+      "regex": true
+    },
+    {
+      "id": "taxiroad",
+      "label": "Chemins de roulage absents",
+      "help": "L'IA ne trouve pas de chemin de roulage entre deux points d'un aerodrome.",
+      "default_hidden": true,
+      "match": "No taxiroad found on ",
+      "regex": true
+    },
+    {
+      "id": "ic_fail",
+      "label": "Controle d'integrite (IC fail)",
+      "help": "Fichiers modifies detectes par le controle d'integrite. Attendu avec des mods.",
+      "default_hidden": true,
+      "match": "IC fail: ",
+      "regex": true
+    },
+    {
+      "id": "antifreeze",
+      "label": "ModelTimeQuantizer",
+      "help": "Regulation interne de la boucle de simulation.",
+      "default_hidden": true,
+      "match": "ModelTimeQuantizer: ",
+      "regex": true
+    },
+    {
+      "id": "dds_reprocess",
+      "label": "Textures DDS reconverties",
+      "help": "Texture au mauvais format, reconvertie a la volee.",
+      "default_hidden": true,
+      "match": "Need to reprocess \\[DDS\\] image",
+      "regex": true
+    },
+    {
+      "id": "obsolete_vfs",
+      "label": "API son depreciee",
+      "help": "Appel d'API deprecie par un mod de son.",
+      "default_hidden": true,
+      "match": "OBSOLETE mount_vfs_sound_path\\(\\)",
+      "regex": true
+    },
+    {
+      "id": "hypervisor",
+      "label": "Hyperviseur actif",
+      "help": "Avertissement de demarrage, normal avec la virtualisation Windows.",
+      "default_hidden": true,
+      "match": "hypervisor is active",
+      "regex": true
+    },
+    {
+      "id": "simapp_pro",
+      "label": "SimApp Pro / WWT",
+      "help": "Perte de liaison avec Winwing SimApp Pro, repetee en boucle.",
+      "default_hidden": false,
+      "match": "No message received from SimApp Pro",
+      "regex": true
+    },
+    {
+      "id": "verbose_veaf_debug",
+      "label": "Traces DEBUG des scripts VEAF",
+      "help": "VEAF-SHORTCUTS et VEAF-RADIO en DEBUG representent l'essentiel du volume.",
+      "default_hidden": false,
+      "match": "^VEAF(-[A-Z0-9]+)?\\|[DT]\\|",
+      "regex": true,
+      "on_message": true
+    }
+  ],
+
+  "levels": {
+    "ALERT":      {"color": "#ffffff", "background": "#7d1a1a", "weight": 700, "order": 0},
+    "ERROR":      {"color": "#ff6b6b", "background": "#3a1414", "weight": 700, "order": 1},
+    "ERROR_ONCE": {"color": "#ff9d6b", "background": "#33200f", "weight": 600, "order": 2},
+    "WARNING":    {"color": "#e3b341", "background": "#2b2410", "weight": 600, "order": 3},
+    "INFO":       {"color": "#c9d1d9", "background": null,      "weight": 400, "order": 4},
+    "DEBUG":      {"color": "#7d8590", "background": null,      "weight": 400, "order": 5},
+    "TRACE":      {"color": "#6e7681", "background": null,      "weight": 400, "order": 6},
+    "UNKNOWN":    {"color": "#8b949e", "background": null,      "weight": 400, "order": 7}
+  }
+}

--- a/src/python/veaf-tools/veaf_logs/rules.py
+++ b/src/python/veaf-tools/veaf_logs/rules.py
@@ -1,0 +1,137 @@
+"""Chargement et application du catalogue de regles (`rules.json`).
+
+Le catalogue est la source unique : `store` en tire les motifs qui classent
+chaque ligne, l'interface les couleurs et les libelles. Le modifier n'exige
+aucune modification de code.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_RULES_PATH = Path(__file__).with_name("rules.json")
+
+LEVEL_NAMES = frozenset(("ALERT", "ERROR", "ERROR_ONCE", "WARNING", "INFO", "DEBUG", "TRACE", "UNKNOWN"))
+
+# Couleur de repli pour un sous-systeme DCS natif, qui n'est pas dans `sources`.
+NATIVE_SOURCE = "dcs"
+NATIVE_LABEL = "DCS"
+NATIVE_COLOR = "#8b949e"
+
+
+@dataclass(slots=True)
+class Source:
+    id: str
+    label: str
+    color: str
+    pattern: re.Pattern
+    level_group: str | int | None = None
+    level_map: dict[str, str] | None = None
+    module_pattern: re.Pattern | None = None
+
+
+@dataclass(slots=True)
+class NoiseFamily:
+    id: str
+    label: str
+    help: str
+    pattern: re.Pattern
+    default_hidden: bool
+    on_message: bool  # tester le message seul plutot que la ligne entiere
+
+
+@dataclass(slots=True)
+class LevelStyle:
+    color: str
+    background: str | None
+    weight: int
+    order: int
+
+
+class Rules:
+    """Catalogue charge, avec ses expressions deja compilees."""
+
+    def __init__(self, data: dict) -> None:
+        self._data = data
+        self.sources: list[Source] = []
+        self.noise: list[NoiseFamily] = []
+        self.levels: dict[str, LevelStyle] = {}
+        self.subsystem_families: dict[str, list[str]] = {}
+        self._compile()
+
+    # -- chargement -------------------------------------------------------
+
+    @classmethod
+    def load(cls, path: Path | str | None = None) -> Rules:
+        path = Path(path) if path else DEFAULT_RULES_PATH
+        with open(path, encoding="utf-8") as handle:
+            return cls(json.load(handle))
+
+    def _compile(self) -> None:
+        for raw in self._data.get("sources", []):
+            module = raw.get("module_pattern")
+            self.sources.append(
+                Source(
+                    id=raw["id"],
+                    label=raw["label"],
+                    color=raw["color"],
+                    pattern=re.compile(raw["match"]),
+                    level_group=raw.get("level_group"),
+                    level_map=raw.get("level_map"),
+                    module_pattern=re.compile(module) if module else None,
+                )
+            )
+
+        for raw in self._data.get("noise", []):
+            pattern = raw["match"] if raw.get("regex", True) else re.escape(raw["match"])
+            self.noise.append(
+                NoiseFamily(
+                    id=raw["id"],
+                    label=raw["label"],
+                    help=raw.get("help", ""),
+                    pattern=re.compile(pattern),
+                    default_hidden=bool(raw.get("default_hidden", False)),
+                    on_message=bool(raw.get("on_message", False)),
+                )
+            )
+
+        for name, raw in self._data.get("levels", {}).items():
+            self.levels[name] = LevelStyle(
+                color=raw["color"],
+                background=raw.get("background"),
+                weight=int(raw.get("weight", 400)),
+                order=int(raw.get("order", 99)),
+            )
+
+        self.subsystem_families = {
+            key: value for key, value in self._data.get("subsystem_families", {}).items() if not key.startswith("$")
+        }
+
+    # -- acces ------------------------------------------------------------
+
+    def source_color(self, source_id: str) -> str:
+        for source in self.sources:
+            if source.id == source_id:
+                return source.color
+        return NATIVE_COLOR
+
+    def level_style(self, level: str) -> LevelStyle:
+        return self.levels.get(level) or LevelStyle(NATIVE_COLOR, None, 400, 99)
+
+    def level_order(self, level: str) -> int:
+        return self.level_style(level).order
+
+    def default_hidden_noise(self) -> set[str]:
+        return {family.id for family in self.noise if family.default_hidden}
+
+    def source_labels(self) -> dict[str, str]:
+        labels = {source.id: source.label for source in self.sources}
+        labels[NATIVE_SOURCE] = NATIVE_LABEL
+        return labels
+
+    @property
+    def data(self) -> dict:
+        return self._data

--- a/src/python/veaf-tools/veaf_logs/session.py
+++ b/src/python/veaf-tools/veaf_logs/session.py
@@ -1,0 +1,90 @@
+"""Sauvegarde et restauration de la session de travail.
+
+Ce qui est conserve : les fichiers ouverts et l'onglet actif, les filtres en
+cours, le profil selectionne, la geometrie de la fenetre. La session est ecrite
+dans le repertoire de configuration de l'utilisateur, pas dans le depot.
+
+La session retient l'etat *courant*, meme s'il ne correspond a aucun profil
+enregistre : on retrouve son travail tel qu'on l'a laisse.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from .filters import FilterSet
+
+SESSION_VERSION = 2
+
+
+def default_session_path() -> Path:
+    """`%APPDATA%\\dcslog\\session.json` sous Windows, `~/.config` ailleurs."""
+    base = os.environ.get("APPDATA") or os.path.expanduser("~/.config")
+    return Path(base) / "veaf_logs" / "session.json"
+
+
+@dataclass
+class OpenFile:
+    path: str
+    archive_member: str | None = None
+
+
+@dataclass
+class Session:
+    files: list[OpenFile] = field(default_factory=list)
+    active: int = 0
+    profile: str = ""
+    filters: dict = field(default_factory=dict)
+    geometry: str | None = None
+
+    # -- persistance ------------------------------------------------------
+
+    def save(self, path: Path | None = None) -> Path:
+        path = path or default_session_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = asdict(self)
+        payload["version"] = SESSION_VERSION
+        # Ecriture atomique : une session tronquee par un arret brutal
+        # empecherait le demarrage suivant.
+        temporary = path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        temporary.replace(path)
+        return path
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> Session:
+        path = path or default_session_path()
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            # Session absente ou illisible : on repart d'une session vierge
+            # plutot que d'empecher le lancement.
+            return cls()
+        if payload.get("version") != SESSION_VERSION:
+            # Format d'une autre version : on ne tente pas de le convertir, on
+            # repart proprement.
+            return cls()
+        payload.pop("version", None)
+        files = [OpenFile(**item) for item in payload.pop("files", [])]
+        known = set(cls.__dataclass_fields__)
+        payload = {key: value for key, value in payload.items() if key in known}
+        payload.pop("files", None)
+        return cls(files=files, **payload)
+
+    # -- conversions ------------------------------------------------------
+
+    def set_filters(self, filters: FilterSet) -> None:
+        self.filters = filters.to_dict()
+
+    def get_filters(self) -> FilterSet:
+        try:
+            return FilterSet.from_dict(self.filters or {})
+        except (TypeError, ValueError, AttributeError):
+            return FilterSet()
+
+    def existing_files(self) -> list[OpenFile]:
+        """Ecarte les fichiers disparus depuis la derniere session."""
+        return [item for item in self.files if Path(item.path).exists()]

--- a/src/python/veaf-tools/veaf_logs/store.py
+++ b/src/python/veaf-tools/veaf_logs/store.py
@@ -1,0 +1,396 @@
+"""Index compact d'un journal.
+
+Le texte reste dans le `Buffer` ; la memoire ne contient que des tableaux
+paralleles decrivant chaque entree — environ 30 octets par entree, contre
+plus de 700 quand on gardait les chaines. Un journal d'un million de lignes
+tient ainsi dans quelques dizaines de mega-octets.
+
+Toute l'indexation travaille sur des octets : les en-tetes DCS et les prefixes
+de scripts sont de l'ASCII, et eviter le decodage divise le temps de lecture.
+Seules les lignes reellement affichees sont decodees, a la demande.
+"""
+
+from __future__ import annotations
+
+from array import array
+from bisect import bisect_right
+
+from .buffer import Buffer
+from .parser import LEVELS, Entry
+
+LEVEL_INDEX = {name: index for index, name in enumerate(LEVELS)}
+UNKNOWN_LEVEL = LEVEL_INDEX["UNKNOWN"]
+
+# Nombre maximal de familles de bruit, impose par le masque binaire 64 bits.
+MAX_NOISE_FAMILIES = 64
+
+# Taille des blocs d'indexation : borne la memoire copiee a chaque passe.
+_INDEX_CHUNK = 8 << 20
+
+# Taille des blocs de recherche, meme raison.
+_SEARCH_CHUNK = 8 << 20
+
+
+class LogStore:
+    """Entrees d'un journal, decrites par tableaux paralleles."""
+
+    def __init__(self, rules, buffer: Buffer) -> None:
+        self.rules = rules
+        self.buffer = buffer
+
+        self._offset = array("q")  # debut de l'entree dans le fichier
+        self._length = array("L")  # longueur totale, continuations comprises
+        self._head = array("L")  # longueur de la seule ligne d'en-tete
+        self._msg_at = array("H")  # debut du message dans la ligne d'en-tete
+        self._level = array("B")
+        self._source = array("B")
+        self._module = array("H")  # index dans `self.modules`, 0 = aucun
+        self._noise = array("Q")  # masque des familles de bruit
+        self._lineno = array("L")
+        self._conts = array("H")  # nombre de lignes de continuation
+
+        self.modules: list[str] = [""]
+        self._module_index: dict[str, int] = {"": 0}
+
+        self._cursor = 0  # octets deja indexes
+        self._lines_seen = 0
+        self._matchers = _Matchers(rules)
+
+        # Comptages tenus a jour a l'insertion. Les recalculer a la demande
+        # imposerait de reparcourir tout l'index a chaque rafraichissement du
+        # panneau lateral, ce qui domine largement le cout de l'indexation.
+        self._by_level: dict[str, int] = {}
+        self._by_source: dict[str, int] = {}
+        self._by_noise: dict[str, int] = {}
+
+    # -- taille -----------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._offset)
+
+    def clear(self) -> None:
+        for tableau in (
+            self._offset,
+            self._length,
+            self._head,
+            self._msg_at,
+            self._level,
+            self._source,
+            self._module,
+            self._noise,
+            self._lineno,
+            self._conts,
+        ):
+            del tableau[:]
+        self.modules = [""]
+        self._module_index = {"": 0}
+        self._cursor = 0
+        self._lines_seen = 0
+        self._by_level.clear()
+        self._by_source.clear()
+        self._by_noise.clear()
+
+    # -- indexation -------------------------------------------------------
+
+    def index_new(self, max_bytes: int | None = None) -> int:
+        """Indexe ce qui a ete ecrit depuis le dernier appel.
+
+        Rend le nombre d'entrees ajoutees. Une ligne incomplete en fin de
+        fichier n'est pas indexee : elle le sera quand sa fin de ligne arrivera.
+
+        `max_bytes` borne le travail d'un appel, pour que l'indexation d'un gros
+        journal se decoupe en tranches sans bloquer l'interface.
+        """
+        size = self.buffer.refresh()
+        if size <= self._cursor:
+            return 0
+        if max_bytes is not None:
+            size = min(size, self._cursor + max_bytes)
+
+        before = len(self._offset)
+        # On avance par blocs : lire d'un seul tenant les 119 Mo d'un journal
+        # de serveur en ferait une copie complete en memoire, ce que tout le
+        # reste de cette classe s'emploie a eviter.
+        while self._cursor < size:
+            base = self._cursor
+            data = self.buffer.slice(base, min(_INDEX_CHUNK, size - base))
+            # On s'arrete a la derniere fin de ligne : DCS ecrit en continu, la
+            # fin du bloc est presque toujours une ligne incomplete.
+            cut = data.rfind(b"\n")
+            if cut < 0:
+                break
+            data = data[: cut + 1]
+            self._cursor += len(data)
+
+            position = 0
+            while True:
+                end = data.find(b"\n", position)
+                if end < 0:
+                    break
+                self._add_line(base + position, data[position:end], (end - position) + 1)
+                position = end + 1
+        return len(self._offset) - before
+
+    def _add_line(self, offset: int, line: bytes, raw_length: int) -> None:
+        self._lines_seen += 1
+        stripped = line.rstrip(b"\r")
+        match = self._matchers.header.match(stripped)
+
+        if match is None and self._matchers.log_opened.match(stripped) is None and self._offset:
+            # Ligne sans en-tete : suite de l'entree precedente. On etend sa
+            # portee au lieu de creer une entree, pour que la trace de pile
+            # reste solidaire de l'erreur qui la porte.
+            self._length[-1] += raw_length
+            self._conts[-1] += 1
+            ajout = self._matchers.noise_mask(stripped, stripped) & ~self._noise[-1]
+            if ajout:
+                self._noise[-1] |= ajout
+                self._count_noise(ajout)
+            return
+
+        self._offset.append(offset)
+        self._length.append(raw_length)
+        self._head.append(len(stripped))
+        self._lineno.append(self._lines_seen)
+        self._conts.append(0)
+
+        if match is None:
+            opened = self._matchers.log_opened.match(stripped) is not None
+            self._msg_at.append(0)
+            self._level.append(LEVEL_INDEX["INFO"] if opened else UNKNOWN_LEVEL)
+            self._source.append(self._matchers.native_source)
+            self._module.append(0)
+            masque = self._matchers.noise_mask(stripped, stripped)
+            self._noise.append(masque)
+            self._tally(self._level[-1], self._source[-1], masque)
+            return
+
+        message = match.group("message") or b""
+        self._msg_at.append(min(match.start("message"), 0xFFFF))
+        level = match.group("level")
+        source, module, refined = self._matchers.classify(message)
+        self._source.append(source)
+        self._module.append(self._module_id(module))
+        self._level.append(refined if refined is not None else self._matchers.level_id(level))
+        masque = self._matchers.noise_mask(stripped, message)
+        self._noise.append(masque)
+        self._tally(self._level[-1], self._source[-1], masque)
+
+    def _tally(self, level: int, source: int, noise_mask: int) -> None:
+        nom = LEVELS[level]
+        self._by_level[nom] = self._by_level.get(nom, 0) + 1
+        nom = self._matchers.source_id(source)
+        self._by_source[nom] = self._by_source.get(nom, 0) + 1
+        if noise_mask:
+            self._count_noise(noise_mask)
+
+    def _count_noise(self, mask: int) -> None:
+        for nom in self._matchers.noise_names(mask):
+            self._by_noise[nom] = self._by_noise.get(nom, 0) + 1
+
+    def _module_id(self, module: bytes) -> int:
+        if not module:
+            return 0
+        name = module.decode("ascii", "replace")
+        index = self._module_index.get(name)
+        if index is None:
+            index = len(self.modules)
+            self.modules.append(name)
+            self._module_index[name] = index
+        return index
+
+    # -- lecture ----------------------------------------------------------
+
+    def entry(self, index: int) -> Entry:
+        """Reconstitue une entree complete. Decode a la demande."""
+        offset = self._offset[index]
+        blob = self.buffer.slice(offset, self._length[index])
+        text = blob.decode("utf-8", "replace")
+        lines = text.splitlines()
+        raw = lines[0] if lines else ""
+        message_at = self._msg_at[index]
+
+        entry = Entry(
+            lineno=self._lineno[index],
+            raw=raw,
+            level=LEVELS[self._level[index]],
+            subsystem="",
+            message=raw[message_at:] if message_at else raw,
+            source=self._matchers.source_id(self._source[index]),
+            module=self.modules[self._module[index]],
+            continuations=lines[1:],
+        )
+        entry.source_label = self._matchers.source_label(self._source[index])
+        entry.timestamp = raw[:23] if len(raw) >= 23 and raw[4] == "-" else ""
+        entry.noise = self._matchers.noise_names(self._noise[index])
+        # Le sous-systeme est une donnee de la ligne : on la releve toujours,
+        # meme quand la source affichee est celle d'un script.
+        entry.subsystem = self._matchers.subsystem_of(raw)
+        if entry.source == "dcs":
+            entry.source_label = entry.subsystem or "DCS"
+        return entry
+
+    # -- acces aux colonnes, sans construire d'entree ----------------------
+
+    def level_of(self, index: int) -> str:
+        return LEVELS[self._level[index]]
+
+    def source_of(self, index: int) -> str:
+        return self._matchers.source_id(self._source[index])
+
+    def noise_of(self, index: int) -> tuple[str, ...]:
+        return self._matchers.noise_names(self._noise[index])
+
+    @property
+    def offsets(self) -> array:
+        return self._offset
+
+    @property
+    def indexed_bytes(self) -> int:
+        """Octets deja indexes : la recherche ne doit pas aller au-dela."""
+        return self._cursor
+
+    def index_at_offset(self, position: int) -> int:
+        """Entree contenant cette position du fichier."""
+        return bisect_right(self._offset, position) - 1
+
+    def iter_blocks(self, max_bytes: int = _SEARCH_CHUNK):
+        """Parcourt le journal par blocs, pour une recherche par lots.
+
+        Chaque bloc rend `(index de la premiere entree, offset, octets)` et
+        s'arrete sur une frontiere d'entree. Comme une correspondance ne peut
+        pas enjamber deux entrees — les motifs ne franchissent pas les fins de
+        ligne — aucun resultat n'est perdu au decoupage.
+        """
+        total = len(self._offset)
+        start = 0
+        while start < total:
+            base = self._offset[start]
+            stop = start
+            while stop < total and self._offset[stop] + self._length[stop] - base <= max_bytes:
+                stop += 1
+            if stop == start:
+                # Une entree plus grosse que le bloc : on la traite seule.
+                stop = start + 1
+            end = self._offset[stop - 1] + self._length[stop - 1]
+            yield start, base, self.buffer.slice(base, end - base)
+            start = stop
+
+    # -- comptages --------------------------------------------------------
+
+    def counts_by_level(self) -> dict[str, int]:
+        return dict(self._by_level)
+
+    def counts_by_source(self) -> dict[str, int]:
+        return dict(self._by_source)
+
+    def counts_by_noise(self) -> dict[str, int]:
+        return dict(self._by_noise)
+
+    # -- reclassement (rechargement du catalogue) --------------------------
+
+    def reclassify(self, rules) -> None:
+        """Reapplique un catalogue modifie sans relire le fichier."""
+        self.rules = rules
+        self._matchers = _Matchers(rules)
+        cursor, self._cursor = self._cursor, 0
+        self.clear()
+        self._cursor = 0
+        self.buffer.refresh()
+        self.index_new()
+        del cursor
+
+
+class _Matchers:
+    """Motifs du catalogue compiles en octets, plus les tables de correspondance."""
+
+    def __init__(self, rules) -> None:
+        import re
+
+        from .parser import HEADER_PATTERN, LOG_OPENED_PATTERN
+
+        self.rules = rules
+        self.header = re.compile(HEADER_PATTERN.encode("utf-8"))
+        self.log_opened = re.compile(LOG_OPENED_PATTERN.encode("utf-8"))
+
+        self.source_ids: list[str] = [source.id for source in rules.sources] + ["dcs"]
+        self.source_labels: list[str] = [source.label for source in rules.sources] + ["DCS"]
+        self.native_source = len(self.source_ids) - 1
+
+        self._sources = []
+        for position, source in enumerate(rules.sources):
+            pattern = re.compile(source.pattern.pattern.encode("utf-8"))
+            module = (
+                re.compile(source.module_pattern.pattern.encode("utf-8")) if source.module_pattern is not None else None
+            )
+            self._sources.append((position, pattern, module, source))
+
+        if len(rules.noise) > MAX_NOISE_FAMILIES:
+            raise ValueError(f"{len(rules.noise)} familles de bruit : le masque en accepte {MAX_NOISE_FAMILIES}")
+        self.noise_order = [family.id for family in rules.noise]
+        self._noise = [
+            (1 << bit, re.compile(family.pattern.pattern.encode("utf-8")), family.on_message)
+            for bit, family in enumerate(rules.noise)
+        ]
+        self._noise_cache: dict[int, tuple[str, ...]] = {0: ()}
+        self._subsystem = re.compile(r"^[\d-]{10} [\d:.]+ +\w+ +([\w:]*)")
+
+    # -- classement -------------------------------------------------------
+
+    def classify(self, message: bytes) -> tuple[int, bytes, int | None]:
+        """Rend (index de source, nom de module, niveau affine ou None)."""
+        for position, pattern, module_pattern, source in self._sources:
+            match = pattern.search(message)
+            if match is None:
+                continue
+            module = b""
+            if module_pattern is not None:
+                found = module_pattern.match(message)
+                if found is not None:
+                    module = found.group(1)
+            return position, module, self._refine(source, match)
+        return self.native_source, b"", None
+
+    @staticmethod
+    def _refine(source, match) -> int | None:
+        """Niveau porte par le prefixe du script, qui prime sur celui de DCS."""
+        if source.level_group is None:
+            return None
+        try:
+            token = match.group(source.level_group)
+        except (IndexError, KeyError):
+            return None
+        if not token:
+            return None
+        name = token.decode("ascii", "replace")
+        name = (source.level_map or {}).get(name, name.upper())
+        return LEVEL_INDEX.get(name)
+
+    def level_id(self, level: bytes | None) -> int:
+        if not level:
+            return UNKNOWN_LEVEL
+        return LEVEL_INDEX.get(level.decode("ascii", "replace"), UNKNOWN_LEVEL)
+
+    def noise_mask(self, line: bytes, message: bytes) -> int:
+        mask = 0
+        for bit, pattern, on_message in self._noise:
+            if pattern.search(message if on_message else line):
+                mask |= bit
+        return mask
+
+    def noise_names(self, mask: int) -> tuple[str, ...]:
+        cached = self._noise_cache.get(mask)
+        if cached is None:
+            cached = tuple(name for bit, name in enumerate(self.noise_order) if mask & (1 << bit))
+            self._noise_cache[mask] = cached
+        return cached
+
+    def source_id(self, index: int) -> str:
+        return self.source_ids[index]
+
+    def source_label(self, index: int) -> str:
+        return self.source_labels[index]
+
+    def subsystem_of(self, raw: str) -> str:
+        match = self._subsystem.match(raw)
+        return match.group(1) if match else ""

--- a/src/python/veaf-tools/veaf_logs/tailer.py
+++ b/src/python/veaf-tools/veaf_logs/tailer.py
@@ -1,0 +1,161 @@
+"""Ouverture d'un journal et detection de sa rotation.
+
+DCS ne tronque pas son journal en cours de route ; il le renomme en `.old` au
+lancement suivant et repart d'un fichier neuf. Cette classe fournit le `Buffer`
+d'ou l'index lit ses octets, et signale les cas ou il faut tout reprendre :
+fichier remplace, tronque, ou reecrit sans changer de taille.
+"""
+
+from __future__ import annotations
+
+import os
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from .buffer import Buffer, BytesBuffer, FileBuffer
+
+# Les archives produites par DCS contiennent aussi le vidage memoire, la mission
+# et le rapport dxdiag. On ne veut que le journal.
+_ARCHIVE_LOG_SUFFIXES = (".log", ".txt")
+_ARCHIVE_PREFERRED = ("dcs.", "dcs-")
+
+# Empreinte de debut de fichier, relue a chaque passage pour reperer une
+# rotation qui n'aurait change ni la taille ni l'identite du fichier.
+_HEAD_BYTES = 512
+
+
+class LogUnavailable(OSError):
+    """Le fichier a suivre est momentanement absent (rotation en cours)."""
+
+
+@dataclass(slots=True)
+class FileIdentity:
+    """De quoi detecter qu'on ne lit plus le meme fichier."""
+
+    inode: int
+    device: int
+    created: float
+
+    @classmethod
+    def of(cls, path: Path) -> FileIdentity:
+        info = path.stat()
+        return cls(inode=info.st_ino, device=info.st_dev, created=info.st_ctime)
+
+
+def archive_members(path: Path) -> list[str]:
+    """Journaux contenus dans une archive, le plus probable en tete."""
+    with zipfile.ZipFile(path) as archive:
+        names = [
+            name
+            for name in archive.namelist()
+            if not name.endswith("/") and name.lower().endswith(_ARCHIVE_LOG_SUFFIXES)
+        ]
+
+    def rank(name: str) -> tuple[int, int]:
+        base = os.path.basename(name).lower()
+        # Un `dcs.<date>.log` passe avant `dxdiag.txt`.
+        return (0 if base.endswith(".log") else 1, 0 if base.startswith(_ARCHIVE_PREFERRED) else 1)
+
+    return sorted(names, key=rank)
+
+
+class LogSource:
+    """Un journal ouvert : son tampon d'octets et l'etat de sa rotation."""
+
+    def __init__(self, path: Path | str, *, archive_member: str | None = None) -> None:
+        self.path = Path(path)
+        self.archive_member = archive_member
+        self.is_archive = self.path.suffix.lower() == ".zip"
+        self._identity: FileIdentity | None = None
+        self._head = b""
+        self._buffer: Buffer | None = None
+
+    # -- ouverture --------------------------------------------------------
+
+    def open(self) -> Buffer:
+        """Cree le tampon. Leve `LogUnavailable` si le fichier a disparu."""
+        if self.is_archive:
+            self._buffer = BytesBuffer(self._read_archive())
+            return self._buffer
+        if not self.path.exists():
+            raise LogUnavailable(str(self.path))
+        self._buffer = FileBuffer(self.path)
+        self._identity = FileIdentity.of(self.path)
+        self._head = self._read_head()
+        return self._buffer
+
+    def _read_archive(self) -> bytes:
+        members = archive_members(self.path)
+        if not members:
+            raise LogUnavailable(f"aucun journal dans l'archive {self.path.name}")
+        self.archive_member = self.archive_member or members[0]
+        with zipfile.ZipFile(self.path) as archive:
+            return archive.read(self.archive_member)
+
+    @property
+    def buffer(self) -> Buffer:
+        if self._buffer is None:
+            return self.open()
+        return self._buffer
+
+    def close(self) -> None:
+        if self._buffer is not None:
+            self._buffer.close()
+            self._buffer = None
+
+    # -- etat -------------------------------------------------------------
+
+    @property
+    def display_name(self) -> str:
+        if self.is_archive and self.archive_member:
+            return f"{self.path.name} : {os.path.basename(self.archive_member)}"
+        return self.path.name
+
+    @property
+    def followable(self) -> bool:
+        """Une archive est un instantane : rien n'y sera ajoute."""
+        return not self.is_archive
+
+    def check_rotation(self, indexed: int) -> bool:
+        """Le fichier a-t-il ete remplace depuis ? Leve `LogUnavailable` s'il manque.
+
+        `indexed` est le nombre d'octets deja pris en compte : un fichier plus
+        court que cela a forcement ete reecrit.
+        """
+        if self.is_archive:
+            return False
+        try:
+            identity = FileIdentity.of(self.path)
+            size = self.path.stat().st_size
+            head = self._read_head()
+        except FileNotFoundError as exc:
+            # DCS est en train de faire tourner le fichier : on patiente sans
+            # rien perdre, la lecture reprendra au passage suivant.
+            raise LogUnavailable(str(self.path)) from exc
+
+        rotated = identity != self._identity or size < indexed or self._head_changed(head)
+        self._identity = identity
+        self._head = head
+        return rotated
+
+    def reopen(self) -> Buffer:
+        """Repart de zero apres une rotation."""
+        self.close()
+        return self.open()
+
+    # -- interne ----------------------------------------------------------
+
+    def _read_head(self) -> bytes:
+        with open(self.path, "rb") as handle:
+            return handle.read(_HEAD_BYTES)
+
+    def _head_changed(self, head: bytes) -> bool:
+        """Le debut du fichier a-t-il ete reecrit ?
+
+        La comparaison porte sur la longueur commune : tant que le journal fait
+        moins de `_HEAD_BYTES`, l'empreinte s'allonge a chaque ecriture sans que
+        rien n'ait ete reecrit.
+        """
+        common = min(len(head), len(self._head))
+        return head[:common] != self._head[:common]

--- a/src/python/veaf-tools/veaf_logs/tailer.py
+++ b/src/python/veaf-tools/veaf_logs/tailer.py
@@ -31,16 +31,27 @@ class LogUnavailable(OSError):
 
 @dataclass(slots=True)
 class FileIdentity:
-    """De quoi detecter qu'on ne lit plus le meme fichier."""
+    """De quoi detecter qu'on ne lit plus le meme fichier.
+
+    Volontairement reduit au couple inode / peripherique, l'identite canonique
+    d'un fichier. On a d'abord ajoute `st_ctime` en pensant y gagner de la
+    robustesse : sous Windows c'est la date de creation, qui ne bouge jamais.
+    Sous Linux, c'est l'heure du dernier changement d'inode, donc **chaque
+    ecriture la modifie** — un journal qui grossit passait alors pour un
+    fichier neuf, et etait relu du debut a chaque ligne ajoutee.
+
+    Reste le cas ou `st_ino` vaut 0, ce qui arrive sur certains systemes de
+    fichiers Windows : la comparaison ne distingue plus rien, et c'est
+    l'empreinte de debut de fichier (`_head_changed`) qui prend le relais.
+    """
 
     inode: int
     device: int
-    created: float
 
     @classmethod
     def of(cls, path: Path) -> FileIdentity:
         info = path.stat()
-        return cls(inode=info.st_ino, device=info.st_dev, created=info.st_ctime)
+        return cls(inode=info.st_ino, device=info.st_dev)
 
 
 def archive_members(path: Path) -> list[str]:

--- a/src/python/veaf-tools/veaf_logs/ui/__init__.py
+++ b/src/python/veaf-tools/veaf_logs/ui/__init__.py
@@ -1,0 +1,8 @@
+"""Interface graphique de veaf-logs (Qt / PySide6).
+
+* `main_window` assemble la fenetre : onglets, profils, suivi ;
+* `model`       expose l'index a la vue, sans jamais garder de texte ;
+* `delegate`    dessine la colonne Message et surligne les correspondances ;
+* `panels`      le panneau lateral a trois etats et la barre de recherche ;
+* `indexing`    etale l'indexation d'un gros journal sur plusieurs tranches.
+"""

--- a/src/python/veaf-tools/veaf_logs/ui/delegate.py
+++ b/src/python/veaf-tools/veaf_logs/ui/delegate.py
@@ -1,0 +1,117 @@
+"""Rendu de la colonne Message avec surlignage des correspondances.
+
+Qt ne sait pas colorer une partie d'une cellule ; il faut dessiner le texte
+soi-meme. On passe par `QTextDocument`, qui gere le rendu riche et la mesure,
+plutot que par un decoupage manuel au `QPainter` : le texte reste selectionnable
+visuellement et l'elision de fin est correcte.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtGui import (
+    QAbstractTextDocumentLayout,
+    QPalette,
+    QTextDocument,
+    QTextOption,
+)
+from PySide6.QtWidgets import QApplication, QStyle, QStyledItemDelegate, QStyleOptionViewItem
+
+from .model import COL_MESSAGE
+
+# Fond du surlignage des correspondances de la recherche.
+MATCH_BACKGROUND = "#7a5c00"
+MATCH_FOREGROUND = "#ffffff"
+
+
+class MessageDelegate(QStyledItemDelegate):
+    """Dessine le message en surlignant ce que la recherche a trouve."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._patterns: list[re.Pattern] = []
+        self._document = QTextDocument()
+        self._document.setDocumentMargin(0)
+        # Une ligne de journal reste sur une ligne : sans cela le message
+        # deborde sur plusieurs lignes dans la hauteur d'une seule cellule.
+        options = QTextOption()
+        options.setWrapMode(QTextOption.WrapMode.NoWrap)
+        self._document.setDefaultTextOption(options)
+
+    def set_patterns(self, patterns: list[re.Pattern]) -> None:
+        self._patterns = patterns
+
+    def paint(self, painter, option: QStyleOptionViewItem, index) -> None:
+        if index.column() != COL_MESSAGE or not self._patterns:
+            super().paint(painter, option, index)
+            return
+
+        text = index.data(Qt.ItemDataRole.DisplayRole) or ""
+        marked = self._mark(str(text))
+        if marked is None:
+            super().paint(painter, option, index)
+            return
+
+        self.initStyleOption(option, index)
+        option.text = ""
+        style = option.widget.style() if option.widget else QApplication.style()
+        style.drawControl(QStyle.ControlElement.CE_ItemViewItem, option, painter, option.widget)
+
+        colour = option.palette.color(
+            QPalette.ColorRole.HighlightedText
+            if option.state & QStyle.StateFlag.State_Selected
+            else QPalette.ColorRole.Text
+        )
+        foreground = index.data(Qt.ItemDataRole.ForegroundRole)
+        if foreground is not None and not (option.state & QStyle.StateFlag.State_Selected):
+            colour = foreground.color()
+
+        self._document.setDefaultFont(option.font)
+        self._document.setHtml(f'<span style="color:{colour.name()}">{marked}</span>')
+
+        painter.save()
+        painter.translate(option.rect.topLeft())
+        context = QAbstractTextDocumentLayout.PaintContext()
+        self._document.documentLayout().draw(painter, context)
+        painter.restore()
+
+    def sizeHint(self, option: QStyleOptionViewItem, index) -> QSize:
+        size = super().sizeHint(option, index)
+        return QSize(size.width(), max(size.height(), option.fontMetrics.height() + 4))
+
+    def _mark(self, text: str) -> str | None:
+        """Rend le texte en HTML avec les correspondances surlignees.
+
+        Rend None si aucun motif ne correspond : l'appelant retombe alors sur le
+        rendu standard, nettement moins couteux.
+        """
+        spans: list[tuple[int, int]] = []
+        for pattern in self._patterns:
+            for match in pattern.finditer(text):
+                if match.end() > match.start():
+                    spans.append((match.start(), match.end()))
+        if not spans:
+            return None
+
+        spans.sort()
+        fused: list[list[int]] = []
+        for start, end in spans:
+            if fused and start <= fused[-1][1]:
+                fused[-1][1] = max(fused[-1][1], end)
+            else:
+                fused.append([start, end])
+
+        out: list[str] = []
+        cursor = 0
+        for start, end in fused:
+            out.append(html.escape(text[cursor:start]))
+            out.append(
+                f'<span style="background-color:{MATCH_BACKGROUND};'
+                f'color:{MATCH_FOREGROUND}">{html.escape(text[start:end])}</span>'
+            )
+            cursor = end
+        out.append(html.escape(text[cursor:]))
+        return "".join(out)

--- a/src/python/veaf-tools/veaf_logs/ui/indexing.py
+++ b/src/python/veaf-tools/veaf_logs/ui/indexing.py
@@ -1,0 +1,126 @@
+"""Indexation progressive d'un gros journal.
+
+Indexer 119 Mo prend une huitaine de secondes. Fait d'un bloc, l'interface
+gelerait tout ce temps ; on decoupe donc le travail en tranches courtes,
+enchainees par la boucle d'evenements de Qt.
+
+Le decoupage se fait volontairement **sur le fil de l'interface** plutot que
+dans un `QThread`. Un fil separe qui remplirait l'index pendant que la vue le
+lit exigerait de verrouiller chaque acces — et un modele Qt lu depuis un autre
+fil que celui qui l'a cree est une source classique de plantages difficiles a
+reproduire. Entre deux tranches, l'interface reprend la main : le resultat
+percu est le meme, sans le risque.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QObject, QTimer, Signal
+
+# Duree visee pour une tranche. Assez courte pour que l'interface reste
+# reactive, assez longue pour que le va-et-vient ne coute pas plus que le
+# travail lui-meme.
+SLICE_MS = 60
+
+# Nombre d'octets traites par tranche, ajuste au fil de l'eau entre ces bornes.
+MIN_CHUNK = 256 << 10
+MAX_CHUNK = 16 << 20
+
+# Traite d'emblee, sans passer par la boucle d'evenements : au-dela d'environ
+# 4 Mo l'attente devient perceptible, en deca elle ne l'est pas.
+UPFRONT_CHUNK = 4 << 20
+
+
+class ProgressiveIndexer(QObject):
+    """Indexe un journal par tranches, en rendant la main entre chacune."""
+
+    progress = Signal(int, int)  # octets indexes, total
+    batch_ready = Signal(int)  # entrees ajoutees par cette tranche
+    finished = Signal()
+
+    def __init__(self, store, parent=None) -> None:
+        super().__init__(parent)
+        self.store = store
+        self._chunk = 1 << 20
+        self._timer = QTimer(self)
+        self._timer.setSingleShot(True)
+        self._timer.setInterval(0)
+        self._timer.timeout.connect(self._step)
+        self._running = False
+        self._cancelled = False
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    @property
+    def total_bytes(self) -> int:
+        return self.store.buffer.size()
+
+    def start(self, upfront: int = UPFRONT_CHUNK) -> bool:
+        """Demarre l'indexation. Rend True si elle se poursuit en tranches.
+
+        Une premiere tranche genereuse est traitee tout de suite : la plupart
+        des journaux DCS y tiennent entierement, et il serait desagreable de
+        voir une barre de progression apparaitre et disparaitre pour un fichier
+        traite en un clin d'oeil.
+        """
+        if self._running:
+            return True
+        self._cancelled = False
+
+        added = self.store.index_new(max_bytes=upfront)
+        if added:
+            self.batch_ready.emit(added)
+        if self.store.indexed_bytes >= self.total_bytes:
+            self.progress.emit(self.store.indexed_bytes, self.total_bytes)
+            self.finished.emit()
+            return False
+
+        self._running = True
+        self.progress.emit(self.store.indexed_bytes, self.total_bytes)
+        self._timer.start()
+        return True
+
+    def cancel(self) -> None:
+        """Interrompt l'indexation. Ce qui est deja indexe reste utilisable."""
+        self._cancelled = True
+
+    def run_to_completion(self) -> int:
+        """Indexe tout d'un trait. Pour les tests et les petits journaux."""
+        added = 0
+        while True:
+            batch = self.store.index_new(max_bytes=MAX_CHUNK)
+            if not batch:
+                break
+            added += batch
+        return added
+
+    # -- interne ----------------------------------------------------------
+
+    def _step(self) -> None:
+        if self._cancelled:
+            self._running = False
+            self.finished.emit()
+            return
+
+        from time import perf_counter
+
+        started = perf_counter()
+        added = self.store.index_new(max_bytes=self._chunk)
+        elapsed = (perf_counter() - started) * 1000
+
+        if added:
+            self.batch_ready.emit(added)
+        self.progress.emit(self.store.indexed_bytes, self.total_bytes)
+
+        if self.store.indexed_bytes >= self.total_bytes or not added:
+            self._running = False
+            self.finished.emit()
+            return
+
+        # On vise `SLICE_MS` par tranche : si la derniere est allee vite, on
+        # prend plus gros la prochaine fois, et inversement.
+        if elapsed > 0:
+            facteur = SLICE_MS / elapsed
+            self._chunk = int(max(MIN_CHUNK, min(MAX_CHUNK, self._chunk * facteur)))
+        self._timer.start()

--- a/src/python/veaf-tools/veaf_logs/ui/main_window.py
+++ b/src/python/veaf-tools/veaf_logs/ui/main_window.py
@@ -1,0 +1,760 @@
+"""Fenetre principale : onglets de journaux, panneau lateral, profils."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import QByteArray, Qt, QTimer, QUrl, Signal
+from PySide6.QtGui import QAction, QDesktopServices, QFont, QKeySequence
+from PySide6.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QFileDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QInputDialog,
+    QLabel,
+    QMainWindow,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QSplitter,
+    QStatusBar,
+    QTableView,
+    QTabWidget,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..filters import FilterSet, highlight_patterns
+from ..profiles import DEFAULT_PROFILE, ProfileStore
+from ..rules import Rules
+from ..session import OpenFile, Session
+from ..store import LogStore
+from ..tailer import LogSource, LogUnavailable, archive_members
+from .delegate import MessageDelegate
+from .indexing import ProgressiveIndexer
+from .model import COL_LEVEL, COL_LINE, COL_MESSAGE, COL_SOURCE, COL_TIME, LogModel
+from .panels import SearchBar, SidePanel
+
+POLL_MS = 400
+
+# Intervalle minimal entre deux reconstructions du panneau lateral pendant
+# l'indexation d'un gros journal.
+PANEL_REFRESH_MS = 400
+
+
+def _now_ms() -> float:
+    from time import perf_counter
+
+    return perf_counter() * 1000
+
+
+DIALOG_FILTER = "Journaux DCS (*.log *.log.old *.zip);;Tous les fichiers (*)"
+
+
+class LogTab(QWidget):
+    """Un journal ouvert : sa source, son index, sa vue."""
+
+    counts_changed = Signal()
+    indexing_finished = Signal()
+
+    def __init__(self, source: LogSource, rules: Rules, parent=None) -> None:
+        super().__init__(parent)
+        self.source = source
+        self.rules = rules
+        self.store = LogStore(rules, source.buffer)
+        self.model = LogModel(self.store, rules, self)
+        self.follow = source.followable
+        self._last_panel_refresh = 0.0
+
+        self.view = QTableView()
+        self.view.setModel(self.model)
+        self.view.setShowGrid(False)
+        self.view.setSelectionBehavior(QTableView.SelectionBehavior.SelectRows)
+        self.view.setWordWrap(False)
+        self.view.verticalHeader().setVisible(False)
+        self.view.verticalHeader().setDefaultSectionSize(18)
+        self.view.setFont(QFont("Cascadia Mono", 9))
+
+        self.delegate = MessageDelegate(self.view)
+        self.view.setItemDelegateForColumn(COL_MESSAGE, self.delegate)
+
+        header = self.view.horizontalHeader()
+        header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(COL_MESSAGE, QHeaderView.ResizeMode.Stretch)
+        self.view.setColumnWidth(COL_LINE, 68)
+        self.view.setColumnWidth(COL_TIME, 92)
+        self.view.setColumnWidth(COL_LEVEL, 78)
+        self.view.setColumnWidth(COL_SOURCE, 130)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.view)
+
+        self.progress = QProgressBar()
+        self.progress.setVisible(False)
+        self.progress.setFormat("Indexation… %p%")
+        self.progress.setMaximumHeight(16)
+        layout.addWidget(self.progress)
+
+        self.cancel_button = QPushButton("Interrompre l'indexation")
+        self.cancel_button.setVisible(False)
+        self.cancel_button.clicked.connect(self._cancel_indexing)
+        layout.addWidget(self.cancel_button)
+
+        self.detail = QLabel()
+        self.detail.setWordWrap(True)
+        self.detail.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.detail.setFont(QFont("Cascadia Mono", 9))
+        self.detail.setVisible(False)
+        self.detail.setStyleSheet("padding: 6px; background: #161b22;")
+        layout.addWidget(self.detail)
+        self.view.selectionModel().selectionChanged.connect(self._on_selection)
+
+        self.indexer = ProgressiveIndexer(self.store, self)
+        self.indexer.batch_ready.connect(self._on_batch)
+        self.indexer.progress.connect(self._on_progress)
+        self.indexer.finished.connect(self._on_indexing_done)
+
+    # -- indexation -------------------------------------------------------
+
+    def start_indexing(self) -> None:
+        """Lance l'indexation initiale.
+
+        La barre n'apparait que si le journal est assez gros pour que
+        l'indexation se poursuive en tranches.
+        """
+        poursuit = self.indexer.start()
+        self.progress.setVisible(poursuit)
+        self.cancel_button.setVisible(poursuit)
+
+    def _cancel_indexing(self) -> None:
+        self.indexer.cancel()
+
+    def _on_batch(self, added: int) -> None:
+        shown = self.model.refresh_from_store()
+        if shown and self.follow:
+            self.view.scrollToBottom()
+        # Pendant l'indexation d'un gros journal, reconstruire le panneau a
+        # chaque tranche coute plus cher que l'indexation elle-meme. On espace,
+        # et `_on_indexing_done` donne le compte definitif.
+        if not self.indexer.running or self._since_refresh() > PANEL_REFRESH_MS:
+            self._last_panel_refresh = _now_ms()
+            self.counts_changed.emit()
+
+    def _since_refresh(self) -> float:
+        return _now_ms() - self._last_panel_refresh
+
+    def _on_progress(self, done: int, total: int) -> None:
+        if total <= 0:
+            return
+        self.progress.setMaximum(total)
+        self.progress.setValue(done)
+
+    def _on_indexing_done(self) -> None:
+        self.progress.setVisible(False)
+        self.cancel_button.setVisible(False)
+        self.counts_changed.emit()
+        self.indexing_finished.emit()
+
+    def poll(self) -> int:
+        """Prend en compte ce qui a ete ecrit depuis le dernier passage."""
+        if self.indexer.running:
+            # L'indexation initiale avance deja : la laisser finir plutot que
+            # de lui disputer le curseur.
+            return 0
+        try:
+            rotated = self.source.check_rotation(self.store.indexed_bytes)
+        except LogUnavailable:
+            return 0
+
+        if rotated:
+            # DCS a remplace le journal : on repart du nouveau fichier.
+            self.store.buffer = self.source.reopen()
+            self.store.clear()
+            self.model.clear()
+
+        last_before = len(self.store) - 1
+        added = self.store.index_new()
+        if not added:
+            return 0
+
+        # La derniere entree deja affichee a pu recevoir sa trace de pile.
+        if last_before >= 0:
+            self.model.invalidate(last_before)
+        shown = self.model.refresh_from_store()
+        if shown and self.follow:
+            self.view.scrollToBottom()
+        self.counts_changed.emit()
+        return added
+
+    def close_source(self) -> None:
+        self.source.close()
+
+    def _on_selection(self) -> None:
+        rows = self.view.selectionModel().selectedRows()
+        entry = self.model.entry_at(rows[0].row()) if rows else None
+        if entry is None or not entry.continuations:
+            self.detail.setVisible(False)
+            return
+        self.detail.setText(entry.text)
+        self.detail.setVisible(True)
+
+
+class MainWindow(QMainWindow):
+    def __init__(self, rules: Rules, session: Session) -> None:
+        super().__init__()
+        self.rules = rules
+        self.session = session
+        self.profiles = ProfileStore(rules)
+        self.filters: FilterSet = session.get_filters()
+        # Vrai pendant qu'on reflete un etat dans les widgets : sans ce verrou,
+        # le signal emis par les widgets serait repris comme une action de
+        # l'utilisateur et reecrirait aussitot ce qu'on vient de charger.
+        self._syncing = False
+
+        self.setWindowTitle("veaf-logs — journaux DCS")
+        self.resize(1500, 900)
+
+        self.tabs = QTabWidget()
+        self.tabs.setTabsClosable(True)
+        self.tabs.setMovable(True)
+        self.tabs.tabCloseRequested.connect(self.close_tab)
+        self.tabs.currentChanged.connect(self._on_tab_changed)
+
+        self.side = SidePanel(rules)
+        self.side.changed.connect(self._on_side_changed)
+
+        self.search = SearchBar()
+        self.search.changed.connect(self.apply_filters)
+        self.search.add_requested.connect(self.add_current_filter)
+
+        right = QWidget()
+        right_layout = QVBoxLayout(right)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.setSpacing(0)
+        right_layout.addWidget(self._build_profile_bar())
+        right_layout.addWidget(self.search)
+        right_layout.addWidget(self._build_chips())
+        right_layout.addWidget(self.tabs, 1)
+
+        splitter = QSplitter()
+        splitter.addWidget(self.side)
+        splitter.addWidget(right)
+        splitter.setStretchFactor(1, 1)
+        splitter.setSizes([320, 1180])
+        self.setCentralWidget(splitter)
+
+        self.status = QStatusBar()
+        self.setStatusBar(self.status)
+        self.status_counts = QLabel()
+        self.status_follow = QLabel()
+        # Les deux sont permanents : `showMessage()` occupe la zone de gauche
+        # et masquerait un widget ordinaire au lieu de cohabiter avec lui.
+        self.status.addPermanentWidget(self.status_counts)
+        self.status.addPermanentWidget(self.status_follow)
+
+        self._build_menus()
+        self._refresh_chips()
+        self._sync_side()
+
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self._poll_all)
+        self.timer.start(POLL_MS)
+
+        self._restore(session)
+
+    # -- barre de profils -------------------------------------------------
+
+    def _build_profile_bar(self) -> QWidget:
+        bar = QWidget()
+        layout = QHBoxLayout(bar)
+        layout.setContentsMargins(6, 4, 6, 2)
+
+        layout.addWidget(QLabel("Profil :"))
+        self.profile_box = QComboBox()
+        self.profile_box.setMinimumWidth(250)
+        self.profile_box.setToolTip("Jeu de filtres enregistre")
+        layout.addWidget(self.profile_box)
+
+        self.profile_save = QToolButton()
+        self.profile_save.setText("Enregistrer…")
+        self.profile_save.setToolTip("Enregistrer les filtres courants sous un nom")
+        self.profile_save.clicked.connect(self.save_profile)
+        layout.addWidget(self.profile_save)
+
+        self.profile_delete = QToolButton()
+        self.profile_delete.setText("Supprimer")
+        self.profile_delete.clicked.connect(self.delete_profile)
+        layout.addWidget(self.profile_delete)
+
+        layout.addStretch(1)
+        self._reload_profile_box(self.session.profile or DEFAULT_PROFILE)
+        self.profile_box.currentTextChanged.connect(self.load_profile)
+        return bar
+
+    def _build_chips(self) -> QWidget:
+        self.chips = QWidget()
+        self.chips_layout = QHBoxLayout(self.chips)
+        self.chips_layout.setContentsMargins(6, 0, 6, 4)
+        self.chips_layout.addStretch(1)
+        self.chips.setVisible(False)
+        return self.chips
+
+    def _reload_profile_box(self, selected: str | None = None) -> None:
+        self.profile_box.blockSignals(True)
+        self.profile_box.clear()
+        # En tete : les filtres en cours, qui n'ont pas encore de nom.
+        self.profile_box.addItem(DEFAULT_PROFILE)
+        self.profile_box.insertSeparator(1)
+        self.profile_box.addItems(self.profiles.names())
+        if selected:
+            self.profile_box.setCurrentIndex(max(0, self.profile_box.findText(selected)))
+        self.profile_box.blockSignals(False)
+        self._update_profile_buttons()
+
+    def _update_profile_buttons(self) -> None:
+        name = self.profile_box.currentText()
+        self.profile_delete.setEnabled(name != DEFAULT_PROFILE and not self.profiles.is_builtin(name))
+
+    def load_profile(self, name: str) -> None:
+        if not name or name == DEFAULT_PROFILE:
+            self._update_profile_buttons()
+            return
+        filters = self.profiles.get(name)
+        if filters is None:
+            return
+        self.filters = filters
+        self.search.field.clear()
+        if self.profile_box.currentText() != name:
+            self.profile_box.blockSignals(True)
+            self.profile_box.setCurrentIndex(max(0, self.profile_box.findText(name)))
+            self.profile_box.blockSignals(False)
+        self._sync_side()
+        self._refresh_chips()
+        self.apply_filters()
+        self._update_profile_buttons()
+        self.status.showMessage(f"Profil « {name} » charge.", 3000)
+
+    def save_profile(self) -> None:
+        current = self.profile_box.currentText()
+        known = current == DEFAULT_PROFILE or self.profiles.is_builtin(current)
+        name, ok = QInputDialog.getText(self, "Enregistrer le profil", "Nom :", text="" if known else current)
+        if not ok:
+            return
+        self.side.collect(self.filters)
+        try:
+            self.profiles.save_profile(name, self.filters)
+        except (ValueError, OSError) as exc:
+            QMessageBox.warning(self, "Profil non enregistre", str(exc))
+            return
+        self._reload_profile_box(name.strip())
+        self.status.showMessage(f"Profil « {name.strip()} » enregistre.", 3000)
+
+    def delete_profile(self) -> None:
+        name = self.profile_box.currentText()
+        if name == DEFAULT_PROFILE or self.profiles.is_builtin(name):
+            return
+        confirm = QMessageBox.question(self, "Supprimer le profil", f"Supprimer definitivement « {name} » ?")
+        if confirm != QMessageBox.StandardButton.Yes:
+            return
+        try:
+            self.profiles.delete(name)
+        except (ValueError, OSError) as exc:
+            QMessageBox.warning(self, "Profil conserve", str(exc))
+            return
+        self._reload_profile_box(DEFAULT_PROFILE)
+
+    # -- menus ------------------------------------------------------------
+
+    def _build_menus(self) -> None:
+        files = self.menuBar().addMenu("&Fichier")
+        self._action(files, "Ouvrir le journal DCS courant", "Ctrl+D", self.open_current_dcs_log)
+        self._action(files, "Ouvrir un fichier…", QKeySequence.StandardKey.Open, self.open_dialog)
+        files.addSeparator()
+        self._action(files, "Fermer l'onglet", "Ctrl+W", lambda: self.close_tab(self.tabs.currentIndex()))
+        self._action(files, "Quitter", "Ctrl+Q", self.close)
+
+        view = self.menuBar().addMenu("&Affichage")
+        self.action_follow = self._action(view, "Suivre la fin du fichier", "F", self.toggle_follow, checkable=True)
+        self.action_follow.setChecked(True)
+        self._action(view, "Aller a la fin", "Ctrl+Fin", self.scroll_to_end)
+        view.addSeparator()
+        self._action(view, "Tout afficher (reinitialiser les filtres)", "Ctrl+R", self.reset_filters)
+        self._action(view, "Chercher", "Ctrl+F", lambda: self.search.field.setFocus())
+
+        profils = self.menuBar().addMenu("&Profils")
+        self._action(profils, "Enregistrer sous…", "Ctrl+S", self.save_profile)
+        self._action(profils, "Supprimer le profil courant", None, self.delete_profile)
+
+        rules_menu = self.menuBar().addMenu("&Regles")
+        self._action(rules_menu, "Recharger le catalogue", "F5", self.reload_rules)
+        self._action(rules_menu, "Ouvrir rules.json", None, self.open_rules_file)
+
+    def _action(self, menu, text, shortcut, slot, checkable=False) -> QAction:
+        action = QAction(text, self)
+        if shortcut:
+            action.setShortcut(shortcut)
+        action.setCheckable(checkable)
+        action.triggered.connect(slot)
+        menu.addAction(action)
+        self.addAction(action)
+        return action
+
+    # -- ouverture --------------------------------------------------------
+
+    def open_current_dcs_log(self) -> None:
+        path = Path.home() / "Saved Games" / "DCS" / "Logs" / "dcs.log"
+        if not path.exists():
+            QMessageBox.warning(
+                self,
+                "Journal introuvable",
+                f"Aucun fichier a {path}.\nUtilise « Ouvrir un fichier… ».",
+            )
+            return
+        self.open_path(path)
+
+    def open_dialog(self) -> None:
+        start = str(Path.home() / "Saved Games" / "DCS" / "Logs")
+        paths, _ = QFileDialog.getOpenFileNames(self, "Ouvrir un journal DCS", start, DIALOG_FILTER)
+        for path in paths:
+            self.open_path(Path(path))
+
+    def open_path(self, path: Path, member: str | None = None) -> LogTab | None:
+        path = Path(path)
+        if path.suffix.lower() == ".zip" and member is None:
+            member = self._choose_archive_member(path)
+            if member is None:
+                return None
+
+        source = LogSource(path, archive_member=member)
+        try:
+            source.open()
+        except (LogUnavailable, OSError) as exc:
+            QMessageBox.warning(self, "Ouverture impossible", str(exc))
+            return None
+
+        tab = LogTab(source, self.rules, self)
+        tab.counts_changed.connect(self._refresh_side)
+        index = self.tabs.addTab(tab, source.display_name)
+        self.tabs.setTabToolTip(index, str(path))
+        self.tabs.setCurrentIndex(index)
+
+        tab.indexing_finished.connect(self._refresh_side)
+        tab.start_indexing()
+        self._refresh_side()
+        self.apply_filters()
+        return tab
+
+    def _choose_archive_member(self, path: Path) -> str | None:
+        """Une archive DCS contient aussi le vidage memoire et la mission."""
+        try:
+            members = archive_members(path)
+        except (OSError, ValueError) as exc:
+            QMessageBox.warning(self, "Archive illisible", str(exc))
+            return None
+        if not members:
+            QMessageBox.warning(self, "Archive", f"Aucun journal dans {path.name}.")
+            return None
+        if len(members) == 1:
+            return members[0]
+        choice, ok = QInputDialog.getItem(
+            self,
+            "Contenu de l'archive",
+            f"{path.name} contient plusieurs fichiers :",
+            members,
+            0,
+            False,
+        )
+        return choice if ok else None
+
+    def close_tab(self, index: int) -> None:
+        if index < 0:
+            return
+        widget = self.tabs.widget(index)
+        self.tabs.removeTab(index)
+        if isinstance(widget, LogTab):
+            widget.close_source()
+            widget.deleteLater()
+        self._refresh_side()
+
+    # -- filtres ----------------------------------------------------------
+
+    def current_tab(self) -> LogTab | None:
+        widget = self.tabs.currentWidget()
+        return widget if isinstance(widget, LogTab) else None
+
+    def effective_filters(self) -> FilterSet:
+        """Filtres enregistres, plus le critere en cours de frappe."""
+        effective = self.filters.copy()
+        live = self.search.current_filter()
+        if live.pattern:
+            effective.text_filters.append(live)
+        return effective
+
+    def apply_filters(self) -> None:
+        effective = self.effective_filters()
+        patterns = highlight_patterns(effective)
+        for index in range(self.tabs.count()):
+            tab = self.tabs.widget(index)
+            if not isinstance(tab, LogTab):
+                continue
+            tab.model.set_filters(effective)
+            tab.delegate.set_patterns(patterns)
+            tab.view.viewport().update()
+        self._refresh_status()
+
+    def _on_side_changed(self) -> None:
+        if self._syncing:
+            return
+        self.side.collect(self.filters)
+        self._mark_modified()
+        self.apply_filters()
+
+    def _mark_modified(self) -> None:
+        """Les filtres ne correspondent plus au profil affiche.
+
+        On revient a l'entree sans nom plutot que de laisser croire que le
+        profil enregistre a change.
+        """
+        if self.profile_box.currentText() == DEFAULT_PROFILE:
+            return
+        self.profile_box.blockSignals(True)
+        self.profile_box.setCurrentIndex(0)
+        self.profile_box.blockSignals(False)
+        self._update_profile_buttons()
+
+    def add_current_filter(self) -> None:
+        live = self.search.current_filter()
+        if not live.pattern:
+            return
+        self.filters.text_filters.append(live)
+        self.search.field.clear()
+        self._mark_modified()
+        self._refresh_chips()
+        self.apply_filters()
+
+    def remove_filter(self, index: int) -> None:
+        if 0 <= index < len(self.filters.text_filters):
+            del self.filters.text_filters[index]
+            self._mark_modified()
+            self._refresh_chips()
+            self.apply_filters()
+
+    def _refresh_chips(self) -> None:
+        while self.chips_layout.count() > 1:
+            item = self.chips_layout.takeAt(0)
+            widget = item.widget() if item is not None else None
+            if widget is not None:
+                widget.setParent(None)
+                widget.deleteLater()
+        for position, text_filter in enumerate(self.filters.text_filters):
+            button = QPushButton(f"{text_filter.describe()}  ✕")
+            button.setToolTip("Retirer ce filtre")
+            button.setFlat(True)
+            button.setStyleSheet(
+                "QPushButton { background:#21262d; border:1px solid #30363d; border-radius:9px; padding:2px 8px; }"
+            )
+            button.clicked.connect(lambda _=False, i=position: self.remove_filter(i))
+            self.chips_layout.insertWidget(position, button)
+        self.chips.setVisible(bool(self.filters.text_filters))
+
+    def reset_filters(self) -> None:
+        self.filters = FilterSet()
+        self.search.field.clear()
+        self._mark_modified()
+        self._sync_side()
+        self._refresh_chips()
+        self.apply_filters()
+
+    # -- suivi ------------------------------------------------------------
+
+    def toggle_follow(self, checked: bool) -> None:
+        tab = self.current_tab()
+        if tab is not None:
+            tab.follow = checked
+            if checked:
+                tab.view.scrollToBottom()
+        self._refresh_status()
+
+    def scroll_to_end(self) -> None:
+        tab = self.current_tab()
+        if tab is not None:
+            tab.view.scrollToBottom()
+
+    def _poll_all(self) -> None:
+        changed = False
+        for index in range(self.tabs.count()):
+            tab = self.tabs.widget(index)
+            if isinstance(tab, LogTab) and tab.source.followable:
+                changed |= bool(tab.poll())
+        if changed:
+            self._refresh_status()
+
+    # -- catalogue --------------------------------------------------------
+
+    def reload_rules(self) -> None:
+        try:
+            rules = Rules.load()
+        except (OSError, ValueError) as exc:
+            QMessageBox.critical(self, "Catalogue invalide", str(exc))
+            return
+        self.rules = rules
+        self.side.rules = rules
+        self.profiles = ProfileStore(rules)
+        for index in range(self.tabs.count()):
+            tab = self.tabs.widget(index)
+            if not isinstance(tab, LogTab):
+                continue
+            tab.rules = rules
+            tab.model.rules = rules
+            tab.store.reclassify(rules)
+            tab.model.clear()
+        self._reload_profile_box(self.profile_box.currentText())
+        self._refresh_side()
+        self.apply_filters()
+        self.status.showMessage("Catalogue recharge.", 4000)
+
+    def open_rules_file(self) -> None:
+        from ..rules import DEFAULT_RULES_PATH
+
+        QDesktopServices.openUrl(QUrl.fromLocalFile(str(DEFAULT_RULES_PATH)))
+
+    # -- rafraichissements ------------------------------------------------
+
+    def _on_tab_changed(self) -> None:
+        tab = self.current_tab()
+        if tab is not None:
+            self.action_follow.setChecked(tab.follow)
+            self.action_follow.setEnabled(tab.source.followable)
+        self._refresh_side()
+
+    def _sync_side(self) -> None:
+        """Reflete `self.filters` dans les widgets, sans declencher de rebond."""
+        self._syncing = True
+        try:
+            self.side.apply(self.filters)
+        finally:
+            self._syncing = False
+
+    def _refresh_side(self) -> None:
+        tab = self.current_tab()
+        if tab is None:
+            return
+        self._syncing = True
+        try:
+            self.side.refresh(tab.model)
+            self.side.apply(self.filters)
+        finally:
+            self._syncing = False
+        self._refresh_status()
+
+    def _refresh_status(self) -> None:
+        tab = self.current_tab()
+        if tab is None:
+            self.status_counts.setText("Aucun journal ouvert.")
+            self.status_follow.setText("")
+            return
+        total = tab.model.total
+        shown = tab.model.rowCount()
+        hidden = tab.model.hidden_count
+        message = f"{shown} lignes affichees sur {total}"
+        if hidden:
+            message += f"   —   {hidden} masquees par les filtres"
+        self.status_counts.setText(message)
+        if not tab.source.followable:
+            self.status_follow.setText("archive (pas de suivi)")
+        else:
+            self.status_follow.setText("suivi actif" if tab.follow else "suivi en pause")
+
+    # -- session ----------------------------------------------------------
+
+    def _restore(self, session: Session) -> None:
+        if session.geometry:
+            self.restoreGeometry(QByteArray.fromBase64(session.geometry.encode()))
+        for item in session.existing_files():
+            self.open_path(Path(item.path), item.archive_member)
+        if session.files and 0 <= session.active < self.tabs.count():
+            self.tabs.setCurrentIndex(session.active)
+        self._refresh_chips()
+        self.apply_filters()
+
+    def _capture(self) -> Session:
+        files = []
+        for index in range(self.tabs.count()):
+            tab = self.tabs.widget(index)
+            if isinstance(tab, LogTab):
+                files.append(OpenFile(str(tab.source.path), tab.source.archive_member))
+        self.side.collect(self.filters)
+        session = Session(
+            files=files,
+            active=max(0, self.tabs.currentIndex()),
+            profile=self.profile_box.currentText(),
+            geometry=bytes(self.saveGeometry().toBase64().data()).decode("ascii"),
+        )
+        session.set_filters(self.filters)
+        return session
+
+    def closeEvent(self, event) -> None:
+        try:
+            self._capture().save()
+        except OSError:
+            # Une session non sauvegardee ne doit pas empecher de fermer.
+            pass
+        for index in range(self.tabs.count()):
+            tab = self.tabs.widget(index)
+            if isinstance(tab, LogTab):
+                tab.close_source()
+        super().closeEvent(event)
+
+
+def main() -> int:
+    """Point d'entree de la commande `veaf-logs`."""
+    import sys
+
+    return run(sys.argv)
+
+
+def run(argv: list[str] | None = None) -> int:
+    import sys
+
+    argv = sys.argv if argv is None else argv
+    app = QApplication(argv)
+    app.setApplicationName("veaf_logs")
+    app.setStyle("Fusion")
+    _apply_dark_palette(app)
+
+    rules = Rules.load()
+    session = Session.load()
+    window = MainWindow(rules, session)
+
+    extra = [Path(arg) for arg in argv[1:] if not arg.startswith("-")]
+    for path in extra:
+        window.open_path(path)
+    if not window.tabs.count() and not extra:
+        default = Path.home() / "Saved Games" / "DCS" / "Logs" / "dcs.log"
+        if default.exists():
+            window.open_path(default)
+
+    window.show()
+    return app.exec()
+
+
+def _apply_dark_palette(app: QApplication) -> None:
+    from PySide6.QtGui import QColor, QPalette
+
+    palette = QPalette()
+    palette.setColor(QPalette.ColorRole.Window, QColor("#0d1117"))
+    palette.setColor(QPalette.ColorRole.WindowText, QColor("#c9d1d9"))
+    palette.setColor(QPalette.ColorRole.Base, QColor("#0d1117"))
+    palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#161b22"))
+    palette.setColor(QPalette.ColorRole.Text, QColor("#c9d1d9"))
+    palette.setColor(QPalette.ColorRole.Button, QColor("#21262d"))
+    palette.setColor(QPalette.ColorRole.ButtonText, QColor("#c9d1d9"))
+    palette.setColor(QPalette.ColorRole.Highlight, QColor("#1f6feb"))
+    palette.setColor(QPalette.ColorRole.HighlightedText, QColor("#ffffff"))
+    palette.setColor(QPalette.ColorRole.ToolTipBase, QColor("#161b22"))
+    palette.setColor(QPalette.ColorRole.ToolTipText, QColor("#c9d1d9"))
+    app.setPalette(palette)

--- a/src/python/veaf-tools/veaf_logs/ui/model.py
+++ b/src/python/veaf-tools/veaf_logs/ui/model.py
@@ -1,0 +1,212 @@
+"""Modele de tableau pour l'affichage du journal.
+
+Le modele ne detient aucun texte : il s'appuie sur un `LogStore` et ne garde
+qu'un tableau d'indices visibles. Une cellule n'est decodee qu'au moment ou Qt
+la demande, c'est-a-dire pour les quelques dizaines de lignes a l'ecran. Le cout
+d'affichage est donc independant de la taille du journal.
+"""
+
+from __future__ import annotations
+
+from array import array
+
+from PySide6.QtCore import QAbstractTableModel, QModelIndex, QPersistentModelIndex, Qt
+from PySide6.QtGui import QBrush, QColor, QFont
+
+from ..filters import FilterSet, evaluate
+from ..parser import Entry
+
+COL_LINE, COL_TIME, COL_LEVEL, COL_SOURCE, COL_MESSAGE = range(5)
+HEADERS = ("Ligne", "Heure", "Niveau", "Source", "Message")
+
+# Role personnalise : recuperer l'entree complete depuis la vue.
+EntryRole = int(Qt.ItemDataRole.UserRole) + 1
+
+# Nombre d'entrees decodees gardees sous la main. Qt interroge chaque cellule
+# d'une ligne separement : sans ce cache, une meme ligne serait decodee cinq
+# fois par rafraichissement.
+_CACHE_SIZE = 512
+
+
+class LogModel(QAbstractTableModel):
+    def __init__(self, store, rules, parent=None) -> None:
+        super().__init__(parent)
+        self.store = store
+        self.rules = rules
+        self._visible = array("l")
+        self._filters = FilterSet()
+        self._mono = QFont("Cascadia Mono", 9)
+        self._mono.setStyleHint(QFont.StyleHint.Monospace)
+        self._brushes: dict[str, QBrush] = {}
+        self._cache: dict[int, Entry] = {}
+
+    # -- interface Qt -----------------------------------------------------
+
+    def rowCount(self, parent=QModelIndex()) -> int:
+        return 0 if parent.isValid() else len(self._visible)
+
+    def columnCount(self, parent=QModelIndex()) -> int:
+        return 0 if parent.isValid() else len(HEADERS)
+
+    def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):
+        if role != Qt.ItemDataRole.DisplayRole or orientation != Qt.Orientation.Horizontal:
+            return None
+        return HEADERS[section]
+
+    def data(
+        self,
+        index: QModelIndex | QPersistentModelIndex,
+        role=Qt.ItemDataRole.DisplayRole,
+    ):
+        if not index.isValid():
+            return None
+        entry = self.entry_at(index.row())
+        if entry is None:
+            return None
+        column = index.column()
+
+        if role == Qt.ItemDataRole.DisplayRole:
+            return self._display(entry, column)
+        if role == EntryRole:
+            return entry
+        if role == Qt.ItemDataRole.ForegroundRole:
+            return self._foreground(entry, column)
+        if role == Qt.ItemDataRole.BackgroundRole:
+            style = self.rules.level_style(entry.level)
+            return self._brush(style.background) if style.background else None
+        if role == Qt.ItemDataRole.FontRole:
+            font = QFont(self._mono)
+            if self.rules.level_style(entry.level).weight >= 600:
+                font.setBold(True)
+            return font
+        if role == Qt.ItemDataRole.ToolTipRole and entry.continuations:
+            return entry.text
+        if role == Qt.ItemDataRole.TextAlignmentRole and column == COL_LINE:
+            return int(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        return None
+
+    # -- rendu ------------------------------------------------------------
+
+    def _display(self, entry: Entry, column: int):
+        if column == COL_LINE:
+            return entry.lineno
+        if column == COL_TIME:
+            return entry.time_only
+        if column == COL_LEVEL:
+            return entry.level
+        if column == COL_SOURCE:
+            label = entry.source_label
+            return f"{label}-{entry.module}" if entry.module else label
+        message = entry.message or entry.raw
+        if entry.continuations:
+            # Signale qu'une trace est repliee derriere la ligne.
+            return f"{message}  [+{len(entry.continuations)}]"
+        return message
+
+    def _foreground(self, entry: Entry, column: int):
+        if column == COL_SOURCE:
+            return self._brush(self.rules.source_color(entry.source))
+        if column in (COL_LINE, COL_TIME):
+            return self._brush("#6e7681")
+        return self._brush(self.rules.level_style(entry.level).color)
+
+    def _brush(self, color: str) -> QBrush:
+        brush = self._brushes.get(color)
+        if brush is None:
+            brush = QBrush(QColor(color))
+            self._brushes[color] = brush
+        return brush
+
+    # -- alimentation -----------------------------------------------------
+
+    def refresh_from_store(self) -> int:
+        """Recalcule les lignes visibles apres l'arrivee de nouvelles entrees.
+
+        Tant que rien n'est filtre, les nouvelles entrees sont simplement
+        ajoutees a la suite : reevaluer un million de lignes a chaque battement
+        du suivi serait inutile.
+        """
+        total = len(self.store)
+        known = self._visible[-1] + 1 if len(self._visible) else 0
+
+        if self._filters.is_empty and known == len(self._visible):
+            if total <= known:
+                return 0
+            first = len(self._visible)
+            self.beginInsertRows(QModelIndex(), first, first + (total - known) - 1)
+            self._visible.extend(range(known, total))
+            self.endInsertRows()
+            return total - known
+
+        before = len(self._visible)
+        self.refilter()
+        return max(0, len(self._visible) - before)
+
+    def clear(self) -> None:
+        self.beginResetModel()
+        self._visible = array("l")
+        self._cache.clear()
+        self.endResetModel()
+
+    # -- filtrage ---------------------------------------------------------
+
+    def set_filters(self, filters: FilterSet) -> None:
+        self._filters = filters
+        self.refilter()
+
+    def refilter(self) -> None:
+        self.beginResetModel()
+        self._cache.clear()
+        self._visible = array("l", evaluate(self.store, self._filters))
+        self.endResetModel()
+
+    @property
+    def filters(self) -> FilterSet:
+        return self._filters
+
+    # -- consultation -----------------------------------------------------
+
+    def entry_at(self, row: int) -> Entry | None:
+        if not 0 <= row < len(self._visible):
+            return None
+        index = self._visible[row]
+        entry = self._cache.get(index)
+        if entry is None:
+            if len(self._cache) >= _CACHE_SIZE:
+                self._cache.clear()
+            entry = self.store.entry(index)
+            self._cache[index] = entry
+        return entry
+
+    def row_of_index(self, index: int) -> int:
+        """Ligne affichee correspondant a une entree, ou -1 si elle est masquee."""
+        from bisect import bisect_left
+
+        position = bisect_left(self._visible, index)
+        if position < len(self._visible) and self._visible[position] == index:
+            return position
+        return -1
+
+    def invalidate(self, index: int) -> None:
+        """Signale qu'une entree a change : sa trace de pile vient d'arriver."""
+        self._cache.pop(index, None)
+        row = self.row_of_index(index)
+        if row >= 0:
+            self.dataChanged.emit(self.index(row, 0), self.index(row, len(HEADERS) - 1))
+
+    def counts_by_level(self) -> dict[str, int]:
+        return self.store.counts_by_level()
+
+    def counts_by_source(self) -> dict[str, int]:
+        return self.store.counts_by_source()
+
+    def counts_by_noise(self) -> dict[str, int]:
+        return self.store.counts_by_noise()
+
+    @property
+    def total(self) -> int:
+        return len(self.store)
+
+    @property
+    def hidden_count(self) -> int:
+        return len(self.store) - len(self._visible)

--- a/src/python/veaf-tools/veaf_logs/ui/panels.py
+++ b/src/python/veaf-tools/veaf_logs/ui/panels.py
@@ -1,0 +1,404 @@
+"""Panneau lateral et barre de recherche."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QComboBox,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QScrollArea,
+    QSpinBox,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..filters import Mode, PatternError, State, TextFilter, compile_pattern
+
+# Symbole et infobulle de chaque etat, dans l'ordre de defilement au clic.
+_STATE_CYCLE = (State.ON, State.CONTEXT, State.OFF)
+_STATE_MARK = {State.ON: "✓", State.CONTEXT: "◐", State.OFF: "✕"}
+_STATE_HINT = {
+    State.ON: "affiche",
+    State.CONTEXT: "affiche seulement autour des lignes retenues",
+    State.OFF: "masque",
+}
+
+
+class SearchBar(QWidget):
+    """Champ de recherche, choix du mode, inversion, sensibilite a la casse."""
+
+    changed = Signal()
+    add_requested = Signal()
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(6, 4, 6, 4)
+
+        self.field = QLineEdit()
+        self.field.setPlaceholderText("Rechercher…  (Ctrl+F)")
+        self.field.setClearButtonEnabled(True)
+
+        self.mode = QComboBox()
+        for mode in Mode:
+            self.mode.addItem(mode.label, mode)
+        self.mode.setToolTip(
+            "Texte : recherche litterale.\n"
+            "Jokers : * (n'importe quelle suite), ? (un caractere) ; le point reste litteral.\n"
+            "Regex : expression reguliere complete."
+        )
+
+        self.invert = QToolButton()
+        self.invert.setText("≠")
+        self.invert.setCheckable(True)
+        self.invert.setToolTip("Masquer les lignes qui correspondent")
+
+        self.case = QToolButton()
+        self.case.setText("Aa")
+        self.case.setCheckable(True)
+        self.case.setToolTip("Respecter la casse")
+
+        self.add = QPushButton("Ajouter au filtre")
+        self.add.setToolTip("Cumuler ce critere avec les filtres deja actifs")
+
+        self.error = QLabel()
+        self.error.setStyleSheet("color: #ff6b6b;")
+
+        layout.addWidget(self.field, 1)
+        layout.addWidget(self.mode)
+        layout.addWidget(self.invert)
+        layout.addWidget(self.case)
+        layout.addWidget(self.add)
+        layout.addWidget(self.error)
+
+        self.field.textChanged.connect(self._on_changed)
+        self.mode.currentIndexChanged.connect(self._on_changed)
+        self.invert.toggled.connect(self._on_changed)
+        self.case.toggled.connect(self._on_changed)
+        self.add.clicked.connect(self.add_requested)
+
+    def current_filter(self) -> TextFilter:
+        return TextFilter(
+            pattern=self.field.text(),
+            mode=self.mode.currentData(),
+            case_sensitive=self.case.isChecked(),
+            invert=self.invert.isChecked(),
+        )
+
+    def _on_changed(self) -> None:
+        """Valide le motif avant de propager : une regex en cours de frappe est
+        souvent invalide, on affiche l'erreur sans reconstruire la vue."""
+        try:
+            compile_pattern(self.field.text(), self.mode.currentData(), self.case.isChecked())
+        except PatternError as exc:
+            self.error.setText(str(exc))
+            return
+        self.error.clear()
+        self.changed.emit()
+
+
+class StateButton(QPushButton):
+    """Categorie a trois etats : affiche, contexte, masque.
+
+    Un bouton plutot qu'une case a cocher : Qt propose bien un troisieme etat
+    (`PartiallyChecked`) mais il se lit comme « partiellement selectionne »,
+    alors qu'il s'agit ici d'un mode a part entiere.
+    """
+
+    changed = Signal()
+
+    def __init__(self, key: str, label: str, count: int, colour: str | None, hint: str) -> None:
+        super().__init__()
+        self.key = key
+        self._label = label
+        self._count = count
+        self._state = State.ON
+        self._hint = hint
+        self.setFlat(True)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._colour = colour or "#c9d1d9"
+        if colour:
+            font = QFont(self.font())
+            font.setBold(True)
+            self.setFont(font)
+        self.clicked.connect(self._cycle)
+        self._render()
+
+    def state(self) -> State:
+        return self._state
+
+    def set_state(self, state: State, notify: bool = False) -> None:
+        if state == self._state:
+            return
+        self._state = state
+        self._render()
+        if notify:
+            self.changed.emit()
+
+    def set_count(self, count: int) -> None:
+        if count != self._count:
+            self._count = count
+            self._render()
+
+    def _cycle(self) -> None:
+        position = _STATE_CYCLE.index(self._state)
+        self.set_state(_STATE_CYCLE[(position + 1) % len(_STATE_CYCLE)], notify=True)
+
+    def _render(self) -> None:
+        self.setText(f" {_STATE_MARK[self._state]}  {self._label}  ({self._count})")
+        colour = "#5a6169" if self._state is State.OFF else self._colour
+        style = "italic" if self._state is State.CONTEXT else "normal"
+        self.setStyleSheet(
+            f"QPushButton {{ color:{colour}; font-style:{style}; text-align:left;"
+            " border:none; padding:1px 2px; }"
+            " QPushButton:hover { background:#21262d; }"
+        )
+        etat = f"Etat : {_STATE_HINT[self._state]}\nClic : etat suivant"
+        self.setToolTip(f"{self._hint}\n\n{etat}" if self._hint else etat)
+
+
+class CategoryRow(QWidget):
+    """Une categorie : son bouton d'etat et, en mode contexte, sa portee.
+
+    La portee n'apparait que lorsqu'elle a un sens. Laisser un champ inerte a
+    cote de chaque categorie encombrerait le panneau pour rien.
+    """
+
+    changed = Signal()
+
+    def __init__(self, key: str, label: str, count: int, colour: str | None, hint: str) -> None:
+        super().__init__()
+        self.key = key
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        self.button = StateButton(key, label, count, colour, hint)
+        self.button.changed.connect(self._on_state_changed)
+        layout.addWidget(self.button, 1)
+
+        self.span = QSpinBox()
+        self.span.setRange(0, 999)
+        self.span.setPrefix("±")
+        self.span.setMaximumWidth(64)
+        self.span.setToolTip(
+            "Lignes gardees de part et d'autre, pour cette categorie.\nVide le champ pour revenir a la valeur commune."
+        )
+        self.span.setSpecialValueText("")
+        self.span.setVisible(False)
+        self.span.valueChanged.connect(lambda _: self.changed.emit())
+        layout.addWidget(self.span)
+
+    def _on_state_changed(self) -> None:
+        self._sync_span_visibility()
+        self.changed.emit()
+
+    def _sync_span_visibility(self) -> None:
+        self.span.setVisible(self.button.state() is State.CONTEXT)
+
+    # -- etat -------------------------------------------------------------
+
+    def state(self) -> State:
+        return self.button.state()
+
+    def set_state(self, state: State) -> None:
+        self.button.set_state(state)
+        self._sync_span_visibility()
+
+    def set_count(self, count: int) -> None:
+        self.button.set_count(count)
+
+    def span_value(self) -> int | None:
+        """Portee choisie, ou None si la categorie suit la valeur commune."""
+        if self.button.state() is not State.CONTEXT:
+            return None
+        return self.span.value() or None
+
+    def set_span(self, value: int | None, default: int) -> None:
+        self.span.blockSignals(True)
+        self.span.setValue(0 if value is None else value)
+        self.span.blockSignals(False)
+        self.span.setSuffix("" if value else f" ({default})")
+
+
+class StateList(QGroupBox):
+    """Groupe de categories a trois etats."""
+
+    changed = Signal()
+
+    def __init__(self, title: str, parent=None) -> None:
+        super().__init__(title, parent)
+        self._layout = QVBoxLayout(self)
+        self._layout.setContentsMargins(8, 6, 8, 6)
+        self._layout.setSpacing(0)
+        self._rows: dict[str, CategoryRow] = {}
+
+        actions = QHBoxLayout()
+        for label, state in (("tout", State.ON), ("contexte", State.CONTEXT), ("rien", State.OFF)):
+            button = QToolButton()
+            button.setText(label)
+            button.clicked.connect(lambda _=False, s=state: self.set_all(s))
+            actions.addWidget(button)
+        actions.addStretch(1)
+        self._layout.addLayout(actions)
+
+    def rebuild(self, items: list[tuple[str, str, int, str | None, str]]) -> None:
+        """items : (cle, libelle, compte, couleur ou None, infobulle).
+
+        Les boutons deja presents sont conserves — seul leur compteur change —
+        pour que l'etat choisi survive au rafraichissement provoque par
+        l'arrivee de nouvelles lignes.
+        """
+        seen = set()
+        for key, label, count, colour, hint in items:
+            seen.add(key)
+            row = self._rows.get(key)
+            if row is None:
+                row = CategoryRow(key, label, count, colour, hint)
+                row.changed.connect(self.changed)
+                self._layout.addWidget(row)
+                self._rows[key] = row
+            else:
+                row.set_count(count)
+
+        for key in [key for key in self._rows if key not in seen]:
+            row = self._rows.pop(key)
+            self._layout.removeWidget(row)
+            row.setParent(None)
+            row.deleteLater()
+
+    def set_all(self, state: State) -> None:
+        for row in self._rows.values():
+            row.set_state(state)
+        self.changed.emit()
+
+    def apply_states(self, states: dict[str, State]) -> None:
+        """Impose un etat par cle ; les cles absentes reviennent a `ON`."""
+        for key, row in self._rows.items():
+            row.set_state(states.get(key, State.ON))
+
+    def states(self) -> dict[str, State]:
+        """Etats differents de `ON` seulement."""
+        return {key: row.state() for key, row in self._rows.items() if row.state() is not State.ON}
+
+    def apply_spans(self, filters, kind: str) -> None:
+        for key, row in self._rows.items():
+            surcharge = filters.context_spans.get(filters.span_key(kind, key))
+            row.set_span(surcharge, filters.context_lines)
+
+    def collect_spans(self, filters, kind: str) -> None:
+        for key, row in self._rows.items():
+            filters.set_span(kind, key, row.span_value())
+
+    def keys(self) -> list[str]:
+        return list(self._rows)
+
+
+class SidePanel(QScrollArea):
+    """Colonne de gauche : niveaux, sources, bruit ED, largeur du contexte."""
+
+    changed = Signal()
+
+    def __init__(self, rules, parent=None) -> None:
+        super().__init__(parent)
+        self.rules = rules
+        self.setWidgetResizable(True)
+        self.setMinimumWidth(300)
+
+        content = QWidget()
+        layout = QVBoxLayout(content)
+        layout.setContentsMargins(6, 6, 6, 6)
+
+        legend = QLabel("✓ affiche     ◐ contexte     ✕ masque")
+        legend.setStyleSheet("color:#8b949e; padding:2px;")
+        layout.addWidget(legend)
+
+        context = QHBoxLayout()
+        context.addWidget(QLabel("Contexte commun : ±"))
+        self.context_lines = QSpinBox()
+        self.context_lines.setRange(0, 200)
+        self.context_lines.setSuffix(" lignes")
+        self.context_lines.setToolTip(
+            "Nombre de lignes gardees de part et d'autre d'une ligne retenue,\n"
+            "pour les categories en mode contexte (◐)."
+        )
+        context.addWidget(self.context_lines)
+        context.addStretch(1)
+        layout.addLayout(context)
+
+        self.levels = StateList("Niveaux")
+        self.sources = StateList("Sources")
+        self.noise = StateList("Bruit ED")
+        for widget in (self.levels, self.sources, self.noise):
+            widget.changed.connect(self.changed)
+            layout.addWidget(widget)
+        layout.addStretch(1)
+        self.setWidget(content)
+
+        self.context_lines.valueChanged.connect(self.changed)
+
+    def refresh(self, model) -> None:
+        """Met a jour les compteurs sans toucher aux etats choisis."""
+        levels = model.counts_by_level()
+        self.levels.rebuild(
+            [
+                (level, level, levels[level], self.rules.level_style(level).color, "")
+                for level in sorted(levels, key=self.rules.level_order)
+            ]
+        )
+
+        labels = self.rules.source_labels()
+        sources = model.counts_by_source()
+        self.sources.rebuild(
+            [
+                (source, labels.get(source, source), count, self.rules.source_color(source), "")
+                for source, count in sorted(sources.items(), key=lambda kv: -kv[1])
+            ]
+        )
+
+        noise = model.counts_by_noise()
+        self.noise.rebuild(
+            [
+                (family.id, family.label, noise.get(family.id, 0), None, family.help)
+                for family in self.rules.noise
+                if noise.get(family.id, 0) or family.default_hidden
+            ]
+        )
+
+    # -- lecture / ecriture de l'etat -------------------------------------
+
+    def apply(self, filters) -> None:
+        for kind, widget in self._lists():
+            widget.apply_states(getattr(filters, kind))
+            widget.apply_spans(filters, kind)
+        self.context_lines.blockSignals(True)
+        self.context_lines.setValue(filters.context_lines)
+        self.context_lines.blockSignals(False)
+
+    def _lists(self):
+        return (("levels", self.levels), ("sources", self.sources), ("noise", self.noise))
+
+    def collect(self, filters) -> None:
+        """Reporte l'etat des boutons dans un jeu de filtres.
+
+        Les categories absentes du journal courant n'ont pas de bouton : leur
+        etat est conserve tel quel. Sans cela, charger un profil qui masque les
+        traces DEBUG puis ouvrir un journal qui n'en contient pas encore
+        perdrait la consigne, et les premieres traces venues s'afficheraient.
+        """
+
+        def merge(current: dict, shown: dict, keys: list[str]) -> dict:
+            merged = {key: state for key, state in current.items() if key not in keys}
+            merged.update(shown)
+            return merged
+
+        filters.context_lines = self.context_lines.value()
+        for kind, widget in self._lists():
+            setattr(filters, kind, merge(getattr(filters, kind), widget.states(), widget.keys()))
+            widget.collect_spans(filters, kind)

--- a/test/python/testlib/veaf_logs_journal.py
+++ b/test/python/testlib/veaf_logs_journal.py
@@ -1,0 +1,29 @@
+"""Journal de reference partage par les tests de veaf-logs.
+
+Les helpers communs vivent dans `testlib` plutot que dans un `conftest` :
+avec `--import-mode=importlib`, un module de test ne peut pas importer un
+fichier voisin, alors que `testlib` est sur le `pythonpath`.
+"""
+
+from __future__ import annotations
+
+# Une erreur ED connue, deux lignes VEAF dont un avertissement masque sous un
+# INFO de DCS, une ligne CTLD, une erreur de script suivie de sa trace de pile,
+# et un avertissement ED bavard.
+JOURNAL = [
+    "2026-08-31 11:50:40.872 ERROR   APP (Main): Error: Unit [F-14B]: Corrupt damage model.",
+    "2026-08-31 11:50:41.000 INFO    SCRIPTING (Main): VEAF|I|5390: Loading version 6.16.5",
+    "2026-08-31 11:50:42.000 INFO    SCRIPTING (Main): VEAF|W|log|123: zone introuvable",
+    "2026-08-31 11:50:43.000 INFO    SCRIPTING (Main): [CTLD][INFO] scene registered",
+    "2026-08-31 11:55:01.930 ERROR   SCRIPTING (Main): Mission script error: CSAR.lua:2213",
+    "stack traceback:",
+    "\t[C]: in function 'getUnitRecordById'",
+    "2026-08-31 11:55:10.095 WARNING FLIGHT (Main): No taxiroad found on Batumi from 1 to 2",
+]
+
+# Six entrees : les deux lignes de trace rejoignent l'erreur de script.
+ENTRIES = 6
+
+
+def journal_bytes() -> bytes:
+    return ("\n".join(JOURNAL) + "\n").encode("utf-8")

--- a/test/python/veaf_logs/conftest.py
+++ b/test/python/veaf_logs/conftest.py
@@ -1,0 +1,33 @@
+"""Fixtures communes aux tests de veaf-logs."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from veaf_logs.buffer import BytesBuffer  # noqa: E402
+from veaf_logs.rules import Rules  # noqa: E402
+from veaf_logs.store import LogStore  # noqa: E402
+from veaf_logs_journal import journal_bytes  # noqa: E402
+
+
+@pytest.fixture(scope="session")
+def rules() -> Rules:
+    return Rules.load()
+
+
+@pytest.fixture
+def store(rules) -> LogStore:
+    store = LogStore(rules, BytesBuffer(journal_bytes()))
+    store.index_new()
+    return store
+
+
+@pytest.fixture
+def journal_file(tmp_path):
+    path = tmp_path / "dcs.log"
+    path.write_bytes(journal_bytes())
+    return path

--- a/test/python/veaf_logs/test_catalogue.py
+++ b/test/python/veaf_logs/test_catalogue.py
@@ -1,0 +1,232 @@
+"""Tests du catalogue applique par l'index : sources, niveaux, familles de bruit.
+
+Les cas viennent tous de journaux DCS reels. Ils passent par `LogStore`,
+c'est-a-dire par le chemin reellement emprunte par l'application.
+"""
+
+from __future__ import annotations
+
+import pytest
+from veaf_logs.buffer import BytesBuffer
+from veaf_logs.store import LogStore
+
+HEAD = "2026-08-31 11:50:46.140 INFO    SCRIPTING (Main): "
+
+
+def indexer(rules, *lignes) -> LogStore:
+    data = ("\n".join(lignes) + "\n").encode("utf-8")
+    store = LogStore(rules, BytesBuffer(data))
+    store.index_new()
+    return store
+
+
+def une(rules, ligne):
+    store = indexer(rules, ligne)
+    assert len(store) == 1, f"attendu 1 entree, obtenu {len(store)}"
+    return store.entry(0)
+
+
+class TestEnTete:
+    def test_ligne_standard(self, rules):
+        entry = une(
+            rules,
+            "2026-08-31 11:50:40.872 ERROR   DX11BACKEND (20628): Unknown DLSS preset 'L', use default preset 'C'",
+        )
+        assert entry.timestamp == "2026-08-31 11:50:40.872"
+        assert entry.level == "ERROR"
+        assert entry.subsystem == "DX11BACKEND"
+        assert entry.message.startswith("Unknown DLSS preset")
+
+    def test_thread_principal(self, rules):
+        entry = une(rules, "2026-08-31 11:49:47.842 INFO    APP (Main): Build number: 554")
+        assert entry.message == "Build number: 554"
+
+    def test_sous_systeme_avec_deux_points(self, rules):
+        entry = une(
+            rules,
+            "2026-08-31 11:55:18.131 INFO    MissionScripting::initialize (Main): "
+            "[dcs-fiddle-server] - Handling Request",
+        )
+        assert entry.subsystem == "MissionScripting::initialize"
+
+    def test_niveau_error_once(self, rules):
+        entry = une(
+            rules,
+            "2026-01-16 10:37:11.100 ERROR_ONCE DX11BACKEND (1234): render target 'uiTargetDepth' not found",
+        )
+        assert entry.level == "ERROR_ONCE"
+
+    def test_niveau_alert(self, rules):
+        entry = une(
+            rules,
+            "2026-01-16 10:37:11.100 ALERT   APP (Main): MiG-21PD MISMATCH DESCRIPTOR TYPE !!!!",
+        )
+        assert entry.level == "ALERT"
+
+    def test_niveau_inconnu(self, rules):
+        entry = une(rules, "2026-01-16 10:37:11.100 BIZARRE APP (Main): quelque chose")
+        assert entry.level == "UNKNOWN"
+
+    def test_message_vide(self, rules):
+        """Releve tel quel dans un journal : sous-systeme absent, message vide."""
+        entry = une(rules, "2026-01-16 10:37:11.100 ERROR_ONCE  ():")
+        assert entry.level == "ERROR_ONCE"
+        assert entry.message == ""
+
+    def test_ligne_d_ouverture_du_journal(self, rules):
+        entry = une(rules, "=== Log opened UTC 2026-08-31 11:49:46")
+        assert entry.level == "INFO"
+        assert entry.timestamp == ""
+
+
+class TestSources:
+    @pytest.mark.parametrize(
+        "message,source,label",
+        [
+            ("VEAF|I|5390: Loading version 6.16.5", "veaf", "VEAF"),
+            ("VEAF-GRASS|I|123: bearing", "veaf", "VEAF"),
+            ("VEAF-DYNAMICLOADER: D:/dev/_VEAF/", "veaf-dynamicloader", "VEAF"),
+            ("[CTLD][INFO] CTLDSceneManager: initialized", "ctld", "CTLD"),
+            (" I - CSAR - Loading version 2024.07.11.01-VEAF", "csar", "CSAR"),
+            ("AIEN|I|4047: loading desanitized function", "aien", "AIEN"),
+            ("--- SKYNET VERSION: 3.4.0RP-VEAF ---", "skynet", "Skynet"),
+            ("Slmod: no config file detected.", "slmod", "Slmod"),
+            ("[dcs-bridge] no connection for 5s", "dcs-bridge", "dcs-bridge"),
+        ],
+    )
+    def test_identification(self, rules, message, source, label):
+        entry = une(rules, HEAD + message)
+        assert entry.source == source
+        assert entry.source_label == label
+
+    def test_module(self, rules):
+        assert une(rules, HEAD + "VEAF-GRASS|I|123: buildFarp").module == "GRASS"
+
+    def test_sans_module(self, rules):
+        assert une(rules, HEAD + "VEAF|I|5390: version").module == ""
+
+    def test_sous_systeme_natif(self, rules):
+        entry = une(rules, "2026-08-31 11:50:40.872 ERROR   DX11BACKEND (20628): rien")
+        assert entry.source == "dcs"
+        assert entry.source_label == "DX11BACKEND"
+
+
+class TestNiveauAffine:
+    """DCS journalise tout le Lua en INFO ; le vrai niveau est dans le prefixe."""
+
+    def test_avertissement_veaf_sous_un_info_dcs(self, rules):
+        entry = une(rules, HEAD + "VEAF|W|log|123: CTLDCoreManager: extractable not found")
+        assert entry.level == "WARNING", "le W de VEAF doit primer sur le INFO de DCS"
+
+    @pytest.mark.parametrize(
+        "prefixe,niveau",
+        [
+            ("VEAF-SHORTCUTS|D|42: x", "DEBUG"),
+            ("VEAF-RADIO|T|42: x", "TRACE"),
+            ("VEAF|E|42: x", "ERROR"),
+            ("VEAF|I|42: x", "INFO"),
+        ],
+    )
+    def test_niveaux_veaf(self, rules, prefixe, niveau):
+        assert une(rules, HEAD + prefixe).level == niveau
+
+    def test_niveau_ctld_nomme(self, rules):
+        assert une(rules, HEAD + "[CTLD][WARNING] souci").level == "WARNING"
+
+    def test_lettre_inconnue_ignoree(self, rules):
+        """Un prefixe inattendu ne doit pas ecraser le niveau de DCS."""
+        assert une(rules, HEAD + "VEAF|X|42: x").level == "INFO"
+
+    def test_niveau_dcs_conserve_hors_script(self, rules):
+        entry = une(
+            rules,
+            "2026-08-31 11:50:40.872 ERROR   APP (Main): Error: Unit [F-14B]: Corrupt damage model.",
+        )
+        assert entry.level == "ERROR"
+
+
+class TestBruit:
+    @pytest.mark.parametrize(
+        "ligne,famille",
+        [
+            ("ERROR   APP (Main): Error: Unit [F-14B]: Corrupt damage model.", "damage_model"),
+            ("ALERT   APP (Main): MiG-21PD MISMATCH DESCRIPTOR TYPE !!!!", "invalid_unit_module"),
+            ('ERROR   wInfo (Main): negative weight of payload "{X}"', "payload_weight"),
+            ('ERROR   wInfo (Main): negative drag of payload "{X}"', "payload_weight"),
+            ("WARNING LOG (27444): 16 duplicate message(s) skipped.", "duplicate_skipped"),
+            ("ERROR   DX11BACKEND (1): Unknown DLSS preset 'L'", "dlss_preset"),
+            ("WARNING FLIGHT (Main): No taxiroad found on Batumi from 1 to 2", "taxiroad"),
+            ("WARNING SECURITYCONTROL (Main): IC fail: /textures/x", "ic_fail"),
+            ("WARNING SCENE (Main): Scene was removed with 4 alive objects", "scene_alive"),
+            ("WARNING EDTERRAIN4 (1): Removed degenerate triangle in collision 'x'", "degenerate_triangle"),
+            ("ERROR_ONCE DX11BACKEND (1): render target 'uiTargetDepth' not found", "render_target"),
+            ("WARNING GRAPHICSCORE (Main): already registered Renderer callback", "renderer_callback"),
+            ("WARNING WORLD (Main): ModelTimeQuantizer: ANTIFREEZE ENABLED", "antifreeze"),
+            ("WARNING EDCORE (Main): hypervisor is active", "hypervisor"),
+        ],
+    )
+    def test_famille_reconnue(self, rules, ligne, famille):
+        store = indexer(rules, f"2026-08-31 11:50:40.872 {ligne}")
+        assert famille in store.noise_of(0)
+
+    def test_ligne_utile_jamais_marquee(self, rules):
+        store = indexer(
+            rules,
+            "2026-08-31 11:55:01.930 ERROR   SCRIPTING (Main): Mission script error: "
+            "[string \"l10n/DEFAULT/CSAR.lua\"]:2213: attempt to call field 'x'",
+        )
+        assert store.noise_of(0) == (), "une vraie erreur de script n'est pas du bruit"
+
+    def test_famille_ancree_sur_le_message(self, rules):
+        """`verbose_veaf_debug` porte sur le message, pas sur la ligne entiere."""
+        store = indexer(rules, HEAD + "VEAF-SHORTCUTS|D|42: bla")
+        assert "verbose_veaf_debug" in store.noise_of(0)
+
+    def test_bruit_d_une_continuation_remonte(self, rules):
+        """Le bruit trouve dans une suite marque l'entree qui la porte."""
+        store = indexer(
+            rules,
+            "2026-08-31 11:50:00.000 INFO    DCS (Main): CPU info:",
+            "hypervisor is active",
+        )
+        assert len(store) == 1
+        assert "hypervisor" in store.noise_of(0)
+
+    def test_familles_masquees_par_defaut(self, rules):
+        hidden = rules.default_hidden_noise()
+        assert "damage_model" in hidden
+        assert "verbose_veaf_debug" not in hidden, "les traces VEAF restent visibles"
+
+
+class TestCatalogue:
+    def test_charge(self, rules):
+        assert rules.sources and rules.noise and rules.levels
+
+    def test_niveaux_ordonnes(self, rules):
+        assert rules.level_order("ERROR") < rules.level_order("INFO")
+
+    def test_couleurs(self, rules):
+        assert rules.source_color("veaf").startswith("#")
+        assert rules.source_color("inconnue") == "#8b949e"
+
+    def test_libelles_de_source(self, rules):
+        labels = rules.source_labels()
+        assert labels["veaf"] == "VEAF"
+        assert labels["dcs"] == "DCS"
+
+    def test_style_de_niveau_inconnu(self, rules):
+        assert rules.level_style("PAS_UN_NIVEAU").color.startswith("#")
+
+
+class TestSousSysteme:
+    """Le sous-systeme est releve meme quand la source affichee est un script."""
+
+    def test_script_reconnu_garde_son_sous_systeme(self, rules):
+        entry = une(rules, HEAD + "VEAF|I|1: x")
+        assert entry.subsystem == "SCRIPTING"
+        assert entry.source_label == "VEAF", "la colonne Source montre le script"
+
+    def test_ligne_native(self, rules):
+        entry = une(rules, "2026-08-31 11:50:00.000 ERROR   EDCORE (Main): boum")
+        assert entry.subsystem == "EDCORE"
+        assert entry.source_label == "EDCORE"

--- a/test/python/veaf_logs/test_filters.py
+++ b/test/python/veaf_logs/test_filters.py
@@ -1,0 +1,308 @@
+"""Tests des modes de recherche, du cumul, et du tri-etat avec contexte."""
+
+from __future__ import annotations
+
+import pytest
+from veaf_logs.buffer import BytesBuffer
+from veaf_logs.filters import (
+    FilterSet,
+    Mode,
+    PatternError,
+    State,
+    TextFilter,
+    compile_pattern,
+    evaluate,
+    glob_to_regex,
+    highlight_patterns,
+)
+from veaf_logs.store import LogStore
+
+
+def visible(store, filters) -> list[int]:
+    return evaluate(store, filters)
+
+
+class TestJokers:
+    def test_etoile(self):
+        assert glob_to_regex("VEAF*error") == "VEAF.*error"
+
+    def test_point_interrogation(self):
+        assert glob_to_regex("v?") == "v."
+
+    def test_point_est_litteral(self):
+        """C'est la difference avec la regex : `.` ne doit pas etre un joker."""
+        regex = compile_pattern("CSAR.lua", Mode.GLOB)
+        assert regex.search("CSAR.lua")
+        assert not regex.search("CSARxlua")
+
+    def test_crochets_echappes(self):
+        assert compile_pattern("[CTLD]", Mode.GLOB).search("[CTLD][INFO] x")
+
+    def test_barre_verticale_litterale(self):
+        regex = compile_pattern("VEAF|W|", Mode.GLOB)
+        assert regex.search("VEAF|W|log|123: x")
+        assert not regex.search("VEAF|I|5390: x")
+
+
+class TestModes:
+    def test_texte_simple_est_litteral(self):
+        regex = compile_pattern("a.b", Mode.PLAIN)
+        assert regex.search("xa.by")
+        assert not regex.search("axb")
+
+    def test_regex_complete(self):
+        regex = compile_pattern(r"VEAF\|[WE]\|", Mode.REGEX)
+        assert regex.search("VEAF|W|log|1: x")
+        assert not regex.search("VEAF|I|1: x")
+
+    def test_regex_invalide(self):
+        with pytest.raises(PatternError):
+            compile_pattern("[non fermee", Mode.REGEX)
+
+    def test_casse_ignoree_par_defaut(self):
+        assert compile_pattern("veaf", Mode.PLAIN).search("VEAF|I|")
+
+    def test_casse_respectee(self):
+        assert not compile_pattern("veaf", Mode.PLAIN, case_sensitive=True).search("VEAF|I|")
+
+    def test_motif_vide(self):
+        assert compile_pattern("", Mode.REGEX) is None
+
+    def test_mode_recu_en_chaine(self):
+        """Qt rend `currentData()` sous forme de chaine pour une enum de str."""
+        assert TextFilter(pattern="a.b", mode="plain").mode is Mode.PLAIN
+        assert not compile_pattern("a.b", "plain").search("axb")
+
+    def test_mode_inconnu_rejete(self):
+        with pytest.raises(ValueError):
+            TextFilter(pattern="x", mode="inconnu")
+
+
+class TestRechercheTextuelle:
+    def test_sans_critere_tout_passe(self, store):
+        assert len(visible(store, FilterSet())) == len(store)
+
+    def test_texte_simple(self, store):
+        fs = FilterSet(text_filters=[TextFilter(pattern="zone introuvable")])
+        assert visible(store, fs) == [2]
+
+    def test_recherche_dans_une_trace_rattachee(self, store):
+        """Un symbole present seulement dans la trace doit ramener l'erreur."""
+        fs = FilterSet(text_filters=[TextFilter(pattern="getUnitRecordById")])
+        assert visible(store, fs) == [4]
+
+    def test_regex(self, store):
+        fs = FilterSet(text_filters=[TextFilter(pattern=r"VEAF\|[WE]\|", mode=Mode.REGEX)])
+        assert visible(store, fs) == [2]
+
+    def test_jokers(self, store):
+        fs = FilterSet(text_filters=[TextFilter(pattern="No taxiroad*Batumi*", mode=Mode.GLOB)])
+        assert visible(store, fs) == [5]
+
+    def test_filtre_inverse(self, store):
+        fs = FilterSet(text_filters=[TextFilter(pattern="VEAF", invert=True)])
+        assert 1 not in visible(store, fs)
+        assert 2 not in visible(store, fs)
+
+    def test_cumul_en_et(self, store):
+        fs = FilterSet(text_filters=[TextFilter(pattern="VEAF"), TextFilter(pattern="zone")])
+        assert visible(store, fs) == [2]
+
+    def test_filtre_desactive_ignore(self, store):
+        fs = FilterSet(text_filters=[TextFilter(pattern="zone", enabled=False)])
+        assert len(visible(store, fs)) == len(store)
+
+    def test_motifs_surlignes_excluent_les_inverses(self):
+        fs = FilterSet(text_filters=[TextFilter(pattern="VEAF"), TextFilter(pattern="x", invert=True)])
+        assert len(highlight_patterns(fs)) == 1
+
+
+class TestEtatsDesCategories:
+    def test_niveau_masque(self, store):
+        fs = FilterSet(levels={"INFO": State.OFF})
+        assert visible(store, fs) == [0, 2, 4, 5]
+
+    def test_source_masquee(self, store):
+        fs = FilterSet(sources={"veaf": State.OFF})
+        assert 1 not in visible(store, fs)
+
+    def test_bruit_masque(self, store):
+        fs = FilterSet(noise={"damage_model": State.OFF, "taxiroad": State.OFF})
+        assert visible(store, fs) == [1, 2, 3, 4]
+
+    def test_off_prime_sur_context(self, store):
+        """Une entree exclue par un critere le reste, meme en contexte ailleurs."""
+        fs = FilterSet(levels={"INFO": State.CONTEXT}, sources={"veaf": State.OFF})
+        assert 1 not in visible(store, fs)
+
+    def test_categorie_inconnue_affichee(self, store):
+        """Un niveau qui apparait en cours de suivi ne doit pas etre masque."""
+        fs = FilterSet(levels={"NOUVEAU": State.OFF})
+        assert len(visible(store, fs)) == len(store)
+
+
+class TestContexte:
+    def test_contexte_autour_des_erreurs(self, store):
+        """INFO en contexte : on ne les voit qu'autour d'une ligne retenue."""
+        fs = FilterSet(
+            levels={"INFO": State.CONTEXT, "WARNING": State.OFF},
+            context_lines=1,
+        )
+        # Retenues : 0 et 4 (ERROR). Voisines a +/-1 et de niveau INFO : 1 et 3.
+        assert visible(store, fs) == [0, 1, 3, 4]
+
+    def test_contexte_zero_desactive_le_voisinage(self, store):
+        fs = FilterSet(
+            levels={"INFO": State.CONTEXT, "WARNING": State.OFF},
+            context_lines=0,
+        )
+        assert visible(store, fs) == [0, 4]
+
+    def test_contexte_large(self, store):
+        fs = FilterSet(levels={"INFO": State.CONTEXT, "WARNING": State.OFF}, context_lines=10)
+        assert visible(store, fs) == [0, 1, 3, 4]
+
+    def test_le_contexte_ne_subit_pas_le_filtre_textuel(self, store):
+        """Une ligne de contexte n'a pas a contenir le texte cherche.
+
+        Sinon elle n'apporterait rien : c'est justement ce qui entoure la
+        correspondance qu'on veut lire.
+        """
+        fs = FilterSet(
+            levels={"INFO": State.CONTEXT, "WARNING": State.OFF},
+            text_filters=[TextFilter(pattern="Mission script error")],
+            context_lines=1,
+        )
+        assert visible(store, fs) == [3, 4]
+
+    def test_sans_categorie_en_contexte_rien_ne_change(self, store):
+        fs = FilterSet(levels={"INFO": State.OFF}, context_lines=5)
+        assert visible(store, fs) == [0, 2, 4, 5]
+
+    def test_bornes_du_journal(self, store):
+        """Le voisinage ne deborde pas du debut ni de la fin."""
+        fs = FilterSet(
+            levels={"ERROR": State.OFF, "WARNING": State.OFF, "INFO": State.CONTEXT},
+            context_lines=50,
+        )
+        assert visible(store, fs) == [], "sans ligne retenue, aucun contexte"
+
+    def test_uses_context(self):
+        assert not FilterSet().uses_context
+        assert FilterSet(levels={"INFO": State.CONTEXT}).uses_context
+        assert not FilterSet(levels={"INFO": State.OFF}).uses_context
+
+
+class TestPersistance:
+    def test_aller_retour(self):
+        fs = FilterSet(
+            levels={"INFO": State.CONTEXT},
+            sources={"veaf": State.OFF},
+            noise={"taxiroad": State.OFF},
+            text_filters=[TextFilter(pattern="x", mode=Mode.REGEX, invert=True)],
+            context_lines=7,
+        )
+        relu = FilterSet.from_dict(fs.to_dict())
+        assert relu.levels == {"INFO": State.CONTEXT}
+        assert relu.sources == {"veaf": State.OFF}
+        assert relu.context_lines == 7
+        assert relu.text_filters[0].invert and relu.text_filters[0].mode is Mode.REGEX
+
+    def test_etat_on_non_stocke(self):
+        """Seules les categories qui derogent sont retenues."""
+        fs = FilterSet.from_dict({"levels": {"INFO": "on", "DEBUG": "off"}})
+        assert fs.levels == {"DEBUG": State.OFF}
+
+    def test_valeurs_invalides_ignorees(self):
+        fs = FilterSet.from_dict(
+            {"levels": {"INFO": "n_importe_quoi"}, "text_filters": [{"pattern": "a", "mode": "?"}]}
+        )
+        assert fs.levels == {}
+        assert fs.text_filters == []
+
+    def test_copie_independante(self):
+        fs = FilterSet(levels={"INFO": State.OFF}, text_filters=[TextFilter(pattern="a")])
+        copie = fs.copy()
+        copie.levels["INFO"] = State.CONTEXT
+        copie.text_filters.append(TextFilter(pattern="b"))
+        assert fs.levels == {"INFO": State.OFF}
+        assert len(fs.text_filters) == 1
+
+    def test_set_state(self):
+        fs = FilterSet()
+        fs.set_state("levels", "INFO", State.OFF)
+        assert fs.levels == {"INFO": State.OFF}
+        fs.set_state("levels", "INFO", State.ON)
+        assert fs.levels == {}, "revenir a ON retire l'entree"
+
+
+class TestJournalVide:
+    def test_aucune_entree(self, rules):
+        store = LogStore(rules, BytesBuffer(b""))
+        store.index_new()
+        assert evaluate(store, FilterSet(levels={"INFO": State.OFF})) == []
+
+
+class TestPorteeParCategorie:
+    """Chaque categorie en contexte peut avoir sa propre portee."""
+
+    def test_defaut_commun(self):
+        fs = FilterSet(context_lines=4)
+        assert fs.span_for("levels", "INFO") == 4
+
+    def test_surcharge(self):
+        fs = FilterSet(context_lines=4)
+        fs.set_span("levels", "INFO", 10)
+        assert fs.span_for("levels", "INFO") == 10
+        assert fs.span_for("levels", "DEBUG") == 4, "les autres suivent le defaut"
+
+    def test_surcharge_egale_au_defaut_non_stockee(self):
+        fs = FilterSet(context_lines=4)
+        fs.set_span("levels", "INFO", 4)
+        assert fs.context_spans == {}
+
+    def test_retour_au_defaut(self):
+        fs = FilterSet(context_lines=4)
+        fs.set_span("levels", "INFO", 10)
+        fs.set_span("levels", "INFO", None)
+        assert fs.span_for("levels", "INFO") == 4
+
+    def test_familles_independantes(self):
+        fs = FilterSet(context_lines=1)
+        fs.set_span("levels", "INFO", 5)
+        assert fs.span_for("sources", "INFO") == 1, "meme cle, famille differente"
+
+    def test_portee_appliquee(self, store):
+        """INFO a large portee, WARNING masque : seules les INFO proches sortent."""
+        fs = FilterSet(levels={"INFO": State.CONTEXT, "WARNING": State.OFF}, context_lines=0)
+        assert visible(store, fs) == [0, 4]
+        fs.set_span("levels", "INFO", 1)
+        assert visible(store, fs) == [0, 1, 3, 4]
+
+    def test_la_plus_large_gagne(self, store):
+        """Une entree en contexte par deux criteres prend la plus grande portee."""
+        fs = FilterSet(
+            levels={"INFO": State.CONTEXT, "WARNING": State.OFF},
+            sources={"veaf": State.CONTEXT},
+            context_lines=0,
+        )
+        fs.set_span("sources", "veaf", 1)
+        # L'entree 1 est INFO (portee 0) et VEAF (portee 1) : elle sort.
+        assert 1 in visible(store, fs)
+
+    def test_persistance(self):
+        fs = FilterSet(levels={"INFO": State.CONTEXT}, context_lines=2)
+        fs.set_span("levels", "INFO", 8)
+        relu = FilterSet.from_dict(fs.to_dict())
+        assert relu.span_for("levels", "INFO") == 8
+
+    def test_valeurs_invalides_ignorees(self):
+        fs = FilterSet.from_dict({"context_spans": {"levels:INFO": "beaucoup", "levels:X": True}})
+        assert fs.context_spans == {}
+
+    def test_copie_independante(self):
+        fs = FilterSet()
+        fs.set_span("levels", "INFO", 9)
+        copie = fs.copy()
+        copie.set_span("levels", "INFO", 1)
+        assert fs.span_for("levels", "INFO") == 9

--- a/test/python/veaf_logs/test_indexing.py
+++ b/test/python/veaf_logs/test_indexing.py
@@ -1,0 +1,170 @@
+"""Tests de l'indexation progressive.
+
+Un gros journal doit se lire par tranches, sans figer l'interface, et un petit
+doit se charger d'un trait sans faire clignoter une barre de progression.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+from veaf_logs.buffer import FileBuffer  # noqa: E402
+from veaf_logs.store import LogStore  # noqa: E402
+from veaf_logs.ui.indexing import ProgressiveIndexer  # noqa: E402
+
+LIGNE = "2026-08-31 11:50:00.000 INFO    APP (Main): remplissage numero {n}\n"
+
+
+@pytest.fixture(scope="session")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def gros_journal(tmp_path):
+    """Un journal assez gros pour depasser la premiere tranche."""
+    path = tmp_path / "gros.log"
+    with open(path, "w", encoding="utf-8") as handle:
+        for n in range(20_000):
+            handle.write(LIGNE.format(n=n))
+    return path
+
+
+class TestParTranches:
+    def test_petit_journal_indexe_d_un_trait(self, app, journal_file, rules):
+        store = LogStore(rules, FileBuffer(journal_file))
+        indexer = ProgressiveIndexer(store)
+        poursuit = indexer.start()
+        assert not poursuit, "un petit journal ne doit pas etaler son indexation"
+        assert store.indexed_bytes == store.buffer.size()
+
+    def test_gros_journal_etale(self, app, gros_journal, rules):
+        store = LogStore(rules, FileBuffer(gros_journal))
+        indexer = ProgressiveIndexer(store)
+        # Premiere tranche volontairement minuscule, pour forcer l'etalement.
+        assert indexer.start(upfront=4096), "l'indexation doit se poursuivre"
+        assert indexer.running
+        assert 0 < store.indexed_bytes < store.buffer.size()
+
+    def test_les_premieres_lignes_sont_lisibles_aussitot(self, app, gros_journal, rules):
+        store = LogStore(rules, FileBuffer(gros_journal))
+        ProgressiveIndexer(store).start(upfront=64 << 10)
+        assert len(store) > 0
+        assert store.entry(0).message.startswith("remplissage")
+
+    def test_va_jusqu_au_bout(self, app, gros_journal, rules):
+        store = LogStore(rules, FileBuffer(gros_journal))
+        indexer = ProgressiveIndexer(store)
+        indexer.start(upfront=4096)
+        while indexer.running:
+            app.processEvents()
+        assert store.indexed_bytes == store.buffer.size()
+        assert len(store) == 20_000
+
+    def test_signaux_emis(self, app, gros_journal, rules):
+        store = LogStore(rules, FileBuffer(gros_journal))
+        indexer = ProgressiveIndexer(store)
+        lots, fini, avancement = [], [], []
+        indexer.batch_ready.connect(lots.append)
+        indexer.finished.connect(lambda: fini.append(True))
+        indexer.progress.connect(lambda done, total: avancement.append((done, total)))
+
+        indexer.start(upfront=4096)
+        while indexer.running:
+            app.processEvents()
+
+        assert len(lots) > 1, "l'indexation doit avancer par lots"
+        assert sum(lots) == 20_000
+        assert fini == [True]
+        assert avancement[-1][0] == avancement[-1][1], "la progression finit a 100 %"
+
+    def test_interruption(self, app, gros_journal, rules):
+        """Ce qui est deja indexe reste consultable apres une interruption."""
+        store = LogStore(rules, FileBuffer(gros_journal))
+        indexer = ProgressiveIndexer(store)
+        indexer.start(upfront=4096)
+        indexer.cancel()
+        while indexer.running:
+            app.processEvents()
+
+        partiel = len(store)
+        assert 0 < partiel < 20_000
+        assert store.entry(partiel - 1) is not None
+
+    def test_reprise_apres_interruption(self, app, gros_journal, rules):
+        store = LogStore(rules, FileBuffer(gros_journal))
+        indexer = ProgressiveIndexer(store)
+        indexer.start(upfront=4096)
+        indexer.cancel()
+        while indexer.running:
+            app.processEvents()
+
+        indexer.start(upfront=4096)
+        while indexer.running:
+            app.processEvents()
+        assert len(store) == 20_000, "l'indexation reprend ou elle s'etait arretee"
+
+    def test_pas_de_double_demarrage(self, app, gros_journal, rules):
+        store = LogStore(rules, FileBuffer(gros_journal))
+        indexer = ProgressiveIndexer(store)
+        indexer.start(upfront=4096)
+        avant = store.indexed_bytes
+        assert indexer.start() is True
+        assert store.indexed_bytes == avant, "le second appel ne relance rien"
+
+
+class TestBorneParTranche:
+    def test_max_bytes_borne_le_travail(self, rules, gros_journal):
+        store = LogStore(rules, FileBuffer(gros_journal))
+        store.index_new(max_bytes=8192)
+        assert 0 < store.indexed_bytes <= 8192
+
+    def test_appels_successifs_avancent(self, rules, gros_journal):
+        store = LogStore(rules, FileBuffer(gros_journal))
+        premier = store.index_new(max_bytes=8192)
+        second = store.index_new(max_bytes=8192)
+        assert premier and second
+        assert store.indexed_bytes <= 16384
+
+    def test_sans_borne_tout_est_lu(self, rules, gros_journal):
+        store = LogStore(rules, FileBuffer(gros_journal))
+        store.index_new()
+        assert store.indexed_bytes == store.buffer.size()
+
+
+class TestComptagesIncrementaux:
+    """Les compteurs sont tenus a jour a l'insertion, jamais recalcules."""
+
+    def test_coherents_apres_indexation_partielle(self, rules, gros_journal):
+        store = LogStore(rules, FileBuffer(gros_journal))
+        store.index_new(max_bytes=8192)
+        assert sum(store.counts_by_level().values()) == len(store)
+        assert sum(store.counts_by_source().values()) == len(store)
+
+    def test_coherents_apres_indexation_complete(self, store):
+        assert sum(store.counts_by_level().values()) == len(store)
+        assert store.counts_by_level() == {"ERROR": 2, "INFO": 2, "WARNING": 2}
+
+    def test_remis_a_zero(self, store):
+        store.clear()
+        assert store.counts_by_level() == {}
+        assert store.counts_by_noise() == {}
+
+    def test_bruit_d_une_continuation_compte_une_fois(self, rules, tmp_path):
+        """Deux suites porteuses du meme bruit ne comptent pas double."""
+        path = tmp_path / "trace.log"
+        path.write_text(
+            "2026-08-31 11:50:00.000 INFO    DCS (Main): CPU info:\nhypervisor is active\nhypervisor is active\n",
+            encoding="utf-8",
+        )
+        store = LogStore(rules, FileBuffer(path))
+        store.index_new()
+        assert len(store) == 1
+        assert store.counts_by_noise().get("hypervisor") == 1

--- a/test/python/veaf_logs/test_profiles.py
+++ b/test/python/veaf_logs/test_profiles.py
@@ -1,0 +1,171 @@
+"""Tests des profils et de la session."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from veaf_logs.filters import FilterSet, Mode, State, TextFilter
+from veaf_logs.profiles import PROFILES_VERSION, ProfileStore
+from veaf_logs.session import SESSION_VERSION, OpenFile, Session
+
+
+@pytest.fixture
+def profiles(rules, tmp_path) -> ProfileStore:
+    return ProfileStore(rules, tmp_path / "profiles.json")
+
+
+class TestProfilsFournis:
+    def test_presents(self, profiles):
+        noms = profiles.names()
+        assert "Tout" in noms
+        assert any("Lecture" in nom for nom in noms)
+        assert any("Diagnostic" in nom for nom in noms)
+
+    def test_tout_n_a_aucun_filtre(self, profiles):
+        assert profiles.get("Tout").is_empty
+
+    def test_lecture_masque_le_bruit(self, profiles, rules):
+        filtres = profiles.get("Lecture (sans le bruit ED)")
+        assert filtres.noise["damage_model"] is State.OFF
+        assert set(filtres.noise) == rules.default_hidden_noise()
+
+    def test_diagnostic_met_l_info_en_contexte(self, profiles):
+        filtres = profiles.get("Diagnostic (erreurs + contexte)")
+        assert filtres.levels["INFO"] is State.CONTEXT
+        assert filtres.context_lines > 0
+
+    def test_non_modifiables(self, profiles):
+        with pytest.raises(ValueError, match="fourni"):
+            profiles.save_profile("Tout", FilterSet())
+        with pytest.raises(ValueError, match="fourni"):
+            profiles.delete("Tout")
+
+    def test_rendus_en_copie(self, profiles):
+        """Modifier les filtres courants ne doit pas reecrire le profil."""
+        filtres = profiles.get("Tout")
+        filtres.levels["INFO"] = State.OFF
+        assert profiles.get("Tout").levels == {}
+
+
+class TestProfilsUtilisateur:
+    def test_enregistrer_et_relire(self, profiles, rules, tmp_path):
+        filtres = FilterSet(
+            levels={"INFO": State.CONTEXT},
+            text_filters=[TextFilter(pattern="CSAR", mode=Mode.PLAIN)],
+            context_lines=5,
+        )
+        profiles.save_profile("Mon profil", filtres)
+
+        relu = ProfileStore(rules, tmp_path / "profiles.json")
+        recharge = relu.get("Mon profil")
+        assert recharge.levels == {"INFO": State.CONTEXT}
+        assert recharge.text_filters[0].pattern == "CSAR"
+        assert recharge.context_lines == 5
+
+    def test_remplacer(self, profiles):
+        profiles.save_profile("P", FilterSet(context_lines=1))
+        profiles.save_profile("P", FilterSet(context_lines=9))
+        assert profiles.get("P").context_lines == 9
+
+    def test_supprimer(self, profiles):
+        profiles.save_profile("P", FilterSet())
+        profiles.delete("P")
+        assert profiles.get("P") is None
+
+    def test_renommer(self, profiles):
+        profiles.save_profile("Avant", FilterSet(context_lines=4))
+        profiles.rename("Avant", "Apres")
+        assert profiles.get("Avant") is None
+        assert profiles.get("Apres").context_lines == 4
+
+    def test_nom_vide_refuse(self, profiles):
+        with pytest.raises(ValueError):
+            profiles.save_profile("   ", FilterSet())
+
+    def test_nom_normalise(self, profiles):
+        profiles.save_profile("  espace  ", FilterSet())
+        assert profiles.get("espace") is not None
+
+    def test_ordre(self, profiles):
+        """Les profils fournis d'abord, les autres par ordre alphabetique."""
+        profiles.save_profile("Zeta", FilterSet())
+        profiles.save_profile("Alpha", FilterSet())
+        noms = profiles.names()
+        assert noms[:3] == list(profiles.builtin)
+        assert noms[3:] == ["Alpha", "Zeta"]
+
+    def test_fichier_illisible(self, rules, tmp_path):
+        path = tmp_path / "profiles.json"
+        path.write_text("{ pas du json", encoding="utf-8")
+        assert ProfileStore(rules, path).user == {}
+
+    def test_version_incompatible(self, rules, tmp_path):
+        path = tmp_path / "profiles.json"
+        path.write_text(json.dumps({"version": PROFILES_VERSION + 1, "profiles": {"X": {}}}), encoding="utf-8")
+        assert ProfileStore(rules, path).user == {}
+
+
+class TestSession:
+    def test_aller_retour(self, tmp_path):
+        path = tmp_path / "session.json"
+        session = Session(
+            files=[OpenFile("C:/dcs.log"), OpenFile("C:/a.zip", "dcs.log")],
+            active=1,
+            profile="Mon profil",
+        )
+        session.set_filters(
+            FilterSet(
+                levels={"INFO": State.CONTEXT},
+                text_filters=[TextFilter(pattern="x", invert=True)],
+                context_lines=4,
+            )
+        )
+        session.save(path)
+
+        relue = Session.load(path)
+        assert relue.active == 1
+        assert relue.profile == "Mon profil"
+        assert relue.files[1].archive_member == "dcs.log"
+        filtres = relue.get_filters()
+        assert filtres.levels == {"INFO": State.CONTEXT}
+        assert filtres.context_lines == 4
+        assert filtres.text_filters[0].invert
+
+    def test_session_absente(self, tmp_path):
+        assert Session.load(tmp_path / "rien.json").files == []
+
+    def test_session_illisible(self, tmp_path):
+        path = tmp_path / "session.json"
+        path.write_text("{ pas du json", encoding="utf-8")
+        assert Session.load(path).files == []
+
+    def test_version_incompatible(self, tmp_path):
+        path = tmp_path / "session.json"
+        path.write_text(json.dumps({"version": SESSION_VERSION + 1, "active": 3}), encoding="utf-8")
+        assert Session.load(path).active == 0
+
+    def test_champ_inconnu_ignore(self, tmp_path):
+        path = tmp_path / "session.json"
+        path.write_text(
+            json.dumps({"version": SESSION_VERSION, "active": 2, "nouveaute": 42}),
+            encoding="utf-8",
+        )
+        assert Session.load(path).active == 2
+
+    def test_filtres_corrompus(self, tmp_path):
+        path = tmp_path / "session.json"
+        path.write_text(json.dumps({"version": SESSION_VERSION, "filters": "pas un objet"}), encoding="utf-8")
+        assert Session.load(path).get_filters().is_empty
+
+    def test_fichiers_disparus_ecartes(self, tmp_path):
+        present = tmp_path / "present.log"
+        present.write_text("x", encoding="utf-8")
+        session = Session(files=[OpenFile(str(present)), OpenFile(str(tmp_path / "parti.log"))])
+        assert [item.path for item in session.existing_files()] == [str(present)]
+
+    def test_ecriture_atomique(self, tmp_path):
+        path = tmp_path / "session.json"
+        Session(active=1).save(path)
+        assert not path.with_suffix(".tmp").exists()
+        assert Session.load(path).active == 1

--- a/test/python/veaf_logs/test_store.py
+++ b/test/python/veaf_logs/test_store.py
@@ -1,0 +1,174 @@
+"""Tests de l'index : decoupage, classement, rattachement, suivi."""
+
+from __future__ import annotations
+
+import pytest
+from veaf_logs.buffer import BytesBuffer, FileBuffer
+from veaf_logs.store import LogStore
+from veaf_logs_journal import ENTRIES, JOURNAL
+
+
+class TestIndexation:
+    def test_nombre_d_entrees(self, store):
+        assert len(store) == ENTRIES
+
+    def test_les_traces_rejoignent_leur_erreur(self, store):
+        erreur = store.entry(4)
+        assert erreur.level == "ERROR"
+        assert erreur.continuations == ["stack traceback:", "\t[C]: in function 'getUnitRecordById'"]
+
+    def test_la_recherche_porte_sur_la_trace(self, store):
+        assert "getUnitRecordById" in store.entry(4).text
+
+    def test_numerotation_sur_les_lignes_du_fichier(self, store):
+        """La derniere entree est la 8e ligne, pas la 6e entree."""
+        assert store.entry(ENTRIES - 1).lineno == len(JOURNAL)
+
+    def test_horodatage(self, store):
+        assert store.entry(0).timestamp == "2026-08-31 11:50:40.872"
+        assert store.entry(0).time_only == "11:50:40.872"
+
+    def test_message_sans_l_entete(self, store):
+        assert store.entry(0).message.startswith("Error: Unit [F-14B]")
+
+    def test_ligne_vide_de_fin_ignoree(self, rules):
+        store = LogStore(rules, BytesBuffer(b"2026-08-31 11:00:00.000 INFO APP (Main): a\n"))
+        assert store.index_new() == 1
+
+    def test_ligne_incomplete_attendue(self, rules):
+        """DCS ecrit en continu : une ligne sans fin de ligne n'est pas indexee."""
+        store = LogStore(rules, BytesBuffer(b"2026-08-31 11:00:00.000 INFO APP (Main): tronq"))
+        assert store.index_new() == 0
+
+    def test_fins_de_ligne_windows(self, rules):
+        data = b"2026-08-31 11:00:00.000 INFO    APP (Main): crlf\r\n"
+        store = LogStore(rules, BytesBuffer(data))
+        store.index_new()
+        assert store.entry(0).message == "crlf", "le \\r ne doit pas rester"
+
+    def test_octets_invalides(self, rules):
+        data = b"2026-08-31 11:00:00.000 INFO    APP (Main): \xff\xfe casse\n"
+        store = LogStore(rules, BytesBuffer(data))
+        assert store.index_new() == 1
+        assert "casse" in store.entry(0).message
+
+
+class TestClassement:
+    def test_niveaux(self, store):
+        assert [store.level_of(i) for i in range(ENTRIES)] == [
+            "ERROR",
+            "INFO",
+            "WARNING",
+            "INFO",
+            "ERROR",
+            "WARNING",
+        ]
+
+    def test_avertissement_veaf_sous_un_info_dcs(self, store):
+        """DCS journalise tout le Lua en INFO ; le vrai niveau est dans le prefixe."""
+        assert store.level_of(2) == "WARNING"
+        assert "zone introuvable" in store.entry(2).message
+
+    def test_sources(self, store):
+        assert store.source_of(1) == "veaf"
+        assert store.source_of(3) == "ctld"
+        assert store.source_of(0) == "dcs"
+
+    def test_sous_systeme_en_libelle_de_source(self, store):
+        assert store.entry(0).source_label == "APP"
+
+    def test_bruit_reconnu(self, store):
+        assert "damage_model" in store.noise_of(0)
+        assert "taxiroad" in store.noise_of(5)
+
+    def test_erreur_de_script_jamais_du_bruit(self, store):
+        assert store.noise_of(4) == ()
+
+    def test_module_veaf(self, rules):
+        data = b"2026-08-31 11:00:00.000 INFO    SCRIPTING (Main): VEAF-GRASS|I|1: x\n"
+        store = LogStore(rules, BytesBuffer(data))
+        store.index_new()
+        assert store.entry(0).module == "GRASS"
+
+
+class TestComptages:
+    def test_par_niveau(self, store):
+        assert store.counts_by_level() == {"ERROR": 2, "INFO": 2, "WARNING": 2}
+
+    def test_par_source(self, store):
+        counts = store.counts_by_source()
+        assert counts["veaf"] == 2
+        assert counts["ctld"] == 1
+
+    def test_par_famille_de_bruit(self, store):
+        counts = store.counts_by_noise()
+        assert counts["damage_model"] == 1
+        assert counts["taxiroad"] == 1
+
+
+class TestSuiviIncremental:
+    def test_indexation_par_lots(self, rules, journal_file):
+        store = LogStore(rules, FileBuffer(journal_file))
+        assert store.index_new() == ENTRIES
+        assert store.index_new() == 0, "rien de neuf"
+
+        with open(journal_file, "ab") as handle:
+            handle.write(b"2026-08-31 12:00:00.000 ERROR   APP (Main): nouvelle\n")
+        assert store.index_new() == 1
+        assert store.entry(len(store) - 1).message == "nouvelle"
+        store.buffer.close()
+
+    def test_trace_arrivee_apres_coup(self, rules, journal_file):
+        """La derniere ligne est indexee tout de suite ; sa trace la rejoint."""
+        store = LogStore(rules, FileBuffer(journal_file))
+        store.index_new()
+        with open(journal_file, "ab") as handle:
+            handle.write(b"2026-08-31 12:00:00.000 ERROR   SCRIPTING (Main): boum\n")
+        store.index_new()
+        dernier = len(store) - 1
+        assert store.entry(dernier).continuations == []
+
+        with open(journal_file, "ab") as handle:
+            handle.write(b"stack traceback:\n")
+        assert store.index_new() == 0, "une suite ne cree pas d'entree"
+        assert store.entry(dernier).continuations == ["stack traceback:"]
+        store.buffer.close()
+
+    def test_octets_indexes_bornent_la_recherche(self, rules, journal_file):
+        store = LogStore(rules, FileBuffer(journal_file))
+        store.index_new()
+        assert store.indexed_bytes == journal_file.stat().st_size
+        store.buffer.close()
+
+    def test_remise_a_zero(self, store):
+        store.clear()
+        assert len(store) == 0
+        assert store.indexed_bytes == 0
+        assert store.index_new() == ENTRIES, "tout doit pouvoir etre relu"
+
+
+class TestCorrespondanceOffsets:
+    def test_chaque_position_appartient_a_une_entree(self, store):
+        """La recherche ramene une position du fichier a son entree."""
+        assert store.index_at_offset(0) == 0
+        for index in range(len(store)):
+            debut = store.offsets[index]
+            assert store.index_at_offset(debut) == index
+
+    def test_une_position_dans_la_trace_designe_l_erreur(self, store):
+        data = b"\n".join(line.encode() for line in JOURNAL)
+        position = data.index(b"getUnitRecordById")
+        assert store.index_at_offset(position) == 4
+
+
+class TestLimites:
+    def test_trop_de_familles_de_bruit(self, rules):
+        """Le masque binaire ne va pas au-dela de 64 familles."""
+        from veaf_logs.rules import Rules
+        from veaf_logs.store import MAX_NOISE_FAMILIES
+
+        data = dict(rules.data)
+        modele = data["noise"][0]
+        data["noise"] = [dict(modele, id=f"f{i}") for i in range(MAX_NOISE_FAMILIES + 1)]
+        with pytest.raises(ValueError, match="familles de bruit"):
+            LogStore(Rules(data), BytesBuffer(b""))

--- a/test/python/veaf_logs/test_tailer.py
+++ b/test/python/veaf_logs/test_tailer.py
@@ -1,0 +1,172 @@
+"""Tests de l'ouverture, de la rotation et des archives."""
+
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+from veaf_logs.buffer import FileBuffer
+from veaf_logs.store import LogStore
+from veaf_logs.tailer import LogSource, LogUnavailable, archive_members
+
+LIGNE = "2026-08-31 11:5{n}:00.000 INFO    APP (Main): message {n}\n"
+
+
+@pytest.fixture
+def journal(tmp_path):
+    path = tmp_path / "dcs.log"
+    path.write_text(LIGNE.format(n=0), encoding="utf-8")
+    return path
+
+
+class TestOuverture:
+    def test_fichier_ordinaire(self, journal):
+        source = LogSource(journal)
+        buffer = source.open()
+        assert buffer.size() == journal.stat().st_size
+        source.close()
+
+    def test_fichier_absent(self, tmp_path):
+        with pytest.raises(LogUnavailable):
+            LogSource(tmp_path / "rien.log").open()
+
+    def test_fichier_vide(self, tmp_path):
+        """Le journal existe mais DCS n'a encore rien ecrit."""
+        path = tmp_path / "vide.log"
+        path.touch()
+        source = LogSource(path)
+        assert source.open().size() == 0
+        source.close()
+
+    def test_suivi_possible(self, journal):
+        assert LogSource(journal).followable
+
+
+class TestRotation:
+    def test_pas_de_rotation_quand_le_fichier_grossit(self, journal):
+        source = LogSource(journal)
+        source.open()
+        for n in range(1, 4):
+            with open(journal, "a", encoding="utf-8") as handle:
+                handle.write(LIGNE.format(n=n))
+            assert not source.check_rotation(journal.stat().st_size)
+        source.close()
+
+    def test_reecriture_de_meme_longueur(self, journal):
+        """Ni la taille ni l'identite ne changent : seule l'empreinte le dit."""
+        source = LogSource(journal)
+        source.open()
+        taille = journal.stat().st_size
+        remplacement = LIGNE.format(n=7)
+        assert len(remplacement) == len(LIGNE.format(n=0))
+        journal.write_text(remplacement, encoding="utf-8")
+        assert source.check_rotation(taille)
+        source.close()
+
+    def test_fichier_tronque(self, journal):
+        source = LogSource(journal)
+        source.open()
+        indexe = journal.stat().st_size
+        journal.write_text("court\n", encoding="utf-8")
+        assert source.check_rotation(indexe)
+        source.close()
+
+    def test_fichier_disparu(self, journal):
+        source = LogSource(journal)
+        source.open()
+        journal.unlink()
+        with pytest.raises(LogUnavailable):
+            source.check_rotation(0)
+
+    def test_reouverture_repart_du_nouveau_fichier(self, rules, journal):
+        source = LogSource(journal)
+        store = LogStore(rules, source.open())
+        assert store.index_new() == 1
+
+        journal.write_text(LIGNE.format(n=4) + LIGNE.format(n=5), encoding="utf-8")
+        assert source.check_rotation(store.indexed_bytes)
+        store.buffer = source.reopen()
+        store.clear()
+        assert store.index_new() == 2
+        assert "message 4" in store.entry(0).message
+        source.close()
+
+
+class TestArchives:
+    @pytest.fixture
+    def archive(self, tmp_path):
+        path = tmp_path / "dcs.log-20260613-184244.zip"
+        with zipfile.ZipFile(path, "w") as zf:
+            # Ordre volontairement defavorable : le journal en dernier.
+            zf.writestr("dxdiag.txt", "rapport materiel")
+            zf.writestr("dcs.20260613-184244.dmp", b"\x00binaire")
+            zf.writestr("dcs.20260613-184244.log", LIGNE.format(n=0) + LIGNE.format(n=1))
+        return path
+
+    def test_le_journal_passe_avant_dxdiag(self, archive):
+        assert archive_members(archive)[0].endswith(".log")
+
+    def test_le_binaire_est_ecarte(self, archive):
+        assert not any(name.endswith(".dmp") for name in archive_members(archive))
+
+    def test_lecture(self, rules, archive):
+        source = LogSource(archive)
+        store = LogStore(rules, source.open())
+        assert store.index_new() == 2
+
+    def test_pas_de_suivi(self, archive):
+        assert not LogSource(archive).followable
+
+    def test_rotation_sans_objet(self, archive):
+        source = LogSource(archive)
+        source.open()
+        assert not source.check_rotation(0)
+
+    def test_nom_affiche(self, archive):
+        source = LogSource(archive)
+        source.open()
+        assert "dcs.20260613-184244.log" in source.display_name
+
+    def test_archive_sans_journal(self, tmp_path):
+        path = tmp_path / "vide.zip"
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("data.bin", b"\x00")
+        with pytest.raises(LogUnavailable):
+            LogSource(path).open()
+
+    def test_membre_impose(self, archive):
+        source = LogSource(archive, archive_member="dxdiag.txt")
+        buffer = source.open()
+        assert buffer.slice(0, buffer.size()) == b"rapport materiel"
+
+
+class TestBufferFichier:
+    def test_croissance_prise_en_compte(self, journal):
+        buffer = FileBuffer(journal)
+        premiere = buffer.size()
+        with open(journal, "a", encoding="utf-8") as handle:
+            handle.write(LIGNE.format(n=1))
+        assert buffer.refresh() > premiere
+        assert b"message 1" in buffer.slice(0, buffer.size())
+
+    def test_lecture_partielle(self, journal):
+        assert FileBuffer(journal).slice(0, 4) == b"2026"
+
+    def test_le_journal_n_est_jamais_verrouille(self, journal, tmp_path):
+        """DCS renomme son journal au lancement : rien ne doit l'en empecher.
+
+        Sous Windows, un descripteur ouvert — projection memoire ou simple
+        `open()` maintenu — suffit a faire echouer le renommage.
+        """
+        import os
+
+        buffer = FileBuffer(journal)
+        buffer.slice(0, 10)
+        buffer.refresh()
+        os.rename(journal, tmp_path / "dcs.log.old")  # ne doit pas lever
+
+    def test_fichier_disparu_rend_des_octets_vides(self, journal):
+        buffer = FileBuffer(journal)
+        journal.unlink()
+        assert buffer.slice(0, 10) == b""
+        assert buffer.refresh() == 0

--- a/test/python/veaf_logs/test_tailer.py
+++ b/test/python/veaf_logs/test_tailer.py
@@ -42,6 +42,30 @@ class TestOuverture:
         assert LogSource(journal).followable
 
 
+class TestIdentiteDuFichier:
+    """L'identite ne doit tenir qu'a l'inode et au peripherique.
+
+    Elle a un temps inclus `st_ctime`, ce qui passait sous Windows — la date de
+    creation n'y bouge pas — et faussait tout sous Linux, ou cette date est
+    celle du dernier changement d'inode : chaque ecriture la modifie.
+    """
+
+    def test_ecrire_ne_change_pas_l_identite(self, journal):
+        from veaf_logs.tailer import FileIdentity
+
+        avant = FileIdentity.of(journal)
+        with open(journal, "a", encoding="utf-8") as handle:
+            handle.write(LIGNE.format(n=1))
+        assert FileIdentity.of(journal) == avant
+
+    def test_un_autre_fichier_a_une_autre_identite(self, journal, tmp_path):
+        from veaf_logs.tailer import FileIdentity
+
+        autre = tmp_path / "autre.log"
+        autre.write_text(LIGNE.format(n=2), encoding="utf-8")
+        assert FileIdentity.of(autre) != FileIdentity.of(journal)
+
+
 class TestRotation:
     def test_pas_de_rotation_quand_le_fichier_grossit(self, journal):
         source = LogSource(journal)

--- a/test/python/veaf_logs/test_ui.py
+++ b/test/python/veaf_logs/test_ui.py
@@ -1,0 +1,239 @@
+"""Tests d'integration de l'interface, en rendu hors ecran.
+
+Ils couvrent les enchainements ou les bugs se logent : l'etat des filtres qui
+survit a l'ouverture d'un second onglet et au rafraichissement des compteurs,
+le suivi qui alimente la vue sans relacher les filtres, et le va-et-vient entre
+profils et filtres courants.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+from veaf_logs.filters import State  # noqa: E402
+from veaf_logs.profiles import DEFAULT_PROFILE, ProfileStore  # noqa: E402
+from veaf_logs.rules import Rules  # noqa: E402
+from veaf_logs.session import Session  # noqa: E402
+from veaf_logs.ui.main_window import MainWindow  # noqa: E402
+from veaf_logs_journal import ENTRIES  # noqa: E402
+
+
+@pytest.fixture(scope="session")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def window(app, journal_file, tmp_path, rules):
+    window = MainWindow(rules, Session())
+    # Profils isoles : on ne touche pas a ceux de l'utilisateur.
+    window.profiles = ProfileStore(rules, tmp_path / "profiles.json")
+    window._reload_profile_box(DEFAULT_PROFILE)
+    window.open_path(journal_file)
+    yield window
+    window.timer.stop()
+    window.close()
+
+
+def rows(window) -> int:
+    return window.current_tab().model.rowCount()
+
+
+class TestChargement:
+    def test_entrees_indexees(self, window):
+        assert window.current_tab().model.total == ENTRIES
+
+    def test_tout_affiche_par_defaut(self, window):
+        assert rows(window) == ENTRIES
+
+    def test_colonnes_lues_a_la_demande(self, window):
+        entry = window.current_tab().model.entry_at(0)
+        assert entry.level == "ERROR"
+        assert entry.source_label == "APP"
+
+
+class TestRecherche:
+    def test_texte(self, window):
+        window.search.field.setText("zone introuvable")
+        window.apply_filters()
+        assert rows(window) == 1
+
+    def test_dans_une_trace_rattachee(self, window):
+        window.search.field.setText("getUnitRecordById")
+        window.apply_filters()
+        assert rows(window) == 1
+
+    def test_regex(self, window):
+        window.search.mode.setCurrentIndex(2)
+        window.search.field.setText(r"VEAF\|[WE]\|")
+        window.apply_filters()
+        assert rows(window) == 1
+
+    def test_jokers(self, window):
+        window.search.mode.setCurrentIndex(1)
+        window.search.field.setText("No taxiroad*Batumi*")
+        window.apply_filters()
+        assert rows(window) == 1
+
+    def test_regex_invalide_n_applique_rien(self, window):
+        window.search.mode.setCurrentIndex(2)
+        window.search.field.setText("[non fermee")
+        assert window.search.error.text()
+        assert rows(window) == ENTRIES
+
+    def test_cumul_puis_retrait(self, window):
+        window.search.field.setText("VEAF")
+        window.add_current_filter()
+        assert len(window.filters.text_filters) == 1
+        # `isVisible` est faux tant que la fenetre n'est pas affichee : on
+        # interroge la visibilite propre du widget.
+        assert not window.chips.isHidden()
+        window.remove_filter(0)
+        assert window.filters.text_filters == []
+        assert rows(window) == ENTRIES
+
+
+class TestTriEtat:
+    def test_masquer_un_niveau(self, window):
+        window.side.levels.apply_states({"INFO": State.OFF})
+        window.side.changed.emit()
+        assert rows(window) == 4
+
+    def test_contexte(self, window):
+        window.side.levels.apply_states({"INFO": State.CONTEXT, "WARNING": State.OFF})
+        window.side.context_lines.setValue(1)
+        window.side.changed.emit()
+        assert rows(window) == 4, "les 2 erreurs, plus 2 INFO voisines"
+
+    def test_le_contexte_se_combine_avec_la_recherche(self, window):
+        window.side.levels.apply_states({"INFO": State.CONTEXT, "WARNING": State.OFF})
+        window.side.context_lines.setValue(1)
+        window.side.changed.emit()
+        window.search.field.setText("Mission script error")
+        window.apply_filters()
+        assert rows(window) == 2, "l'erreur trouvee et sa voisine de contexte"
+
+    def test_bruit_masque_puis_niveaux(self, window):
+        """Les deux dimensions se cumulent au lieu de se remplacer."""
+        window.side.noise.apply_states({"damage_model": State.OFF})
+        window.side.changed.emit()
+        assert rows(window) == ENTRIES - 1
+        window.side.levels.apply_states({"INFO": State.OFF})
+        window.side.changed.emit()
+        assert rows(window) == 3
+
+    def test_reinitialiser(self, window):
+        window.side.levels.apply_states({"INFO": State.OFF})
+        window.side.changed.emit()
+        window.reset_filters()
+        assert rows(window) == ENTRIES
+        assert window.filters.is_empty
+
+
+class TestEtatPersistant:
+    def test_second_onglet_herite_des_filtres(self, window, journal_file):
+        window.side.levels.apply_states({"INFO": State.OFF})
+        window.side.changed.emit()
+        avant = rows(window)
+
+        window.open_path(journal_file)
+        assert rows(window) == avant, "le nouvel onglet applique les memes filtres"
+        window.tabs.setCurrentIndex(0)
+        assert rows(window) == avant, "l'onglet d'origine garde les siens"
+
+    def test_le_suivi_n_efface_pas_les_filtres(self, window, journal_file):
+        window.side.levels.apply_states({"INFO": State.OFF})
+        window.side.changed.emit()
+        avant = rows(window)
+        with open(journal_file, "a", encoding="utf-8") as handle:
+            handle.write("2026-08-31 12:00:00.000 INFO    APP (Main): sans interet\n")
+        window._poll_all()
+        assert rows(window) == avant, "une ligne INFO masquee ne doit pas apparaitre"
+
+    def test_les_nouvelles_lignes_arrivent(self, window, journal_file):
+        with open(journal_file, "a", encoding="utf-8") as handle:
+            handle.write("2026-08-31 12:00:00.000 ERROR   APP (Main): nouvelle\n")
+        window._poll_all()
+        assert rows(window) == ENTRIES + 1
+
+    def test_categorie_absente_conservee(self, window, journal_file):
+        """Masquer DEBUG doit tenir meme si le journal n'en contient pas encore."""
+        window.filters.levels["DEBUG"] = State.OFF
+        window.side.collect(window.filters)
+        assert window.filters.levels.get("DEBUG") is State.OFF
+
+        with open(journal_file, "a", encoding="utf-8") as handle:
+            handle.write("2026-08-31 12:00:00.000 INFO    SCRIPTING (Main): VEAF|D|1: trace\n")
+        window._poll_all()
+        window.apply_filters()
+        assert rows(window) == ENTRIES, "la trace DEBUG ne doit pas s'afficher"
+
+
+class TestProfils:
+    def test_profils_fournis_listes(self, window):
+        assert window.profile_box.findText("Tout") > 0
+
+    def test_charger_un_profil_fourni(self, window):
+        window.load_profile("Lecture (sans le bruit ED)")
+        assert rows(window) == ENTRIES - 2, "les deux lignes de bruit connu"
+
+    def test_charger_le_profil_diagnostic(self, window):
+        window.load_profile("Diagnostic (erreurs + contexte)")
+        assert window.filters.levels["INFO"] is State.CONTEXT
+        assert window.side.context_lines.value() == window.filters.context_lines
+
+    def test_enregistrer_et_recharger(self, window, tmp_path):
+        window.side.levels.apply_states({"INFO": State.OFF})
+        window.side.changed.emit()
+        window.side.collect(window.filters)
+        window.profiles.save_profile("Mon profil", window.filters)
+        window._reload_profile_box("Mon profil")
+
+        window.reset_filters()
+        assert rows(window) == ENTRIES
+        window.load_profile("Mon profil")
+        assert rows(window) == 4
+
+    def test_charger_ne_reecrit_pas_le_profil(self, window):
+        """Refleter un profil dans les widgets ne doit pas passer pour une action."""
+        window.profiles.save_profile("P", window.filters.copy())
+        window.load_profile("P")
+        window.side.levels.apply_states({"INFO": State.OFF})
+        window.side.changed.emit()
+        assert window.profiles.get("P").levels == {}, "le profil enregistre est intact"
+
+    def test_profil_fourni_non_supprimable(self, window):
+        window.profile_box.setCurrentText("Tout")
+        window._update_profile_buttons()
+        assert not window.profile_delete.isEnabled()
+
+
+class TestSession:
+    def test_capture_et_restauration(self, window, journal_file, tmp_path, rules):
+        window.search.field.setText("VEAF")
+        window.add_current_filter()
+        window.side.levels.apply_states({"INFO": State.OFF})
+        window.side.changed.emit()
+
+        chemin = tmp_path / "session.json"
+        window._capture().save(chemin)
+
+        relue = Session.load(chemin)
+        assert [item.path for item in relue.files] == [str(journal_file)]
+        assert relue.get_filters().levels == {"INFO": State.OFF}
+
+        rouverte = MainWindow(rules, relue)
+        try:
+            assert rouverte.tabs.count() == 1
+            assert len(rouverte.filters.text_filters) == 1
+            assert rouverte.current_tab().model.rowCount() == 1
+        finally:
+            rouverte.timer.stop()
+            rouverte.close()

--- a/veaf-logs.spec
+++ b/veaf-logs.spec
@@ -1,0 +1,73 @@
+# Recette PyInstaller du programme autonome `veaf-logs`.
+#
+# `veaf-tools` est construit par `veaf-build build-standalone` ; `veaf-logs` a
+# sa propre recette parce que ses besoins n'ont rien de commun : il embarque Qt
+# et rien de la chaine de construction des missions. Les garder separes evite
+# aussi de faire grossir `veaf-tools.exe` de plusieurs dizaines de mega-octets
+# pour une interface que la plupart de ses utilisateurs n'ouvriront jamais.
+#
+#   poetry run pyinstaller veaf-logs.spec
+#
+# Produit `dist/veaf-logs.exe` sous Windows, `dist/veaf-logs` ailleurs.
+
+from pathlib import Path
+
+SOURCE = Path("src/python/veaf-tools")
+
+# Modules Qt dont l'application n'a aucun usage. Sans ces exclusions, PyInstaller
+# embarque le moteur web, la 3D et le multimedia — plusieurs centaines de
+# mega-octets pour rien.
+UNUSED_QT = [
+    "PySide6.Qt3DAnimation",
+    "PySide6.Qt3DCore",
+    "PySide6.Qt3DExtras",
+    "PySide6.Qt3DInput",
+    "PySide6.Qt3DLogic",
+    "PySide6.Qt3DRender",
+    "PySide6.QtCharts",
+    "PySide6.QtDataVisualization",
+    "PySide6.QtMultimedia",
+    "PySide6.QtMultimediaWidgets",
+    "PySide6.QtOpenGL",
+    "PySide6.QtOpenGLWidgets",
+    "PySide6.QtPdf",
+    "PySide6.QtPdfWidgets",
+    "PySide6.QtQml",
+    "PySide6.QtQuick",
+    "PySide6.QtQuick3D",
+    "PySide6.QtQuickWidgets",
+    "PySide6.QtSql",
+    "PySide6.QtTest",
+    "PySide6.QtWebEngineCore",
+    "PySide6.QtWebEngineWidgets",
+]
+
+analysis = Analysis(
+    [str(SOURCE / "veaf_logs" / "__main__.py")],
+    pathex=[str(SOURCE)],
+    binaries=[],
+    # Le catalogue de regles est lu au demarrage, a cote du module.
+    datas=[(str(SOURCE / "veaf_logs" / "rules.json"), "veaf_logs")],
+    hiddenimports=[],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=UNUSED_QT + ["tkinter", "unittest", "pytest"],
+    noarchive=False,
+)
+
+pyz = PYZ(analysis.pure)
+
+exe = EXE(
+    pyz,
+    analysis.scripts,
+    analysis.binaries,
+    analysis.datas,
+    [],
+    name="veaf-logs",
+    debug=False,
+    strip=False,
+    upx=False,
+    # Pas de console : c'est une application a fenetre.
+    console=False,
+    disable_windowed_traceback=False,
+)


### PR DESCRIPTION
## Description

A DCS log buries what matters under noise nobody can act on. `veaf-logs` knows our scripts and hides the rest: on a real session log, **2,710 severe lines come down to 362**.

Three things it does that a general-purpose log viewer structurally cannot:

- **A stack trace stays with its error.** A `Mission script error` and its `stack traceback` form one entry, so filtering on errors no longer hides the explanation. Searching a symbol that only appears in the trace brings back the error that produced it.
- **The level shown is the real one.** DCS logs all Lua as `INFO SCRIPTING`, so a `VEAF|W|` warning arrives labelled INFO. This reads it from the prefix — filtering on WARNING finally surfaces VEAF, CTLD and CSAR warnings.
- **ED's harmless errors are hidden by family** — corrupt damage models, negative payload weights, missing taxi routes, IC failures — each switchable, with a running count of what is hidden so the filter is never silent.

Every level, source and noise family has a third state besides shown and hidden: **context**, which keeps a category only around the lines that matter, the way `grep -C` does, each with its own span. A complete filter set saves as a **profile**; three ship with the tool (`Tout`, `Lecture`, `Diagnostic`).

The rule catalogue lives in one editable `rules.json`, reloadable from the menu without restarting.

### Large logs

The text is never held in memory — only a compact index is, and lines are decoded as they are displayed. On a 119 MB server log (991,392 lines):

| | |
|---|---|
| First lines readable | 0.3 s |
| Full indexing | 8.6 s, in the background, interruptible |
| Longest UI stall | 74 ms |
| Memory | 37 MB |
| Search (text or regex) | 0.65 s |

Indexing is sliced on the UI thread rather than run in a `QThread`: a thread filling the index while the view reads it would need a lock on every access, and a Qt model read from another thread is a classic source of irreproducible crashes. The perceived result is the same, without the risk — the reasoning is in `ui/indexing.py`.

### It never locks the log

On Windows, a file held open cannot be renamed — and that is exactly what DCS does to its own `dcs.log` at launch. A viewer holding a descriptor would keep the game from starting. `veaf-logs` opens and closes on each read; a test guards it.

This was found by a failing test, not by reading the code: the first implementation used `mmap`.

## Packaging

Shipped as a **separate `veaf-logs.exe`** (37 MB) built from its own PyInstaller recipe, uploaded as a release asset. Qt is an **optional dependency** (`--extras logs`), so `veaf-tools.exe` neither grows nor changes.

`python-quality.yml` already covered `src/python/**` and `test/python/**` with `--all-extras`, so the gate picks this up as it stands; the only additions are the Qt runtime libraries the Linux runner needs, and a `veaf-logs-exe-smoke` job that builds the binary and opens a real log with it. That job exists because the failure already happened: the first build died instantly on a relative import that resolves fine from the checkout and not at all from a bundle.

## Type of change

- [x] New feature
- [x] Documentation
- [x] Chore / tooling / CI

## Quality checklist

### Lua changes

No Lua touched.

### Python changes
- [x] `poetry run ruff check src/python/veaf-tools` passes
- [x] `poetry run ruff format --check src/python/veaf-tools` passes
- [x] `poetry run mypy src/python/veaf-tools` passes
- [x] `poetry run pytest` passes (includes coverage check)

**214 tests**, and the new code sits at **84.3 % coverage**, above the 81 % gate. Every edge case comes from a real log: `ALERT` and `ERROR_ONCE` levels, subsystems with `::`, empty messages, headerless lines, Windows line endings, invalid bytes, a log rewritten to the same length, an archive holding several files.

`poetry.lock` is regenerated — without it `poetry install` fails on the first CI step.

### All changes
- [x] `CHANGELOG.md` updated (entry under `[Unreleased] / Added`)

Docs: `doc/mission-maker/LOGS.md` and `LOGS.en.md`, listed in the mkdocs nav.
