### PR TITLE
fix(chatbot): stop a self-declared header from opening the Worker

### DIFF
--- a/.backlog/FEAT-SUPPORT-LOG-ANALYSIS/tickets/02-worker-multi-client.md
+++ b/.backlog/FEAT-SUPPORT-LOG-ANALYSIS/tickets/02-worker-multi-client.md
@@ -1,6 +1,6 @@
 # 02 — The Worker learns to serve more than one kind of client
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: fix
 
@@ -54,10 +54,10 @@ here.
 
 ## Definition of done
 
-- [ ] Client modes declared, with a limit per mode
-- [ ] A self-declared header alone no longer grants browser-bypassing access
-- [ ] Rate limiting fails closed; a KV outage cannot remove the limit
-- [ ] Body size ceiling enforced before parsing
-- [ ] A log-analysis mode accepting an excerpt plus matched catalogue entries
-- [ ] Unit tests extended, including the fail-closed path and the body ceiling
-- [ ] Deployment steps written down in the Worker README, which is stale and gets refreshed here
+- [x] Client modes declared, with a limit per mode
+- [x] A self-declared header alone no longer grants browser-bypassing access
+- [x] Rate limiting fails closed; a KV outage cannot remove the limit
+- [x] Body size ceiling enforced before parsing
+- [x] A log-analysis mode accepting an excerpt plus matched catalogue entries
+- [x] Unit tests extended, including the fail-closed path and the body ceiling
+- [x] Deployment steps written down in the Worker README, which is stale and gets refreshed here

--- a/.github/workflows/chatbot-worker.yml
+++ b/.github/workflows/chatbot-worker.yml
@@ -1,0 +1,50 @@
+# Runs the documentation chatbot Worker's unit tests.
+#
+# Added after FEAT-SUPPORT-LOG-ANALYSIS/02: the suite existed but no CI ever ran it on a pull
+# request. Its only caller was the `Rebuild docs chatbot index` workflow, which is `on: push` to
+# `develop` and filtered on `doc/**` plus `scripts/build-index.mjs` — neither `worker/src/**` nor
+# `worker/test/**`. A pull request rewriting the Worker's admission control therefore went green
+# without a single one of these tests running, and the merge did not run them either.
+#
+# The Worker itself is deployed by hand (`npx wrangler deploy`); this job gates the code, not the
+# deployment.
+name: Chatbot Worker
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+    paths:
+      - "poc/doc-chatbot/worker/**"
+      - ".github/workflows/chatbot-worker.yml"
+  pull_request:
+    paths:
+      - "poc/doc-chatbot/worker/**"
+      - ".github/workflows/chatbot-worker.yml"
+
+jobs:
+  worker-tests:
+    name: Worker unit tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: poc/doc-chatbot/worker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      # `npm ci` also pulls wrangler, which the tests do not need — but the lockfile is the only
+      # install this package declares, and an out-of-sync lockfile is itself worth catching here.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,19 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ceiling when KV is unreachable, never to none. Bodies are bounded while streaming, before parsing.
   A new `POST /analyze` route explains a bounded DCS log excerpt against the catalogue entries the
   caller matched locally, saying "pattern not catalogued" rather than guessing a culprit — the mode
-  the forthcoming `veaf-logs` analysis will use. The documentation widget and `veaf-tools ask` are
-  unaffected: both keep the access they had.
+  the forthcoming `veaf-logs` analysis will use. The documentation widget and `veaf-tools ask` keep
+  the access they had, with **one number moving**: because each mode now owns its bucket instead of
+  sharing one per-IP counter, `veaf-tools ask` gets **60 questions a day instead of 100**. The
+  browser widget keeps its 100. Both burst limits are unchanged at 10 per minute, and 60 questions
+  a day from one machine is well past what asking the documentation looks like in practice.
+
+  Two residual holes on that path were closed with it. A rate-limit counter that KV hands back
+  unreadable is now treated as the ceiling rather than as zero: `parseInt("NaN")` is `NaN` and
+  `NaN >= limit` is false, so a corrupted counter used to let requests straight through — and
+  writing `NaN + 1` back with a fresh 24 h expiry kept it corrupted indefinitely. Such a value is
+  now refused and left untouched, so it simply expires. And the counter lookup no longer reads the
+  client name off the prototype chain, where `constructor` and `toString` answered with a quota-less
+  object that compared favourably against every ceiling.
 
 ## [6.19.0] — 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,23 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   rescues it, deliberately. The file is left out of the build, so nothing is broken while the
   mission folder still carries it.
 
+- **A header was enough to use the documentation chatbot's Worker from anywhere.** Its admission
+  check read `cliHeader === "cli" || origin allow-listed`: anyone sending `X-VEAF-Client: cli` was
+  admitted whatever their origin, so the browser allow-list protected nothing and the Worker — and
+  the shared free Gemini quota behind it — was open to any caller. The per-IP rate limit that was
+  supposed to make up for it returned `true` from its own `catch`, so a KV outage removed every
+  limit instead of tightening one. And nothing capped the request body before it was parsed.
+
+  The Worker now declares a client vocabulary (`web`, `cli`, `logs`, `discord`), each with its own
+  quota, routes and body ceiling. A request carrying an `Origin` is judged on the allow-list alone
+  and its self-declared header is ignored; without an `Origin` the header only *selects* a mode and
+  buys nothing beyond that mode's quota. Rate limiting falls back to a much stricter per-isolate
+  ceiling when KV is unreachable, never to none. Bodies are bounded while streaming, before parsing.
+  A new `POST /analyze` route explains a bounded DCS log excerpt against the catalogue entries the
+  caller matched locally, saying "pattern not catalogued" rather than guessing a culprit — the mode
+  the forthcoming `veaf-logs` analysis will use. The documentation widget and `veaf-tools ask` are
+  unaffected: both keep the access they had.
+
 ## [6.19.0] — 2026-09-02
 
 ### Fixed

--- a/poc/doc-chatbot/README.md
+++ b/poc/doc-chatbot/README.md
@@ -13,7 +13,8 @@ MkDocs page (static, public)
        │  detects page language (FR/EN) → POST {messages, lang} (SSE)
        ▼
   Cloudflare Worker (poc/doc-chatbot/worker) — free tier
-       │  • Origin allow-list (anti-CSRF) + per-IP rate-limit (KV)
+       │  • declared client vocabulary + per-client rate-limit (KV), Origin allow-list for browsers
+       │  • body ceiling enforced before the payload is parsed
        │  • GEMINI_API_KEY held as a Worker Secret (never shipped to the client)
        │  • embeds the question (gemini-embedding-001, 768d)
        │  • ranks the language's doc vectors by cosine similarity IN THE WORKER
@@ -98,6 +99,41 @@ poetry run mkdocs serve
 `http://localhost:8000` and `http://127.0.0.1:8000` are on the Worker's Origin allow-list, and the
 widget auto-targets the local Worker on localhost.
 
+## Routes and clients
+
+The Worker serves two routes, and every caller belongs to a **declared client mode** (`CLIENTS` in
+`worker/src/index.js`). Each mode carries its own quota and its own body ceiling, so one client
+misbehaving cannot starve the documentation widget of the shared free Gemini quota.
+
+| Route | Purpose | Payload |
+|-------|---------|---------|
+| `POST /chat` | Grounded documentation answer (RAG) | `{ lang, messages: [{role, content}] }` |
+| `POST /analyze` | Explain a DCS log excerpt | `{ lang, excerpt, matches: [{id, label, help, count}], question? }` |
+
+| Client | Selected by | Routes | Burst / day | Body ceiling |
+|--------|-------------|--------|-------------|--------------|
+| `web` | an allow-listed `Origin` (the doc widget) | `/chat` | 10 / 60s, 100 / day | 64 KiB |
+| `cli` | `X-VEAF-Client: cli`, no `Origin` (`veaf-tools ask`) | `/chat` | 10 / 60s, 60 / day | 64 KiB |
+| `logs` | `X-VEAF-Client: logs`, no `Origin` (`veaf-logs`) | `/analyze` | 4 / 60s, 30 / day | 128 KiB |
+| `discord` | `X-VEAF-Client: discord` **plus** `X-VEAF-Auth` matching the `DISCORD_CLIENT_SECRET` Secret | both | 5 / 60s, 40 / day **per user** | 64 KiB |
+
+**How admission works, and what it deliberately does not do.** A request carrying an `Origin` is a
+browser request: the allow-list decides, and its `X-VEAF-Client` header is ignored outright. Without
+an `Origin`, the header *selects* a non-browser mode — it is a routing label, not a credential, and
+it buys nothing beyond that mode's own quota. It used to be treated as proof: `X-VEAF-Client: cli`
+short-circuited the allow-list entirely, so any caller at all could use the Worker (and VEAF's
+Gemini key) from anywhere.
+
+`discord` is groundwork for [`FEAT-SUPPORT-DISCORD-QA`](../../.backlog/FEAT-SUPPORT-DISCORD-QA/PRD.md):
+a whole Discord sits behind one IP, so that mode presents a shared Secret and passes its own
+per-user `subject` in the payload to carry the quota. While `DISCORD_CLIENT_SECRET` is unset, the
+mode is refused — an unconfigured Secret is a closed door, not an open one.
+
+**Rate limiting fails closed.** The KV counters are the normal path; if KV is unavailable the Worker
+falls back to a much stricter per-isolate ceiling (`DEGRADED_MAX_PER_WINDOW`). A KV outage degrades
+the limit, it never removes it. Callers without a `CF-Connecting-IP` still share one `unknown`
+bucket, which is strict rather than lax and is left as is.
+
 ## Configuration knobs (worker/src/index.js)
 
 | Constant | Default | Meaning |
