### PR TITLE
fix(spawner,mission-db): naval spawn search, diagnosable terrain refusal, and cloned groups keep their editor task

### DIFF
--- a/.backlog/FIX-TRIPACK-FIELD-REPORTS/PRD.md
+++ b/.backlog/FIX-TRIPACK-FIELD-REPORTS/PRD.md
@@ -122,10 +122,10 @@ drops `taskSelected`, `uncontrolled`, `frequency`, `modulation`, `communication`
 | # | Ticket | Type | Status |
 |---|--------|------|--------|
 | 01 | [Skynet's scheduler keeps the promise its docstring makes](tickets/01-skynet-scheduler-floor.md) | fix | 🧑 |
-| 02 | [A zone's naval element looks for water, not for dry land](tickets/02-naval-elements-look-for-water.md) | fix | ⬜ |
-| 03 | [Why the terrain check refuses a ship already at sea](tickets/03-measure-the-naval-refusal.md) | fix | ⬜ |
+| 02 | [A zone's naval element looks for water, not for dry land](tickets/02-naval-elements-look-for-water.md) | fix | ✅ |
+| 03 | [Why the terrain check refuses a ship already at sea](tickets/03-measure-the-naval-refusal.md) | fix | ✅ |
 | 04 | [ZU-23s of a combat zone come up kilometres out to sea](tickets/04-units-displaced-out-to-sea.md) | fix | ⬜ |
-| 05 | [A cloned group loses the mission task the editor gave it](tickets/05-qra-scrambles-without-engaging.md) | fix | ⬜ |
+| 05 | [A cloned group loses the mission task the editor gave it](tickets/05-qra-scrambles-without-engaging.md) | fix | ✅ |
 
 **All five are workable.** Tripack sent `Snowfox_20260903.miz`, its Skynet-off twin and the mission
 sources on 2026-09-05, and the measurements below replaced three open questions with answers. Only

--- a/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/02-naval-elements-look-for-water.md
+++ b/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/02-naval-elements-look-for-water.md
@@ -1,6 +1,6 @@
 # 02 — A zone's naval element looks for water, not for dry land
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: fix
 

--- a/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/03-measure-the-naval-refusal.md
+++ b/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/03-measure-the-naval-refusal.md
@@ -1,6 +1,6 @@
 # 03 — A ship at a quay is dragged ashore, then refused
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: fix
 

--- a/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/05-qra-scrambles-without-engaging.md
+++ b/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/05-qra-scrambles-without-engaging.md
@@ -1,6 +1,6 @@
 # 05 — A cloned group loses the mission task the editor gave it
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,18 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   days earlier, when the same defect swallowed `spawnSmoke`. Repetition, stop time and cancellation
   are unchanged. `skynet-iads-compiled.lua` is regenerated at build 05.09.2026.
 
+- **A combat zone's naval element now searches for water, not for dry land.** `veaf.findSpawnPoint`
+  only ever accepted dry ground, so a ship or submarine anchored near a quay was dragged onto it and
+  then correctly refused by the terrain check downstream — six groups of a real mission never spawned.
+  `findSpawnPoint` now takes the acceptable surfaces as a parameter (defaulting to today's land-only
+  criterion, so no other caller changes), and a combat zone reads the surfaces its element's category
+  calls for from the same table the spawner already uses.
+
+- **A terrain refusal now names what was actually wrong.** `_drawOrigin`'s error used to print only the
+  radius and the group name; it now also names the resolved category, the surfaces it accepted, the
+  point it tested, and the surface DCS reported there — enough to diagnose the naval-spawn defect above
+  from the log alone, without needing the mission file.
+
 ## [6.19.0] — 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,6 +329,15 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   point it tested, and the surface DCS reported there — enough to diagnose the naval-spawn defect above
   from the log alone, without needing the mission file.
 
+- **A cloned or respawned group now carries the group-level fields the editor set on it.**
+  `veafMissionDb`'s group record held exactly ten fields, and `task` was not one of them — so a QRA
+  flight cloned from a pre-placed group reached DCS with its per-waypoint engagement intact and no
+  mission task at all, which is one read of *"tout se déclenche mais ils font leur nav tranquilos"*.
+  MiST carried this field, and the loss lands squarely on the version that dropped it. The record now
+  also carries `taskSelected`, `uncontrolled`, `frequency`, `modulation`, `communication` and
+  `radioSet`, plus `hidden` — an editor-hidden group no longer becomes visible on the F10 map the
+  moment it is cloned.
+
 ## [6.19.0] — 2026-09-02
 
 ### Fixed

--- a/DCS-SESSION-TODO.md
+++ b/DCS-SESSION-TODO.md
@@ -911,3 +911,33 @@ regarder si l'interface de choix de slot propose quoi que ce soit du côté neut
 
 Utile même en cas de « non » : c'est la seule asymétrie de coalition qui reste dans l'arbre après ce
 lot, et savoir qu'elle est **voulue** évite qu'un prochain passage la « corrige » sans savoir.
+
+---
+
+## Une QRA clonée engage-t-elle vraiment, maintenant que `task` la suit ?
+
+Ouvert par `FIX-TRIPACK-FIELD-REPORTS` (ticket 05), correctif du 2026-09-05.
+
+Ce qui est établi sans DCS : `veafMissionDb`'s group record ne portait que dix champs, et `task`
+n'en faisait pas partie — vérifié, le mot n'apparaissait nulle part dans le fichier. Un clone ou un
+respawn atteignait donc `coalition.addGroup` sans tâche de groupe du tout, alors même que la tâche
+par point de route (`EngageTargetsInZone`) survivait, elle. Les tests unitaires prouvent que le champ
+suit désormais le clone jusqu'à l'appel — `task`, `taskSelected`, `uncontrolled`, `frequency`,
+`modulation`, `communication`, `radioSet` et `hidden`.
+
+Ce qu'ils ne peuvent pas dire : si l'absence de `task` est bien ce qui rendait Tripack's QRA
+« tranquilos » — sans engager — plutôt qu'un autre effet de bord. C'est plausible (une IA sans tâche
+de groupe peut plausiblement ignorer les tâches de route) mais pas prouvé hors du jeu.
+
+**À faire** : déployer une QRA dont un des groupes pré-placés porte `task = 'CAP'` et un
+`EngageTargetsInZone` sur une route, comme `CAP_AL_MINHAD-1` dans la mission de Tripack. Déclencher
+son scramble, faire pénétrer un intrus dans sa zone d'engagement.
+
+- **Attendu** : le groupe engage l'intrus, comme avant la régression (avant 6.19.0 / `REFACTOR-SPAWNER`).
+- **Ce qui contredirait le correctif** : le groupe continue sa route sans engager malgré `task` et
+  l'`EngageTargetsInZone` tous deux présents. Dans ce cas le dire : ça voudrait dire que la cause de
+  Tripack est ailleurs, et que ce correctif — juste en soi, puisqu'il restitue un champ que l'éditeur
+  a posé — ne referme pas son rapport.
+
+Accessoirement, vérifier au passage que le groupe cloné reste **caché** sur la carte F10 si l'éditeur
+l'avait déclaré `hidden = true` — capture d'écran de Tripack à comparer, plus rapide qu'un vol.

--- a/src/scripts/veaf/veaf.lua
+++ b/src/scripts/veaf/veaf.lua
@@ -1260,20 +1260,24 @@ veaf.DEFAULT_SPAWN_CLEARANCE = 100
 --- Set to true to skip the scenery-aware tier of veaf.findSpawnPoint
 veaf.doNotAvoidScenery = false
 
---- Places a candidate on the terrain and tells whether a ground unit can stand there
+--- Every surface `veaf.findSpawnPoint` accepts when a caller does not say — today's land-only
+--- criterion, unchanged: everything but open water, so SHALLOW_WATER keeps passing as it does
+--- today (FIX-CSAR-SPAWNS-ON-WATER, "a survivor wading a few metres off a beach is rescuable").
+veaf.DEFAULT_SPAWN_TERRAIN = { "LAND", "SHALLOW_WATER", "ROAD", "RUNWAY" }
+
+--- Places a candidate on the terrain and tells whether it may be used
 -- Placing first normalises vec2 and vec3 inputs, so the surface test always has a z.
--- Only open water is rejected, which is the criterion veafUnits.checkPositionForUnit applies
--- to a ground unit — SHALLOW_WATER keeps passing, as it does today (veaf.OPEN_WATER).
 -- The shape guard is not paranoia: tier 1 candidates come from an undocumented API whose
 -- return shape we have not measured, and veaf.placePointOnLand would raise on a non-table
 -- — outside the pcall, which only wraps the call to the singleton itself.
--- @return vec3 placed on land, or nil when the candidate is unusable
-local function acceptableGroundPoint(candidate)
+-- @param surfaces table the surfaces this candidate may stand on
+-- @return vec3 placed on the terrain, or nil when the candidate is unusable
+local function acceptableGroundPoint(candidate, surfaces)
   if type(candidate) ~= "table" then
     return nil
   end
   local placed = veaf.placePointOnLand(candidate)
-  if not veaf.isTerrainValid(placed, veaf.OPEN_WATER) then
+  if veaf.isTerrainValid(placed, surfaces) then
     return placed
   end
   return nil
@@ -1298,9 +1302,12 @@ end
 -- @param vec3 centre point
 -- @param radius search radius in metres — honoured by **every** tier, see below
 -- @param safeRadius required clearance from scenery (default veaf.DEFAULT_SPAWN_CLEARANCE)
--- @return vec3 placed on land, or nil when no acceptable point was found
-function veaf.findSpawnPoint(vec3, radius, safeRadius)
+-- @param surfaces table surfaces the point may stand on (default veaf.DEFAULT_SPAWN_TERRAIN,
+--        today's land-only criterion — an omitted argument changes nothing for an existing caller)
+-- @return vec3 placed on the terrain, or nil when no acceptable point was found
+function veaf.findSpawnPoint(vec3, radius, safeRadius, surfaces)
   safeRadius = safeRadius or veaf.DEFAULT_SPAWN_CLEARANCE
+  surfaces = surfaces or veaf.DEFAULT_SPAWN_TERRAIN
 
   -- Tier 1 — every criterion, clearance from buildings and forests included.
   -- Disposition is a native but *undocumented* DCS singleton, found in TUM. Measured in a live
@@ -1318,7 +1325,7 @@ function veaf.findSpawnPoint(vec3, radius, safeRadius)
     local ok, candidates = pcall(Disposition.getSimpleZones, vec3, radius, safeRadius, veaf.SPAWN_SEARCH_ATTEMPTS)
     if ok and type(candidates) == "table" then
       for _, candidate in ipairs(candidates) do
-        local placed = acceptableGroundPoint(candidate)
+        local placed = acceptableGroundPoint(candidate, surfaces)
         -- The distance test is not belt-and-braces: **Disposition's radius argument does not
         -- bound its answers.** Measured around one centre in wooded terrain — asked for 800 m
         -- it returned points 2035-2258 m out, and asked for 1600 m with a count of *one* it
@@ -1339,7 +1346,7 @@ function veaf.findSpawnPoint(vec3, radius, safeRadius)
 
   -- Tier 2 — every criterion except clearance from scenery.
   for _ = 1, veaf.SPAWN_SEARCH_ATTEMPTS do
-    local placed = acceptableGroundPoint(veaf.getRandomPointInCircle(vec3, radius))
+    local placed = acceptableGroundPoint(veaf.getRandomPointInCircle(vec3, radius), surfaces)
     if placed then
       return placed
     end

--- a/src/scripts/veaf/veafCombatZone.lua
+++ b/src/scripts/veaf/veafCombatZone.lua
@@ -1490,6 +1490,19 @@ function VeafCombatZone:destroySpawnedGroup(groupName)
   end
 end
 
+--- The surfaces a zone element's naval category may stand on, or nil to keep
+--- `veaf.findSpawnPoint`'s own land-only default unchanged for anything else.
+-- Read from `veafDcsSpawner.TERRAIN_BY_CATEGORY`, the same table the terrain check downstream
+-- already uses, so "what can this thing stand on" has one source instead of two that can disagree.
+local function surfacesForZoneElement(zoneElement)
+  local record = veaf.getGroupRecord(zoneElement:getName())
+  local category = record and record.category
+  if category and string.lower(category) == "ship" then
+    return veafDcsSpawner.TERRAIN_BY_CATEGORY.ship
+  end
+  return nil
+end
+
 function VeafCombatZone:spawnElement(zoneElement, now)
   veaf.loggers
     .get(veafCombatZone.Id)
@@ -1521,7 +1534,7 @@ function VeafCombatZone:spawnElement(zoneElement, now)
       -- the mission loads, so a partially built zone would be worse than an imperfect one.
       -- Refusing is for what a command spawns (David, 2026-08-27), and per ADR 0018 the scenery
       -- criterion is quality-only, never correctness.
-      local found = veaf.findSpawnPoint(position, zoneElement:getSpawnRadius())
+      local found = veaf.findSpawnPoint(position, zoneElement:getSpawnRadius(), nil, surfacesForZoneElement(zoneElement))
       if found then
         veaf.loggers.get(veafCombatZone.Id):trace(string.format("found=[%s]", veaf.vecToString(found)))
         position = { x = found.x, y = position.y, z = found.z }

--- a/src/scripts/veaf/veafDcsSpawner.lua
+++ b/src/scripts/veaf/veafDcsSpawner.lua
@@ -882,6 +882,21 @@ function VeafGroupSpawn:_sourceData(verb)
   return record and veaf.deepCopy(record) or nil
 end
 
+--- The surface name DCS reports at a point, for a diagnosable refusal message.
+-- Mirrors the flattening `veaf.isTerrainValid` applies, so this reads the same surface it tested.
+-- @param point table a vec2 or vec3
+-- @return string a `land.SurfaceType` name, or the raw id when it does not match one
+local function surfaceNameAt(point)
+  local flat = { x = point.x, y = point.z or point.y }
+  local actual = land.getSurfaceType(flat)
+  for name, value in pairs(land.SurfaceType) do
+    if value == actual then
+      return name
+    end
+  end
+  return tostring(actual)
+end
+
 --- A point in the circle whose terrain suits this group, and the offset to reach it.
 function VeafGroupSpawn:_drawOrigin(data)
   local first = data.units[1]
@@ -890,16 +905,24 @@ function VeafGroupSpawn:_drawOrigin(data)
   end
 
   local surfaces = self.terrain or veafDcsSpawner.terrainForCategory(data.category)
+  local lastCandidate
   for _ = 1, VeafGroupSpawn.TERRAIN_ATTEMPTS do
     local candidate = veaf.getRandomPointInCircle(self.point, self.radius)
+    lastCandidate = candidate
     if self.anyTerrain or veafDcsSpawner.isTerrainValid(candidate, surfaces) then
       return { x = candidate.x - first.x, y = candidate.y - first.y }, candidate
     end
   end
 
-  veaf.loggers
-    .get(veafDcsSpawner.Id)
-    :error("no point within %sm of the requested spot is valid terrain for [%s]", veaf.p(self.radius), veaf.p(self.groupName))
+  veaf.loggers.get(veafDcsSpawner.Id):error(
+    "no point within %sm of the requested spot is valid terrain for [%s]: category [%s] accepts [%s], point [%s] is [%s]",
+    veaf.p(self.radius),
+    veaf.p(self.groupName),
+    veaf.p(data.category),
+    veaf.p(table.concat(surfaces, ", ")),
+    veaf.p(veaf.vecToString(lastCandidate)),
+    veaf.p(surfaceNameAt(lastCandidate))
+  )
   return nil, nil
 end
 

--- a/src/scripts/veaf/veafMissionDb.lua
+++ b/src/scripts/veaf/veafMissionDb.lua
@@ -190,12 +190,25 @@ function veafMissionDb.buildSnapshot()
                   -- into the ten fields a caller reads; MiST walked `env.mission` from scratch on every
                   -- call to reach the same table.
                   route = groupData.route,
+                  -- FIX-TRIPACK-FIELD-REPORTS ticket 05: the group-level fields a clone, respawn or
+                  -- teleport needs to reproduce faithfully. MiST carried every one of these
+                  -- (mist.lua:264, mist.lua:1030); this record did not, so a cloned QRA flight reached
+                  -- DCS with its per-waypoint engagement intact and no mission task at all. `nil` when
+                  -- the editor never set one, so `addGroup`'s own default (`hidden` -> false) still
+                  -- applies to a group with no editor record.
+                  task = groupData.task,
+                  taskSelected = groupData.taskSelected,
+                  uncontrolled = groupData.uncontrolled,
+                  frequency = groupData.frequency,
+                  modulation = groupData.modulation,
+                  communication = groupData.communication,
+                  radioSet = groupData.radioSet,
+                  hidden = groupData.hidden,
                   -- The whole editor table for this group, by reference for the same reason as the
                   -- route. This is what `veaf.getGroupData` hands back: its callers read fields no
-                  -- record projects and none of them the same ones — `communication` and `frequency`
-                  -- for a tanker, a unit's `callsign`, `unitId` and `modulation` for a carrier's ATC.
-                  -- Projecting that set would be a second copy of the mission to keep in step, so the
-                  -- record carries the door rather than the rooms.
+                  -- record projects and none of them the same ones — a unit's `callsign` for a
+                  -- carrier's ATC, among others. Projecting that whole set would be a second copy of
+                  -- the mission to keep in step, so the record carries the door rather than the rooms.
                   missionData = groupData,
                 }
                 for _, unitData in pairs(groupData.units or {}) do

--- a/test/lua/test_veaf.lua
+++ b/test/lua/test_veaf.lua
@@ -2249,6 +2249,33 @@ function TestVeafFindSpawnPoint:test_first_clear_candidate_of_several_is_taken()
   luaunit.assertEquals(self._jitterCalls, 0)
 end
 
+--- FIX-TRIPACK-FIELD-REPORTS ticket 02 — an explicit surface list, so a naval element can
+--- search on water instead of the land-only default.
+function TestVeafFindSpawnPoint:test_explicit_surfaces_accept_water_for_a_ship()
+  self:_waterAt({ 500 })
+  self:_jitterSequence({ 500 })
+  local point = veaf.findSpawnPoint({ x = 0, y = 0, z = 0 }, 1000, nil, veaf.WATER_TERRAIN)
+  luaunit.assertNotNil(point, "a ship's surface list must accept open water")
+  luaunit.assertEquals(point.x, 500)
+end
+
+function TestVeafFindSpawnPoint:test_explicit_surfaces_still_reject_what_they_do_not_list()
+  -- Land everywhere (setUp default); a water-only surface list must refuse it.
+  self:_jitterSequence({ 500 })
+  local point = veaf.findSpawnPoint({ x = 0, y = 0, z = 0 }, 1000, nil, veaf.WATER_TERRAIN)
+  luaunit.assertNil(point, "land must not satisfy a water-only surface list")
+end
+
+function TestVeafFindSpawnPoint:test_omitting_surfaces_keeps_the_land_only_default()
+  -- An unconverted caller passes only vec3/radius/safeRadius — the fourth argument must
+  -- default to today's land-only behaviour, not be silently required.
+  self:_waterAt({ 500 })
+  self:_jitterSequence({ 500, 600 })
+  local point = veaf.findSpawnPoint({ x = 0, y = 0, z = 0 }, 1000, veaf.DEFAULT_SPAWN_CLEARANCE)
+  luaunit.assertNotNil(point)
+  luaunit.assertEquals(point.x, 600, "the water candidate at 500 must still be rejected")
+end
+
 -- ---------------------------------------------------------------------------
 -- Trigger-zone properties (FEAT-SCENERY-AWARE-SPAWN ticket 04)
 --

--- a/test/lua/test_veafCombatZone.lua
+++ b/test/lua/test_veafCombatZone.lua
@@ -2097,6 +2097,132 @@ function TestVeafCombatZoneRenameOption:test_one_zone_declining_does_not_affect_
 end
 
 -- ============================================================================
+-- FIX-TRIPACK-FIELD-REPORTS ticket 02 — a naval element searches on water, not on dry land.
+--
+-- Tripack's log showed thirteen `findSpawnPoint` failures at 50 m, mechanical: `acceptableGroundPoint`
+-- only ever accepted dry land, and `spawnElement` called it for every element regardless of category,
+-- ships included. `spawnElement` must now read the element's category from the mission record and pass
+-- the matching surfaces, from the same `veafDcsSpawner.TERRAIN_BY_CATEGORY` the terrain check downstream
+-- already uses — and it must not narrow the search for anything but a naval element.
+-- ============================================================================
+TestVeafCombatZoneSpawnElementSurfaces = {}
+
+function TestVeafCombatZoneSpawnElementSurfaces:setUp()
+  self.z = VeafCombatZone:new():setFriendlyName("Naval Zone"):setMissionEditorZoneName("NAVALZONE")
+  self.z:setActive(true)
+
+  self.el = VeafCombatZoneElement:new()
+  self.el:setName("NAVALZONE-SHIP")
+  self.el:setPosition({ x = 0, y = 0, z = 0 })
+  self.el:setCoalition(coalition.side.RED)
+  self.el:setDcsGroup(true)
+  self.el:setSpawnRadius(50)
+
+  self._spawnImpl = VeafGroupSpawn._spawn
+  VeafGroupSpawn._spawn = function()
+    return nil
+  end
+
+  self._findSpawnPointImpl = veaf.findSpawnPoint
+  self._capturedSurfaces = "not called"
+  veaf.findSpawnPoint = function(_vec3, _radius, _safeRadius, surfaces)
+    self._capturedSurfaces = surfaces
+    return nil
+  end
+
+  self._savedGroups = veafMissionDb.groupsByName
+  veafMissionDb.groupsByName = {}
+end
+
+function TestVeafCombatZoneSpawnElementSurfaces:tearDown()
+  VeafGroupSpawn._spawn = self._spawnImpl
+  veaf.findSpawnPoint = self._findSpawnPointImpl
+  veafMissionDb.groupsByName = self._savedGroups
+end
+
+function TestVeafCombatZoneSpawnElementSurfaces:test_a_ship_element_searches_on_water()
+  veafMissionDb.groupsByName["NAVALZONE-SHIP"] = { category = "ship" }
+  self.z:spawnElement(self.el, true)
+  luaunit.assertEquals(self._capturedSurfaces, veafDcsSpawner.TERRAIN_BY_CATEGORY.ship)
+end
+
+function TestVeafCombatZoneSpawnElementSurfaces:test_a_vehicle_element_keeps_findspawnpoints_own_default()
+  veafMissionDb.groupsByName["NAVALZONE-SHIP"] = { category = "vehicle" }
+  self.z:spawnElement(self.el, true)
+  luaunit.assertNil(self._capturedSurfaces, "a ground element's search must not narrow")
+end
+
+function TestVeafCombatZoneSpawnElementSurfaces:test_an_unknown_category_keeps_the_default_too()
+  -- no mission record at all for this element's name
+  self.z:spawnElement(self.el, true)
+  luaunit.assertNil(self._capturedSurfaces)
+end
+
+-- ============================================================================
+-- FIX-TRIPACK-FIELD-REPORTS ticket 03 — the combined path. A ship at anchor near a quay used to be
+-- dragged onto dry land by `findSpawnPoint` and then refused by `_drawOrigin`'s own, correctly
+-- category-aware terrain check — the six groups of `Snowfox_20260903.miz` that never spawned.
+-- Ticket 02's fix makes the naval search accept water in the first place; this reproduces the whole
+-- path end to end, with nothing stubbed between the zone element and `coalition.addGroup`.
+-- ============================================================================
+TestVeafCombatZoneNavalSpawnRegression = {}
+
+function TestVeafCombatZoneNavalSpawnRegression:setUp()
+  dcs_mocks.reset()
+  Disposition = nil
+  land.getHeight = function()
+    return 0
+  end
+  -- The quay sits within 10 m of the declared position; open water lies beyond it.
+  land.getSurfaceType = function(vec2)
+    if math.abs(vec2.x) <= 10 then
+      return land.SurfaceType.LAND
+    end
+    return land.SurfaceType.WATER
+  end
+
+  env.mission.coalition.blue.country = {
+    [1] = {
+      name = "USA",
+      id = country.id.USA,
+      ship = {
+        group = {
+          {
+            name = "ZONE-SHIP",
+            groupId = 7,
+            units = { { name = "ZONE-SHIP-1", unitId = 3, type = "Dry-cargo ship-2", x = 0, y = 0 } },
+          },
+        },
+      },
+    },
+  }
+  veafMissionDb.buildSnapshot()
+
+  self.z = VeafCombatZone:new():setFriendlyName("Naval Zone"):setMissionEditorZoneName("NAVALZONE")
+  self.z:setActive(true)
+
+  self.el = VeafCombatZoneElement:new()
+  self.el:setName("ZONE-SHIP")
+  self.el:setPosition({ x = 0, y = 0, z = 0 })
+  self.el:setCoalition(coalition.side.BLUE)
+  self.el:setDcsGroup(true)
+  self.el:setSpawnRadius(50)
+
+  -- Two draws per findSpawnPoint attempt (theta, distance): the first candidate lands at x=5,
+  -- on the quay; the second lands at x=45, in open water and still within the 50 m search radius.
+  dcs_mocks.setRandomSequence({ 0, 0.01, 0, 0.81 })
+end
+
+function TestVeafCombatZoneNavalSpawnRegression:tearDown()
+  dcs_mocks.reset()
+end
+
+function TestVeafCombatZoneNavalSpawnRegression:test_a_ship_near_a_quay_spawns_on_water()
+  self.z:spawnElement(self.el, true)
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 1, "the ship must be created, not refused")
+end
+
+-- ============================================================================
 -- FIX-COMBATZONE-ZONE-TYPE-SILENT, second pass — Sourcery's review point on #775.
 --
 -- The helper returned nil for "I cannot read this zone" and the caller wrote `or {}`, so the

--- a/test/lua/test_veafDcsSpawner.lua
+++ b/test/lua/test_veafDcsSpawner.lua
@@ -1528,4 +1528,96 @@ function TestVeafGroupSpawnChain:test_a_unit_with_no_position_creates_nothing()
   luaunit.assertEquals(#dcs_mocks.groupsAdded, 0)
 end
 
+-- ---------------------------------------------------------------------------
+-- TestVeafGroupSpawnFieldForwarding
+-- ---------------------------------------------------------------------------
+-- FIX-TRIPACK-FIELD-REPORTS ticket 05 — the group-level fields a clone or respawn must carry
+-- through to `coalition.addGroup`, asserted on **the wiring**: what the spawn actually submits,
+-- not that some helper along the way was called. Reproduces Tripack's QRA report: a pre-placed
+-- `CAP_AL_MINHAD-1`-style group carries `task = 'CAP'`, and the clone used to submit none of it.
+-- ---------------------------------------------------------------------------
+TestVeafGroupSpawnFieldForwarding = {}
+
+function TestVeafGroupSpawnFieldForwarding:setUp()
+  dcs_mocks.reset()
+  land.getHeight = function()
+    return 0
+  end
+  land.getSurfaceType = function()
+    return land.SurfaceType.LAND
+  end
+  env.mission.coalition.blue.country = {
+    [1] = {
+      name = "USA",
+      id = country.id.USA,
+      plane = {
+        group = {
+          {
+            name = "CAP_AL_MINHAD-1",
+            groupId = 42,
+            task = "CAP",
+            taskSelected = true,
+            uncontrolled = false,
+            frequency = 251.5,
+            modulation = 0,
+            communication = true,
+            radioSet = true,
+            hidden = true,
+            units = { { name = "CAP_AL_MINHAD-1-1", unitId = 4, type = "F-15C", x = 1000, y = 2000, alt = 3000 } },
+          },
+        },
+      },
+    },
+  }
+  veafMissionDb.buildSnapshot()
+end
+
+local function lastSpawned()
+  local entries = dcs_mocks.groupsAdded
+  return entries[#entries] and entries[#entries].group
+end
+
+function TestVeafGroupSpawnFieldForwarding:test_a_clone_submits_the_editors_task()
+  VeafGroupSpawn:new():forGroup("CAP_AL_MINHAD-1"):at({ x = 5000, y = 0, z = 6000 }):clone()
+  luaunit.assertEquals(lastSpawned().task, "CAP")
+  luaunit.assertTrue(lastSpawned().taskSelected)
+end
+
+function TestVeafGroupSpawnFieldForwarding:test_a_clone_submits_the_radio_fields()
+  VeafGroupSpawn:new():forGroup("CAP_AL_MINHAD-1"):at({ x = 5000, y = 0, z = 6000 }):clone()
+  luaunit.assertEquals(lastSpawned().frequency, 251.5)
+  luaunit.assertEquals(lastSpawned().modulation, 0)
+  luaunit.assertTrue(lastSpawned().communication)
+  luaunit.assertTrue(lastSpawned().radioSet)
+end
+
+function TestVeafGroupSpawnFieldForwarding:test_a_clone_submits_uncontrolled()
+  VeafGroupSpawn:new():forGroup("CAP_AL_MINHAD-1"):at({ x = 5000, y = 0, z = 6000 }):clone()
+  luaunit.assertFalse(lastSpawned().uncontrolled)
+end
+
+--- The regression named explicitly in the ticket: the editor hid this group, so a scrambled QRA
+--- flight must not become visible on the F10 map just because it was cloned.
+function TestVeafGroupSpawnFieldForwarding:test_a_clone_keeps_the_editors_hidden_flag()
+  VeafGroupSpawn:new():forGroup("CAP_AL_MINHAD-1"):at({ x = 5000, y = 0, z = 6000 }):clone()
+  luaunit.assertTrue(lastSpawned().hidden, "the editor hid this group; the clone must stay hidden")
+end
+
+--- A group with no editor record at all (no `forGroup`, built inline) keeps `addGroup`'s own
+--- default: hidden must fall back to false, not be forced true by this fix.
+function TestVeafGroupSpawnFieldForwarding:test_a_group_with_no_editor_record_keeps_addgroups_default()
+  local result = VeafGroupSpawn:new()
+    :withGroupData({
+      name = "Inline",
+      country = "USA",
+      category = "vehicle",
+      units = { { type = "M-1 Abrams", x = 1, y = 2 } },
+    })
+    :at({ x = 10, y = 0, z = 20 })
+    :teleport()
+
+  luaunit.assertNotNil(result)
+  luaunit.assertFalse(lastSpawned().hidden)
+end
+
 os.exit(luaunit.LuaUnit.run())

--- a/test/lua/test_veafDcsSpawner.lua
+++ b/test/lua/test_veafDcsSpawner.lua
@@ -1281,6 +1281,29 @@ function TestVeafGroupSpawnChain:test_terrain_the_group_cannot_use_is_refused()
   luaunit.assertEquals(#dcs_mocks.groupsAdded, 0)
 end
 
+--- FIX-TRIPACK-FIELD-REPORTS ticket 03 — the refusal used to name only the radius and the group,
+--- which is what made this defect take Tripack's mission file to diagnose instead of the log alone.
+function TestVeafGroupSpawnChain:test_the_refusal_names_category_surfaces_point_and_actual_surface()
+  land.getSurfaceType = function()
+    return land.SurfaceType.WATER
+  end
+  local logger = veaf.loggers.get(veafDcsSpawner.Id)
+  local savedError = logger.error
+  local captured
+  logger.error = function(_self, text, ...)
+    captured = { text, ... }
+  end
+
+  VeafGroupSpawn:new():forGroup("Convoy"):at({ x = 5000, y = 0, z = 6000 }):withRadius(500):respawn()
+
+  logger.error = savedError
+  luaunit.assertNotNil(captured, "the refusal must be logged")
+  local message = string.format(veaf.safeUnpack(captured))
+  luaunit.assertStrContains(message, "vehicle", false, "the resolved category")
+  luaunit.assertStrContains(message, "LAND", false, "an accepted surface")
+  luaunit.assertStrContains(message, "WATER", false, "the surface DCS actually reported")
+end
+
 function TestVeafGroupSpawnChain:test_any_terrain_skips_the_check()
   -- What veafMove uses for a dynamically spawned AFAC.
   land.getSurfaceType = function()

--- a/test/lua/test_veafMissionDb.lua
+++ b/test/lua/test_veafMissionDb.lua
@@ -37,6 +37,14 @@ local function buildTestMission()
               [1] = {
                 name = "Chevy",
                 groupId = 10,
+                task = "CAP",
+                taskSelected = true,
+                uncontrolled = false,
+                frequency = 251.5,
+                modulation = 0,
+                communication = true,
+                radioSet = true,
+                hidden = true,
                 units = {
                   [1] = {
                     name = "Chevy11",
@@ -182,6 +190,35 @@ end
 
 function TestVeafMissionDbSnapshot:test_aGroupCarriesItsUnits()
   luaunit.assertEquals(#veaf.getGroupRecord("Chevy").units, 2)
+end
+
+--- FIX-TRIPACK-FIELD-REPORTS ticket 05 — the group-level fields a clone or respawn needs to
+--- reproduce faithfully. `task` is the one that made a QRA flight scramble without engaging: MiST
+--- carried it (mist.lua:264), and the ten-field record here did not.
+function TestVeafMissionDbSnapshot:test_aGroupCarriesTheFieldsAClonerRelies()
+  local record = veaf.getGroupRecord("Chevy")
+  luaunit.assertEquals(record.task, "CAP")
+  luaunit.assertTrue(record.taskSelected)
+  luaunit.assertFalse(record.uncontrolled)
+  luaunit.assertEquals(record.frequency, 251.5)
+  luaunit.assertEquals(record.modulation, 0)
+  luaunit.assertTrue(record.communication)
+  luaunit.assertTrue(record.radioSet)
+  luaunit.assertTrue(record.hidden)
+end
+
+--- A group the editor never gave any of these fields must not fabricate one — `nil` stays `nil`, so
+--- `addGroup`'s own defaulting (hidden -> false when the editor said nothing) still applies.
+function TestVeafMissionDbSnapshot:test_a_group_without_the_fields_carries_nil_not_a_fabricated_default()
+  local record = veaf.getGroupRecord("Convoy")
+  luaunit.assertNil(record.task)
+  luaunit.assertNil(record.taskSelected)
+  luaunit.assertNil(record.uncontrolled)
+  luaunit.assertNil(record.frequency)
+  luaunit.assertNil(record.modulation)
+  luaunit.assertNil(record.communication)
+  luaunit.assertNil(record.radioSet)
+  luaunit.assertNil(record.hidden)
 end
 
 --- A record exists for a unit that has not spawned and for one already destroyed — the whole reason


### PR DESCRIPTION
## Summary

Tickets 02, 03 and 05 of `.backlog/FIX-TRIPACK-FIELD-REPORTS`, from Tripack's 2026-09-03 field
report, measured against his actual mission file and sources on 2026-09-05.

- **Ticket 02** — `veaf.findSpawnPoint` only ever searched for dry land, so a combat zone's naval
  element (ship, submarine) anchored near a quay was dragged onto it. `findSpawnPoint` now takes the
  acceptable surfaces as a parameter, defaulting to today's land-only criterion so no other caller
  changes; `VeafCombatZone:spawnElement` reads the surfaces its element's category calls for from the
  same `veafDcsSpawner.TERRAIN_BY_CATEGORY` table the terrain check downstream already uses.

- **Ticket 03** — `_drawOrigin`'s refusal used to name only the radius and the group. It now also
  names the resolved category, the surfaces it accepted, the point it tested and the surface DCS
  reported there — this whole investigation would have been readable from Tripack's log alone with
  this message. A regression test reproduces the exact combined-path bug (search finds a nearby quay,
  the ship is moved onto it, the category-aware terrain check refuses it) end to end.

- **Ticket 05** — `veafMissionDb`'s group record carried exactly ten fields, and `task` was not one
  of them (verified: zero matches in the file). A QRA flight cloned from a pre-placed group therefore
  reached `coalition.addGroup` with its per-waypoint `EngageTargetsInZone` intact and no group-level
  mission task — read as "scrambles but never engages". MiST carried this field
  (`mist.lua:264`/`:1030`); the loss lands on the version that replaced it. The record now also
  carries `taskSelected`, `uncontrolled`, `frequency`, `modulation`, `communication`, `radioSet`, and
  `hidden` (an editor-hidden group no longer becomes visible on the F10 map once cloned). Fields the
  editor never set stay `nil`, so `addGroup`'s own default (`hidden` → false) still applies to a group
  with no editor record.

  The field list was enumerated against the vendored `dcs-world-schema` `GroupSpawnData` definition
  plus MiST's own field reads, not sampled from Tripack's mission alone. `x`, `y`, `start_time`,
  `visible` and `lateActivation` are deliberately **not** carried — a spawn computes its own position
  and timing rather than replaying the editor's, and a live clone is not a late-activation template.
  An in-game check (does a scrambled QRA now actually engage) is queued in `DCS-SESSION-TODO.md`
  rather than assumed.

## Test plan

- [x] `poetry run test-lua` — all 45 suites green (added tests included)
- [x] `stylua --check src/scripts/veaf/ test/lua/` — clean
- [ ] `luacheck --config .luacheckrc src/scripts/veaf/` — the local `luacheck` binary errors on
      startup on this machine (a Lua 5.5/module incompatibility unrelated to this change); relying on
      the CI Lua gate for this check, per `CLAUDE.md`
- [x] Lua coverage floor checked: 80.32% measured, floor is 80 — within the ~2-point ratchet
      tolerance, not bumped
- [x] `CHANGELOG.md` updated under `[Unreleased]`, one entry per ticket, appended at the end
- [ ] In-game verification of tickets 03 (the six naval groups spawn) and 05 (a scrambled QRA
      engages) — queued in `DCS-SESSION-TODO.md`, not done here (no DCS on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix naval spawn placement and cloned-group state preservation while making terrain rejection failures easier to diagnose.

Bug Fixes:
- Allow naval combat-zone elements to search for valid water surfaces instead of being restricted to land.
- Preserve group-level mission settings, including tasks, radio configuration, and hidden status, when cloning or respawning groups.

Enhancements:
- Expand terrain-refusal logging with the resolved category, accepted surfaces, tested point, and reported surface to make spawn failures diagnosable.

Documentation:
- Update the changelog and session follow-up documentation for the naval spawning, terrain diagnostics, and cloned-group task fixes.

Tests:
- Add regression coverage for surface-aware spawn searches, naval spawning near quays, diagnostic terrain refusals, and forwarding of cloned group fields.

Chores:
- Mark Tripack field-report tickets 02, 03, and 05 as completed.