### PR TITLE
chore(logs): five more families of ED noise the tool should have hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`veaf-logs` recognises five more families of ED noise.** Running the tool on a real log turned up
+  errors it should have hidden and did not: missing livery, model and animation files, refused
+  levels of detail, missing UI textures, unloadable sound waves — and `No cell for property record`,
+  which is the same defect as the already-known `No property record for cell` written the other way
+  round. On the reference corpus, severe lines drop from **363 to 278**.
+
+  `Can't open file` is deliberately bounded to the asset directories. DCS writes it for a missing
+  livery, which is noise, but also for a mission or script it cannot open, which is exactly what a
+  mission maker must see; a test states that.
+
 - **`veaf-logs`, a reader for DCS logs.** A DCS log buries what matters under noise nobody can act on.
   This one knows our scripts and hides the rest — on a real session log, it takes 2,710 severe lines
   down to **362**.

--- a/doc/mission-maker/LOGS.en.md
+++ b/doc/mission-maker/LOGS.en.md
@@ -42,7 +42,7 @@ can have its own span: the `±` field appears beside it as soon as it switches t
 ◐, and leaving that field empty falls back to the shared value set at the top of
 the panel.
 
-On a real session log, dropping the ED noise takes 2,710 severe lines down to 362.
+On a real session log, dropping the ED noise takes 2,714 severe lines down to 278.
 
 ## Profiles
 

--- a/doc/mission-maker/LOGS.md
+++ b/doc/mission-maker/LOGS.md
@@ -44,8 +44,8 @@ explique. Chaque catégorie peut avoir sa propre portée : le champ `±` appara�
 sa droite dès qu'elle passe en ◐, et laisser le champ vide reprend la valeur
 commune réglée en haut du panneau.
 
-Sur un journal de session réel, écarter le bruit ED ramène 2 710 lignes de niveau
-grave à 362.
+Sur un journal de session réel, écarter le bruit ED ramène 2 714 lignes de niveau
+grave à 278.
 
 ## Profils
 

--- a/src/python/veaf-tools/veaf_logs/rules.json
+++ b/src/python/veaf-tools/veaf_logs/rules.json
@@ -144,9 +144,9 @@
     {
       "id": "property_record",
       "label": "Segments 3D non declares",
-      "help": "Segments de modele 3D non declares. Bruit constant au chargement.",
+      "help": "Segments ou cellules de modele 3D non declares. Bruit constant au chargement. DCS l'ecrit dans les deux sens, d'ou les deux formulations.",
       "default_hidden": true,
-      "match": "No property record for (segment|cell)",
+      "match": "(No property record for (segment|cell)|No cell for property record)",
       "regex": true
     },
     {
@@ -168,9 +168,9 @@
     {
       "id": "sound_source",
       "label": "Sources sonores introuvables",
-      "help": "source_add / invalid source_params : prototypes de son absents. Inaudible.",
+      "help": "Prototypes de son absents, fichiers d'onde introuvables. Inaudible.",
       "default_hidden": true,
-      "match": "(source_add\\(host:|invalid source_params\\()",
+      "match": "(source_add\\(host:|invalid source_params\\(|can't load wave:|can't find proto)",
       "regex": true
     },
     {
@@ -259,6 +259,30 @@
       "help": "Perte de liaison avec Winwing SimApp Pro, repetee en boucle.",
       "default_hidden": false,
       "match": "No message received from SimApp Pro",
+      "regex": true
+    },
+    {
+      "id": "missing_asset_file",
+      "label": "Fichiers d'assets absents",
+      "help": "Livrees, modeles ou animations qu'un mod reference sans les fournir. Volontairement borne aux repertoires d'assets : un fichier de mission ou de script introuvable est une vraie erreur, et reste visible.",
+      "default_hidden": true,
+      "match": "Can't open file: /(textures|models|animations|sounds)/",
+      "regex": true
+    },
+    {
+      "id": "model_lod",
+      "label": "Niveaux de detail non charges",
+      "help": "Modeles 3D dont un niveau de detail est refuse : boite englobante invalide, version de fichier incorrecte, ordre des lods.",
+      "default_hidden": true,
+      "match": "Can't load lod .* Reason:",
+      "regex": true
+    },
+    {
+      "id": "ui_texture",
+      "label": "Textures d'interface introuvables",
+      "help": "Images de theme reclamees par l'interface de DCS. Sans effet visible.",
+      "default_hidden": true,
+      "match": "Texture \\[[^\\]]*\\] not found",
       "regex": true
     },
     {

--- a/test/python/veaf_logs/test_catalogue.py
+++ b/test/python/veaf_logs/test_catalogue.py
@@ -163,6 +163,37 @@ class TestBruit:
             ("WARNING GRAPHICSCORE (Main): already registered Renderer callback", "renderer_callback"),
             ("WARNING WORLD (Main): ModelTimeQuantizer: ANTIFREEZE ENABLED", "antifreeze"),
             ("WARNING EDCORE (Main): hypervisor is active", "hypervisor"),
+            # Releves sur un journal reel apres la premiere mise en service.
+            (
+                "ERROR   WORLDGENERAL (Main): Error: Unit [MiG-23MLD]: No cell for property record GEAR_C.",
+                "property_record",
+            ),
+            (
+                "ERROR   WORLDGENERAL (Main): Error: Unit [MiG-21Bis]: No cell for property records MTG_L CELL#137",
+                "property_record",
+            ),
+            (
+                "ERROR   EDCORE (Main): Can't open file: /textures/liveries/s-3b/usa/description.lua.",
+                "missing_asset_file",
+            ),
+            ("ERROR   EDCORE (24556): Can't open file: /models/.", "missing_asset_file"),
+            (
+                "ERROR   EDCORE (37208): Can't open file: /animations/typegl.anim.",
+                "missing_asset_file",
+            ),
+            (
+                "ERROR   NGMODEL (21308): Can't load lod //models/invisiblefarp.edm of model "
+                "invisiblefarp. Reason: Model has invalid bounding box.",
+                "model_lod",
+            ),
+            (
+                "ERROR   DXGUI_EDGE_RENDER (Main): Texture [dxgui/skins/skinme/images/x.png] not found!",
+                "ui_texture",
+            ),
+            (
+                'ERROR   ED_SOUND (20376): can\'t load wave: "effects/ambient/field_night1.ogg"',
+                "sound_source",
+            ),
         ],
     )
     def test_famille_reconnue(self, rules, ligne, famille):
