### PR TITLE
fix(skynet): an overdue scheduled task must still run, or the whole IADS stays asleep

### DIFF
--- a/.backlog/FIX-TRIPACK-FIELD-REPORTS/PRD.md
+++ b/.backlog/FIX-TRIPACK-FIELD-REPORTS/PRD.md
@@ -121,7 +121,7 @@ drops `taskSelected`, `uncontrolled`, `frequency`, `modulation`, `communication`
 
 | # | Ticket | Type | Status |
 |---|--------|------|--------|
-| 01 | [Skynet's scheduler keeps the promise its docstring makes](tickets/01-skynet-scheduler-floor.md) | fix | ⬜ |
+| 01 | [Skynet's scheduler keeps the promise its docstring makes](tickets/01-skynet-scheduler-floor.md) | fix | 🧑 |
 | 02 | [A zone's naval element looks for water, not for dry land](tickets/02-naval-elements-look-for-water.md) | fix | ⬜ |
 | 03 | [Why the terrain check refuses a ship already at sea](tickets/03-measure-the-naval-refusal.md) | fix | ⬜ |
 | 04 | [ZU-23s of a combat zone come up kilometres out to sea](tickets/04-units-displaced-out-to-sea.md) | fix | ⬜ |

--- a/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/01-skynet-scheduler-floor.md
+++ b/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/01-skynet-scheduler-floor.md
@@ -1,6 +1,6 @@
 # 01 — Skynet's scheduler keeps the promise its docstring makes
 
-Status: ⬜ ready
+Status: 🧑 waiting-human
 
 Type: fix
 
@@ -81,10 +81,27 @@ Then, per [`vendored.yaml`](../../../vendored.yaml) and in this order:
 
 ## Definition of done
 
-- [ ] A Skynet task scheduled for a time already elapsed runs at the next tick
-- [ ] Repetition, stop time and `removeFunction` keep their current semantics
-- [ ] Test in the fork covering due-now, overdue, and comfortably-future
-- [ ] Artefact regenerated, stylua'd, label and `vendored.yaml` `pinned:` updated together
-- [ ] `luacheck` + `stylua --check` clean on `src/scripts/veaf/ test/lua/`
-- [ ] In-game verification queued in `DCS-SESSION-TODO.md`: a mission with `SKYNET.enabled: true`
-      shows a populated IADS status and SAMs that engage
+- [x] A Skynet task scheduled for a time already elapsed runs at the next tick
+- [x] Repetition, stop time and `removeFunction` keep their current semantics
+- [x] Test covering due-now, overdue, and comfortably-future — **not in the fork**: its `unit-tests/`
+      run inside DCS from a `.miz` on top of MiST, so there is no headless harness to add a case to.
+      The coverage lives on this side, in `test/lua/test_skynetIadsUtils.lua`, asserted against the
+      vendored artefact itself. Verified both ways: three of its eight cases fail on the pre-fix
+      artefact.
+- [x] Artefact regenerated, stylua'd, label and `vendored.yaml` `pinned:` updated together
+      (build 05.09.2026). Diff against the previous artefact is two hunks — the version banner and
+      the 24 added lines — and nothing else moved.
+- [x] `luacheck` + `stylua --check` clean on `src/scripts/veaf/ test/lua/`
+- [x] In-game verification queued in `DCS-SESSION-TODO.md` as **R13**, paired with R12: both fixes
+      rest on the same unproven wager about the native timer, so they are checked in one session
+
+## What shipped
+
+- Fork: [VEAF/Skynet-IADS](https://github.com/VEAF/Skynet-IADS) branch `fix/scheduler-past-start-time`
+  — `MINIMUM_DELAY = 0.01` in `skynet-iads-utils.lua`, clamping the **first** run only. Repetition is
+  re-armed from `timer.getTime()` inside `runScheduledTask` and so is future by construction;
+  `stopTime` is a comparison, not a delay.
+- One open follow-up: `vendored.yaml`'s watch pin for `VEAF/Skynet-IADS`
+  (`demo-missions/skynet-iads-compiled.lua`, still `820d3cc0eb85`) can only be moved once the fork PR
+  is merged, since it names a commit on the fork's `master`. Until then the drift watcher will flag
+  the entry, correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,21 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   colon — each of which used to lose every citation *and* leave the raw instruction line in the
   answer.
 
+- **Skynet left every SAM asleep and its status page blank.** Reported by Tripack with
+  `SKYNET.enabled: true`: no site ever engaged, the radio menu showed neither status nor contacts,
+  and the same mission with Skynet switched off worked perfectly. One lost task explains all three.
+  Skynet arms its contact-evaluation cycle with a hardcoded start time of **one second of mission
+  time**, and an IADS that initialises later than that — three minutes in, on his mission — asks the
+  DCS timer for a moment already gone. MiST, which the vendored Skynet no longer carries, ran an
+  overdue task on its next tick; the native timer is not something to rely on for that, and a
+  dropped task raises nothing, so `dcs.log` held no Skynet error at all. Since the whole cycle ends
+  with `printSystemStatus`, the status page had nothing to print either.
+
+  Fixed where the three call sites converge rather than at each of them: the fork's scheduler now
+  arms a first run due now, or overdue, for the next tick — the same floor `veafScheduler` got four
+  days earlier, when the same defect swallowed `spawnSmoke`. Repetition, stop time and cancellation
+  are unchanged. `skynet-iads-compiled.lua` is regenerated at build 05.09.2026.
+
 ## [6.19.0] — 2026-09-02
 
 ### Fixed

--- a/DCS-SESSION-TODO.md
+++ b/DCS-SESSION-TODO.md
@@ -176,6 +176,28 @@ set `STTS: false` at step 2, so this is only about knowing whether leaving it **
 noisy at start-up. Grep the log for `STTS` — if it is silent, the tutorial's note can relax from
 "switch it off" to "it does nothing".
 
+### R13. Skynet's SAMs must wake up, and its status page must have something to print
+
+Unblocks [`FIX-TRIPACK-FIELD-REPORTS`](.backlog/FIX-TRIPACK-FIELD-REPORTS/PRD.md) ticket 01. Tripack
+reported it on 2026-09-03 against 6.19.0: with `SKYNET.enabled: true` no SAM ever engaged and the
+radio menu showed neither status nor contacts; the same mission with Skynet off worked. Cause held
+and fixed — Skynet arms its contact cycle for one second of mission time, and the vendored scheduler
+handed that already-elapsed time to the native timer, so `evaluateContacts` never ran. The artefact
+is regenerated at build 05.09.2026.
+
+**This is the same wager as R12**, on the other side of the repository boundary, so run them in the
+same session: both fixes assume DCS drops a call scheduled for a time already gone.
+
+**Run**: a mission with `SKYNET.enabled: true` (Tripack's `Snowfox_20260903.miz` is the reported one).
+Let it come up, then **F10 → the Skynet menu → the status command**, and fly into a defended area.
+
+- **Fixed**: the status page lists sites and contacts, and SAMs engage.
+- **Not fixed**: still blank and still asleep. Then the lost task was not the cause and the diagnosis
+  is dead. Bring back a `dcs.log`: the banner line must read `SKYNET VERSION: 3.4.0RP-VEAF build
+  05.09.2026` — anything older means the mission carries a stale artefact and the check never
+  happened — and grep for `SkynetIADS: error in scheduled function`, which the module logs on any
+  raise inside a scheduled call.
+
 ---
 
 ## ✅ SETTLED — there was no DCS SAM bug (2026-08-22)

--- a/doc/TESTING.en.md
+++ b/doc/TESTING.en.md
@@ -145,6 +145,7 @@ luaunit.assertIsTrue(ok, err)
 | `test_veaf.lua` | Core utilities, string/table/vector helpers, logging |
 | `test_veafCacheManager.lua` | Cache get/set/invalidate |
 | `test_veafScheduler.lua` | Native-timer scheduler: repetition, stop time, a failing task |
+| `test_skynetIadsUtils.lua` | Vendored Skynet's own scheduler: an overdue first run is armed for the next tick, and repetition, stop time and cancellation are unchanged |
 | `test_veafMath.lua` | Unit conversions, vectors, coordinate shapes, deep copy |
 | `test_veafGeo.lua` | Coordinate text output, zones, average positions, polygons |
 | `test_veafGeo_ported.lua` | Geometry ported off MiST: random point in a circle, units in a circular zone, heading, zone drawing |

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -145,6 +145,7 @@ luaunit.assertIsTrue(ok, err)
 | `test_veaf.lua` | Utilitaires de base, helpers string/table/vecteur, logging |
 | `test_veafCacheManager.lua` | Cache get/set/invalidate |
 | `test_veafScheduler.lua` | Planificateur sur le timer natif : répétition, heure d'arrêt, tâche en échec |
+| `test_skynetIadsUtils.lua` | Planificateur interne du Skynet vendorisé : une première exécution déjà passée est armée pour le tick suivant, répétition, heure d'arrêt et annulation inchangées |
 | `test_veafMath.lua` | Conversions d'unités, vecteurs, formes de coordonnées, copie profonde |
 | `test_veafGeo.lua` | Rendu texte des coordonnées, zones, positions moyennes, polygones |
 | `test_veafGeo_ported.lua` | Géométrie portée depuis MiST : tirage dans un cercle, unités en zone circulaire, cap, dessin de zone |

--- a/src/scripts/community/skynet-iads-compiled.lua
+++ b/src/scripts/community/skynet-iads-compiled.lua
@@ -1,4 +1,4 @@
-env.info("--- SKYNET VERSION: 3.4.0RP-VEAF build 30.08.2026 | BUILD TIME: 30.08.2026 1926Z ---")
+env.info("--- SKYNET VERSION: 3.4.0RP-VEAF build 05.09.2026 | BUILD TIME: 05.09.2026 1434Z ---")
 do
   --[[
 SkynetIADSUtils -- the handful of helpers Skynet used to borrow from MiST.
@@ -148,6 +148,23 @@ it, the reason is written at the call site.
   local scheduledTasks = {}
   local lastTaskId = 0
 
+  --- Smallest delay this module will ever hand to the native timer, in seconds.
+  --
+  -- MiST's task list was walked by a loop re-armed every 0.01 s that ran anything whose time had
+  -- come **or gone**, so a task asked for a moment already past simply ran on the next tick. One
+  -- native timer.scheduleFunction per task carries no such promise, and Skynet leans on it hard:
+  -- SkynetIADS:activate, SkynetIADS:scanForHarms and SkynetIADSJammer:masterArmOn all pass a
+  -- hardcoded startTime of 1 -- one second of mission time. Only goSilentToEvadeHARM passes an
+  -- absolute future time.
+  --
+  -- Measured 2026-09-03 on a Persian Gulf mission whose IADS initialised at 18:29:48, some three
+  -- minutes in: evaluateContacts never ran once. Every SAM stayed dark (the IADS darkens a site's
+  -- radar when it registers it, and only re-enables it from that cycle), the status page stayed
+  -- blank (printSystemStatus is the last statement of evaluateContacts), and dcs.log carried no
+  -- Skynet error at all -- the signature of a lost task rather than a crash. This floor is what
+  -- keeps those three hardcoded call sites equivalent to what they got under MiST.
+  local MINIMUM_DELAY = 0.01
+
   --- Runs one scheduled task and answers when it should run next, or nil to stop.
   local function runScheduledTask(id)
     local task = scheduledTasks[id]
@@ -194,6 +211,13 @@ it, the reason is written at the call site.
     lastTaskId = lastTaskId + 1
     local id = lastTaskId
     scheduledTasks[id] = { fn = fn, args = args or {}, repeatInterval = repeatInterval, stopTime = stopTime }
+    -- A first run due now, or overdue, is armed for the next tick instead -- see MINIMUM_DELAY.
+    -- Only the first run is clamped: repetition is re-armed from timer.getTime() inside
+    -- runScheduledTask, so it is future by construction, and stopTime is a comparison, not a delay.
+    local earliest = timer.getTime() + MINIMUM_DELAY
+    if startTime < earliest then
+      startTime = earliest
+    end
     timer.scheduleFunction(runScheduledTask, id, startTime)
     return id
   end

--- a/test/lua/test_skynetIadsUtils.lua
+++ b/test/lua/test_skynetIadsUtils.lua
@@ -1,0 +1,153 @@
+--- Tests for the MiST-replacement scheduler inside the vendored Skynet artefact.
+---
+--- Run:  lua test/lua/test_skynetIadsUtils.lua
+---
+--- `src/scripts/community/skynet-iads-compiled.lua` is a compiled artefact, regenerated from
+--- https://github.com/VEAF/Skynet-IADS — it is not edited here. The fork has no headless test
+--- harness (its `unit-tests/` run inside DCS from a `.miz`, on top of MiST), so the guarantee the
+--- artefact must keep is asserted on this side, against the artefact itself.
+---
+--- What is being guarded: `SkynetIADSUtils.scheduleFunction` replaced MiST's 0.01 s task loop,
+--- which ran anything whose time had come **or gone**. Skynet passes a hardcoded `startTime` of 1
+--- at three sites (`SkynetIADS:activate`, `SkynetIADS:scanForHarms`,
+--- `SkynetIADSJammer:masterArmOn`), so once an IADS initialises more than a second into a mission
+--- that time is already past. Handing it to the native timer unchanged lost the task silently —
+--- Tripack's 2026-09-03 flight, three minutes in: no contact evaluation, every SAM dark, blank
+--- status page, and not one error in `dcs.log`.
+---
+--- The assertions read the time actually handed to `timer.scheduleFunction` rather than the
+--- module's floor constant: the constant was right before the fix too, it simply was not applied.
+---
+--- Covers:
+---   - An overdue first run is armed in the future, and still runs
+---   - A first run due exactly now is armed in the future, and still runs
+---   - A comfortably future first run is armed at the time asked for, untouched
+---   - Repetition survives a clamped first run
+---   - `stopTime` still ends a repeating task
+---   - `removeFunction` still cancels, and still answers false for an unknown id
+
+-- ---------------------------------------------------------------------------
+-- Bootstrap: DCS mocks, then the vendored artefact.
+-- ---------------------------------------------------------------------------
+local _base = debug.getinfo(1, "S").source:match("^@(.+)[\\/]") or "."
+luaunit = dofile(_base .. "/luaunit.lua") -- exported as global for test methods
+dofile(_base .. "/dcs_mocks.lua")
+dofile(_base .. "/../../src/scripts/community/skynet-iads-compiled.lua")
+
+--- The single task the mock timer is currently holding, as the native timer received it.
+---
+--- `SkynetIADSUtils` hands back an id of its own, not the native one, so the arming time is read
+--- from the mock's own record. Each test schedules exactly one task after a reset.
+local function armedTask()
+  local found = nil
+  for _, task in pairs(dcs_mocks.scheduledTasks) do
+    luaunit.assertNil(found, "expected exactly one armed task")
+    found = task
+  end
+  luaunit.assertNotNil(found, "expected one armed task, found none")
+  return found
+end
+
+TestSkynetIadsUtilsScheduler = {}
+
+function TestSkynetIadsUtilsScheduler:setUp()
+  dcs_mocks.reset()
+end
+
+-- ---------------------------------------------------------------------------
+-- The floor on the first run
+-- ---------------------------------------------------------------------------
+
+function TestSkynetIadsUtilsScheduler:test_overdueFirstRunIsArmedInTheFutureAndStillRuns()
+  dcs_mocks.currentTime = 180 -- an IADS coming up three minutes into the mission
+  local calls = 0
+  SkynetIADSUtils.scheduleFunction(function()
+    calls = calls + 1
+  end, {}, 1) -- the hardcoded start time SkynetIADS:activate uses
+
+  local task = armedTask()
+  luaunit.assertTrue(task.time > 180, "an overdue task must not be handed to the timer as-is, got " .. tostring(task.time))
+
+  dcs_mocks.runScheduled(181)
+  luaunit.assertEquals(calls, 1)
+end
+
+function TestSkynetIadsUtilsScheduler:test_firstRunDueNowIsArmedInTheFutureAndStillRuns()
+  dcs_mocks.currentTime = 42
+  local calls = 0
+  SkynetIADSUtils.scheduleFunction(function()
+    calls = calls + 1
+  end, {}, timer.getTime())
+
+  local task = armedTask()
+  luaunit.assertTrue(task.time > 42, "a task due now must be armed for the next tick, got " .. tostring(task.time))
+
+  dcs_mocks.runScheduled(43)
+  luaunit.assertEquals(calls, 1)
+end
+
+function TestSkynetIadsUtilsScheduler:test_comfortablyFutureFirstRunIsLeftAlone()
+  dcs_mocks.currentTime = 100
+  SkynetIADSUtils.scheduleFunction(function() end, {}, 160)
+
+  luaunit.assertEquals(armedTask().time, 160)
+end
+
+function TestSkynetIadsUtilsScheduler:test_argumentsAreStillUnpackedIntoAClampedFirstRun()
+  dcs_mocks.currentTime = 180
+  local seen = nil
+  SkynetIADSUtils.scheduleFunction(function(a, b)
+    seen = { a, b }
+  end, { "iads", 7 }, 1)
+
+  dcs_mocks.runScheduled(181)
+  luaunit.assertEquals(seen, { "iads", 7 })
+end
+
+-- ---------------------------------------------------------------------------
+-- Semantics the clamp must not have changed
+-- ---------------------------------------------------------------------------
+
+function TestSkynetIadsUtilsScheduler:test_repetitionSurvivesAClampedFirstRun()
+  dcs_mocks.currentTime = 180
+  local calls = 0
+  SkynetIADSUtils.scheduleFunction(function()
+    calls = calls + 1
+  end, {}, 1, 5) -- Skynet's contact cycle: overdue start, then every few seconds
+
+  dcs_mocks.runScheduled(200)
+  luaunit.assertEquals(calls, 4) -- 180.01, 185.01, 190.01, 195.01; the next one falls past 200
+end
+
+function TestSkynetIadsUtilsScheduler:test_stopTimeStillEndsARepeatingTask()
+  dcs_mocks.currentTime = 100
+  local calls = 0
+  SkynetIADSUtils.scheduleFunction(function()
+    calls = calls + 1
+  end, {}, 101, 5, 120)
+
+  dcs_mocks.runScheduled(200)
+  luaunit.assertEquals(calls, 4) -- 101, 106, 111, 116; the run at 121 is past the stop time
+end
+
+function TestSkynetIadsUtilsScheduler:test_removeFunctionStillCancelsAClampedTask()
+  dcs_mocks.currentTime = 180
+  local calls = 0
+  local id = SkynetIADSUtils.scheduleFunction(function()
+    calls = calls + 1
+  end, {}, 1, 5)
+
+  luaunit.assertTrue(SkynetIADSUtils.removeFunction(id))
+  dcs_mocks.runScheduled(300)
+  luaunit.assertEquals(calls, 0)
+end
+
+function TestSkynetIadsUtilsScheduler:test_removeFunctionStillAnswersFalseForAnUnknownId()
+  luaunit.assertFalse(SkynetIADSUtils.removeFunction(999999))
+  luaunit.assertFalse(SkynetIADSUtils.removeFunction(nil))
+end
+
+-- ---------------------------------------------------------------------------
+-- Run
+-- ---------------------------------------------------------------------------
+os.exit(luaunit.LuaUnit.run())

--- a/vendored.yaml
+++ b/vendored.yaml
@@ -119,7 +119,7 @@ artifacts:
   - id: skynet
     source: https://github.com/VEAF/Skynet-IADS
     upstream: https://github.com/regroupement-patrouille/Skynet-IADS
-    pinned: "3.4.0RP-VEAF build 30.08.2026"
+    pinned: "3.4.0RP-VEAF build 05.09.2026"
     vendoring: compiled
     path: src/scripts/community/skynet-iads-compiled.lua
     # Three steps, and the second one is the one that gets forgotten: the artefact the fork commits is


### PR DESCRIPTION
Ticket 01 of [`FIX-TRIPACK-FIELD-REPORTS`](.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/01-skynet-scheduler-floor.md).

Source change: **VEAF/Skynet-IADS#5** — this PR carries the regenerated artefact, the test and the
changelog.

## The defect

Tripack, 2026-09-03, on a mission built with 6.19.0 and `SKYNET.enabled: true`: every SAM inactive,
IADS status and contacts blank. Half an hour later, the measurement that closed the question — *"même
mission relancée en l'ayant coupé, les sam fonctionnent nickel"*.

`SkynetIADS:activate` arms its contact-evaluation cycle with a **hardcoded start time of `1`**, one
second of mission time. In his log the IADS initialises at 18:29:48, some three minutes in, so that
time is long past. Skynet does this at three sites; only `goSilentToEvadeHARM` passes an absolute
future time.

MiST tolerated it by construction — a 0.01 s loop that ran anything whose time had come *or gone*. The
compatibility module that replaced MiST inside the fork (#846) hands the value straight to the native
timer, with a docstring promising the floor it does not implement. One lost task explains all three
symptoms: no cycle, so no radar ever re-enabled and `printSystemStatus` — the last statement of that
same cycle — never called. No `SKYNET` error anywhere in `dcs.log`, which is exactly the signature.

**This is the same defect as `FIX-TUTORIAL-FIRST-RUN` ticket 05**, found four days earlier on
`spawnSmoke` and fixed by clamping in `veafScheduler` (#908). That fix stopped at the repository
boundary: Skynet ships standalone and carries its own copy of the replacement.

## What is in here

- `src/scripts/community/skynet-iads-compiled.lua` regenerated from VEAF/Skynet-IADS branch
  `fix/scheduler-past-start-time`, following `vendored.yaml`'s three steps in order: recompile with
  `build-tools/build-compiled-script.ps1`, run **stylua** on it, re-apply the `RP-VEAF` label.
  `vendored.yaml`'s `pinned:` moves with the label, to `3.4.0RP-VEAF build 05.09.2026`.
- `test/lua/test_skynetIadsUtils.lua`, new.
- `CHANGELOG.md` under `[Unreleased]`, and `DCS-SESSION-TODO.md` **R13**.

## Verifying the regeneration

The artefact is compiled, so the thing worth proving is that nothing else moved:

| | before | after |
|---|---|---|
| lines | 4338 | 4362 |
| function definitions | 301 | 301 |
| signature list | — | identical, 0 differences |
| changed lines, total | — | 26 |

Those 26 are the version banner (1 out, 1 in) and the 24 added lines. Two hunks, both in
`SkynetIADSUtils`; every other function is byte-identical.

## The test, and why it lives here

The fork has **no headless harness** — its `unit-tests/` run inside DCS from a `.miz` on top of MiST —
so there was no case to add there. The coverage is on this side instead, asserted against the vendored
artefact itself, which is also the thing that actually ships.

It reads **the time handed to `timer.scheduleFunction`**, not the module's floor constant: the constant
was right before the fix too, it simply was never applied. Eight cases — overdue, due-now, comfortably
future, argument unpacking, repetition, stop time, cancellation, unknown id.

The check can fail both ways: run against the pre-fix artefact, three of the eight fail, and the
repeating one is the loud one — the forgiving test timer replays the overdue task **40 times** catching
up from t=1, which is precisely the behaviour the native timer does not offer.

## Gates

- `poetry run test-lua` — **46 suites, all passing**
- `stylua --check src/scripts/veaf/ test/lua/` — clean
- `luacheck` is not installed on this machine; relying on the CI Lua gate

## Still open, deliberately

- **Whether DCS really discards a past-due call is unproven** (item R12 of `DCS-SESSION-TODO.md`). It
  does not need settling here: the contract MiST held is that a task due now or overdue still runs, and
  restoring it costs one tick if DCS turns out to be forgiving.
- The in-game check is queued as **R13**, paired with R12 so both wagers are settled in one session.
  Ticket 01 is `🧑 waiting-human` until then.
- `vendored.yaml`'s watch pin for the fork (`820d3cc0eb85`) names a commit on the fork's `master`, so it
  can only move once VEAF/Skynet-IADS#5 merges. Until then the drift watcher flags that entry,
  correctly.

## Summary by Sourcery

Restore Skynet's scheduler guarantee that overdue tasks execute, so initialized IADS instances resume contact evaluation and SAM operations.

Bug Fixes:
- Ensure overdue or immediately due Skynet scheduler tasks run on the next timer tick, preventing the IADS contact cycle from being silently lost and leaving SAMs inactive with blank status information.

Enhancements:
- Regenerate the vendored Skynet artefact with the updated scheduler while preserving repetition, stop-time, argument, and cancellation semantics.

Documentation:
- Document the Skynet scheduler fix, testing coverage, and the pending in-game verification procedure.

Tests:
- Add Lua coverage for overdue, due-now, and future scheduling along with repetition, stop-time, argument passing, and cancellation behavior.

Chores:
- Mark the scheduler ticket as awaiting human verification and update the related session checklist.