### PR TITLE
docs(logs): say which corpus the figures come from, and use one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **`veaf-logs` recognises five more families of ED noise.** Running the tool on a real log turned up
-  errors it should have hidden and did not: missing livery, model and animation files, refused
-  levels of detail, missing UI textures, unloadable sound waves — and `No cell for property record`,
-  which is the same defect as the already-known `No property record for cell` written the other way
-  round. On the reference corpus, severe lines drop from **363 to 278**.
-
-  `Can't open file` is deliberately bounded to the asset directories. DCS writes it for a missing
-  livery, which is noise, but also for a mission or script it cannot open, which is exactly what a
-  mission maker must see; a test states that.
-
 - **`veaf-logs`, a reader for DCS logs.** A DCS log buries what matters under noise nobody can act on.
-  This one knows our scripts and hides the rest — on a real session log, it takes 2,710 severe lines
-  down to **362**.
+  This one knows our scripts and hides the rest. On the reference corpus below, it takes 2,714
+  severe lines down to **363**; on a single current `dcs.log`, 416 down to **69**.
 
   Three things it does that a general-purpose log viewer structurally cannot. **A stack trace stays
   with its error**: filtering on errors no longer hides the `stack traceback` that explains them.
@@ -51,6 +41,22 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
   Shipped as a separate `veaf-logs.exe` asset. Its Qt dependency is optional (`--extras logs`), so
   `veaf-tools.exe` neither grows nor changes. Documented in `doc/mission-maker/LOGS.md`.
+
+- **`veaf-logs` recognises five more families of ED noise.** Running the tool on a real log turned up
+  errors it should have hidden and did not: missing livery, model and animation files, refused
+  levels of detail, missing UI textures, unloadable sound waves — and `No cell for property record`,
+  which is the same defect as the already-known `No property record for cell` written the other way
+  round. On the reference corpus, severe lines drop further, from 363 to **278**; on a single
+  current `dcs.log`, from 69 to **34**.
+
+  `Can't open file` is deliberately bounded to the asset directories. DCS writes it for a missing
+  livery, which is noise, but also for a mission or script it cannot open, which is exactly what a
+  mission maker must see; a test states that.
+
+  *Reference corpus, for both entries above: one `dcs.log` plus four archived session logs from
+  `Saved Games\DCS\Logs` — 2,714 lines of level ERROR, ERROR_ONCE or ALERT. Measuring both on the
+  same corpus is what makes the two figures comparable. A log grows while the game runs, so counts
+  taken on another day differ by a few lines.*
 
 ### Fixed
 

--- a/doc/mission-maker/LOGS.en.md
+++ b/doc/mission-maker/LOGS.en.md
@@ -42,7 +42,15 @@ can have its own span: the `±` field appears beside it as soon as it switches t
 ◐, and leaving that field empty falls back to the shared value set at the top of
 the panel.
 
-On a real session log, dropping the ED noise takes 2,714 severe lines down to 278.
+Dropping the ED noise changes the scale of what is left to read:
+
+| Log | Severe lines | Shown |
+|---|---|---|
+| One session `dcs.log` | 416 | **34** |
+| That `dcs.log` and four archived logs | 2,714 | **278** |
+
+"Severe" means level `ERROR`, `ERROR_ONCE` or `ALERT`. A log grows while the game
+runs, so counts taken on another day differ by a few lines.
 
 ## Profiles
 

--- a/doc/mission-maker/LOGS.md
+++ b/doc/mission-maker/LOGS.md
@@ -44,8 +44,16 @@ explique. Chaque catégorie peut avoir sa propre portée : le champ `±` appara�
 sa droite dès qu'elle passe en ◐, et laisser le champ vide reprend la valeur
 commune réglée en haut du panneau.
 
-Sur un journal de session réel, écarter le bruit ED ramène 2 714 lignes de niveau
-grave à 278.
+Écarter le bruit ED change l'échelle de ce qu'il reste à lire :
+
+| Journal | Lignes graves | Affichées |
+|---|---|---|
+| Un `dcs.log` de session | 416 | **34** |
+| Ce `dcs.log` et quatre journaux archivés | 2 714 | **278** |
+
+« Lignes graves » : de niveau `ERROR`, `ERROR_ONCE` ou `ALERT`. Un journal grossit
+tant que le jeu tourne, donc un relevé fait un autre jour donne quelques lignes
+d'écart.
 
 ## Profils
 


### PR DESCRIPTION
## Description

Sourcery pointed this out on #855, and it was right: three different before/after counts had made it into the repository, and not one said what was measured.

| Where | What it said |
|---|---|
| Changelog, first entry | 2,710 → 362 |
| Changelog, second entry | 363 → 278 |
| `LOGS.md` / `LOGS.en.md` | 2,714 → 278 |

The spread is explained — a `dcs.log` grows between two runs, so the same corpus counted 2,710 severe lines one day and 2,714 the next — but no reader could know that, and the two changelog entries could not be compared with each other at all.

### What changed

Everything is measured on **one named corpus**, stated once, where both entries can see it: one `dcs.log` plus four archived session logs, 2,714 lines of level `ERROR`, `ERROR_ONCE` or `ALERT`.

Both documents also gained the figure a reader can actually relate to, which had never been published: on a **single current `dcs.log`, 416 severe lines down to 34**.

| Corpus | Severe | After #853 | After #855 |
|---|---|---|---|
| One session `dcs.log` | 416 | 69 | **34** |
| That log plus four archives | 2,714 | 363 | **278** |

Both guides now carry that table, and a sentence saying a log grows while the game runs — so a count taken another day differing by a few lines is expected, not a contradiction.

### One more thing

The two changelog entries are back in the order the section asks for. `CHANGELOG.md` opens with a note explaining that entries are **appended, not prepended**, precisely so two open PRs merge cleanly — and I had prepended the second one. That also put the corpus note above an entry it claimed to describe.

Documentation only: no code, no rules, no behaviour change.

## Type of change

- [x] Documentation

## Quality checklist

### Lua changes

No Lua touched.

### Python changes

No Python touched. The suite was run anyway and passes.

### All changes
- [x] `CHANGELOG.md` updated — that is the point of this PR

## Summary by Sourcery

Clarify and standardize the published veaf-logs measurements across the changelog and user guides.

Documentation:
- Document the log-filtering results using a single named reference corpus and add comparable counts for both archived logs and a current session log.
- Clarify that log counts vary as DCS logs grow during gameplay.

Chores:
- Restore the changelog entries to append order so their corpus context is associated correctly.