@@ -105,25 +141,59 @@ widget auto-targets the local Worker on localhost.
 | `MODEL` | `gemini-2.5-flash-lite` | Gemini generation model (2.0-flash-lite is deprecated) |
 | `EMBED_MODEL` / `EMBED_DIMS` | `gemini-embedding-001` / `768` | Embedding model + dims (must match the built index) |
 | `TOP_K` | `6` | Passages retrieved per question |
-| `RL_MAX_PER_WINDOW` / `RL_WINDOW` | `10` / `60s` | Per-IP burst limit |
-| `RL_MAX_PER_DAY` | `100` | Per-IP daily limit |
-| `ALLOWED_ORIGINS` | localhost + veaf.github.io | Domain allow-list |
+| `CLIENTS` | see the table above | Client vocabulary: routes, quotas, body ceilings |
+| `RL_WINDOW` | `60s` | Burst window for every client |
+| `DEGRADED_MAX_PER_WINDOW` | `2` | Per-isolate ceiling used when KV is unreachable |
+| `MAX_EXCERPT_CHARS` / `MAX_MATCHES` | `40000` / `40` | Log excerpt and catalogue entries kept in an `/analyze` prompt |
+| `ALLOWED_ORIGINS` | localhost + veaf.github.io | Browser Origin allow-list |
 
-## Definition of Done (POC)
+## Tests
 
-- [ ] KV namespace created, `GEMINI_API_KEY` set, index built & uploaded.
-- [ ] Worker deployed to `*.workers.dev`; widget visible on local `mkdocs serve`.
-- [ ] FR page → streamed FR answer grounded in docs; EN page → streamed EN answer.
-- [ ] Several questions in quick succession all answer (no TPM ceiling at low traffic).
-- [ ] Non-allow-listed Origin → 403; >10 req/60s → graceful 429 message.
+```bash
+cd poc/doc-chatbot/worker
+npm test          # node --test, no network, no Cloudflare account needed
+```
 
-## Gaps for VEAF productionization (out of POC scope)
+## Deploying a change
 
-- Create a BACKLOG lot, branch from `develop`, add tests, open a PR.
-- **Automated re-indexing is wired** in `.github/workflows/docs-chatbot-index.yml` (rebuilds + uploads
-  to KV on doc changes). It needs three repository secrets: `GEMINI_API_KEY`, `CLOUDFLARE_API_TOKEN`
-  (Workers KV edit), `CLOUDFLARE_ACCOUNT_ID`. Note: KV free tier allows 1,000 writes/day — a full
-  re-index writes ~500 keys, so avoid many rebuilds per day.
-- Map a Gemini 429 to the friendly "too many requests" message (currently generic).
+The Worker is deployed **by hand** — there is no pipeline for it. The
+`.github/workflows/docs-chatbot-index.yml` workflow only rebuilds and uploads the KV index; it never
+touches the Worker code. So any change under `worker/src/` reaches production only when someone runs:
+
+```bash
+cd poc/doc-chatbot/worker
+npm test                        # gate
+npx wrangler deploy --dry-run   # bundles without shipping, checks the bindings resolve
+npx wrangler deploy             # ships it
+```
+
+Secrets are set once per environment and are not part of a deploy:
+
+```bash
+npx wrangler secret put GEMINI_API_KEY
+npx wrangler secret put DISCORD_CLIENT_SECRET   # only when the Discord bot lot ships
+```
+
+## State of the POC
+
+- [x] KV namespace created, `GEMINI_API_KEY` set, index built & uploaded.
+- [x] Worker deployed to `*.workers.dev`; widget live on the documentation site.
+- [x] FR page → streamed FR answer grounded in docs; EN page → streamed EN answer.
+- [x] Several questions in quick succession all answer (no TPM ceiling at low traffic).
+- [x] Non-allow-listed Origin → 403; over the burst limit → graceful 429 message.
+- [x] Automated re-indexing wired in `.github/workflows/docs-chatbot-index.yml` (rebuilds + uploads
+      to KV on doc changes). It needs three repository secrets: `GEMINI_API_KEY`,
+      `CLOUDFLARE_API_TOKEN` (Workers KV edit), `CLOUDFLARE_ACCOUNT_ID`. Note: the KV free tier
+      allows 1,000 writes/day — a full re-index writes ~500 keys, so avoid many rebuilds per day.
+- [x] A Gemini 429 maps to the friendly "too many requests" message.
+- [x] Unit tests under `worker/test/`, run by `npm test`.
+- [x] Declared client modes, admission that ignores a self-declared header for browsers,
+      fail-closed rate limiting, body ceiling, `/analyze` log-analysis mode.
+
+## Remaining
+
 - Integrate the widget into the versioned (mike) docs; pick which branch's docs to index.
 - Custom Worker domain and observability.
+- Per-client counters are read-then-written non-atomically in an eventually consistent KV, so the
+  burst limit is approximate under concurrency. Acceptable for an abuse guard; a Durable Object
+  would be the fix if it ever needs to be exact.