@@ -230,3 +261,31 @@ class TestSousSysteme:
         entry = une(rules, "2026-08-31 11:50:00.000 ERROR   EDCORE (Main): boum")
         assert entry.subsystem == "EDCORE"
         assert entry.source_label == "EDCORE"
+
+
+class TestBruitBorne:
+    """Les familles larges ne doivent pas masquer une vraie erreur.
+
+    `Can't open file` en particulier : DCS l'ecrit pour une livree manquante,
+    bruit qu'on veut cacher, mais aussi pour un fichier de mission ou de script
+    introuvable, qui est exactement ce qu'un createur de mission doit voir.
+    """
+
+    @pytest.mark.parametrize(
+        "ligne",
+        [
+            "ERROR   EDCORE (Main): Can't open file: /Missions/veaf-demo.miz.",
+            "ERROR   SCRIPTING (Main): Can't open file: veafRadio.lua.",
+            "ERROR   EDCORE (Main): Can't open file: l10n/DEFAULT/CTLD.lua.",
+        ],
+    )
+    def test_un_fichier_de_mission_reste_visible(self, rules, ligne):
+        store = indexer(rules, f"2026-08-31 11:50:40.872 {ligne}")
+        assert "missing_asset_file" not in store.noise_of(0)
+
+    def test_une_erreur_de_modele_nest_pas_un_lod(self, rules):
+        store = indexer(
+            rules,
+            "2026-08-31 11:50:40.872 ERROR   NGMODEL (1): Can't load lod without a reason",
+        )
+        assert "model_lod" not in store.noise_of(0), "le motif exige un 'Reason:'"


### PR DESCRIPTION
## Description

Running `veaf-logs` on a real log — the first thing done after #853 merged — turned up errors it was meant to hide and did not. On the reference corpus, severe lines drop from **363 to 278**.

Five patterns, but only three new families: two of them are defects already catalogued, written another way.

| Pattern | Family |
|---|---|
| `No cell for property record(s)` | extends `property_record` — DCS writes it both ways round |
| `can't load wave:` , `can't find proto` | extends `sound_source` — same subsystem, same kind of miss |
| `Can't open file: /textures\|models\|animations\|sounds/` | **new** `missing_asset_file` |
| `Can't load lod … Reason:` | **new** `model_lod` |
| `Texture [...] not found` | **new** `ui_texture` |

### One deliberate boundary

`Can't open file` is restricted to the asset directories. DCS writes it for a missing livery, which is noise worth hiding, but also for a mission or a script it cannot open — which is exactly what a mission maker must see. Every occurrence in the corpus sits under `/textures/`, `/models/` or `/animations/`, and a test states the boundary directly: `Can't open file: /Missions/veaf-demo.miz` and `Can't open file: veafRadio.lua` stay visible.

The same care applies to `Can't load lod`, which requires the `Reason:` DCS always appends.

This is catalogue only — `rules.json`, no code — which is what the file is for. Anyone can do the same from **Règles → Ouvrir rules.json**, then `F5`.

## Type of change

- [x] Chore / tooling
- [x] Documentation

## Quality checklist

### Lua changes

No Lua touched.

### Python changes
- [x] `poetry run ruff check src/python/veaf-tools` passes
- [x] `poetry run ruff format --check src/python/veaf-tools` passes
- [x] `poetry run mypy src/python/veaf-tools` passes
- [x] `poetry run pytest` passes

10 new cases, each taken from a real log line, plus 4 that guard the boundary above.

### All changes
- [x] `CHANGELOG.md` updated
- [x] Docs updated — `LOGS.md` and `LOGS.en.md` carried the old figure, now remeasured on the same corpus

## Summary by Sourcery

Expand the `veaf-logs` noise catalogue to hide five additional families of actionable-free ED errors while preserving important file and model failures.

Enhancements:
- Expand `veaf-logs` noise filtering to recognize five additional ED error families, including property-record and sound-source variants plus missing asset files, model LOD failures, and missing UI textures.
- Keep broad file-error filtering limited to asset directories and require the expected reason marker for model LOD errors so actionable mission and script failures remain visible.

Documentation:
- Update the English and French log documentation with the remeasured reduction in severe lines from 2,714 to 278.

Tests:
- Add real-log catalogue cases and boundary tests covering the new noise families and preserving visible mission, script, and malformed LOD errors.

Chores:
- Update the changelog with the expanded ED noise catalogue and its filtering boundaries.