--- a/poc/doc-chatbot/worker/src/index.js
+++ b/poc/doc-chatbot/worker/src/index.js
@@ -196,6 +196,27 @@ function degradedAllow(key, now = Date.now()) {
 }
 
 /**
+ * Read a KV rate-limit counter, treating anything that is not a plain non-negative integer as the
+ * worst case (the ceiling itself, so the caller is refused).
+ *
+ * Absent is zero — that is the normal first request. A *present but unreadable* value is not:
+ * `parseInt("NaN")` is `NaN`, `NaN >= limit` is false, so a corrupted counter used to let requests
+ * straight through, and writing `String(NaN + 1)` back with a fresh 24 h TTL kept it corrupted for
+ * good. A poisoned counter now closes its own gate and, since nothing rewrites it, expires on the
+ * TTL it already carries.
+ *
+ * @param {string|null} raw The stored value.
+ * @param {number} limit The ceiling to report when the value cannot be trusted.
+ * @returns {number} The counter value, or `limit` when it is unreadable.
+ */
+function readCounter(raw, limit) {
+  if (raw === null || raw === undefined) return 0;
+  const text = String(raw).trim();
+  if (!text) return 0;
+  return /^\d+$/.test(text) ? Number(text) : limit;
+}
+
+/**
  * Per-client, per-subject rate-limiting backed by KV. KV is eventually consistent and the
  * read-then-write is not atomic, which is acceptable for an abuse guard on a POC.
  *
@@ -209,14 +230,17 @@ function degradedAllow(key, now = Date.now()) {
  * @returns {Promise<boolean>} True when the request is allowed.
  */
 async function allowRequest(env, client, subject) {
-  const spec = CLIENTS[client];
+  // Own-property lookup, never a bare read: `CLIENTS["constructor"]` is `Object`, which is truthy
+  // and has no `perWindow`, so every comparison below would be `>= undefined` — i.e. false — and
+  // the request would be allowed. `resolveClient` already refuses those names, and so does this.
+  const spec = Object.prototype.hasOwnProperty.call(CLIENTS, client) ? CLIENTS[client] : null;
   if (!spec) return false;
   const minKey = `rl:min:${client}:${subject}`;
   const dayKey = `rl:day:${client}:${subject}`;
   try {
     const [minRaw, dayRaw] = await Promise.all([env.CHAT_KV.get(minKey), env.CHAT_KV.get(dayKey)]);
-    const minCount = minRaw ? parseInt(minRaw, 10) : 0;
-    const dayCount = dayRaw ? parseInt(dayRaw, 10) : 0;
+    const minCount = readCounter(minRaw, spec.perWindow);
+    const dayCount = readCounter(dayRaw, spec.perDay);
     if (minCount >= spec.perWindow || dayCount >= spec.perDay) return false;
     await Promise.all([
       env.CHAT_KV.put(minKey, String(minCount + 1), { expirationTtl: RL_WINDOW }),

--- a/poc/doc-chatbot/worker/src/index.js
+++ b/poc/doc-chatbot/worker/src/index.js
@@ -2,21 +2,32 @@
  * VEAF documentation chatbot — Cloudflare Worker proxy (POC, RAG edition).
  *
  * Responsibilities:
- *   - CORS / domain allow-list (anti-CSRF): only accept requests from known doc origins.
- *   - Per-IP rate-limiting via KV (burst + daily guards).
- *   - RAG retrieval: embed the user question (Gemini embeddings), then rank the documentation
- *     passages by cosine similarity against an embeddings index stored in KV (binary Float32
- *     vectors, L2-normalized so cosine == dot product), and inject only the top-K passages into
- *     the prompt — keeping each request small enough to stay well under the Gemini free-tier
- *     tokens-per-minute ceiling. The similarity search runs in the Worker (no paid vector DB).
- *   - Proxy the conversation to Gemini and stream the answer back to the browser as SSE.
+ *   - Admission control: a declared client vocabulary (see CLIENTS) with a quota per client.
+ *     Browsers are judged on their Origin (anti-CSRF allow-list); the `X-VEAF-Client` header
+ *     only *selects* a non-browser client mode, it never grants access an anonymous caller
+ *     would not already have.
+ *   - Per-client, per-subject rate-limiting via KV (burst + daily guards), failing to a
+ *     stricter per-isolate ceiling — never to "no limit" — when KV is unavailable.
+ *   - A request body ceiling enforced before the payload is parsed.
+ *   - RAG retrieval (`POST /chat`): embed the user question (Gemini embeddings), then rank the
+ *     documentation passages by cosine similarity against an embeddings index stored in KV
+ *     (binary Float32 vectors, L2-normalized so cosine == dot product), and inject only the
+ *     top-K passages into the prompt — keeping each request small enough to stay well under the
+ *     Gemini free-tier tokens-per-minute ceiling. The similarity search runs in the Worker
+ *     (no paid vector DB).
+ *   - Log analysis (`POST /analyze`): the caller (the `veaf-logs` tool) sends a bounded log
+ *     excerpt plus the catalogue entries it already matched locally; the model explains them,
+ *     with the catalogue as the sole authority on what a pattern means.
+ *   - Proxy the conversation to Gemini and stream the answer back to the caller as SSE.
  *
  * The Gemini API key is held as a Worker Secret (GEMINI_API_KEY) and never reaches the client.
  *
  * Bindings expected (see wrangler.toml):
  *   - env.GEMINI_API_KEY  (Secret)         Google Gemini API key (used for embeddings + generation).
- *   - env.CHAT_KV         (KV namespace)   per-IP rate-limit counters + the embeddings index
+ *   - env.CHAT_KV         (KV namespace)   rate-limit counters + the embeddings index
  *                                          (`idx:vec:{lang}` binary blob, `idx:txt:{lang}:{i}` JSON).
+ *   - env.DISCORD_CLIENT_SECRET (Secret)   optional; until it is set, the `discord` client mode
+ *                                          is refused outright (it is groundwork, not an open door).
  */
 
 const MODEL = "gemini-2.5-flash-lite";
@@ -27,16 +38,81 @@ const GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta/models";
 
 const MAX_HISTORY = 12; // trim very long conversations sent to the model
 
-// Anti-abuse: per-IP rate limits.
+const MAX_EXCERPT_CHARS = 40000; // log excerpt kept out of the prompt beyond this
+const MAX_MATCHES = 40; // catalogue entries rendered into the prompt
+
+// Anti-abuse: rate-limit window, and the ceiling used when KV cannot be reached.
 const RL_WINDOW = 60; // seconds
-const RL_MAX_PER_WINDOW = 10; // requests / 60s / IP
-const RL_MAX_PER_DAY = 100; // requests / 24h / IP
+const DEGRADED_MAX_PER_WINDOW = 2; // requests / 60s / isolate when KV is down
+const DEGRADED_MAX_TRACKED = 5000; // cap on the in-memory degraded counter map
 
 const ALLOWED_ORIGINS = new Set([
   "http://localhost:8000",
   "http://127.0.0.1:8000",
   "https://veaf.github.io",
 ]);
+
+const ROUTES = new Set(["/chat", "/analyze"]);
+
+/**
+ * The declared client vocabulary.
+ *
+ * A client is a *kind of caller*, never an identity: the `X-VEAF-Client` header only selects
+ * one of these entries. It is self-declared, so it must never buy more than a plain anonymous
+ * caller gets — in particular it can no longer bypass the browser Origin allow-list, which is
+ * what the previous `cliHeader === "cli" || origin allow-listed` admission let any caller do.
+ *
+ * Each entry carries its own quota and its own body ceiling, so one client hammering the free
+ * Gemini quota cannot starve the documentation widget.
+ *
+ * Fields:
+ *   - `routes`           the paths this client may call.
+ *   - `headerDeclarable` may this client be selected by the `X-VEAF-Client` header?
+ *                        `web` cannot: it is derived from an allow-listed Origin.
+ *   - `secretBinding`    name of the env Secret this client must prove it holds, or `null`.
+ *                        A client with a secret binding is refused while the Secret is unset.
+ *   - `perWindow` / `perDay`  requests allowed per RL_WINDOW / per 24h, per subject.
+ *   - `maxBody`          request body ceiling in bytes, enforced before parsing.
+ *
+ * On the conversational ceiling: the documentation widget replays its *whole* history on every
+ * turn and does not trim it client-side, while the Worker caps each answer at 1024 output tokens
+ * (~4 KB). MAX_HISTORY turns of that reach a few tens of KB, so 64 KiB is the smallest ceiling
+ * that cannot cut a legitimate conversation short. It is still a bound where there was none.
+ */
+const CLIENTS = {
+  web: {
+    routes: ["/chat"],
+    headerDeclarable: false,
+    secretBinding: null,
+    perWindow: 10,
+    perDay: 100,
+    maxBody: 64 * 1024,
+  },
+  cli: {
+    routes: ["/chat"],
+    headerDeclarable: true,
+    secretBinding: null,
+    perWindow: 10,
+    perDay: 60,
+    maxBody: 64 * 1024,
+  },
+  logs: {
+    routes: ["/analyze"],
+    headerDeclarable: true,
+    secretBinding: null,
+    perWindow: 4,
+    perDay: 30,
+    maxBody: 128 * 1024,
+  },
+  discord: {
+    routes: ["/chat", "/analyze"],
+    headerDeclarable: true,
+    secretBinding: "DISCORD_CLIENT_SECRET",
+    perWindow: 5,
+    perDay: 40,
+    maxBody: 64 * 1024,
+  },
+};
 
 /** Localized, user-facing messages (kept short, mirroring the Solde tone). */
 const MESSAGES = {
@@ -76,7 +152,7 @@ function systemInstruction(lang, passages) {
 function corsHeaders(origin) {
   const headers = {
     "Access-Control-Allow-Methods": "POST, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Headers": "Content-Type, X-VEAF-Client",
     "Access-Control-Max-Age": "86400",
     Vary: "Origin",
   };
@@ -91,26 +167,66 @@ function sse(data) {
   return `data: ${payload}\n\n`;
 }
 
+// Degraded (KV-less) counters, per isolate. Cleared wholesale if the map ever grows unreasonably:
+// this is a last-resort brake, not an accounting ledger.
+const degradedCounters = new Map();
+
 /**
- * Per-IP rate-limiting backed by KV. KV is eventually consistent, which is acceptable
- * for an abuse guard on a POC. Returns true when the request is allowed.
+ * Last-resort in-isolate burst limiter, used when KV cannot be reached.
+ *
+ * It counts per (client, subject) inside a fixed RL_WINDOW slot and allows far fewer requests
+ * than the KV path. An isolate-local counter is weak — Cloudflare may run several isolates —
+ * but it is bounded, which is the whole point: a KV outage must degrade the limit, never remove it.
+ *
+ * @param {string} key Counter key, typically `${client}:${subject}`.
+ * @param {number} now Milliseconds since the epoch (injectable for tests).
+ * @returns {boolean} True when the request may proceed.
  */
-async function allowRequest(env, ip) {
-  const minKey = `rl:min:${ip}`;
-  const dayKey = `rl:day:${ip}`;
+function degradedAllow(key, now = Date.now()) {
+  const slot = Math.floor(now / (RL_WINDOW * 1000));
+  if (degradedCounters.size > DEGRADED_MAX_TRACKED) degradedCounters.clear();
+  const entry = degradedCounters.get(key);
+  if (!entry || entry.slot !== slot) {
+    degradedCounters.set(key, { slot, count: 1 });
+    return true;
+  }
+  if (entry.count >= DEGRADED_MAX_PER_WINDOW) return false;
+  entry.count += 1;
+  return true;
+}
+
+/**
+ * Per-client, per-subject rate-limiting backed by KV. KV is eventually consistent and the
+ * read-then-write is not atomic, which is acceptable for an abuse guard on a POC.
+ *
+ * The subject is the caller's IP for the IP-bound clients; a service that fronts many users
+ * behind one IP (the `discord` mode) passes its own per-user subject instead, so its whole
+ * community does not share a single daily quota.
+ *
+ * @param {object} env Worker bindings (needs `CHAT_KV`).
+ * @param {string} client A key of CLIENTS.
+ * @param {string} subject Rate-limit subject (IP, or a service-supplied user id).
+ * @returns {Promise<boolean>} True when the request is allowed.
+ */
+async function allowRequest(env, client, subject) {
+  const spec = CLIENTS[client];
+  if (!spec) return false;
+  const minKey = `rl:min:${client}:${subject}`;
+  const dayKey = `rl:day:${client}:${subject}`;
   try {
     const [minRaw, dayRaw] = await Promise.all([env.CHAT_KV.get(minKey), env.CHAT_KV.get(dayKey)]);
     const minCount = minRaw ? parseInt(minRaw, 10) : 0;
     const dayCount = dayRaw ? parseInt(dayRaw, 10) : 0;
-    if (minCount >= RL_MAX_PER_WINDOW || dayCount >= RL_MAX_PER_DAY) return false;
+    if (minCount >= spec.perWindow || dayCount >= spec.perDay) return false;
     await Promise.all([
       env.CHAT_KV.put(minKey, String(minCount + 1), { expirationTtl: RL_WINDOW }),
       env.CHAT_KV.put(dayKey, String(dayCount + 1), { expirationTtl: 86400 }),
     ]);
     return true;
   } catch {
-    // Fail open: if KV is unavailable, skip rate-limiting rather than 500 the whole request.
-    return true;
+    // Fail closed-ish: KV is gone, so fall back to a much stricter per-isolate ceiling.
+    // Returning true here (as this used to) meant a KV outage silently removed every limit.
+    return degradedAllow(`${client}:${subject}`);
   }
 }
 
@@ -204,12 +320,19 @@ function toGeminiContents(messages) {
     }));
 }
 
-/** Stream a Gemini answer and re-emit it as `data: {"text": ...}` / `data: [DONE]` SSE. */
-async function streamGemini(env, lang, messages, passages) {
+/**
+ * Stream a Gemini answer and re-emit it as `data: {"text": ...}` / `data: [DONE]` SSE.
+ *
+ * @param {object} env Worker bindings.
+ * @param {string} lang `"fr"` or `"en"`, used for the failure messages.
+ * @param {Array<object>} contents Gemini-shaped `contents` (already trimmed and mapped).
+ * @param {string} instruction The system instruction framing the answer.
+ */
+async function streamGemini(env, lang, contents, instruction) {
   const url = `${GEMINI_BASE}/${MODEL}:streamGenerateContent?alt=sse&key=${env.GEMINI_API_KEY}`;
   const body = {
-    systemInstruction: { parts: [{ text: systemInstruction(lang, passages) }] },
-    contents: toGeminiContents(messages),
+    systemInstruction: { parts: [{ text: instruction }] },
+    contents,
     generationConfig: { temperature: 0.3, maxOutputTokens: 1024 },
   };
 
@@ -273,81 +396,267 @@ function latestQuery(messages) {
   return "";
 }
 
+/** Length-independent string comparison, so a wrong secret leaks nothing through timing. */
+function secretsMatch(given, expected) {
+  if (typeof given !== "string" || typeof expected !== "string") return false;
+  if (!expected) return false;
+  let diff = given.length ^ expected.length;
+  for (let i = 0; i < given.length; i++) {
+    diff |= given.charCodeAt(i) ^ expected.charCodeAt(i % expected.length);
+  }
+  return diff === 0;
+}
+
 /**
- * Decide whether a request may use the chat endpoint.
- * Browsers must come from an allow-listed Origin (anti-CSRF). Non-browser clients
- * (the `veaf-tools ask` CLI) have no Origin, so they identify with the
- * ``X-VEAF-Client: cli`` header instead; both paths stay capped by the per-IP rate limit.
+ * Resolve which declared client, if any, a request belongs to.
+ *
+ * The rules, in order:
+ *   1. A request carrying an `Origin` is a browser request. The allow-list decides, and the
+ *      self-declared `X-VEAF-Client` header is ignored — it cannot promote a hostile origin,
+ *      and it cannot let an allow-listed page spend another client's quota.
+ *   2. Without an `Origin`, the header selects a header-declarable client mode. That grants
+ *      no more than the mode's own quota; it is a routing label, not a credential.
+ *   3. A mode with a `secretBinding` must additionally present the matching Secret, and is
+ *      refused outright while that Secret is unset.
+ *
+ * @param {string|null} origin The request `Origin` header.
+ * @param {string|null} clientHeader The request `X-VEAF-Client` header.
+ * @param {{secret?: string|null, env?: object}} [credentials] Presented secret and the bindings
+ *   the configured one is read from (`env[spec.secretBinding]`).
+ * @returns {{client: string|null, spec: object|null, reason: string|null}} Resolution outcome.
  */
-function isAllowedClient(origin, cliHeader) {
-  return cliHeader === "cli" || (!!origin && ALLOWED_ORIGINS.has(origin));
+function resolveClient(origin, clientHeader, credentials = {}) {
+  if (origin) {
+    return ALLOWED_ORIGINS.has(origin)
+      ? { client: "web", spec: CLIENTS.web, reason: null }
+      : { client: null, spec: null, reason: "origin" };
+  }
+  const declared = typeof clientHeader === "string" ? clientHeader.trim().toLowerCase() : "";
+  const spec = Object.prototype.hasOwnProperty.call(CLIENTS, declared) ? CLIENTS[declared] : null;
+  if (!spec || !spec.headerDeclarable) return { client: null, spec: null, reason: "client" };
+  if (spec.secretBinding) {
+    const expected = credentials.env?.[spec.secretBinding];
+    if (!secretsMatch(credentials.secret, expected)) {
+      return { client: null, spec: null, reason: "secret" };
+    }
+  }
+  return { client: declared, spec, reason: null };
+}
+
+/**
+ * Decide whether a request may reach the Worker at all.
+ * Thin boolean wrapper over {@link resolveClient}, kept for readability at the call site.
+ */
+function isAllowedClient(origin, clientHeader, credentials) {
+  return resolveClient(origin, clientHeader, credentials).client !== null;
+}
+
+/** True when the caller *declares* a body larger than the client's ceiling. */
+function declaredBodyTooLarge(contentLength, maxBytes) {
+  const declared = Number.parseInt(contentLength ?? "", 10);
+  return Number.isFinite(declared) && declared > maxBytes;
+}
+
+/**
+ * Read a request body as text, aborting as soon as it exceeds `maxBytes`.
+ *
+ * `Content-Length` is caller-supplied and may lie or be absent, so the ceiling is also enforced
+ * while streaming: nothing larger than `maxBytes` is ever buffered, let alone parsed.
+ *
+ * @param {ReadableStream|null} body The request body stream.
+ * @param {number} maxBytes Ceiling in bytes.
+ * @returns {Promise<string>} The decoded body.
+ * @throws {Error} With `tooLarge === true` when the ceiling is exceeded.
+ */
+async function readBoundedText(body, maxBytes) {
+  if (!body) return "";
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let size = 0;
+  let text = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength ?? value.length ?? 0;
+    if (size > maxBytes) {
+      await reader.cancel();
+      const err = new Error("body too large");
+      err.tooLarge = true;
+      throw err;
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
+/** Render the locally matched catalogue entries as prompt lines, verbatim and bounded. */
+function renderMatches(matches) {
+  if (!Array.isArray(matches)) return [];
+  return matches
+    .filter((m) => m && typeof m === "object")
+    .slice(0, MAX_MATCHES)
+    .map((m) => {
+      const id = String(m.id ?? "").trim();
+      const label = String(m.label ?? "").trim();
+      const help = String(m.help ?? "").trim();
+      const head = [id, label].filter(Boolean).join(" — ");
+      const count = Number.isFinite(m.count) ? ` (×${m.count})` : "";
+      return `- ${head || "(unnamed entry)"}${count}${help ? `: ${help}` : ""}`;
+    });
+}
+
+/**
+ * Build the system instruction for a log analysis.
+ *
+ * The catalogue entries were matched locally by `veaf-logs` and are the only authority on what a
+ * pattern means: their wording is reproduced as it stands, and anything they do not cover is
+ * declared uncatalogued rather than guessed. A wrong culprit costs a pilot his evening and reads
+ * exactly like a right one, so "I do not know" is the cheaper failure.
+ */
+function logAnalysisInstruction(lang, matches) {
+  const langName = lang === "en" ? "English" : "French";
+  const uncatalogued = lang === "en" ? "pattern not catalogued" : "motif non catalogué";
+  const lines = renderMatches(matches);
+  const catalogue = lines.length
+    ? lines.join("\n")
+    : "(no catalogue entry matched this excerpt)";
+  return (
+    `You are the VEAF DCS log analyst. A local tool (veaf-logs) has already reduced a DCS log to ` +
+    `the excerpt below and matched it against its rules catalogue.\n\n` +
+    `RULES:\n` +
+    `- The catalogue entries below are the ONLY authority on what a pattern means. Reuse their ` +
+    `wording as it stands; do not restate them differently.\n` +
+    `- Chain the clues, put them in context, and say what the user should do next.\n` +
+    `- For anything the catalogue does not cover, say plainly "${uncatalogued}" instead of ` +
+    `inventing a cause. Never blame a module, a mission or a script you cannot support with a ` +
+    `catalogue entry or with a line of the excerpt itself.\n` +
+    `- The excerpt is truncated and filtered: absence of a message is not evidence of absence.\n` +
+    `- Answer in ${langName}, concisely, in Markdown.\n\n` +
+    `---\n\nCATALOGUE ENTRIES MATCHED LOCALLY:\n${catalogue}`
+  );
+}
+
+/** Build the Gemini `contents` for a log analysis, truncating an over-long excerpt. */
+function buildAnalysisContents(excerpt, question) {
+  const raw = typeof excerpt === "string" ? excerpt : "";
+  const bounded =
+    raw.length > MAX_EXCERPT_CHARS
+      ? `${raw.slice(0, MAX_EXCERPT_CHARS)}\n[... excerpt truncated by the Worker ...]`
+      : raw;
+  const ask = typeof question === "string" ? question.trim() : "";
+  const text = ask ? `${ask}\n\n---\n\nLOG EXCERPT:\n${bounded}` : `LOG EXCERPT:\n${bounded}`;
+  return [{ role: "user", parts: [{ text }] }];
 }
 
 // Named exports for unit testing (unused by the Workers runtime, which only calls the default export).
-export { latestQuery, toGeminiContents, upstreamErrorMessage, isAllowedClient };
+export {
+  latestQuery,
+  toGeminiContents,
+  upstreamErrorMessage,
+  isAllowedClient,
+  resolveClient,
+  allowRequest,
+  degradedAllow,
+  declaredBodyTooLarge,
+  readBoundedText,
+  logAnalysisInstruction,
+  buildAnalysisContents,
+  CLIENTS,
+  MAX_EXCERPT_CHARS,
+  DEGRADED_MAX_PER_WINDOW,
+};
 
 export default {
   async fetch(request, env) {
     const origin = request.headers.get("Origin");
     const cors = corsHeaders(origin);
+    const sseHeaders = { ...cors, "Content-Type": "text/event-stream" };
+    const sseError = (lang, status, message) =>
+      new Response(sse({ error: message ?? MESSAGES[lang].badRequest }), {
+        status,
+        headers: sseHeaders,
+      });
+    const sseStream = (stream) =>
+      new Response(stream, {
+        headers: {
+          ...cors,
+          "Content-Type": "text/event-stream; charset=utf-8",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
 
     if (request.method === "OPTIONS") {
       return new Response(null, { status: 204, headers: cors });
     }
 
     const url = new URL(request.url);
-    if (request.method !== "POST" || url.pathname !== "/chat") {
+    const route = url.pathname;
+    if (request.method !== "POST" || !ROUTES.has(route)) {
       return new Response("Not found", { status: 404, headers: cors });
     }
 
-    // Allow browsers from a known doc origin (anti-CSRF) or the CLI (X-VEAF-Client header).
-    if (!isAllowedClient(origin, request.headers.get("X-VEAF-Client"))) {
+    // Admission: an allow-listed browser Origin, or a declared non-browser client mode.
+    const { client, spec } = resolveClient(origin, request.headers.get("X-VEAF-Client"), {
+      secret: request.headers.get("X-VEAF-Auth"),
+      env,
+    });
+    if (!client || !spec.routes.includes(route)) {
       return new Response("Forbidden", { status: 403, headers: cors });
     }
 
+    // Body ceiling, enforced before anything parses the payload.
+    if (declaredBodyTooLarge(request.headers.get("Content-Length"), spec.maxBody)) {
+      return new Response("Payload too large", { status: 413, headers: cors });
+    }
     let payload;
     try {
-      payload = await request.json();
-    } catch {
-      return new Response("Bad request", { status: 400, headers: cors });
+      payload = JSON.parse(await readBoundedText(request.body, spec.maxBody));
+    } catch (err) {
+      return err?.tooLarge
+        ? new Response("Payload too large", { status: 413, headers: cors })
+        : new Response("Bad request", { status: 400, headers: cors });
     }
 
     const lang = payload?.lang === "en" ? "en" : "fr";
+
+    // Rate-limit subject: the caller's IP, unless a secret-bearing service carries the quota for
+    // its own users (a whole Discord otherwise shares one IP, hence one daily quota).
+    const ip = request.headers.get("CF-Connecting-IP") || "unknown";
+    const subjectId = typeof payload?.subject === "string" ? payload.subject.slice(0, 64) : "";
+    const subject = spec.secretBinding && subjectId ? `u:${subjectId}` : ip;
+    if (!(await allowRequest(env, client, subject))) {
+      return sseError(lang, 429, MESSAGES[lang].rateLimited);
+    }
+
+    if (route === "/analyze") {
+      const excerpt = typeof payload?.excerpt === "string" ? payload.excerpt.trim() : "";
+      if (!excerpt) return sseError(lang, 400);
+      return sseStream(
+        await streamGemini(
+          env,
+          lang,
+          buildAnalysisContents(excerpt, payload?.question),
+          logAnalysisInstruction(lang, payload?.matches),
+        ),
+      );
+    }
+
     const messages = Array.isArray(payload?.messages) ? payload.messages : null;
     const query = messages ? latestQuery(messages) : "";
     if (!messages || !messages.length || !query) {
-      return new Response(sse({ error: MESSAGES[lang].badRequest }), {
-        status: 400,
-        headers: { ...cors, "Content-Type": "text/event-stream" },
-      });
-    }
-
-    const ip = request.headers.get("CF-Connecting-IP") || "unknown";
-    if (!(await allowRequest(env, ip))) {
-      return new Response(sse({ error: MESSAGES[lang].rateLimited }), {
-        status: 429,
-        headers: { ...cors, "Content-Type": "text/event-stream" },
-      });
+      return sseError(lang, 400);
     }
 
     let passages;
     try {
       passages = await retrieveContext(env, lang, query);
     } catch (err) {
-      return new Response(sse({ error: upstreamErrorMessage(lang, err?.status) }), {
-        status: err?.status === 429 ? 429 : 502,
-        headers: { ...cors, "Content-Type": "text/event-stream" },
-      });
+      return sseError(lang, err?.status === 429 ? 429 : 502, upstreamErrorMessage(lang, err?.status));
     }
 
-    const stream = await streamGemini(env, lang, messages, passages);
-    return new Response(stream, {
-      headers: {
-        ...cors,
-        "Content-Type": "text/event-stream; charset=utf-8",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-      },
-    });
+    return sseStream(
+      await streamGemini(env, lang, toGeminiContents(messages), systemInstruction(lang, passages)),
+    );
   },
 };

--- a/poc/doc-chatbot/worker/test/unit.test.mjs
+++ b/poc/doc-chatbot/worker/test/unit.test.mjs
@@ -1,7 +1,52 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { chunkMarkdown, MAX_CHARS } from "../scripts/build-index.mjs";
-import { latestQuery, toGeminiContents, upstreamErrorMessage, isAllowedClient } from "../src/index.js";
+import {
+  latestQuery,
+  toGeminiContents,
+  upstreamErrorMessage,
+  isAllowedClient,
+  resolveClient,
+  allowRequest,
+  declaredBodyTooLarge,
+  readBoundedText,
+  logAnalysisInstruction,
+  buildAnalysisContents,
+  CLIENTS,
+  MAX_EXCERPT_CHARS,
+  DEGRADED_MAX_PER_WINDOW,
+} from "../src/index.js";
+
+/** A KV double: an in-memory map, or a store whose every operation throws (KV outage). */
+function fakeKv({ broken = false, values = {} } = {}) {
+  const store = new Map(Object.entries(values));
+  const boom = () => {
+    throw new Error("KV unavailable");
+  };
+  return {
+    CHAT_KV: {
+      async get(key) {
+        return broken ? boom() : (store.get(key) ?? null);
+      },
+      async put(key, value) {
+        return broken ? boom() : void store.set(key, value);
+      },
+    },
+  };
+}
+
+/** Wrap a string in a ReadableStream of Uint8Array chunks, as a Request body would arrive. */
+function bodyStream(text, chunkSize = 8) {
+  const bytes = new TextEncoder().encode(text);
+  let offset = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (offset >= bytes.length) return controller.close();
+      controller.enqueue(bytes.slice(offset, offset + chunkSize));
+      offset += chunkSize;
+    },
+  });
+}
 
 test("chunkMarkdown merges many tiny heading-sections instead of one chunk each", () => {
   const md = Array.from({ length: 20 }, (_, i) => `## H${i}\n\nshort body ${i}`).join("\n");
@@ -75,4 +120,143 @@ test("isAllowedClient accepts the CLI header without an Origin", () => {
 test("isAllowedClient allows an allow-listed Origin regardless of the client header", () => {
   assert.equal(isAllowedClient("https://veaf.github.io", "nope"), true);
   assert.equal(isAllowedClient("https://evil.example", "nope"), false);
+});
+
+test("a self-declared client header no longer bypasses the Origin allow-list", () => {
+  // This used to be admitted: `cliHeader === "cli"` short-circuited the whole allow-list, so any
+  // caller claiming to be the CLI got in from any origin at all.
+  assert.equal(isAllowedClient("https://evil.example", "cli"), false);
+  assert.equal(isAllowedClient("https://evil.example", "logs"), false);
+  assert.equal(resolveClient("https://evil.example", "cli").reason, "origin");
+});
+
+test("resolveClient maps an allow-listed Origin to the web client, header ignored", () => {
+  // An allow-listed page cannot relabel itself to spend another client's quota either.
+  assert.equal(resolveClient("https://veaf.github.io", null).client, "web");
+  assert.equal(resolveClient("https://veaf.github.io", "logs").client, "web");
+});
+
+test("resolveClient accepts the header-declarable non-browser modes", () => {
+  assert.equal(resolveClient(null, "cli").client, "cli");
+  assert.equal(resolveClient(null, "logs").client, "logs");
+  assert.equal(resolveClient(null, "LOGS").client, "logs"); // case/whitespace tolerant
+  assert.equal(resolveClient(null, " cli ").client, "cli");
+});
+
+test("resolveClient refuses the web mode and unknown modes over the header", () => {
+  assert.equal(resolveClient(null, "web").client, null); // web is derived from an Origin only
+  assert.equal(resolveClient(null, "constructor").client, null); // no prototype smuggling
+  assert.equal(resolveClient(null, "").client, null);
+});
+
+test("resolveClient refuses a secret-bearing mode until its Secret is set and matches", () => {
+  assert.equal(resolveClient(null, "discord", { secret: "s3cret", env: {} }).reason, "secret");
+  assert.equal(resolveClient(null, "discord", { secret: null, env: {} }).reason, "secret");
+  const env = { DISCORD_CLIENT_SECRET: "s3cret" };
+  assert.equal(resolveClient(null, "discord", { secret: "wrong", env }).reason, "secret");
+  assert.equal(resolveClient(null, "discord", { secret: "s3cret", env }).client, "discord");
+});
+
+test("every declared client carries its own limits, ceiling and routes", () => {
+  const names = Object.keys(CLIENTS);
+  assert.deepEqual(names.sort(), ["cli", "discord", "logs", "web"]);
+  for (const [name, spec] of Object.entries(CLIENTS)) {
+    assert.ok(spec.perWindow > 0, `${name} has no burst limit`);
+    assert.ok(spec.perDay > 0, `${name} has no daily limit`);
+    assert.ok(spec.maxBody > 0, `${name} has no body ceiling`);
+    assert.ok(spec.routes.length > 0, `${name} reaches no route`);
+  }
+  // Log analysis lives on its own route and its own quota, so it cannot starve the widget.
+  assert.deepEqual(CLIENTS.logs.routes, ["/analyze"]);
+  assert.deepEqual(CLIENTS.web.routes, ["/chat"]);
+  assert.equal(CLIENTS.web.headerDeclarable, false);
+});
+
+test("allowRequest counts per client and denies once the KV counter is at the ceiling", async () => {
+  const env = fakeKv();
+  assert.equal(await allowRequest(env, "cli", "1.2.3.4"), true);
+  const atCeiling = fakeKv({
+    values: { [`rl:min:cli:1.2.3.4`]: String(CLIENTS.cli.perWindow) },
+  });
+  assert.equal(await allowRequest(atCeiling, "cli", "1.2.3.4"), false);
+  // The daily ceiling is independent of the burst one.
+  const dayFull = fakeKv({ values: { [`rl:day:logs:1.2.3.4`]: String(CLIENTS.logs.perDay) } });
+  assert.equal(await allowRequest(dayFull, "logs", "1.2.3.4"), false);
+});
+
+test("allowRequest keeps each client's counters separate", async () => {
+  const env = fakeKv({ values: { "rl:min:web:9.9.9.9": String(CLIENTS.web.perWindow) } });
+  assert.equal(await allowRequest(env, "web", "9.9.9.9"), false);
+  assert.equal(await allowRequest(env, "logs", "9.9.9.9"), true, "logs must not inherit web's count");
+});
+
+test("allowRequest fails closed: a KV outage degrades the limit instead of removing it", async () => {
+  const env = fakeKv({ broken: true });
+  const ip = `kv-outage-${Date.now()}`; // fresh subject: the degraded counter is per isolate
+  let allowed = 0;
+  for (let i = 0; i < 10; i++) {
+    if (await allowRequest(env, "cli", ip)) allowed++;
+  }
+  assert.equal(allowed, DEGRADED_MAX_PER_WINDOW, "a KV outage must not lift the rate limit");
+  assert.equal(await allowRequest(env, "cli", ip), false);
+});
+
+test("allowRequest refuses an undeclared client outright", async () => {
+  assert.equal(await allowRequest(fakeKv(), "not-a-client", "1.2.3.4"), false);
+});
+
+test("declaredBodyTooLarge rejects an over-ceiling Content-Length, tolerates a missing one", () => {
+  assert.equal(declaredBodyTooLarge("20000", 16 * 1024), true);
+  assert.equal(declaredBodyTooLarge("100", 16 * 1024), false);
+  assert.equal(declaredBodyTooLarge(null, 16 * 1024), false); // absent: the stream ceiling catches it
+  assert.equal(declaredBodyTooLarge("not-a-number", 16 * 1024), false);
+});
+
+test("readBoundedText aborts a body that lies about its size", async () => {
+  const payload = "x".repeat(5000);
+  await assert.rejects(
+    () => readBoundedText(bodyStream(payload, 256), 1024),
+    (err) => err.tooLarge === true,
+  );
+});
+
+test("readBoundedText returns a body under the ceiling, multi-byte characters intact", async () => {
+  const payload = JSON.stringify({ excerpt: "réussi — ok", matches: [] });
+  assert.equal(await readBoundedText(bodyStream(payload, 5), 4096), payload);
+  assert.equal(await readBoundedText(null, 4096), "");
+});
+
+test("logAnalysisInstruction reproduces the catalogue wording and forbids guessing", () => {
+  const help = "Modules tiers dont le modèle de dégâts n'est pas au format attendu. Cosmétique.";
+  const out = logAnalysisInstruction("fr", [{ id: "damage-model", label: "Moteur", help, count: 3 }]);
+  assert.ok(out.includes(help), "the catalogue help text must be passed through verbatim");
+  assert.ok(out.includes("damage-model"));
+  assert.ok(out.includes("×3"));
+  assert.ok(out.includes("motif non catalogué"), "FR must instruct the uncatalogued wording");
+  assert.ok(/ONLY authority/.test(out));
+});
+
+test("logAnalysisInstruction survives no match at all and bounds the entry list", () => {
+  const empty = logAnalysisInstruction("en", undefined);
+  assert.ok(empty.includes("no catalogue entry matched"));
+  assert.ok(empty.includes("pattern not catalogued"));
+  const many = logAnalysisInstruction(
+    "en",
+    Array.from({ length: 200 }, (_, i) => ({ id: `e${i}`, help: `h${i}` })),
+  );
+  assert.ok(!many.includes("e199"), "the catalogue block must be bounded");
+});
+
+test("buildAnalysisContents truncates an over-long excerpt and keeps the question", () => {
+  const [content] = buildAnalysisContents("y".repeat(MAX_EXCERPT_CHARS * 2), "  why does it crash? ");
+  assert.equal(content.role, "user");
+  const text = content.parts[0].text;
+  assert.ok(text.startsWith("why does it crash?"));
+  assert.ok(text.includes("excerpt truncated by the Worker"));
+  assert.ok(text.length < MAX_EXCERPT_CHARS * 2, "the excerpt must not be forwarded whole");
+});
+
+test("buildAnalysisContents works without a question", () => {
+  const [content] = buildAnalysisContents("ERROR something", null);
+  assert.ok(content.parts[0].text.includes("ERROR something"));
 });

--- a/poc/doc-chatbot/worker/test/unit.test.mjs
+++ b/poc/doc-chatbot/worker/test/unit.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { chunkMarkdown, MAX_CHARS } from "../scripts/build-index.mjs";
-import {
+import worker, {
   latestQuery,
   toGeminiContents,
   upstreamErrorMessage,
@@ -24,6 +24,7 @@ function fakeKv({ broken = false, values = {} } = {}) {
     throw new Error("KV unavailable");
   };
   return {
+    store, // exposed so a test can assert what was — or was not — written back
     CHAT_KV: {
       async get(key) {
         return broken ? boom() : (store.get(key) ?? null);
@@ -33,6 +34,34 @@ function fakeKv({ broken = false, values = {} } = {}) {
       },
     },
   };
+}
+
+/**
+ * A full Worker `env`: the KV double above plus the bindings `fetch` reads directly
+ * (`GEMINI_API_KEY`, and any Secret a client mode is gated on).
+ */
+function workerEnv({ kv = {}, ...bindings } = {}) {
+  const env = fakeKv({ values: kv });
+  return { GEMINI_API_KEY: "test-key", ...bindings, store: env.store, CHAT_KV: env.CHAT_KV };
+}
+
+/** Build a request the way a real caller would, so `worker.fetch` sees the actual headers. */
+function call(route, { origin, client, secret, headers = {}, body, ip = "203.0.113.1", method = "POST" } = {}) {
+  const h = new Headers({ "CF-Connecting-IP": ip, ...headers });
+  if (origin) h.set("Origin", origin);
+  if (client) h.set("X-VEAF-Client", client);
+  if (secret !== undefined) h.set("X-VEAF-Auth", secret);
+  const init = { method, headers: h };
+  if (body !== undefined) {
+    init.body = body instanceof ReadableStream || typeof body === "string" ? body : JSON.stringify(body);
+    if (body instanceof ReadableStream) init.duplex = "half";
+  }
+  return new Request(`https://chat.example${route}`, init);
+}
+
+/** The rate-limit keys the Worker wrote — they name the client mode it actually resolved. */
+function rateLimitKeys(env) {
+  return [...env.store.keys()].filter((k) => k.startsWith("rl:")).sort();
 }
 
 /** Wrap a string in a ReadableStream of Uint8Array chunks, as a Request body would arrive. */
@@ -201,8 +230,35 @@ test("allowRequest fails closed: a KV outage degrades the limit instead of remov
   assert.equal(await allowRequest(env, "cli", ip), false);
 });
 
-test("allowRequest refuses an undeclared client outright", async () => {
+test("allowRequest refuses an undeclared client outright, inherited names included", async () => {
   assert.equal(await allowRequest(fakeKv(), "not-a-client", "1.2.3.4"), false);
+  // A bare `CLIENTS[client]` read answered `Object` for these — truthy, and with no quota fields,
+  // so every `count >= undefined` comparison was false and the request went through.
+  for (const name of ["constructor", "toString", "__proto__", "hasOwnProperty", "valueOf"]) {
+    assert.equal(await allowRequest(fakeKv(), name, "1.2.3.4"), false, `${name} is not a client`);
+  }
+});
+
+test("allowRequest treats an unreadable counter as the ceiling and does not rewrite it", async () => {
+  // `parseInt("NaN")` is `NaN`, and `NaN >= perDay` is false — so a poisoned counter used to open
+  // the gate, and `String(NaN + 1)` wrote `"NaN"` straight back with a fresh 24 h TTL, keeping it
+  // open for good. Measured before the fix: 10 of 200 requests admitted, value still "NaN".
+  for (const poison of ["NaN", "abc", "-1", "1e3", "9.5"]) {
+    const day = fakeKv({ values: { "rl:day:cli:7.7.7.7": poison } });
+    assert.equal(await allowRequest(day, "cli", "7.7.7.7"), false, `daily counter "${poison}"`);
+    const min = fakeKv({ values: { "rl:min:cli:7.7.7.7": poison } });
+    assert.equal(await allowRequest(min, "cli", "7.7.7.7"), false, `burst counter "${poison}"`);
+  }
+  const env = fakeKv({ values: { "rl:day:cli:7.7.7.7": "NaN" } });
+  assert.equal(await allowRequest(env, "cli", "7.7.7.7"), false);
+  assert.equal(env.store.get("rl:day:cli:7.7.7.7"), "NaN", "the poisoned value must not be refreshed");
+  assert.equal(env.store.has("rl:min:cli:7.7.7.7"), false, "a refused request writes no counter");
+});
+
+test("allowRequest still reads an absent or empty counter as zero", async () => {
+  const env = fakeKv({ values: { "rl:min:cli:7.7.7.9": "" } });
+  assert.equal(await allowRequest(env, "cli", "7.7.7.9"), true);
+  assert.equal(env.store.get("rl:min:cli:7.7.7.9"), "1");
 });
 
 test("declaredBodyTooLarge rejects an over-ceiling Content-Length, tolerates a missing one", () => {
@@ -259,4 +315,166 @@ test("buildAnalysisContents truncates an over-long excerpt and keeps the questio
 test("buildAnalysisContents works without a question", () => {
   const [content] = buildAnalysisContents("ERROR something", null);
   assert.ok(content.parts[0].text.includes("ERROR something"));
+});
+
+// ---------------------------------------------------------------------------------------------
+// Wiring: everything below drives the real entry point, `worker.fetch(request, env)`.
+//
+// The tests above exercise the handlers in isolation, which is exactly how green bugs ship on this
+// repository: the handler is right and nothing checks that it is still plugged in. What these lock
+// is the plumbing — that `X-VEAF-Auth` is the header actually read, that `spec.routes` really
+// filters, that `spec.maxBody` is the ceiling handed to `readBoundedText`, that the call site
+// resolves a *mode* rather than a boolean, and that `/analyze` is a declared route.
+//
+// The lever used throughout: the rate-limit keys the Worker writes name the mode it resolved, and
+// a request that reaches a *later* rejection (400/413/429) is one that got past admission.
+// ---------------------------------------------------------------------------------------------
+
+test("fetch: the widget's allow-listed Origin resolves to the web client", async () => {
+  const env = workerEnv();
+  const res = await worker.fetch(
+    call("/chat", { origin: "https://veaf.github.io", body: { lang: "fr" } }),
+    env,
+  );
+  // 400, not 403: admission passed and the empty message list is what failed.
+  assert.equal(res.status, 400);
+  assert.equal(res.headers.get("Access-Control-Allow-Origin"), "https://veaf.github.io");
+  assert.deepEqual(rateLimitKeys(env), ["rl:day:web:203.0.113.1", "rl:min:web:203.0.113.1"]);
+});
+
+test("fetch: X-VEAF-Client selects the cli mode when there is no Origin", async () => {
+  const env = workerEnv();
+  const res = await worker.fetch(call("/chat", { client: "cli", body: { lang: "fr" } }), env);
+  assert.equal(res.status, 400);
+  assert.deepEqual(rateLimitKeys(env), ["rl:day:cli:203.0.113.1", "rl:min:cli:203.0.113.1"]);
+});
+
+test("fetch: a hostile Origin is refused even while it declares the cli header", async () => {
+  // The bypass this whole change exists to close, checked where it was actually exploitable.
+  const env = workerEnv();
+  const res = await worker.fetch(
+    call("/chat", {
+      origin: "https://evil.example",
+      client: "cli",
+      body: { lang: "fr", messages: [{ role: "user", content: "hi" }] },
+    }),
+    env,
+  );
+  assert.equal(res.status, 403);
+  assert.equal(res.headers.get("Access-Control-Allow-Origin"), null, "no CORS grant either");
+  assert.deepEqual(rateLimitKeys(env), [], "a refused caller never reaches the rate limiter");
+});
+
+test("fetch: each mode only reaches the routes its spec declares", async () => {
+  const analyze = { lang: "fr", excerpt: "ERROR boom" };
+  const chat = { lang: "fr", messages: [{ role: "user", content: "hi" }] };
+  const refused = [
+    ["/analyze", { origin: "https://veaf.github.io", body: analyze }], // web is /chat only
+    ["/analyze", { client: "cli", body: analyze }],
+    ["/chat", { client: "logs", body: chat }], // logs is /analyze only
+  ];
+  for (const [route, opts] of refused) {
+    const res = await worker.fetch(call(route, opts), workerEnv());
+    assert.equal(res.status, 403, `${route} must be out of scope for ${JSON.stringify(opts)}`);
+  }
+
+  // ...and /analyze really is a declared route for `logs`: an empty excerpt earns a 400, not a 404.
+  const env = workerEnv();
+  const admitted = await worker.fetch(
+    call("/analyze", { client: "logs", body: { lang: "fr", excerpt: "  " } }),
+    env,
+  );
+  assert.equal(admitted.status, 400);
+  assert.deepEqual(rateLimitKeys(env), ["rl:day:logs:203.0.113.1", "rl:min:logs:203.0.113.1"]);
+
+  // An undeclared path is a 404, decided before admission runs at all.
+  const unknown = await worker.fetch(call("/explain", { client: "logs", body: analyze }), workerEnv());
+  assert.equal(unknown.status, 404);
+});
+
+test("fetch: the body ceiling is the one the resolved client declares", async () => {
+  const payload = "x".repeat(100 * 1024); // over cli's 64 KiB, under logs' 128 KiB
+
+  const declared = await worker.fetch(call("/chat", { client: "cli", body: payload }), workerEnv());
+  assert.equal(declared.status, 413, "a declared length above CLIENTS.cli.maxBody is refused");
+
+  const roomier = await worker.fetch(call("/analyze", { client: "logs", body: payload }), workerEnv());
+  assert.equal(roomier.status, 400, "the same size fits CLIENTS.logs.maxBody, so it is parsed");
+
+  // A stream body carries no Content-Length, so only the streaming ceiling can catch it.
+  const streamed = await worker.fetch(
+    call("/chat", { client: "cli", body: bodyStream(payload, 4096) }),
+    workerEnv(),
+  );
+  assert.equal(streamed.status, 413, "an undeclared body length is still bounded while streaming");
+});
+
+test("fetch: the discord mode is gated on X-VEAF-Auth matching the configured Secret", async () => {
+  const body = { lang: "fr", excerpt: "", subject: "pilot-42" };
+  const send = (env, opts) => worker.fetch(call("/analyze", { client: "discord", body, ...opts }), env);
+  const configured = () => workerEnv({ DISCORD_CLIENT_SECRET: "s3cret" });
+
+  // 1. Secret never set: groundwork is a closed door, not an open one.
+  assert.equal((await send(workerEnv(), { secret: "s3cret" })).status, 403);
+  // 2. Set but empty: an empty Secret must not be matched by an empty header.
+  assert.equal((await send(workerEnv({ DISCORD_CLIENT_SECRET: "" }), { secret: "" })).status, 403);
+  // 3. Set, wrong secret presented.
+  assert.equal((await send(configured(), { secret: "wrong" })).status, 403);
+  // 4. Right secret, wrong header: X-VEAF-Auth is the header that is read, and only it.
+  assert.equal((await send(configured(), { headers: { Authorization: "s3cret" } })).status, 403);
+
+  // 5. Right secret in X-VEAF-Auth: admitted (400 on the empty excerpt), and the quota is carried
+  //    per Discord user rather than per IP — a whole Discord sits behind one address.
+  const env = configured();
+  assert.equal((await send(env, { secret: "s3cret" })).status, 400);
+  assert.deepEqual(rateLimitKeys(env), ["rl:day:discord:u:pilot-42", "rl:min:discord:u:pilot-42"]);
+});
+
+test("fetch: a caller at its daily ceiling gets a localized 429", async () => {
+  const env = workerEnv({ kv: { "rl:day:cli:203.0.113.9": String(CLIENTS.cli.perDay) } });
+  const res = await worker.fetch(
+    call("/chat", {
+      client: "cli",
+      ip: "203.0.113.9",
+      body: { lang: "en", messages: [{ role: "user", content: "hi" }] },
+    }),
+    env,
+  );
+  assert.equal(res.status, 429);
+  assert.match(await res.text(), /Too many requests/);
+});
+
+test("fetch: /analyze streams the answer back as SSE, framed by the catalogue", async () => {
+  const upstream = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    upstream.push({ url: String(url), body: JSON.parse(init.body) });
+    const chunk = JSON.stringify({ candidates: [{ content: { parts: [{ text: "voilà" }] } }] });
+    return new Response(`data: ${chunk}\n\n`, { status: 200 });
+  };
+  try {
+    const res = await worker.fetch(
+      call("/analyze", {
+        client: "logs",
+        body: {
+          lang: "fr",
+          excerpt: "ERROR boom",
+          matches: [{ id: "damage-model", help: "Cosmétique." }],
+        },
+      }),
+      workerEnv(),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("Content-Type"), /text\/event-stream/);
+    const text = await res.text();
+    assert.match(text, /data: \{"text":"voilà"\}/);
+    assert.match(text, /data: \[DONE\]/);
+
+    assert.equal(upstream.length, 1, "exactly one upstream call");
+    const instruction = upstream[0].body.systemInstruction.parts[0].text;
+    assert.ok(instruction.includes("Cosmétique."), "the catalogue wording frames the answer");
+    assert.ok(upstream[0].body.contents[0].parts[0].text.includes("ERROR boom"));
+  } finally {
+    globalThis.fetch = realFetch;
+  }
 });


### PR DESCRIPTION
**First PR of the `FEAT-SUPPORT-LOG-ANALYSIS` lot** — ticket 02 only. Tickets 01, 03, 04, 05 and 06
follow in their own PRs; the lot PRD stays `⬜ ready`.

Scope is `poc/doc-chatbot/` plus the changelog and one new workflow. Nothing under `src/python/` is
touched.

## The hole this closes

`isAllowedClient` read:

```js
return cliHeader === "cli" || (!!origin && ALLOWED_ORIGINS.has(origin));
```

Any caller sending `X-VEAF-Client: cli` was admitted **whatever its origin**. The Origin allow-list
was not a gate, it was a second chance: the header short-circuited it entirely. So the Worker — and
the shared free Gemini key behind it, which is also what the documentation widget lives on — was
open to anybody who read the source. The mitigation the code leaned on, the per-IP rate limit,
ended in `catch { return true; }`: a KV outage removed every limit instead of tightening one. And
nothing bounded the request body before `request.json()` parsed it.

## What changes

- **A declared client vocabulary** (`web`, `cli`, `logs`, `discord`), each with its own routes,
  burst/daily quota and body ceiling — so a misbehaving client cannot starve the doc widget.
- **A self-declared header is no longer proof.** A request carrying an `Origin` is a browser
  request: the allow-list decides and the header is ignored, in both directions (it cannot promote
  a hostile origin, and an allow-listed page cannot relabel itself to spend another mode's quota).
  Without an `Origin`, the header only *selects* a mode; it buys nothing beyond that mode's quota.
- **A mode may require a real credential.** `discord` presents a shared Secret and carries its own
  per-user rate-limit subject — groundwork for `FEAT-SUPPORT-DISCORD-QA`, where a whole Discord
  sits behind one IP. While `DISCORD_CLIENT_SECRET` is unset the mode is refused outright.
- **Rate limiting fails closed.** A KV outage now degrades to a much stricter per-isolate ceiling
  (`DEGRADED_MAX_PER_WINDOW = 2` per window) instead of to no limit at all.
- **A body ceiling before parsing**, enforced both on `Content-Length` and while streaming, so a
  lying or absent header does not get past it.
- **`POST /analyze`**: a bounded log excerpt plus the catalogue entries `veaf-logs` already matched
  locally, answered with the catalogue as the sole authority and an explicit *"pattern not
  catalogued"* where it is silent. This is the mode ticket 03 will consume.

## Compatibility, and the one number that moves

Both existing clients keep the access they had:

- the doc widget sends `Origin: https://veaf.github.io` and no client header → `web`, `/chat`;
- `veaf-tools ask` sends `X-VEAF-Client: cli` and no `Origin` → `cli`, `/chat`.

**`veaf-tools ask` goes from 100 questions a day to 60**, and that is a real reduction for anyone
who only uses the CLI, not an accounting artefact. The old limit was a single per-IP bucket of
100/day shared by every caller from that address; each mode now owns its own bucket, so someone who
uses both the widget and the CLI from one machine ends up with more (100 + 60) while a CLI-only user
ends up with 40 fewer. The burst limit is unchanged at 10/minute. 60 questions a day from one
machine is well past what asking the documentation looks like in practice, and the number is a
one-line edit to `CLIENTS.cli.perDay` if the ceiling ever gets hit. It is in the README table, in
the changelog entry, and here — a number that moves in silence is exactly what this is avoiding.

`worker_client.py` needs **no change** and was not touched. One design note it drove: the widget
replays its *whole* history on every turn without trimming client-side, so the conversational body
ceiling is 64 KiB rather than something tighter — still a bound where there was none.

## Review follow-ups

Four points from review, all addressed in this PR:

1. **The Worker's tests ran in no CI at all.** `npm test` had exactly one caller — the
   `Rebuild docs chatbot index` workflow, `on: push` to `develop`, filtered on `doc/**` and
   `scripts/build-index.mjs` but on neither `worker/src/**` nor `worker/test/**`, with no
   `pull_request` trigger. This PR's green checks did not contain them and the merge would not have
   run them. New workflow `.github/workflows/chatbot-worker.yml` runs them on every pull request
   touching `poc/doc-chatbot/worker/**`, and on `develop`/`master` pushes.
2. **Nothing exercised the wiring.** The suite imported only the named exports; `worker.fetch` was
   never called, so nothing held in place that `X-VEAF-Auth` is the header read, that `spec.routes`
   filters, that `spec.maxBody` is the ceiling handed to `readBoundedText`, that the call site
   resolves a *mode* rather than a boolean, or that `/analyze` is in `ROUTES`. Ten tests now drive
   `worker.fetch(new Request(...), fakeEnv)` — no new dependency, the model call stubbed in the one
   test that needs it. Each of those five wirings was mutated in turn; the suite caught all five.
3. **Two residual permissive branches in `allowRequest`**, neither reachable through `fetch` today
   but both on lines this PR rewrites:
   - `CLIENTS[client]` was a bare read, so `allowRequest(env, "constructor", ip)` got `Object` back
     — truthy, no `perWindow`/`perDay`, every `count >= undefined` false, request allowed. Now an
     own-property lookup, matching `resolveClient`.
   - An unreadable KV counter **reopened the gate and kept it open**: `parseInt("NaN")` is `NaN`,
     `NaN >= perDay` is false, and `String(NaN + 1)` wrote `"NaN"` back with a fresh 24 h TTL.
     Measured with a poisoned `rl:day`: 10 of 200 requests admitted and the value still `"NaN"`
     afterwards; a poisoned `rl:min` was worse, 30 of 30. A value that is not a plain non-negative
     integer now reads as the ceiling — refused — and is left untouched, so it expires on its own.
4. **The `cli` quota change is announced** in the section above and in the changelog, not only in
   the README table.

## Tests

`npm test` in `poc/doc-chatbot/worker/`: **38 pass, 0 fail** (28 before the review follow-ups). The
existing `isAllowedClient` tests were kept and still pass — the resolver's behaviour is unchanged on
every case they covered. Cases: the closed bypass, header-vs-Origin precedence, secret-gated mode,
per-mode limits declared, per-client counter isolation, the fail-closed path under a throwing KV,
the body ceiling on both paths, the analysis prompt (catalogue wording passed through verbatim,
bounded excerpt), the poisoned-counter and prototype-name paths, and the ten wiring tests through
`worker.fetch`.

`npx wrangler deploy --dry-run` bundles clean and resolves the `CHAT_KV` binding.

## Deployment

The Worker is deployed **by hand** — no workflow ships Worker code; the index workflow only rebuilds
the KV index, and the new one only runs the tests. Nothing here reaches production until someone
runs `npx wrangler deploy` from `poc/doc-chatbot/worker/`. The refreshed README now says so, ticks
the POC checkboxes that were stale (all of them were unticked while the thing has been live for
months) and drops the "Gaps" entries that were already done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden the documentation chatbot Worker’s client admission and resource controls while adding the
log-analysis service mode.

New Features:
- Add declared web, CLI, log-analysis, and Discord client modes with separate routes, quotas, and
request-size limits.
- Add a bounded POST /analyze endpoint for explaining log excerpts using locally matched catalogue
entries.

Bug Fixes:
- Prevent self-declared client headers from bypassing browser Origin validation.
- Make rate limiting fail closed with a restrictive fallback when KV is unavailable.
- Enforce request body limits before JSON parsing.

Enhancements:
- Isolate rate-limit counters by client and subject, including per-user subjects for Discord.
- Refresh the chatbot documentation with route, client, testing, deployment, and POC status information.

Deployment:
- Document the manual Worker deployment process and distinguish it from the KV index CI workflow.

Documentation:
- Document the chatbot's client modes, admission rules, quotas, payload limits, analysis route,
configuration, tests, and deployment steps.

Tests:
- Extend Worker unit coverage for client resolution, secret-gated access, per-client quotas, degraded
rate limiting, body limits, and log-analysis prompt bounds.

Chores:
- Mark the multi-client Worker ticket as complete and update the changelog.
