### PR TITLE
feat(support-bot): nothing is reported twice, and the issue is filed by a GitHub App

### DIFF
--- a/.backlog/FEAT-SUPPORT-BUG-INTAKE/tickets/03-prior-art-sweep.md
+++ b/.backlog/FEAT-SUPPORT-BUG-INTAKE/tickets/03-prior-art-sweep.md
@@ -1,6 +1,6 @@
 # 03 — Nothing gets reported twice
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: feat
 
@@ -41,10 +41,36 @@ informs the decision, it does not take it.
 
 ## Definition of done
 
-- [ ] Sweep across open issues, closed issues, `.backlog/` and `ROADMAP.md`
-- [ ] Each outcome implemented: duplicate, already fixed, lot in progress, nothing found
-- [ ] A proposed match always shows its evidence and can be rejected by the user, who then continues
-- [ ] What was checked is recorded in the draft
-- [ ] Unit tests with the GitHub API mocked and a fixture backlog, one per outcome, including the
+- [x] Sweep across open issues, closed issues, `.backlog/` and `ROADMAP.md`
+- [x] Each outcome implemented: duplicate, already fixed, lot in progress, nothing found
+- [x] A proposed match always shows its evidence and can be rejected by the user, who then continues
+- [x] What was checked is recorded in the draft
+- [x] Unit tests with the GitHub API mocked and a fixture backlog, one per outcome, including the
       rejection path
-- [ ] Quality gate clean
+- [x] Quality gate clean
+
+## What was built
+
+`veaf_support_bot/priorart.py`. The corpus is four kinds of candidate; the score weights *signal*
+tokens — identifiers, file names, versions, anything that is not everyday vocabulary — three times
+an ordinary word, and a proposal needs either a shared signal token or five shared ordinary ones.
+The algorithm is deliberately legible: the score is printed with the words it was computed from, so
+a maintainer who thinks it is wrong can see why it is wrong. A similarity model would score better
+and explain nothing — and would cost a call this lot does not have.
+
+The version that carries a fix is a **lookup, not a guess**: the changelog cites issues as
+`[#123](…/issues/123)`, so the version is the nearest `## [x.y.z]` heading above the citation. An
+issue the changelog does not mention yields no version and the message says so.
+
+Only **open** lots are candidates. Proposing a `✅ done` lot would tell a reporter his bug is being
+worked on when it shipped months ago — the same silencing failure as a wrong duplicate.
+
+## Two decisions worth revisiting
+
+1. **With nobody to ask, the gate answers "rejected".** Ticket 04 owns the click that asks; until it
+   exists the sweep runs, the finding is printed with its evidence and attached to the issue, and
+   the report is filed. The alternative — auto-accepting a high-confidence match — would silence
+   reports on a machine's unverified conclusion, which is exactly what this ticket forbids.
+2. **The attached log is not part of the query.** A log shares hundreds of words with every other
+   log; including it would match a report against everything and teach reporters to dismiss the
+   proposal. The query is the reporter's own words plus what the trace named.

--- a/.backlog/FEAT-SUPPORT-BUG-INTAKE/tickets/05-github-app.md
+++ b/.backlog/FEAT-SUPPORT-BUG-INTAKE/tickets/05-github-app.md
@@ -1,6 +1,6 @@
 # 05 — The issue is filed by a GitHub App, not by a person
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: feat
 
@@ -37,11 +37,51 @@ become indistinguishable from David's.
 
 ## Definition of done
 
-- [ ] GitHub App used, with least-privilege scopes documented
-- [ ] Credentials from the environment only; renewal handled
-- [ ] Issue filled in the template's shape, in the user's language, quotes untranslated
-- [ ] Labelled `bug` plus a machine-filed marker
-- [ ] Discord author and thread link recorded on the issue
-- [ ] Creation idempotent across double click, retry and restart — asserted by tests
-- [ ] Creation failure surfaced to the user
-- [ ] Quality gate clean
+- [x] GitHub App used, with least-privilege scopes documented
+- [x] Credentials from the environment only; renewal handled
+- [x] Issue filled in the template's shape, in the user's language, quotes untranslated
+- [x] Labelled `bug` plus a machine-filed marker
+- [x] Discord author and thread link recorded on the issue
+- [x] Creation idempotent across double click, retry and restart — asserted by tests
+- [x] Creation failure surfaced to the user
+- [x] Quality gate clean
+
+## The permissions to grant, exactly
+
+Installed on `VEAF/VEAF-Mission-Creation-Tools` **only**, webhook **inactive**, **no** events.
+
+| Scope | Permission | Level |
+|---|---|---|
+| Repository | **Issues** | **Read and write** |
+| Repository | **Metadata** | **Read-only** *(mandatory, selected by GitHub)* |
+| Repository | everything else | **No access** |
+| Organisation | everything | **No access** |
+| Account | everything | **No access** |
+
+`Contents` is deliberately **not** granted: the prior-art sweep reads `.backlog/` and `ROADMAP.md`
+from the local checkout, never through the API, so the App never needs to read the code.
+
+## What the ticket asked for and the platform does not allow
+
+**Re-uploading the attachments to the issue.** GitHub has **no REST endpoint that attaches a file to
+an issue** — the one the web interface uses is a session endpoint no App can call. The two
+API-reachable substitutes (committing the file to the repository, publishing it as a release asset)
+both need `Contents: write` on a **public** repository and would permanently publish a stranger's
+`dcs.log` into it. Neither was built.
+
+What was built instead: a **text** attachment small enough is carried *whole, inside the issue*, as
+a comment — it lives as long as the issue does and is a link to nothing. Everything else is listed
+with its name, its size and its SHA-256, and the issue says plainly that the bytes were not
+published; the bounded excerpt and the mission's shape are in the body either way. **No Discord URL
+is ever written into an issue.**
+
+If David wants the raw files to survive, the options are: a dedicated branch written through
+`Contents: write` (permanent, public, and a much broader permission), or asking the reporter for the
+file through the ticket 06 relay when a maintainer actually needs it.
+
+## The other thing to decide
+
+The bot **does not create labels**. If `filed-by-bot` does not exist in the repository, the issue is
+filed with `bug` alone and the reporter is told the label could not be applied. Letting a machine
+invent taxonomy in a public tracker looked like a maintainer's decision rather than the bot's — the
+label has to be created by hand, once.

--- a/.github/workflows/support-bot-ci.yml
+++ b/.github/workflows/support-bot-ci.yml
@@ -106,21 +106,24 @@ jobs:
       - name: Half a GitHub App fails the same way a missing token does
         run: |
           set +e
+          # A key IS supplied here, so the leak check below has something real to catch: a
+          # configuration error is printed at CRITICAL straight into a log collector, and the one
+          # variable in this set that certainly holds a credential is this one.
           output=$(docker run --rm \
             -e SUPPORT_BOT_DISCORD_TOKEN=x \
             -e SUPPORT_BOT_DISCORD_GUILD_ID=1 \
             -e SUPPORT_BOT_WORKER_SECRET=x \
             -e SUPPORT_BOT_GITHUB_APP_ID=123456 \
+            -e "SUPPORT_BOT_GITHUB_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----MIIEnotarealkey-----END RSA PRIVATE KEY-----" \
             veaf-support-bot:ci 2>&1)
           code=$?
           set -e
           echo "$output"
           test "$code" = "78" || { echo "expected EX_CONFIG (78), got $code"; exit 1; }
           echo "$output" | grep -q "SUPPORT_BOT_GITHUB_INSTALLATION_ID is required"
-          echo "$output" | grep -q "GITHUB_PRIVATE_KEY"
-          # And the value that was set is never echoed back — a configuration error is printed at
-          # CRITICAL straight into a log collector, and any of these variables can hold a pasted key.
-          echo "$output" | grep -qv "BEGIN RSA PRIVATE KEY"
+          if echo "$output" | grep -q "MIIEnotarealkey"; then
+            echo "the startup error echoed the private key it refused"; exit 1
+          fi
 
       # `cryptography` is the App's only new runtime dependency and the image installs it by hand,
       # so a Dockerfile that drifts from `pyproject.toml` is caught here rather than on the first

--- a/.github/workflows/support-bot-ci.yml
+++ b/.github/workflows/support-bot-ci.yml
@@ -100,6 +100,36 @@ jobs:
           # rather than discovered on the first question.
           echo "$output" | grep -q "SUPPORT_BOT_WORKER_SECRET is required"
 
+      # The App does not exist yet, so "no App at all" is the normal state and must stay silent.
+      # "Some of an App", though, is a container that would take bug reports for a week and fail to
+      # file every one of them — the exact failure that has to happen at startup instead.
+      - name: Half a GitHub App fails the same way a missing token does
+        run: |
+          set +e
+          output=$(docker run --rm \
+            -e SUPPORT_BOT_DISCORD_TOKEN=x \
+            -e SUPPORT_BOT_DISCORD_GUILD_ID=1 \
+            -e SUPPORT_BOT_WORKER_SECRET=x \
+            -e SUPPORT_BOT_GITHUB_APP_ID=123456 \
+            veaf-support-bot:ci 2>&1)
+          code=$?
+          set -e
+          echo "$output"
+          test "$code" = "78" || { echo "expected EX_CONFIG (78), got $code"; exit 1; }
+          echo "$output" | grep -q "SUPPORT_BOT_GITHUB_INSTALLATION_ID is required"
+          echo "$output" | grep -q "GITHUB_PRIVATE_KEY"
+          # And the value that was set is never echoed back — a configuration error is printed at
+          # CRITICAL straight into a log collector, and any of these variables can hold a pasted key.
+          echo "$output" | grep -qv "BEGIN RSA PRIVATE KEY"
+
+      # `cryptography` is the App's only new runtime dependency and the image installs it by hand,
+      # so a Dockerfile that drifts from `pyproject.toml` is caught here rather than on the first
+      # issue the bot fails to file.
+      - name: The image can actually sign a GitHub App assertion
+        run: |
+          docker run --rm --entrypoint python veaf-support-bot:ci -c \
+            "from cryptography.hazmat.primitives.asymmetric import rsa; print('cryptography ok')"
+
       - name: It starts and answers from outside the container
         run: |
           docker run -d --name support-bot -p 8081:8081 \
@@ -127,10 +157,14 @@ jobs:
           curl -s http://127.0.0.1:8081/readyz | tee readyz.json
           grep -q '"not_ready_reason": "dry-run"' readyz.json
 
-      - name: The quota counters have somewhere to live
+      # Two things live there now: the quota counters, and the ledger of what `/bug` already
+      # filed. A ledger the service cannot write is one report becoming two issues after a restart.
+      - name: The quota counters and the filing ledger have somewhere to live
         run: |
           docker exec support-bot sh -c 'test -w /app/state' \
             || { echo "/app/state is not writable by the service user"; exit 1; }
+          docker exec support-bot sh -c 'test "$SUPPORT_BOT_GITHUB_LEDGER_FILE" = /app/state/filed-issues.json' \
+            || { echo "the filing ledger does not point into the mounted volume"; exit 1; }
 
       - name: The logs are structured, and the heartbeat beats
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -215,5 +215,12 @@ services/support-bot/.env
 services/support-bot/.env.*
 !services/support-bot/.env.example
 
-# Its per-user quota counters, written by a local run. Runtime state, and it names Discord users.
+# Its per-user quota counters and its ledger of filed issues, written by a local run. Runtime
+# state, and the counters name Discord users.
 services/support-bot/state/
+
+# The GitHub App's private key. GitHub downloads it as a `.pem` and an operator testing locally will
+# put it wherever is convenient; this repository is public, so the pattern is deliberately wide and
+# not limited to the service directory. Prefer `SUPPORT_BOT_GITHUB_PRIVATE_KEY_FILE` pointing
+# somewhere outside the working copy entirely.
+*.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -399,6 +399,57 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   closes the fence that was supposed to contain it, and a failed `git fetch` no longer publishes the
   remote's address under every location.
 
+- **A bug report is now compared against what already exists, before anything is opened.** Four
+  sources, all of it text matching and **not one model call**: the open issues, the recently closed
+  ones, the `.backlog/` lots and `ROADMAP.md`. `CONTRIBUTING.md` says issues are an intake desk and
+  the work lives in lots, so sweeping issues alone would have missed most of the answer — and the
+  two file sources are read from the checkout the intake already keeps fresh, which is why this
+  costs nothing.
+
+  **Three of the four outcomes open nothing.** *Already reported* adds the new observation to the
+  existing issue instead of a second one. *Already fixed* answers with the version that carries the
+  fix, read off the changelog entry citing the issue rather than guessed — the most valuable
+  outcome, since the reporter is unblocked on the spot. *A lot is on it* names the lot. Only
+  *nothing found* opens an issue, and the issue records what was swept, so a reader can see it
+  happened.
+
+  **A match is proposed, never applied.** It comes with its evidence — the reference, the score and
+  the exact words the two texts share — and the reporter can say his is different, after which his
+  report is filed as usual. A wrong "this is a duplicate" silences a real bug and the reporter will
+  not insist; with nobody available to ask, the answer is therefore *rejected*, never *accepted*.
+  A source that could not be read is stated as such: "nine issues, none of them yours" and "the
+  tracker was down" must not look the same.
+
+- **The issue is filed by a GitHub App, in the reporter's language.** The bot has its own identity
+  rather than borrowing a person's: one repository, one permission (*Issues: read and write*, plus
+  the *Metadata: read-only* GitHub attaches to every App), and nothing usable at rest — the private
+  key on the host only signs a nine-minute JWT, which mints an installation token good for an hour
+  and renewed on the call that needs it. Revoking the installation ends all of it in one click.
+
+  The body follows `.github/ISSUE_TEMPLATE/bug_report.yml` — a form **0 of the last 60 issues** had
+  used — and is written in the reporter's language, which departs from the repository's English-only
+  rule and matches what the tracker actually contains. Quoted material is never translated and never
+  reworded. It carries the `bug` label plus a `filed-by-bot` marker, the Discord author, and a link
+  back to the thread.
+
+  **One report can never become two issues.** A lock covers the double click, a ledger on disk
+  covers the retry, and a hidden marker inside the issue itself covers a restart between the request
+  and its answer — the only one of the three that survives losing all local state. A failure to file
+  is said in the thread, with the reason and a link to the form, rather than swallowed into a log
+  while the reporter believes an issue exists.
+
+  **One thing the ticket asked for is not possible**: GitHub has no REST endpoint that attaches a
+  file to an issue. A text attachment that fits is therefore carried *whole, inside* the issue,
+  where it lives as long as the issue does; a `.miz`, an archive or an 11 MB log is listed with its
+  size and its SHA-256 and the issue says plainly that the bytes were not published. A Discord
+  attachment URL is never written into an issue — those expire, and evidence behind a dead link is
+  no evidence.
+
+  With no App configured — which is every deployment until one is created — `/bug` still collects,
+  reads and shows a complete report, and says nothing was opened. With *half* an App configured, the
+  service refuses to start: taking bug reports for a week and quietly failing to file every one of
+  them is a failure that belongs at startup.
+
 ## [6.19.0] — 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -450,6 +450,26 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   service refuses to start: taking bug reports for a week and quietly failing to file every one of
   them is a failure that belongs at startup.
 
+- **Support bot — an attachment carried into an issue is redacted, not merely quoted.** A `.log` or
+  a `.txt` small enough to travel whole was posted as an issue comment straight from the downloaded
+  file, so a Windows account name and an e-mail address reached a public repository verbatim while
+  the redacted view of the same file sat unused beside it. The bytes now go through the tools' own
+  redaction helper, and a file nobody could redact is described in the manifest instead of being
+  published.
+
+- **Support bot — a lost bookkeeping file no longer opens a second issue.** The hidden marker that
+  makes a report idempotent was only looked for when the local ledger remembered an interrupted
+  attempt, which is the one state a corrupt, missing or unwritable ledger never produces. The
+  search now runs for every report with no known issue number. An unreadable ledger is also moved
+  aside rather than overwritten, so one bad read no longer erases every other entry.
+
+- **Support bot — a GitHub App key that reads but cannot sign stops the service at startup.** A
+  truncated or non-RSA PEM used to pass every check and fail on the first bug report, a week later.
+
+- **Support bot — a backlog lot that could not be read is stated.** It used to become an empty
+  candidate that matched nothing, so a lot nobody had read was indistinguishable from a lot swept
+  and found irrelevant.
+
 ## [6.19.0] — 2026-09-02
 
 ### Fixed

--- a/services/support-bot/.env.example
+++ b/services/support-bot/.env.example
@@ -92,6 +92,52 @@ SUPPORT_BOT_WORKER_SECRET=put-the-shared-worker-secret-here
 #SUPPORT_BOT_ATTACHMENT_MAX_BYTES=26214400
 #SUPPORT_BOT_ATTACHMENT_TOTAL_BYTES=62914560
 
+# --- the GitHub App the issue is filed under ---------------------------------------------------
+# Leave ALL of these unset and `/bug` still works: it collects, reads the log, sweeps the prior art
+# and shows the reporter a complete report — it simply says that nothing was opened. Set ANY ONE of
+# the first three and the service REFUSES TO START until the other two are set too, because a half
+# configured App is a bot that quietly fails to file every report it takes.
+#
+# Creating the App (once, by hand — see the setup guide):
+#   https://github.com/settings/apps/new  →  install it on THIS repository only.
+#   Repository permissions:  Issues = Read and write.  Metadata = Read-only (GitHub adds it).
+#   Nothing else. No organisation permission, no account permission, no webhook, no event.
+#
+# The App's numeric id, on its settings page under "App ID".
+#SUPPORT_BOT_GITHUB_APP_ID=000000
+
+# The installation id. Install the App, then read the number at the end of the URL of
+#   https://github.com/organizations/VEAF/settings/installations/<this number>
+#SUPPORT_BOT_GITHUB_INSTALLATION_ID=00000000
+
+# The App's private key, in PEM. SECRET — but note what it is and is not: on its own it can do
+# NOTHING. It only signs a ten-minute JWT, which mints a one-hour installation token. Revoking the
+# installation ends all of it at once.
+#
+# Give it EXACTLY ONE of the two forms below. Setting both is refused rather than resolved by a
+# precedence rule: an operator who set the two does not know which one is live, and that is how a
+# rotated key stays unrotated.
+#
+#   1. A file, which is the right form on a host with a secrets mount:
+#SUPPORT_BOT_GITHUB_PRIVATE_KEY_FILE=/run/secrets/veaf-support-bot.pem
+#
+#   2. Inline, which is the only form a plain `--env-file` container can carry. Put the whole PEM
+#      on one line with literal \n between the lines; the service expands them.
+#SUPPORT_BOT_GITHUB_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n
+
+# Where the issues go. Change it only to file against a fork while testing.
+#SUPPORT_BOT_GITHUB_REPOSITORY=VEAF/VEAF-Mission-Creation-Tools
+
+# What the service already filed, so a double click, a retry or a restart never opens a second
+# issue for the same report. Same requirement as the quota counters: WRITABLE, and it must SURVIVE
+# a restart. In a container, the same /app/state volume.
+#SUPPORT_BOT_GITHUB_LEDGER_FILE=state/filed-issues.json
+
+# The label marking an issue as filed by the machine, alongside `bug`. It must ALREADY EXIST in the
+# repository: the bot does not create labels — inventing taxonomy in a public tracker is a
+# maintainer's decision. If it does not exist, the issue is filed without it and says so.
+#SUPPORT_BOT_GITHUB_MACHINE_LABEL=filed-by-bot
+
 # Start everything except the connection to the outside world. Used by the container smoke test.
 # Leaving this on in production is loudly reported in every heartbeat line.
 #SUPPORT_BOT_DRY_RUN=false

--- a/services/support-bot/Dockerfile
+++ b/services/support-bot/Dockerfile
@@ -13,7 +13,8 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     SUPPORT_BOT_HEALTH_HOST=0.0.0.0 \
     SUPPORT_BOT_HEALTH_PORT=8081 \
-    SUPPORT_BOT_QUOTA_STATE_FILE=/app/state/quota.json \n    SUPPORT_BOT_GITHUB_LEDGER_FILE=/app/state/filed-issues.json
+    SUPPORT_BOT_QUOTA_STATE_FILE=/app/state/quota.json \
+    SUPPORT_BOT_GITHUB_LEDGER_FILE=/app/state/filed-issues.json
 
 WORKDIR /app
 

--- a/services/support-bot/Dockerfile
+++ b/services/support-bot/Dockerfile
@@ -13,7 +13,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     SUPPORT_BOT_HEALTH_HOST=0.0.0.0 \
     SUPPORT_BOT_HEALTH_PORT=8081 \
-    SUPPORT_BOT_QUOTA_STATE_FILE=/app/state/quota.json
+    SUPPORT_BOT_QUOTA_STATE_FILE=/app/state/quota.json \n    SUPPORT_BOT_GITHUB_LEDGER_FILE=/app/state/filed-issues.json
 
 WORKDIR /app
 
@@ -23,16 +23,23 @@ WORKDIR /app
 # `typer` is not used by this service at all: it is what the tools' own `.miz` parser imports, and
 # `/bug` summarises a mission through that parser rather than forking a second one. See the comment
 # in `pyproject.toml`.
-RUN pip install --no-cache-dir "discord.py>=2.4,<3" "typer>=0.12,<1"
+#
+# `cryptography` signs the GitHub App's JWT. It is the only way to do RS256 — no stdlib module signs
+# one — and hand-rolling PKCS1v15 in a service that writes to a public repository is not a trade
+# worth making.
+RUN pip install --no-cache-dir "discord.py>=2.4,<3" "typer>=0.12,<1" "cryptography>=42"
 
 COPY veaf_support_bot ./veaf_support_bot
 
-# Unprivileged, with exactly one writable directory: the per-user quota counters.
+# Unprivileged, with exactly one writable directory: the per-user quota counters, and the ledger of
+# what `/bug` has already filed.
 #
-# They must survive a restart — otherwise restarting the container is how anyone gets a fresh
-# allowance — so mount a volume here in production. Without one they survive a restart of the
-# process but not a `docker rm`. The service does not hide the difference: as soon as it cannot read
-# or write them it drops to a much stricter ceiling and says so, in the log and in `/status`.
+# Both must survive a restart — otherwise restarting the container is how anyone gets a fresh
+# allowance, and how one report becomes two issues — so mount a volume here in production. Without
+# one they survive a restart of the process but not a `docker rm`. The service does not hide the
+# difference: as soon as it cannot read or write the counters it drops to a much stricter ceiling
+# and says so, in the log and in `/status`; a ledger it cannot read falls back to the marker each
+# filed issue carries in its own body.
 RUN useradd --system --uid 10001 --user-group --no-create-home veaf \
     && mkdir -p /app/state \
     && chown -R veaf:veaf /app

--- a/services/support-bot/README.md
+++ b/services/support-bot/README.md
@@ -47,6 +47,15 @@ search:
 | an attached `dcs.log` | a bounded excerpt through `veaf_logs`, with what `rules.json` recognises, in the catalogue's own wording |
 | an attached `.miz` | the mission's *shape* — theatre, date, weather, group counts, zone count — never its briefing or its group names |
 
+Before anything is opened, the report is compared against **four places** — the open issues, the
+recently closed ones, `.backlog/` and `ROADMAP.md` — by text matching, with no model involved. Three
+of the four outcomes open nothing at all: *already reported* comments on the existing issue,
+*already fixed* answers with the version that carries the fix, and *a lot is on it* names the lot. A
+match is always **proposed with its evidence** — the reference, the score and the words the two
+texts share — and the reporter can say his is different, after which the report is filed as usual. A
+wrong "this is a duplicate" silences a real bug and the reporter will not insist, so the sweep
+informs the decision and never takes it. With nobody to ask, the answer is *rejected*.
+
 **Everything published is redacted first**, through the same `veaf_libs.redaction` the `doctor`
 command uses — the quoted body of a text file, the member names of an attached archive, the file
 name the reporter's own machine gave it, and every field of the form. What that helper recognises is
@@ -175,7 +184,20 @@ CRITICAL veaf-support-bot.cli the support bot cannot start: 3 configuration prob
 | `SUPPORT_BOT_CHECKOUT_REFRESH_SECONDS` | no | `900` | Shortest gap between two refreshes; `0` pins the revision. |
 | `SUPPORT_BOT_ATTACHMENT_MAX_BYTES` | no | `26214400` (25 MB) | Largest single file one bug report may carry. |
 | `SUPPORT_BOT_ATTACHMENT_TOTAL_BYTES` | no | `62914560` (60 MB) | Largest total across one bug report. |
+| `SUPPORT_BOT_GITHUB_APP_ID` | no* | *(unset)* | The GitHub App's id. Unset means `/bug` prepares reports and files nothing. |
+| `SUPPORT_BOT_GITHUB_INSTALLATION_ID` | no* | *(unset)* | The App's installation on the one repository it serves. |
+| `SUPPORT_BOT_GITHUB_PRIVATE_KEY` | no* | *(unset)* | **Secret.** The App's key, PEM, inline with `\n` escapes. |
+| `SUPPORT_BOT_GITHUB_PRIVATE_KEY_FILE` | no* | *(unset)* | **Secret.** The same key as a file. Exactly one of the two. |
+| `SUPPORT_BOT_GITHUB_REPOSITORY` | no | `VEAF/VEAF-Mission-Creation-Tools` | Where issues are filed. |
+| `SUPPORT_BOT_GITHUB_LEDGER_FILE` | no | `state/filed-issues.json` | What was already filed, so a retry never opens a second issue. Must survive a restart. |
+| `SUPPORT_BOT_GITHUB_MACHINE_LABEL` | no | `filed-by-bot` | Label marking an issue as machine-filed. Must already exist in the repository. |
 | `SUPPORT_BOT_DRY_RUN` | no | `false` | Start everything except the connection to Discord. |
+
+\* **The four starred rows stand or fall together.** None of them is required, and with none of
+them set `/bug` still collects, reads and shows a complete report — it simply says nothing was
+opened. Set *any one* of the first three and the service **refuses to start** until the others are
+set too: a half-configured App is a bot that takes bug reports for a week and quietly fails to file
+every one of them, and that failure belongs at startup (exit `78`) rather than in the first report.
 
 [`.env.example`](.env.example) carries the same list with the reasoning; `tests/test_packaging.py`
 fails when the two drift apart, in either direction.
@@ -197,6 +219,89 @@ Once, at <https://discord.com/developers/applications>:
    `SUPPORT_BOT_DISCORD_GUILD_ID`. Commands are published to that guild only, so they appear
    immediately instead of taking up to an hour to propagate, and the bot stays un-invitable
    elsewhere.
+
+### Registering the GitHub App
+
+The bot files issues under **its own identity**, not under anybody's account. A personal access
+token would be a long-lived credential on the host carrying every right its owner has, whose leak
+nobody would notice; reusing an existing one would make the bot's writes indistinguishable from a
+maintainer's and impossible to revoke separately.
+
+Once, at <https://github.com/settings/apps/new> (or the organisation's *Settings → Developer
+settings → GitHub Apps*):
+
+1. **Name** it something a reader will recognise on an issue — it is the author line every filed
+   issue carries. **Homepage URL**: this repository.
+2. **Uncheck "Active" under Webhook.** The bot never receives events; it only calls out.
+3. **Repository permissions — grant exactly these, and nothing else:**
+
+   | Permission | Level | What it is for |
+   |---|---|---|
+   | **Issues** | **Read and write** | create the issue, comment on an existing one, apply `bug` and `filed-by-bot`, and list issues for the prior-art sweep |
+   | **Metadata** | **Read-only** | mandatory; GitHub selects it automatically and it cannot be removed |
+
+   Leave **every other repository permission at *No access*** — Contents included: the sweep reads
+   `.backlog/` and `ROADMAP.md` from the **local checkout**, never through the API, so the App never
+   needs to read the code. Leave **every organisation permission** and **every account permission**
+   at *No access*, and subscribe to **no events**.
+4. **Where can this GitHub App be installed?** → *Only on this account*.
+5. **Create GitHub App**, then **Generate a private key**. The `.pem` GitHub downloads is
+   `SUPPORT_BOT_GITHUB_PRIVATE_KEY_FILE` (or, pasted with `\n` escapes,
+   `SUPPORT_BOT_GITHUB_PRIVATE_KEY` — set one, never both). The **App ID** on that same page is
+   `SUPPORT_BOT_GITHUB_APP_ID`.
+6. **Install App** → pick **Only select repositories** → `VEAF/VEAF-Mission-Creation-Tools`. The
+   number at the end of the resulting settings URL
+   (`.../settings/installations/<number>`) is `SUPPORT_BOT_GITHUB_INSTALLATION_ID`.
+7. Create the `filed-by-bot` label in the repository. **The bot does not create labels** — inventing
+   taxonomy in a public tracker is a maintainer's decision — so without it the issue is filed with
+   `bug` alone and says in the thread that the label could not be applied.
+
+What sits on the host afterwards is a private key that **can do nothing on its own**: it signs a
+nine-minute JWT, which mints an installation token that expires in an hour and is renewed on the
+call that needs it. Revoking the installation ends all of it in one click.
+
+#### What the issue looks like
+
+- **In the reporter's language.** This departs from the repository's English-only rule for technical
+  content and matches what the tracker actually contains — the regulars report in French. What the
+  reporter typed, what his log said, what his mission is called are **never translated and never
+  reworded**: they are quoted verbatim inside a fence they cannot escape.
+- **In the shape of `.github/ISSUE_TEMPLATE/bug_report.yml`** — version, component, what happened,
+  what was expected, steps, context. The form has been used by **0 of the last 60 issues**; the
+  machine fills it every time. `tests/test_issue_body.py` reads the YAML and fails if a label moves.
+- **Labelled `bug` and `filed-by-bot`**, so machine-filed issues are findable and countable.
+- **Attributed** to the Discord author, with a link back to the thread.
+- **No hypothesis.** The body says so in as many words: everything in it is read, parsed or quoted.
+
+#### Filed once, whatever happens twice
+
+| What happens twice | What stops a second issue |
+|---|---|
+| Two clicks arriving together | a lock per report key — the second waits and reads the first one's result |
+| A retry after a timeout | the ledger, which already holds the issue number |
+| A restart between the `POST` and the answer | a hidden marker inside the issue body; the recovery search finds it |
+
+The key is derived from the report itself — the reporter, his five fields, the names and sizes of
+his attachments — so the same report always produces the same key and a restart can recompute it
+from nothing else.
+
+#### The one thing the API cannot do: attach a file
+
+**GitHub has no REST endpoint that attaches a file to an issue.** The one the web interface uses is
+a session endpoint, not part of the API, and no App can call it. The alternatives that *are* API
+reachable — committing the file to the repository, or publishing it as a release asset — both need
+`Contents: write` on a **public** repository and would publish a stranger's log there permanently.
+
+So the service does the honest thing instead:
+
+- a **text** attachment small enough is carried **whole, inside the issue**, as a comment. It lives
+  as long as the issue does and is not a link to anything;
+- everything else — a `.miz`, a `.zip`, an 11 MB `dcs.log` — is listed in a manifest with its name,
+  its size and its SHA-256, and the issue **says plainly that the bytes were not published**. The
+  bounded excerpt and the mission's shape are in the body either way.
+
+A Discord attachment URL is **never** written into an issue: those expire within days, and an issue
+whose evidence is a dead link is an issue with no evidence.
 
 ### The other half: the Worker Secret
 
@@ -418,7 +523,8 @@ The bot links the pages it cites from an index generated out of `doc/` and check
 page, or changing its first heading, makes that index stale:
 
 ```powershell
-poetry run python scriptsefresh_doc_pages.py
+poetry run python scripts
+efresh_doc_pages.py
 ```
 
 `tests/test_doc_pages.py` rebuilds the index from the real tree and fails when the checked-in copy

--- a/services/support-bot/README.md
+++ b/services/support-bot/README.md
@@ -58,7 +58,9 @@ informs the decision and never takes it. With nobody to ask, the answer is *reje
 
 **Everything published is redacted first**, through the same `veaf_libs.redaction` the `doctor`
 command uses — the quoted body of a text file, the member names of an attached archive, the file
-name the reporter's own machine gave it, and every field of the form. What that helper recognises is
+name the reporter's own machine gave it, the bytes of an attachment carried whole into the issue,
+and every field of the form. Each of those **fails closed**: what the helper cannot reach is
+described rather than published. What that helper recognises is
 personal data by *context* and by *known shape*: a home directory, an address, an IP, a credential.
 It deliberately has no rule for a bare account name, so a reporter who types his own name into
 *"what happened"*, or uploads `mission by Someone.miz`, publishes it — in a report he is filing
@@ -279,7 +281,7 @@ call that needs it. Revoking the installation ends all of it in one click.
 |---|---|
 | Two clicks arriving together | a lock per report key — the second waits and reads the first one's result |
 | A retry after a timeout | the ledger, which already holds the issue number |
-| A restart between the `POST` and the answer | a hidden marker inside the issue body; the recovery search finds it |
+| A restart between the `POST` and the answer, or a ledger that is corrupt, missing or unwritable | a hidden marker inside the issue body; the recovery search runs for every report with no known number, so it needs nothing local to be intact |
 
 The key is derived from the report itself — the reporter, his five fields, the names and sizes of
 his attachments — so the same report always produces the same key and a restart can recompute it

--- a/services/support-bot/poetry.lock
+++ b/services/support-bot/poetry.lock
@@ -310,6 +310,120 @@ files = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.1"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cffi-2.1.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:baed1e86cc735622097354b9d1281406caf42ff42a886d29faa8e8d1630333be"},
+    {file = "cffi-2.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca82be1a1d406ecfe1d25dc16cb33488e5a16bf4438c9fb590484ea29d92478b"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:42e2f76b9455f5a9a844f770bf3e200ed3da0e15f5df3db9c31fe80b04b3d004"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a59cc1c4442bc3d5c703bf720b51138d0bfc173618807c9ee2490a7541dd3d9"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:9f8d177621de5cb38ee3e731eda45d421db093ec0739f46a5594babda7987a98"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:75f80557d1389eddbd0de2681f6a390a0c5338c31ddaa821381c203fc3fd50d9"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:194cffa889098ced9976c3fc6340305e43f6303657d298da55366907c05c22d6"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5bb4e7ea95dcd6a014a6fef62e62467d67d8e582326443f3d68e71d6320a9fcf"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3d22a20b1fb1632cc72c22f95f7b0d2961c3e1c235f245ba4c606c4771035659"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1dea0e4d7d4f11f619fe8c1d76caf49e24405b4b5743c0e3be16a500ecd930c9"},
+    {file = "cffi-2.1.1-cp310-cp310-win32.whl", hash = "sha256:7ce713ace7c0e4520535b42b77eaa742c16dab813978064913e5a3cf82973b41"},
+    {file = "cffi-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a48d62ab9d6f4f98c983223a547af44be6ca3691074c31cecced6facd3ba2dc1"},
+    {file = "cffi-2.1.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c8d2c9fd1f2d16f780d15127abb050d13d1a76c03a4bd87d7e4980e45e511e12"},
+    {file = "cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa"},
+    {file = "cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3"},
+    {file = "cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0"},
+    {file = "cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455"},
+    {file = "cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0"},
+    {file = "cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf"},
+    {file = "cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517"},
+    {file = "cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735"},
+    {file = "cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e"},
+    {file = "cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a"},
+    {file = "cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80"},
+    {file = "cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e"},
+    {file = "cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c"},
+    {file = "cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6"},
+    {file = "cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2"},
+    {file = "cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b"},
+    {file = "cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7"},
+    {file = "cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac"},
+    {file = "cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d"},
+    {file = "cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973"},
+    {file = "cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c"},
+    {file = "cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb"},
+    {file = "cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54"},
+    {file = "cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96"},
+    {file = "cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527"},
+    {file = "cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13"},
+    {file = "cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c"},
+    {file = "cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48"},
+    {file = "cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836"},
+    {file = "cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3"},
+    {file = "cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676"},
+    {file = "cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e"},
+    {file = "cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f"},
+    {file = "cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4"},
+    {file = "cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e"},
+    {file = "cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5"},
+    {file = "cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d"},
+    {file = "cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b"},
+    {file = "cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4"},
+    {file = "cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399"},
+    {file = "cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688"},
+    {file = "cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7"},
+    {file = "cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac"},
+    {file = "cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960"},
+    {file = "cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1"},
+    {file = "cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc"},
+    {file = "cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6"},
+    {file = "cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94"},
+    {file = "cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5"},
+    {file = "cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66"},
+    {file = "cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3"},
+    {file = "cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692"},
+    {file = "cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
+
+[[package]]
 name = "click"
 version = "8.5.0"
 description = "Composable command line interface toolkit"
@@ -467,6 +581,68 @@ files = [
 
 [package.extras]
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
+
+[[package]]
+name = "cryptography"
+version = "50.0.1"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.9"
+groups = ["main"]
+files = [
+    {file = "cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a"},
+    {file = "cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959"},
+    {file = "cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b"},
+    {file = "cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648"},
+    {file = "cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3"},
+    {file = "cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6"},
+    {file = "cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149"},
+    {file = "cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf"},
+    {file = "cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239"},
+    {file = "cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558"},
+    {file = "cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e"},
+    {file = "cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9cb3cb952cf5a8abd50c782a98a89d71699715e802fe349704b47f2425b42a94"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5fe939deeb161024a6be98229c953b6591fef1f41214497a78fe793a244c017f"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fb4b9672d389c738b175c4166e78310f8a70358886aacd9173ee03a85ffdc671"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d63ae8f6481fec907ac0f588eee8a90aefde112c633131fe540e5711ddbb5a4e"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:804728ce710890870f3aaa344b2e161172d258d768ac139d02cfd9092d0d94e6"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:693c99b49bd37d0d096e4334c10232c77248c415b98d35236094cdf96d57258b"},
+    {file = "cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20"},
+]
+
+[package.dependencies]
+cffi = {version = ">=2.0.0", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+ssh = ["bcrypt (>=3.1.5)"]
 
 [[package]]
 name = "discord-py"
@@ -1266,6 +1442,19 @@ files = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
+]
+
+[[package]]
 name = "pygments"
 version = "2.21.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -1533,4 +1722,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "7a48ebb93b40d9311f027a10f229b05b15ab38f682ccbb3bab545e3eea75e1c0"
+content-hash = "01d78cc27fa61dec6415fe504602b7f584802af6f8348d82621b6a8ba333a555"

--- a/services/support-bot/pyproject.toml
+++ b/services/support-bot/pyproject.toml
@@ -28,6 +28,13 @@ discord-py = "^2.4"
 # a fork would drift from the parser every other tool in the repository uses, and it would be the
 # forked one deciding what a bug report publishes about somebody's mission.
 typer = "^0.12"
+# The one thing RS256 cannot be done without. A GitHub App proves itself with a JWT signed by an
+# RSA private key, and no stdlib module signs one. Hand-rolling PKCS1v15 over `pow()` would be a
+# hundred lines of unreviewed cryptography in a service that files to a public repository; this is
+# the package every GitHub App client in Python uses, and it is the only new dependency ticket 05
+# adds. The JWT itself is three base64url fields and is built in `github_app.py`, so PyJWT is not
+# needed on top of it.
+cryptography = ">=42"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.4"

--- a/services/support-bot/tests/intake_fixtures.py
+++ b/services/support-bot/tests/intake_fixtures.py
@@ -121,7 +121,71 @@ def fixture_root() -> Path:
 
     (root / "doc").mkdir()
     (root / "doc" / "GUIDE.md").write_text("# Guide\n", encoding="utf-8")
+    _write_prior_art(root)
     return root
+
+
+#: An open lot, the shape ``.backlog/<LOT>/PRD.md`` really has.
+OPEN_LOT = """# FEAT-SAMPLE-RESOLVER — the resolver drops an alias
+
+Status: 🔄 in-progress
+
+The `veafSample.resolve` alias table loses an entry when the mission carries two aliases of the
+same name, and the spawner then places the group at the wrong airfield.
+"""
+
+#: A closed lot. It must never be proposed: telling a reporter his bug is being worked on when the
+#: lot shipped months ago is the same silencing failure as a wrong duplicate.
+CLOSED_LOT = """# FEAT-ALREADY-DONE — the converter kept a stale warehouse
+
+Status: ✅ done
+
+The `v5_converter` copied a warehouse table nobody had refreshed.
+"""
+
+#: A roadmap with one section that names a parked subject.
+ROADMAP = """# Roadmap
+
+## 1. Where we are
+
+Everything shipped.
+
+## 2. Parked deliberately
+
+The `mission_builder` catalogue rewrite is parked: the airdromes table would have to be regenerated
+per theatre and nobody has asked for it.
+"""
+
+#: A changelog that cites an issue under a released heading, and another under `[Unreleased]`.
+CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+- something not released yet, see #909
+
+## [6.19.0] — 2026-09-02
+
+- **the resolver no longer drops an alias** ([#712](https://example.invalid/issues/712)).
+
+## [6.18.0] — 2026-09-01
+
+- an older fix, #404.
+"""
+
+
+def _write_prior_art(root: Path) -> None:
+    """Add the three prior-art sources the sweep reads out of a checkout.
+
+    Args:
+        root: The fixture repository root.
+    """
+    backlog = root / ".backlog"
+    (backlog / "FEAT-SAMPLE-RESOLVER").mkdir(parents=True)
+    (backlog / "FEAT-SAMPLE-RESOLVER" / "PRD.md").write_text(OPEN_LOT, encoding="utf-8")
+    (backlog / "FEAT-ALREADY-DONE").mkdir(parents=True)
+    (backlog / "FEAT-ALREADY-DONE" / "PRD.md").write_text(CLOSED_LOT, encoding="utf-8")
+    (root / "ROADMAP.md").write_text(ROADMAP, encoding="utf-8")
+    (root / "CHANGELOG.md").write_text(CHANGELOG, encoding="utf-8")
 
 
 def fixture_checkout(refresh_seconds: float = 0.0) -> Checkout:

--- a/services/support-bot/tests/intake_fixtures.py
+++ b/services/support-bot/tests/intake_fixtures.py
@@ -322,6 +322,22 @@ UNREADABLE_MISSION_LUA = (
 )
 
 
+#: The **content** of an attached log, with the account name and the address in the bytes rather
+#: than in a name.
+#:
+#: The fourth path, and the one the fixture did not have: every case above puts personal data in a
+#: *name*, in an archive's member list or in a parser's error message. What an issue carries whole —
+#: the bytes of a ``.log`` or a ``.txt``, posted as a comment — travelled none of them, and that is
+#: exactly where the leak was found. Shaped like a real ``dcs.log``: a header line nothing personal,
+#: then a path under ``Users/`` and an address, which is what the shared helper recognises.
+PERSONAL_LOG = (
+    "2026-09-05 10:00:00.000 INFO    APP (Main): DCS/2.9.29.27278 (x86_64; MT; Windows NT 10.0.26200)\n"
+    "2026-09-05 10:00:01.000 ERROR   SCRIPTING (Main): could not open "
+    rf"C:\Users\{PERSONAL_ACCOUNT}\Saved Games\DCS\Missions\secret-op.miz" + "\n"
+    f"2026-09-05 10:00:02.000 ERROR   SCRIPTING (Main): reported by {PERSONAL_EMAIL}\n"
+)
+
+
 def personal_archive() -> bytes:
     """Build a ``~mis*.zip`` whose member names carry an account name and an e-mail address.
 

--- a/services/support-bot/tests/test_filing.py
+++ b/services/support-bot/tests/test_filing.py
@@ -1,0 +1,316 @@
+"""One report, one issue — across a double click, a retry and a restart.
+
+The three are genuinely different failures and they are asserted separately. The restart case is the
+one that matters most: it is the only one where every local trace of the attempt is gone, and the
+only thing left is the marker inside the issue GitHub already holds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from tests.intake_fixtures import fixture_checkout
+from tests.test_github_app import credentials
+from veaf_support_bot.attachments import Prepared
+from veaf_support_bot.bugreport import BugForm, BugReport, assemble
+from veaf_support_bot.filing import (
+    MACHINE_LABEL,
+    IssueFiler,
+    Ledger,
+    RepositoryIssues,
+    report_key,
+)
+from veaf_support_bot.github_app import GitHubApp, Response
+from veaf_support_bot.issue_body import marker_for
+
+
+class _GitHub:
+    """A GitHub that creates issues, remembers them, and can be told to fail.
+
+    Deliberately stateful: idempotency is a property of *two* calls, and a transport that answers a
+    fixed script cannot show that the second call did not create anything.
+    """
+
+    def __init__(self) -> None:
+        self.issues: list[dict[str, Any]] = []
+        self.comments: list[tuple[int, str]] = []
+        self.creations = 0
+        self.fail_create: Exception | None = None
+        self.refuse_labels = False
+        self.fail_comment = False
+
+    async def __call__(
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        body: bytes | None,
+    ) -> Response:
+        payload = json.loads(body) if body else {}
+        if url.endswith("/access_tokens"):
+            return Response(201, {"token": "ghs-t", "expires_at": "2999-01-01T00:00:00Z"})
+        if method == "POST" and url.endswith("/comments"):
+            if self.fail_comment:
+                return Response(403, {"message": "no"})
+            number = int(url.rsplit("/issues/", 1)[1].split("/")[0])
+            self.comments.append((number, str(payload.get("body") or "")))
+            return Response(201, {"html_url": f"https://example.invalid/issues/{number}#c"})
+        if method == "POST" and url.endswith("/issues"):
+            if self.fail_create is not None:
+                raise self.fail_create
+            if self.refuse_labels and payload.get("labels"):
+                return Response(422, {"message": "Validation Failed", "errors": [{"message": "label not found"}]})
+            self.creations += 1
+            item = {
+                "number": 900 + self.creations,
+                "title": payload.get("title"),
+                "body": payload.get("body"),
+                "html_url": f"https://example.invalid/issues/{900 + self.creations}",
+                "labels": [{"name": name} for name in payload.get("labels") or []],
+                "state": "open",
+            }
+            self.issues.append(item)
+            return Response(201, item)
+        if method == "GET":
+            return Response(200, list(reversed(self.issues)))
+        return Response(200, {})
+
+
+def _report(**overrides: str) -> BugReport:
+    """Assemble a report.
+
+    Args:
+        **overrides: Form fields to replace.
+
+    Returns:
+        The report.
+    """
+    fields = {
+        "summary": "La mission plante",
+        "happened": "KeyError: 'coalition'",
+        "expected": "Elle devrait s'ouvrir",
+        "steps": "1. ouvrir",
+        "reporter": "Tripack",
+        "reporter_id": "4242",
+        "language": "fr",
+    }
+    fields.update(overrides)
+    return assemble(BugForm(**fields), fixture_checkout())
+
+
+class _Filing(unittest.IsolatedAsyncioTestCase):
+    """Shared setup: a fake GitHub, a real ledger on disk."""
+
+    def setUp(self) -> None:
+        self.folder = tempfile.TemporaryDirectory()
+        self.addCleanup(self.folder.cleanup)
+        self.ledger_path = Path(self.folder.name) / "state" / "filed.json"
+        self.github = _GitHub()
+
+    def _filer(self) -> IssueFiler:
+        """Build a filer over the shared fake.
+
+        Returns:
+            The filer.
+        """
+        app = GitHubApp(credentials(), "VEAF/VEAF-Mission-Creation-Tools", self.github)
+        return IssueFiler(app, Ledger(self.ledger_path))
+
+
+class TestTheKey(unittest.TestCase):
+    """Stable for the same report, different for a different one."""
+
+    def test_the_same_report_yields_the_same_key(self) -> None:
+        self.assertEqual(report_key(_report()), report_key(_report()))
+
+    def test_a_different_report_by_the_same_person_yields_a_different_key(self) -> None:
+        self.assertNotEqual(report_key(_report()), report_key(_report(happened="something else entirely")))
+
+    def test_a_different_reporter_yields_a_different_key(self) -> None:
+        self.assertNotEqual(report_key(_report()), report_key(_report(reporter_id="9999")))
+
+    def test_the_attachments_are_part_of_the_identity(self) -> None:
+        base = _report()
+        from dataclasses import replace
+
+        with_file = replace(
+            base,
+            attachments=(Prepared(filename="a.log", kind="log", path=Path("a.log"), size=12),),
+        )
+        self.assertNotEqual(report_key(base), report_key(with_file))
+
+
+class TestFilingOnce(_Filing):
+    """The three ways of asking twice."""
+
+    async def test_a_report_becomes_one_issue_with_both_labels(self) -> None:
+        outcome = await self._filer().file(_report())
+        self.assertEqual(outcome.action, "created")
+        self.assertEqual(self.github.creations, 1)
+        names = [label["name"] for label in self.github.issues[0]["labels"]]
+        self.assertIn("bug", names)
+        self.assertIn(MACHINE_LABEL, names)
+
+    async def test_a_double_click_files_once(self) -> None:
+        filer = self._filer()
+        report = _report()
+        first, second = await asyncio.gather(filer.file(report), filer.file(report))
+        self.assertEqual(self.github.creations, 1)
+        self.assertEqual({first.number, second.number}, {901})
+        self.assertEqual({first.action, second.action}, {"created", "reused"})
+
+    async def test_a_retry_after_a_timeout_reuses_the_ledger(self) -> None:
+        filer = self._filer()
+        report = _report()
+        await filer.file(report)
+        again = await filer.file(report)
+        self.assertEqual(self.github.creations, 1)
+        self.assertEqual(again.action, "reused")
+
+    async def test_a_fresh_process_still_reuses_the_ledger(self) -> None:
+        report = _report()
+        await self._filer().file(report)
+        again = await self._filer().file(report)
+        self.assertEqual(self.github.creations, 1)
+        self.assertEqual(again.action, "reused")
+
+    async def test_a_restart_between_the_post_and_the_ledger_finds_the_issue_by_its_marker(self) -> None:
+        report = _report()
+        key = report_key(report)
+        # Exactly the state a crash leaves: GitHub holds the issue, the ledger holds an attempt.
+        self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        await self._filer().file(report)
+        Ledger(self.ledger_path).record(key, {"state": "filing", "started": 0.0})
+
+        outcome = await self._filer().file(report)
+        self.assertEqual(self.github.creations, 1, "the marker is what stops the second issue")
+        self.assertEqual(outcome.action, "reused")
+        self.assertEqual(outcome.number, 901)
+        self.assertIn(marker_for(key), self.github.issues[0]["body"])
+
+    async def test_an_interrupted_attempt_whose_issue_does_not_exist_files_it(self) -> None:
+        report = _report()
+        Ledger(self.ledger_path).record(report_key(report), {"state": "filing", "started": 0.0})
+        outcome = await self._filer().file(report)
+        self.assertEqual(outcome.action, "created")
+        self.assertEqual(self.github.creations, 1)
+
+    async def test_an_unwritable_ledger_does_not_stop_a_report_being_filed(self) -> None:
+        app = GitHubApp(credentials(), "o/n", self.github)
+        blocked = Path(self.folder.name) / "state.json" / "nested" / "ledger.json"
+        Path(self.folder.name, "state.json").write_text("not a directory", encoding="utf-8")
+        outcome = await IssueFiler(app, Ledger(blocked)).file(_report())
+        self.assertEqual(outcome.action, "created")
+
+    async def test_a_corrupt_ledger_is_ignored_rather_than_losing_the_report(self) -> None:
+        self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        self.ledger_path.write_text("{not json", encoding="utf-8")
+        self.assertEqual((await self._filer().file(_report())).action, "created")
+
+
+class TestWhenItCannotFile(_Filing):
+    """A failure is an answer the reporter gets, never a silence."""
+
+    async def test_a_creation_failure_is_returned_rather_than_raised(self) -> None:
+        self.github.fail_create = OSError("no route to host")
+        outcome = await self._filer().file(_report())
+        self.assertEqual(outcome.action, "failed")
+        self.assertFalse(outcome.filed)
+        self.assertIn("could not be reached", outcome.error)
+
+    async def test_a_refused_label_files_the_issue_anyway_and_says_so(self) -> None:
+        self.github.refuse_labels = True
+        outcome = await self._filer().file(_report())
+        self.assertEqual(outcome.action, "created")
+        self.assertTrue(any("could not be applied" in note for note in outcome.notes))
+
+    async def test_a_failed_attachment_comment_does_not_undo_a_filed_issue(self) -> None:
+        self.github.fail_comment = True
+        folder = Path(self.folder.name)
+        (folder / "veaf-tools.log").write_text("a line", encoding="utf-8")
+        from dataclasses import replace
+
+        report = replace(
+            _report(),
+            attachments=(
+                Prepared(filename="veaf-tools.log", kind="log", path=folder / "veaf-tools.log", size=6),
+            ),
+        )
+        outcome = await self._filer().file(report)
+        self.assertEqual(outcome.action, "created")
+        self.assertTrue(any("could not be added" in note for note in outcome.notes))
+
+    async def test_a_failed_comment_on_an_existing_issue_is_reported(self) -> None:
+        self.github.fail_comment = True
+        outcome = await self._filer().comment_on(712, _report())
+        self.assertEqual(outcome.action, "failed")
+
+
+class TestCommentingInstead(_Filing):
+    """The duplicate outcome: nothing new is opened."""
+
+    async def test_the_observation_lands_on_the_existing_issue(self) -> None:
+        outcome = await self._filer().comment_on(712, _report(), thread_url="https://discord.com/x")
+        self.assertEqual(outcome.action, "commented")
+        self.assertEqual(self.github.creations, 0)
+        number, body = self.github.comments[0]
+        self.assertEqual(number, 712)
+        self.assertIn("KeyError: 'coalition'", body)
+
+
+class TestCarryingTheFiles(_Filing):
+    """What was attached travels into the issue, never as a link."""
+
+    async def test_a_text_attachment_becomes_a_comment_on_the_new_issue(self) -> None:
+        folder = Path(self.folder.name)
+        (folder / "veaf-tools.log").write_text("the interesting line", encoding="utf-8")
+        from dataclasses import replace
+
+        report = replace(
+            _report(),
+            attachments=(
+                Prepared(filename="veaf-tools.log", kind="log", path=folder / "veaf-tools.log", size=20),
+            ),
+        )
+        await self._filer().file(report)
+        self.assertTrue(any("the interesting line" in body for _, body in self.github.comments))
+
+
+class TestTheIssueCorpus(_Filing):
+    """What the prior-art sweep reads through the App."""
+
+    async def test_pull_requests_are_not_offered_as_duplicates(self) -> None:
+        self.github.issues = [
+            {"number": 1, "title": "a real issue", "body": "b", "html_url": "u", "state": "open"},
+            {"number": 2, "title": "a pull request", "body": "b", "html_url": "u", "pull_request": {"url": "x"}},
+        ]
+        app = GitHubApp(credentials(), "o/n", self.github)
+        records = await RepositoryIssues(app).open_issues()
+        self.assertEqual([record.number for record in records], [1])
+
+    async def test_the_closed_half_is_bounded(self) -> None:
+        self.github.issues = [
+            {"number": index, "title": f"issue {index}", "body": "", "html_url": "u", "state": "closed"}
+            for index in range(1, 30)
+        ]
+        app = GitHubApp(credentials(), "o/n", self.github)
+        records = await RepositoryIssues(app, closed_count=5).recently_closed_issues()
+        self.assertEqual(len(records), 5)
+
+    async def test_labels_survive_the_round_trip(self) -> None:
+        self.github.issues = [
+            {"number": 1, "title": "t", "body": "", "html_url": "u", "state": "open", "labels": [{"name": "bug"}]}
+        ]
+        app = GitHubApp(credentials(), "o/n", self.github)
+        records = await RepositoryIssues(app).open_issues()
+        self.assertEqual(records[0].labels, ("bug",))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/services/support-bot/tests/test_filing.py
+++ b/services/support-bot/tests/test_filing.py
@@ -11,7 +11,8 @@ import asyncio
 import json
 import tempfile
 import unittest
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,7 @@ from veaf_support_bot.filing import (
 )
 from veaf_support_bot.github_app import GitHubApp, Response
 from veaf_support_bot.issue_body import marker_for
+from veaf_support_bot.toolkit import redact
 
 
 class _GitHub:
@@ -104,6 +106,15 @@ def _report(**overrides: str) -> BugReport:
     return assemble(BugForm(**fields), fixture_checkout())
 
 
+def _redactor() -> Callable[[str], str]:
+    """Return the tools' own redaction helper, bound to the fixture checkout.
+
+    Returns:
+        The callable an :class:`IssueFiler` needs.
+    """
+    return partial(redact, fixture_checkout().root)
+
+
 class _Filing(unittest.IsolatedAsyncioTestCase):
     """Shared setup: a fake GitHub, a real ledger on disk."""
 
@@ -116,11 +127,14 @@ class _Filing(unittest.IsolatedAsyncioTestCase):
     def _filer(self) -> IssueFiler:
         """Build a filer over the shared fake.
 
+        The redactor is the **real** one, resolved out of the fixture checkout, for the same reason
+        the rest of this suite uses it: a stub would let a filer publish raw bytes and stay green.
+
         Returns:
             The filer.
         """
         app = GitHubApp(credentials(), "VEAF/VEAF-Mission-Creation-Tools", self.github)
-        return IssueFiler(app, Ledger(self.ledger_path))
+        return IssueFiler(app, Ledger(self.ledger_path), redactor=_redactor())
 
 
 class TestTheKey(unittest.TestCase):
@@ -205,7 +219,7 @@ class TestFilingOnce(_Filing):
         app = GitHubApp(credentials(), "o/n", self.github)
         blocked = Path(self.folder.name) / "state.json" / "nested" / "ledger.json"
         Path(self.folder.name, "state.json").write_text("not a directory", encoding="utf-8")
-        outcome = await IssueFiler(app, Ledger(blocked)).file(_report())
+        outcome = await IssueFiler(app, Ledger(blocked), redactor=_redactor()).file(_report())
         self.assertEqual(outcome.action, "created")
 
     async def test_a_corrupt_ledger_is_ignored_rather_than_losing_the_report(self) -> None:

--- a/services/support-bot/tests/test_filing.py
+++ b/services/support-bot/tests/test_filing.py
@@ -16,11 +16,12 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
-from tests.intake_fixtures import fixture_checkout
+from tests.intake_fixtures import PERSONAL_ACCOUNT, PERSONAL_EMAIL, PERSONAL_LOG, fixture_checkout
 from tests.test_github_app import credentials
 from veaf_support_bot.attachments import Prepared
 from veaf_support_bot.bugreport import BugForm, BugReport, assemble
 from veaf_support_bot.filing import (
+    CORRUPT_SUFFIX,
     MACHINE_LABEL,
     IssueFiler,
     Ledger,
@@ -43,8 +44,12 @@ class _GitHub:
         self.issues: list[dict[str, Any]] = []
         self.comments: list[tuple[int, str]] = []
         self.creations = 0
+        # Counted, not asserted away: ungating the marker search buys idempotency with one `GET`,
+        # and a test that does not measure the cost is a test that would not notice it growing.
+        self.searches = 0
         self.fail_create: Exception | None = None
         self.refuse_labels = False
+        self.fail_search = False
         self.fail_comment = False
 
     async def __call__(
@@ -80,6 +85,10 @@ class _GitHub:
             self.issues.append(item)
             return Response(201, item)
         if method == "GET":
+            if "state=all" in url:
+                self.searches += 1
+                if self.fail_search:
+                    return Response(503, {"message": "unavailable"})
             return Response(200, list(reversed(self.issues)))
         return Response(200, {})
 
@@ -227,6 +236,71 @@ class TestFilingOnce(_Filing):
         self.ledger_path.write_text("{not json", encoding="utf-8")
         self.assertEqual((await self._filer().file(_report())).action, "created")
 
+    async def test_losing_the_local_state_does_not_open_a_second_issue(self) -> None:
+        """The case the marker exists for, and the one the ledger cannot help with.
+
+        Enumerated rather than sampled: *interrupted* was the only damage covered, and it is the one
+        shape a lost ledger never takes. Both shapes below make `load()` return an empty mapping,
+        which is why gating the marker search on `state == "filing"` made it unreachable.
+        """
+        damage = {
+            "corrupt": lambda path: path.write_text("{not json", encoding="utf-8"),
+            "deleted": lambda path: path.unlink(),
+        }
+        for name, break_it in damage.items():
+            with self.subTest(ledger=name):
+                self.setUp()
+                report = _report()
+                first = await self._filer().file(report)
+                break_it(self.ledger_path)
+                retry = await self._filer().file(report)
+
+                self.assertEqual(first.action, "created")
+                self.assertEqual(retry.action, "reused", "the marker is the only trace left")
+                self.assertEqual(retry.number, first.number)
+                self.assertEqual(self.github.creations, 1)
+
+    async def test_the_marker_search_runs_before_the_first_creation_too(self) -> None:
+        """What the ungating costs, asserted rather than assumed: one `GET`, once."""
+        await self._filer().file(_report())
+        self.assertEqual(self.github.creations, 1)
+        self.assertEqual(self.github.searches, 1)
+
+    def test_an_unreadable_ledger_is_moved_aside_rather_than_overwritten(self) -> None:
+        """`record` rebuilt the document from `load()`, so one corrupt read erased every entry."""
+        self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        self.ledger_path.write_text('{"version": 1, "reports": {"older": {"number": 7}}}x', encoding="utf-8")
+        Ledger(self.ledger_path).record("newer", {"number": 8})
+
+        aside = self.ledger_path.with_suffix(f"{self.ledger_path.suffix}{CORRUPT_SUFFIX}")
+        self.assertTrue(aside.is_file(), "the entries nobody could parse are still on disk")
+        self.assertIn('"older"', aside.read_text(encoding="utf-8"))
+        self.assertEqual(Ledger(self.ledger_path).load(), {"newer": {"number": 8}})
+
+    def test_a_ledger_that_cannot_even_be_moved_aside_still_records_the_new_entry(self) -> None:
+        """Moving the corrupt file aside is best effort; losing the *new* number would not be."""
+        self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        self.ledger_path.write_text("{not json", encoding="utf-8")
+        # A non-empty directory where the copy would go: `replace` cannot overwrite it.
+        aside = self.ledger_path.with_suffix(f"{self.ledger_path.suffix}{CORRUPT_SUFFIX}")
+        (aside / "in-the-way").mkdir(parents=True)
+
+        Ledger(self.ledger_path).record("newer", {"number": 8})
+        self.assertEqual(Ledger(self.ledger_path).load(), {"newer": {"number": 8}})
+
+    async def test_a_recovery_search_that_fails_does_not_lose_the_report(self) -> None:
+        """Now on every filing's path, so its failure mode is asserted rather than assumed."""
+        self.github.fail_search = True
+        outcome = await self._filer().file(_report())
+        self.assertEqual(outcome.action, "created")
+        self.assertEqual(self.github.creations, 1)
+
+    async def test_a_lock_is_not_kept_for_every_report_the_service_ever_filed(self) -> None:
+        filer = self._filer()
+        for index in range(3):
+            await filer.file(_report(summary=f"report {index}"))
+        self.assertEqual(filer._locks, {}, "one lock per key, kept for the life of the process, is a leak")
+
 
 class TestWhenItCannotFile(_Filing):
     """A failure is an answer the reporter gets, never a silence."""
@@ -290,6 +364,22 @@ class TestCarryingTheFiles(_Filing):
         )
         await self._filer().file(report)
         self.assertTrue(any("the interesting line" in body for _, body in self.github.comments))
+
+    async def test_the_comment_that_reaches_github_is_redacted(self) -> None:
+        """Asserted on the wire, not on `carry`: the leak was one argument away from the transport."""
+        folder = Path(self.folder.name)
+        (folder / "dcs.log").write_text(PERSONAL_LOG, encoding="utf-8")
+        from dataclasses import replace
+
+        report = replace(
+            _report(),
+            attachments=(Prepared(filename="dcs.log", kind="log", path=folder / "dcs.log", size=len(PERSONAL_LOG)),),
+        )
+        await self._filer().file(report)
+        posted = "\n".join(body for _, body in self.github.comments)
+        self.assertNotIn(PERSONAL_ACCOUNT, posted)
+        self.assertNotIn(PERSONAL_EMAIL, posted)
+        self.assertIn("secret-op.miz", posted, "the evidence still travels")
 
 
 class TestTheIssueCorpus(_Filing):

--- a/services/support-bot/tests/test_filing.py
+++ b/services/support-bot/tests/test_filing.py
@@ -238,9 +238,7 @@ class TestWhenItCannotFile(_Filing):
 
         report = replace(
             _report(),
-            attachments=(
-                Prepared(filename="veaf-tools.log", kind="log", path=folder / "veaf-tools.log", size=6),
-            ),
+            attachments=(Prepared(filename="veaf-tools.log", kind="log", path=folder / "veaf-tools.log", size=6),),
         )
         outcome = await self._filer().file(report)
         self.assertEqual(outcome.action, "created")
@@ -274,9 +272,7 @@ class TestCarryingTheFiles(_Filing):
 
         report = replace(
             _report(),
-            attachments=(
-                Prepared(filename="veaf-tools.log", kind="log", path=folder / "veaf-tools.log", size=20),
-            ),
+            attachments=(Prepared(filename="veaf-tools.log", kind="log", path=folder / "veaf-tools.log", size=20),),
         )
         await self._filer().file(report)
         self.assertTrue(any("the interesting line" in body for _, body in self.github.comments))

--- a/services/support-bot/tests/test_github_app.py
+++ b/services/support-bot/tests/test_github_app.py
@@ -159,7 +159,9 @@ class TestResolvingTheKey(unittest.TestCase):
     """Two supported forms, and a refusal to guess between them."""
 
     def test_the_inline_form_expands_its_escaped_newlines(self) -> None:
-        self.assertEqual(read_private_key("-----BEGIN-----\\nbody\\n-----END-----", ""), "-----BEGIN-----\nbody\n-----END-----")
+        self.assertEqual(
+            read_private_key("-----BEGIN-----\\nbody\\n-----END-----", ""), "-----BEGIN-----\nbody\n-----END-----"
+        )
 
     def test_a_file_is_read(self) -> None:
         with tempfile.TemporaryDirectory() as folder:

--- a/services/support-bot/tests/test_github_app.py
+++ b/services/support-bot/tests/test_github_app.py
@@ -1,0 +1,288 @@
+"""The App's identity: a JWT that verifies, a token that renews, and no secret in any message.
+
+The signature is checked against the public half of a key generated here — asserting that a JWT
+"has three parts" would pass on a signature of zeroes.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import tempfile
+import time
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from veaf_support_bot.github_app import (
+    JWT_LIFETIME_SECONDS,
+    RENEW_MARGIN_SECONDS,
+    AppCredentials,
+    GitHubApp,
+    GitHubError,
+    Response,
+    read_private_key,
+)
+
+#: One key pair, generated once: RSA generation is slow enough to matter over a whole file.
+_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+#: Its PEM, as an operator would paste it.
+PEM = _KEY.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+).decode("ascii")
+
+
+def credentials() -> AppCredentials:
+    """Build usable credentials.
+
+    Returns:
+        The credentials.
+    """
+    return AppCredentials(app_id="123456", installation_id="7890", private_key_pem=PEM)
+
+
+def _decode(part: str) -> dict[str, Any]:
+    """Decode one base64url JWT segment.
+
+    Args:
+        part: The segment.
+
+    Returns:
+        The decoded JSON object.
+    """
+    padded = part + "=" * (-len(part) % 4)
+    return dict(json.loads(base64.urlsafe_b64decode(padded)))
+
+
+class _Transport:
+    """Records every call and replays a queued answer."""
+
+    def __init__(self, *answers: Response | Exception) -> None:
+        self.answers = list(answers)
+        self.calls: list[tuple[str, str, Mapping[str, str], bytes | None]] = []
+
+    async def __call__(
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        body: bytes | None,
+    ) -> Response:
+        self.calls.append((method, url, dict(headers), body))
+        answer = self.answers.pop(0) if self.answers else Response(200, {})
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+
+def _token_response(value: str = "ghs-a-token", seconds: int = 3600) -> Response:
+    """Build the answer GitHub gives to an installation-token exchange.
+
+    Args:
+        value: The token.
+        seconds: How long it lives.
+
+    Returns:
+        The response.
+    """
+    expires = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + seconds))
+    return Response(201, {"token": value, "expires_at": expires})
+
+
+class TestTheSignedAssertion(unittest.TestCase):
+    """The JWT the private key signs."""
+
+    def test_the_signature_verifies_against_the_public_key(self) -> None:
+        header, payload, signature = credentials().jwt(now=1_000_000).split(".")
+        signing_input = f"{header}.{payload}".encode("ascii")
+        raw = base64.urlsafe_b64decode(signature + "=" * (-len(signature) % 4))
+        _KEY.public_key().verify(raw, signing_input, padding.PKCS1v15(), hashes.SHA256())
+
+    def test_it_is_short_lived_and_issued_slightly_in_the_past(self) -> None:
+        _, payload, _ = credentials().jwt(now=1_000_000).split(".")
+        claims = _decode(payload)
+        self.assertLess(claims["iat"], 1_000_000, "a host running fast must not have its JWT refused")
+        self.assertEqual(claims["exp"] - claims["iat"], JWT_LIFETIME_SECONDS)
+        self.assertLessEqual(JWT_LIFETIME_SECONDS, 600, "GitHub refuses anything longer than ten minutes")
+
+    def test_it_claims_the_app_and_declares_rs256(self) -> None:
+        header, payload, _ = credentials().jwt(now=1_000_000).split(".")
+        self.assertEqual(_decode(header)["alg"], "RS256")
+        self.assertEqual(_decode(payload)["iss"], "123456")
+
+    def test_an_unreadable_key_is_named_rather_than_producing_a_broken_token(self) -> None:
+        broken = AppCredentials(app_id="1", installation_id="2", private_key_pem="not a pem at all")
+        with self.assertRaises(GitHubError) as caught:
+            broken.jwt()
+        self.assertIn("could not be read", str(caught.exception))
+
+    def test_a_non_rsa_key_is_refused(self) -> None:
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        pem = (
+            ed25519.Ed25519PrivateKey.generate()
+            .private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+            .decode("ascii")
+        )
+        with self.assertRaises(GitHubError):
+            AppCredentials(app_id="1", installation_id="2", private_key_pem=pem).jwt()
+
+
+class TestTheKeyNeverLeaks(unittest.TestCase):
+    """A private key in a stack trace is a private key in a container log."""
+
+    def test_the_repr_masks_it(self) -> None:
+        shown = repr(credentials())
+        self.assertNotIn("PRIVATE KEY", shown)
+        self.assertIn("***", shown)
+
+    def test_an_error_message_never_carries_a_bearer_value(self) -> None:
+        transport = _Transport(Response(401, {"message": "Bad credentials for Bearer ghs-the-real-token"}))
+        app = GitHubApp(credentials(), "o/n", transport)
+        with self.assertRaises(GitHubError) as caught:
+            _run(app.token())
+        self.assertNotIn("ghs-the-real-token", str(caught.exception))
+
+
+class TestResolvingTheKey(unittest.TestCase):
+    """Two supported forms, and a refusal to guess between them."""
+
+    def test_the_inline_form_expands_its_escaped_newlines(self) -> None:
+        self.assertEqual(read_private_key("-----BEGIN-----\\nbody\\n-----END-----", ""), "-----BEGIN-----\nbody\n-----END-----")
+
+    def test_a_file_is_read(self) -> None:
+        with tempfile.TemporaryDirectory() as folder:
+            path = Path(folder) / "key.pem"
+            path.write_text(PEM, encoding="utf-8")
+            self.assertEqual(read_private_key("", str(path)), PEM)
+
+    def test_setting_both_is_refused_rather_than_resolved_by_precedence(self) -> None:
+        with self.assertRaises(GitHubError) as caught:
+            read_private_key(PEM, "/some/path.pem")
+        self.assertIn("keep one", str(caught.exception))
+
+    def test_setting_neither_says_so(self) -> None:
+        with self.assertRaises(GitHubError):
+            read_private_key("", "")
+
+    def test_a_missing_file_names_the_failure(self) -> None:
+        with self.assertRaises(GitHubError) as caught:
+            read_private_key("", str(Path(tempfile.gettempdir()) / "no-such-veaf-key.pem"))
+        self.assertIn("could not be read", str(caught.exception))
+
+
+class TestTheInstallationToken(unittest.TestCase):
+    """Short-lived, renewed on the call that needs it, and never held past its margin."""
+
+    def test_it_is_exchanged_with_the_jwt_and_reused_afterwards(self) -> None:
+        transport = _Transport(_token_response())
+        app = GitHubApp(credentials(), "o/n", transport)
+        first = _run(app.token())
+        second = _run(app.token())
+        self.assertEqual(first, "ghs-a-token")
+        self.assertEqual(second, first)
+        self.assertEqual(len(transport.calls), 1, "a held token is not re-minted on every call")
+        self.assertTrue(transport.calls[0][2]["Authorization"].startswith("Bearer eyJ"))
+
+    def test_it_is_replaced_before_it_expires(self) -> None:
+        transport = _Transport(_token_response("first", 3600), _token_response("second", 3600))
+        app = GitHubApp(credentials(), "o/n", transport)
+        now = time.time()
+        self.assertEqual(_run(app.token(now)), "first")
+        self.assertEqual(_run(app.token(now + 3600 - RENEW_MARGIN_SECONDS + 1)), "second")
+
+    def test_a_response_with_no_token_is_an_error_not_an_empty_credential(self) -> None:
+        app = GitHubApp(credentials(), "o/n", _Transport(Response(201, {"expires_at": "2030-01-01T00:00:00Z"})))
+        with self.assertRaises(GitHubError):
+            _run(app.token())
+
+    def test_an_unparseable_expiry_falls_back_to_the_documented_hour(self) -> None:
+        app = GitHubApp(credentials(), "o/n", _Transport(Response(201, {"token": "t", "expires_at": "not a date"})))
+        self.assertEqual(_run(app.token()), "t")
+
+    def test_a_missing_expiry_falls_back_to_the_documented_hour(self) -> None:
+        app = GitHubApp(credentials(), "o/n", _Transport(Response(201, {"token": "t"})))
+        self.assertEqual(_run(app.token()), "t")
+
+
+class TestTheCalls(unittest.TestCase):
+    """What every request carries, and what a failure becomes."""
+
+    def test_a_request_carries_the_installation_token_and_the_api_version(self) -> None:
+        transport = _Transport(_token_response(), Response(200, {"number": 1}))
+        app = GitHubApp(credentials(), "o/n", transport)
+        _run(app.request("GET", "/repos/o/n/issues"))
+        _, url, headers, body = transport.calls[-1]
+        self.assertEqual(url, "https://api.github.com/repos/o/n/issues")
+        self.assertEqual(headers["Authorization"], "Bearer ghs-a-token")
+        self.assertEqual(headers["X-GitHub-Api-Version"], "2022-11-28")
+        self.assertIsNone(body)
+
+    def test_a_payload_is_sent_as_json(self) -> None:
+        transport = _Transport(_token_response(), Response(201, {"number": 1}))
+        app = GitHubApp(credentials(), "o/n", transport)
+        _run(app.request("POST", "/repos/o/n/issues", {"title": "t"}))
+        _, _, headers, body = transport.calls[-1]
+        self.assertEqual(headers["Content-Type"], "application/json")
+        assert body is not None
+        self.assertEqual(json.loads(body), {"title": "t"})
+
+    def test_a_transport_failure_becomes_a_github_error(self) -> None:
+        app = GitHubApp(credentials(), "o/n", _Transport(OSError("no route to host")))
+        with self.assertRaises(GitHubError) as caught:
+            _run(app.token())
+        self.assertIn("could not be reached", str(caught.exception))
+
+    def test_an_error_status_carries_githubs_own_message(self) -> None:
+        transport = _Transport(
+            _token_response(),
+            Response(422, {"message": "Validation Failed", "errors": [{"message": "label does not exist"}]}),
+        )
+        app = GitHubApp(credentials(), "o/n", transport)
+        with self.assertRaises(GitHubError) as caught:
+            _run(app.request("POST", "/repos/o/n/issues", {"title": "t"}))
+        self.assertEqual(caught.exception.status, 422)
+        self.assertIn("label does not exist", str(caught.exception))
+
+    def test_a_body_that_is_not_json_still_produces_a_message(self) -> None:
+        transport = _Transport(_token_response(), Response(502, "<html>bad gateway</html>"))
+        app = GitHubApp(credentials(), "o/n", transport)
+        with self.assertRaises(GitHubError) as caught:
+            _run(app.request("GET", "/x"))
+        self.assertIn("bad gateway", str(caught.exception))
+
+    def test_an_empty_body_still_produces_a_message(self) -> None:
+        transport = _Transport(_token_response(), Response(500, None))
+        app = GitHubApp(credentials(), "o/n", transport)
+        with self.assertRaises(GitHubError) as caught:
+            _run(app.request("GET", "/x"))
+        self.assertIn("no message", str(caught.exception))
+
+
+def _run(coroutine: Any) -> Any:
+    """Run one coroutine to completion.
+
+    Args:
+        coroutine: What to run.
+
+    Returns:
+        Its result.
+    """
+    import asyncio
+
+    return asyncio.run(coroutine)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/services/support-bot/tests/test_intake_github_wiring.py
+++ b/services/support-bot/tests/test_intake_github_wiring.py
@@ -30,6 +30,7 @@ from veaf_support_bot.attachments import AttachmentCollector
 from veaf_support_bot.bugreport import BugForm
 from veaf_support_bot.config import ConfigurationError, SupportBotConfig
 from veaf_support_bot.filing import Outcome
+from veaf_support_bot.github_app import GitHubError
 from veaf_support_bot.intake import BugIntake, BugSubmission, render_match, sweep_query
 from veaf_support_bot.priorart import DUPLICATE, FIXED, IN_PROGRESS, PriorArtGate, PriorArtSweeper, Sweep
 from veaf_support_bot.service import build_github_app, build_intake
@@ -348,6 +349,36 @@ class TestTheServiceBuildsIt(unittest.TestCase):
         # Not the word "secret": `worker_secret` is a field *name* and appears in every repr.
         self.assertNotIn("MIIEbodyofthekey", repr(config))
         self.assertEqual(config.redacted()["github_private_key"], "***redacted***")
+
+    def test_a_key_that_reads_but_cannot_sign_also_stops_the_process(self) -> None:
+        """Reachable is not usable, and the difference used to surface a week later.
+
+        `read_private_key` proves the bytes were *there*. A truncated PEM reads back fine and dies
+        at the first `jwt()` — which is the first bug report, in a service whose health endpoints,
+        Discord connection and documentation answers are all green.
+        """
+        malformed = Path(self.folder.name) / "truncated.pem"
+        malformed.write_text(PEM[: len(PEM) // 2], encoding="utf-8")
+        with self.assertRaises(GitHubError) as caught:
+            build_github_app(self._configured(GITHUB_PRIVATE_KEY_FILE=str(malformed)))
+        self.assertIn("private key", str(caught.exception))
+        self.assertNotIn("PRIVATE KEY-----", str(caught.exception), "the message must not quote the key")
+
+    def test_a_key_that_is_not_rsa_stops_the_process_too(self) -> None:
+        """The second shape the reader cannot see: valid PEM, wrong algorithm."""
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+
+        elliptic = Path(self.folder.name) / "ec.pem"
+        elliptic.write_bytes(
+            ec.generate_private_key(ec.SECP256R1()).private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+        with self.assertRaises(GitHubError):
+            build_github_app(self._configured(GITHUB_PRIVATE_KEY_FILE=str(elliptic)))
 
     def test_an_unreadable_key_stops_the_process_with_the_configuration_exit_code(self) -> None:
         # Two halves, because the wire has two ends: the build refuses, and the entry point turns

--- a/services/support-bot/tests/test_intake_github_wiring.py
+++ b/services/support-bot/tests/test_intake_github_wiring.py
@@ -1,0 +1,538 @@
+"""The wires between the sweep, the intake, the filer and the process — not the handlers.
+
+Four bugs shipped green on this repository because the tests called the handler and never the thing
+that branches to it. So this file asserts only the connections:
+
+* the sweep runs **before** anything is opened, on the report's own words;
+* an accepted duplicate **comments** and opens nothing; an accepted fix or lot opens nothing at all;
+* a **rejected** match does not stop the report — that is the failure mode the ticket names;
+* a filing failure **reaches the reporter**;
+* the **service builds** the App, the sweeper and the filer out of the configuration, and a
+  half-configured App stops the process instead of the first report.
+
+``TestTheseTestsDetectABrokenWiring`` cuts each wire in **production** code — never in a stand-in
+defined here: a detector that mutates its own double proves the double, not the wire.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from tests.intake_fixtures import fixture_checkout, fixture_root
+from tests.test_attachments import _fake_downloader
+from tests.test_github_app import PEM
+from tests.test_priorart import RESOLVER_REPORT, _Issues, _resolver_issue
+from veaf_support_bot.attachments import AttachmentCollector
+from veaf_support_bot.bugreport import BugForm
+from veaf_support_bot.config import ConfigurationError, SupportBotConfig
+from veaf_support_bot.filing import Outcome
+from veaf_support_bot.intake import BugIntake, BugSubmission, render_match, sweep_query
+from veaf_support_bot.priorart import DUPLICATE, FIXED, IN_PROGRESS, PriorArtGate, PriorArtSweeper, Sweep
+from veaf_support_bot.service import build_github_app, build_intake
+
+
+class _Exchange:
+    """A :class:`~veaf_support_bot.intake.BugExchange` that records what the reporter was told."""
+
+    def __init__(self) -> None:
+        self.deferred = False
+        self.messages: list[str] = []
+
+    async def defer(self) -> None:
+        self.deferred = True
+
+    async def post(self, content: str) -> None:
+        self.messages.append(content)
+
+
+class _Filer:
+    """A :class:`~veaf_support_bot.intake.ReportFiler` that records what it was asked to do."""
+
+    def __init__(self, outcome: Outcome | None = None) -> None:
+        self.outcome = outcome or Outcome(action="created", number=901, url="https://example.invalid/issues/901")
+        self.filed: list[Any] = []
+        self.commented: list[int] = []
+
+    async def file(self, report: Any, *, thread_url: str = "") -> Outcome:
+        self.filed.append(report)
+        return self.outcome
+
+    async def comment_on(self, number: int, report: Any, *, thread_url: str = "") -> Outcome:
+        self.commented.append(number)
+        return Outcome(action="commented", number=number, url=f"https://example.invalid/issues/{number}#c")
+
+
+class _Answer:
+    """A confirmation with a fixed answer."""
+
+    def __init__(self, answer: bool) -> None:
+        self.answer = answer
+        self.asked = 0
+
+    async def confirm(self, sweep: Sweep, lang: str) -> bool:
+        self.asked += 1
+        return self.answer
+
+
+def _intake(**kwargs: Any) -> BugIntake:
+    """Build an intake over the fixture checkout.
+
+    Args:
+        **kwargs: Passed through to :class:`~veaf_support_bot.intake.BugIntake`.
+
+    Returns:
+        The intake.
+    """
+    collector = AttachmentCollector(fixture_checkout(), _fake_downloader({}))
+    return BugIntake(fixture_checkout(), collector, refresh=False, **kwargs)
+
+
+def _submission(summary: str = RESOLVER_REPORT.splitlines()[0]) -> BugSubmission:
+    """Build a submission about the sample resolver.
+
+    Args:
+        summary: The one-line summary.
+
+    Returns:
+        The submission.
+    """
+    return BugSubmission(
+        form=BugForm(
+            summary=summary,
+            happened=RESOLVER_REPORT,
+            expected="it should resolve the alias",
+            steps="1. run it",
+            reporter="Tripack",
+            reporter_id="4242",
+            language="en",
+        ),
+        attachments=[],
+    )
+
+
+def _gate(answer: bool | None, **issues: Any) -> PriorArtGate:
+    """Build a gate over the fixture checkout.
+
+    Args:
+        answer: What the reporter answers, or ``None`` for nobody to ask.
+        **issues: ``opened`` and ``closed`` issue records.
+
+    Returns:
+        The gate.
+    """
+    sweeper = PriorArtSweeper(fixture_root(), _Issues(**issues))
+    return PriorArtGate(sweeper, None if answer is None else _Answer(answer))
+
+
+class TestTheQuery(unittest.TestCase):
+    """What the sweep is given to match on."""
+
+    def test_it_is_the_reporters_own_words(self) -> None:
+        query = sweep_query(_intake()._assemble(_submission().form, _harvest()))
+        self.assertIn("veafSample.resolve", query)
+        self.assertIn("it should resolve the alias", query)
+
+    def test_the_attached_log_is_not_in_it(self) -> None:
+        report = _intake()._assemble(_submission().form, _harvest())
+        from dataclasses import replace
+
+        report = replace(report, log_digests=("a thousand ordinary log words",))
+        self.assertNotIn("a thousand ordinary log words", sweep_query(report))
+
+
+def _harvest() -> Any:
+    """Build an empty attachment harvest.
+
+    Returns:
+        The harvest.
+    """
+    from veaf_support_bot.attachments import Harvest
+
+    return Harvest(prepared=(), rejected=())
+
+
+class TestTheSweepRunsBeforeAnythingOpens(unittest.IsolatedAsyncioTestCase):
+    """Ticket 03's whole point: the four sources are consulted first."""
+
+    async def test_the_finding_is_attached_to_the_report(self) -> None:
+        intake = _intake(prior_art=_gate(False, opened=[_resolver_issue()]), filer=_Filer())
+        report = await intake.handle(_Exchange(), _submission())
+        assert report is not None
+        assert report.prior_art is not None
+        self.assertEqual(report.prior_art.verdict, DUPLICATE)
+
+    async def test_with_no_sweep_configured_the_report_says_nothing_was_checked(self) -> None:
+        report = await _intake(filer=_Filer()).handle(_Exchange(), _submission())
+        assert report is not None
+        self.assertIsNone(report.prior_art, "an absent sweep must not read as a sweep that found nothing")
+
+
+class TestWhatAnAcceptedMatchDoes(unittest.IsolatedAsyncioTestCase):
+    """Three of the four verdicts open nothing at all."""
+
+    async def test_an_accepted_duplicate_comments_and_opens_nothing(self) -> None:
+        filer = _Filer()
+        intake = _intake(prior_art=_gate(True, opened=[_resolver_issue()]), filer=filer)
+        exchange = _Exchange()
+        await intake.handle(exchange, _submission())
+        self.assertEqual(filer.commented, [712])
+        self.assertEqual(filer.filed, [])
+        self.assertIn("#712", exchange.messages[0])
+
+    async def test_an_accepted_fix_opens_nothing_and_names_the_version(self) -> None:
+        filer = _Filer()
+        intake = _intake(prior_art=_gate(True, closed=[_resolver_issue(state="closed")]), filer=filer)
+        exchange = _Exchange()
+        await intake.handle(exchange, _submission())
+        self.assertEqual(filer.filed, [])
+        self.assertEqual(filer.commented, [])
+        self.assertIn("6.19.0", exchange.messages[0])
+
+    async def test_an_accepted_lot_opens_nothing(self) -> None:
+        filer = _Filer()
+        intake = _intake(prior_art=_gate(True), filer=filer)
+        exchange = _Exchange()
+        await intake.handle(exchange, _submission())
+        self.assertEqual((filer.filed, filer.commented), ([], []))
+        self.assertIn("FEAT-SAMPLE-RESOLVER", exchange.messages[0])
+
+
+class TestTheRefusalDoesNotEndTheReport(unittest.IsolatedAsyncioTestCase):
+    """The failure mode: a wrong duplicate silences a real bug, and the reporter will not insist."""
+
+    async def test_a_rejected_duplicate_is_filed_anyway(self) -> None:
+        filer = _Filer()
+        intake = _intake(prior_art=_gate(False, opened=[_resolver_issue()]), filer=filer)
+        exchange = _Exchange()
+        await intake.handle(exchange, _submission())
+        self.assertEqual(len(filer.filed), 1)
+        self.assertEqual(filer.commented, [])
+        self.assertIn("https://example.invalid/issues/901", exchange.messages[0])
+
+    async def test_with_nobody_to_ask_the_report_is_filed_and_the_finding_recorded(self) -> None:
+        filer = _Filer()
+        intake = _intake(prior_art=_gate(None, opened=[_resolver_issue()]), filer=filer)
+        exchange = _Exchange()
+        report = await intake.handle(exchange, _submission())
+        self.assertEqual(len(filer.filed), 1)
+        assert report is not None and report.prior_art is not None
+        self.assertTrue(report.prior_art.found)
+
+    async def test_the_proposal_shown_to_the_reporter_carries_its_evidence(self) -> None:
+        intake = _intake(prior_art=_gate(None, opened=[_resolver_issue()]), filer=_Filer())
+        exchange = _Exchange()
+        await intake.handle(exchange, _submission())
+        self.assertIn("#712", exchange.messages[0])
+        self.assertIn("match on", exchange.messages[0])
+
+
+class TestWhatTheReporterIsTold(unittest.IsolatedAsyncioTestCase):
+    """Never a silence, and never a claim that an issue exists when it does not."""
+
+    async def test_a_filing_failure_is_said_in_the_thread(self) -> None:
+        filer = _Filer(Outcome(action="failed", error="GitHub answered 403: Resource not accessible"))
+        exchange = _Exchange()
+        await _intake(filer=filer).handle(exchange, _submission())
+        self.assertIn("403", exchange.messages[0])
+        self.assertIn("bug_report.yml", exchange.messages[0], "he is told how to file it himself")
+
+    async def test_no_github_app_says_nothing_was_opened(self) -> None:
+        exchange = _Exchange()
+        await _intake().handle(exchange, _submission())
+        self.assertIn("No issue was opened", exchange.messages[0])
+
+    async def test_a_reused_issue_says_it_was_not_opened_twice(self) -> None:
+        filer = _Filer(Outcome(action="reused", number=901, url="https://example.invalid/issues/901"))
+        exchange = _Exchange()
+        await _intake(filer=filer).handle(exchange, _submission())
+        self.assertIn("already been filed", exchange.messages[0])
+
+    async def test_a_degraded_creation_reports_its_notes(self) -> None:
+        filer = _Filer(Outcome(action="created", number=901, url="u", notes=("labels could not be applied",)))
+        exchange = _Exchange()
+        await _intake(filer=filer).handle(exchange, _submission())
+        self.assertIn("labels could not be applied", exchange.messages[0])
+
+    async def test_an_existing_sink_still_owns_the_answer(self) -> None:
+        filer = _Filer()
+
+        async def _sink(report: Any) -> str:
+            return "the preview ticket 04 owns"
+
+        exchange = _Exchange()
+        await _intake(sink=_sink, filer=filer).handle(exchange, _submission())
+        self.assertEqual(exchange.messages, ["the preview ticket 04 owns"])
+        self.assertEqual(filer.filed, [], "the consent click decides, not the intake")
+
+
+class TestTheServiceBuildsIt(unittest.TestCase):
+    """The configuration reaches the objects, or the process refuses to start."""
+
+    def setUp(self) -> None:
+        self.folder = tempfile.TemporaryDirectory()
+        self.addCleanup(self.folder.cleanup)
+        self.key = Path(self.folder.name) / "key.pem"
+        self.key.write_text(PEM, encoding="utf-8")
+
+    def _config(self, **overrides: str) -> SupportBotConfig:
+        env = {
+            "SUPPORT_BOT_DISCORD_TOKEN": "a-token",
+            "SUPPORT_BOT_DISCORD_GUILD_ID": "1",
+            "SUPPORT_BOT_WORKER_SECRET": "a-secret",
+            "SUPPORT_BOT_HEALTH_PORT": "0",
+            "SUPPORT_BOT_CHECKOUT_PATH": str(fixture_root()),
+            "SUPPORT_BOT_CHECKOUT_REFRESH_SECONDS": "0",
+        }
+        env.update({f"SUPPORT_BOT_{key}": value for key, value in overrides.items()})
+        return SupportBotConfig.from_env(env)
+
+    def _configured(self, **overrides: str) -> SupportBotConfig:
+        settings = {
+            "GITHUB_APP_ID": "123456",
+            "GITHUB_INSTALLATION_ID": "7890",
+            "GITHUB_PRIVATE_KEY_FILE": str(self.key),
+        }
+        settings.update(overrides)
+        return self._config(**settings)
+
+    def test_an_intake_without_an_app_still_sweeps_the_checkout(self) -> None:
+        intake = build_intake(self._config())
+        assert intake is not None
+        self.assertIsNotNone(intake._prior_art, "the two file sources need no credentials")
+        self.assertIsNone(intake._filer)
+
+    def test_a_configured_app_produces_a_filer_and_an_issue_backed_sweep(self) -> None:
+        intake = build_intake(self._configured())
+        assert intake is not None
+        self.assertIsNotNone(intake._filer)
+        assert intake._prior_art is not None
+        self.assertIsNotNone(intake._prior_art.sweeper.issues)
+
+    def test_the_app_is_pointed_at_the_configured_repository(self) -> None:
+        app = build_github_app(self._configured(GITHUB_REPOSITORY="VEAF/other"))
+        assert app is not None
+        self.assertEqual(app.repository, "VEAF/other")
+        self.assertEqual(app.credentials.app_id, "123456")
+
+    def test_no_app_configured_builds_no_client(self) -> None:
+        self.assertIsNone(build_github_app(self._config()))
+
+    def test_half_an_app_refuses_to_start(self) -> None:
+        with self.assertRaises(ConfigurationError) as caught:
+            self._config(GITHUB_APP_ID="123456")
+        self.assertIn("GITHUB_INSTALLATION_ID", str(caught.exception))
+
+    def test_a_key_given_twice_refuses_to_start(self) -> None:
+        with self.assertRaises(ConfigurationError) as caught:
+            self._configured(GITHUB_PRIVATE_KEY="-----BEGIN-----\\nx\\n-----END-----")
+        self.assertIn("keep one", str(caught.exception))
+
+    def test_a_repository_that_is_not_owner_slash_name_refuses_to_start(self) -> None:
+        with self.assertRaises(ConfigurationError):
+            self._configured(GITHUB_REPOSITORY="justaname")
+
+    def test_the_private_key_never_reaches_a_log_line(self) -> None:
+        redacted = self._configured(GITHUB_PRIVATE_KEY_FILE=str(self.key)).redacted()
+        self.assertNotIn("PRIVATE KEY", repr(redacted))
+
+    def test_an_inline_key_is_masked_in_the_loggable_configuration(self) -> None:
+        config = self._config(
+            GITHUB_APP_ID="1",
+            GITHUB_INSTALLATION_ID="2",
+            GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\\nMIIEbodyofthekey\\n-----END RSA PRIVATE KEY-----",
+        )
+        # Not the word "secret": `worker_secret` is a field *name* and appears in every repr.
+        self.assertNotIn("MIIEbodyofthekey", repr(config))
+        self.assertEqual(config.redacted()["github_private_key"], "***redacted***")
+
+    def test_an_unreadable_key_stops_the_process_with_the_configuration_exit_code(self) -> None:
+        # Two halves, because the wire has two ends: the build refuses, and the entry point turns
+        # that refusal into the exit code a supervisor reads as "restarting will not help".
+        from veaf_support_bot import cli
+        from veaf_support_bot.github_app import GitHubError
+
+        broken = Path(self.folder.name) / "missing.pem"
+        with self.assertRaises(GitHubError):
+            build_github_app(self._configured(GITHUB_PRIVATE_KEY_FILE=str(broken)))
+
+        config = self._config()
+
+        def _raise(_config: SupportBotConfig) -> None:
+            raise GitHubError("the GitHub App private key file could not be read (FileNotFoundError)")
+
+        original_run, original_from_env = cli._run, SupportBotConfig.from_env
+        cli._run = _raise  # type: ignore[assignment]
+        SupportBotConfig.from_env = classmethod(lambda cls, env=None: config)  # type: ignore[assignment]
+        try:
+            self.assertEqual(cli.main([]), cli.EXIT_CONFIG_ERROR)
+        finally:
+            cli._run = original_run
+            SupportBotConfig.from_env = original_from_env  # type: ignore[method-assign]
+
+
+class TestTheProposalRendering(unittest.TestCase):
+    """A verdict must never be rendered as a bare assertion."""
+
+    def test_a_fixed_verdict_without_a_version_says_so_instead_of_inventing_one(self) -> None:
+        from veaf_support_bot.priorart import Candidate, Match
+
+        sweep = Sweep(
+            verdict=FIXED,
+            best=Match(Candidate("closed issue", "#1", "t", url="u"), 0.5, ("x",)),
+        )
+        rendered = render_match(sweep, "en")
+        self.assertIn("names no version", rendered)
+
+    def test_nothing_found_renders_nothing(self) -> None:
+        self.assertEqual(render_match(Sweep(), "en"), "")
+
+    def test_an_in_progress_verdict_names_the_lot(self) -> None:
+        from veaf_support_bot.priorart import Candidate, Match
+
+        sweep = Sweep(
+            verdict=IN_PROGRESS,
+            best=Match(Candidate("backlog lot", "FEAT-X", "a lot", url=".backlog/FEAT-X/PRD.md"), 0.5, ("x",)),
+        )
+        self.assertIn("FEAT-X", render_match(sweep, "fr"))
+
+
+class TestTheseTestsDetectABrokenWiring(unittest.TestCase):
+    """Cut each wire in the shipped module; the named test must go red."""
+
+    def _fails(self, name: str) -> bool:
+        """Run one test of this file and say whether it failed.
+
+        Args:
+            name: ``Class.method``.
+
+        Returns:
+            ``True`` when it did not pass.
+        """
+        suite = unittest.TestLoader().loadTestsFromName(f"tests.test_intake_github_wiring.{name}")
+        result = unittest.TestResult()
+        suite.run(result)
+        return not result.wasSuccessful()
+
+    def test_an_intake_that_stopped_sweeping_is_caught(self) -> None:
+        from veaf_support_bot import intake as module
+
+        original = module.BugIntake._sweep
+
+        async def _no_sweep(self, report, lang):  # type: ignore[no-untyped-def]
+            return None, False
+
+        module.BugIntake._sweep = _no_sweep  # type: ignore[method-assign]
+        try:
+            self.assertTrue(
+                self._fails("TestTheSweepRunsBeforeAnythingOpens.test_the_finding_is_attached_to_the_report")
+            )
+        finally:
+            module.BugIntake._sweep = original  # type: ignore[method-assign]
+
+    def test_an_accepted_duplicate_that_files_anyway_is_caught(self) -> None:
+        from veaf_support_bot import intake as module
+
+        original = module.BugIntake._act_on
+
+        async def _file_regardless(self, sweep, report, lang, thread_url):  # type: ignore[no-untyped-def]
+            return await self._file(report, lang, thread_url)
+
+        module.BugIntake._act_on = _file_regardless  # type: ignore[method-assign]
+        try:
+            self.assertTrue(
+                self._fails("TestWhatAnAcceptedMatchDoes.test_an_accepted_duplicate_comments_and_opens_nothing")
+            )
+        finally:
+            module.BugIntake._act_on = original  # type: ignore[method-assign]
+
+    def test_a_rejection_that_silences_the_report_is_caught(self) -> None:
+        from veaf_support_bot import intake as module
+
+        original = module.BugIntake._decide
+
+        async def _stop_on_any_match(self, report, lang, thread_url):  # type: ignore[no-untyped-def]
+            sweep, _ = await self._sweep(report, lang)
+            from dataclasses import replace
+
+            report = replace(report, prior_art=sweep)
+            if sweep is not None and sweep.found:
+                return report, render_match(sweep, lang)
+            return report, await self._file(report, lang, thread_url)
+
+        module.BugIntake._decide = _stop_on_any_match  # type: ignore[method-assign]
+        try:
+            self.assertTrue(self._fails("TestTheRefusalDoesNotEndTheReport.test_a_rejected_duplicate_is_filed_anyway"))
+        finally:
+            module.BugIntake._decide = original  # type: ignore[method-assign]
+
+    def test_a_swallowed_filing_failure_is_caught(self) -> None:
+        from veaf_support_bot import intake as module
+
+        original = module._render_outcome
+        module._render_outcome = lambda outcome, lang, report: "done"
+        try:
+            self.assertTrue(self._fails("TestWhatTheReporterIsTold.test_a_filing_failure_is_said_in_the_thread"))
+        finally:
+            module._render_outcome = original
+
+    def test_a_service_that_stopped_building_the_filer_is_caught(self) -> None:
+        from veaf_support_bot import service as module
+
+        original = module.build_github_app
+        module.build_github_app = lambda config: None
+        try:
+            self.assertTrue(
+                self._fails("TestTheServiceBuildsIt.test_a_configured_app_produces_a_filer_and_an_issue_backed_sweep")
+            )
+        finally:
+            module.build_github_app = original
+
+    def test_a_service_that_stopped_building_the_sweeper_is_caught(self) -> None:
+        from veaf_support_bot import service as module
+
+        original = module.PriorArtGate
+        module.PriorArtGate = lambda sweeper: None  # type: ignore[assignment,misc]
+        try:
+            self.assertTrue(
+                self._fails("TestTheServiceBuildsIt.test_an_intake_without_an_app_still_sweeps_the_checkout")
+            )
+        finally:
+            module.PriorArtGate = original  # type: ignore[misc]
+
+    def test_a_half_configured_app_accepted_at_startup_is_caught(self) -> None:
+        from veaf_support_bot import config as module
+
+        original = module._check_github
+        module._check_github = lambda reader, config: None
+        try:
+            self.assertTrue(self._fails("TestTheServiceBuildsIt.test_half_an_app_refuses_to_start"))
+        finally:
+            module._check_github = original
+
+    def test_an_unreadable_key_that_does_not_stop_the_process_is_caught(self) -> None:
+        from veaf_support_bot import github_app as module
+
+        original = module.read_private_key
+        module.read_private_key = lambda inline, path: PEM
+        # `service` resolved the name at import time, so the binding it uses is the one to cut.
+        from veaf_support_bot import service as service_module
+
+        service_original = service_module.read_private_key
+        service_module.read_private_key = lambda inline, path: PEM
+        try:
+            self.assertTrue(
+                self._fails(
+                    "TestTheServiceBuildsIt.test_an_unreadable_key_stops_the_process_with_the_configuration_exit_code"
+                )
+            )
+        finally:
+            module.read_private_key = original
+            service_module.read_private_key = service_original
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/services/support-bot/tests/test_intake_hostile.py
+++ b/services/support-bot/tests/test_intake_hostile.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from functools import partial
 from pathlib import Path
 
 from tests.intake_fixtures import (
@@ -26,6 +27,7 @@ from tests.intake_fixtures import (
     PERSONAL_ACCOUNT,
     PERSONAL_EMAIL,
     PERSONAL_FILENAME,
+    PERSONAL_LOG,
     PERSONAL_MEMBERS,
     PYTHON_TRACEBACK,
     UNREADABLE_MISSION_LUA,
@@ -37,10 +39,12 @@ from tests.intake_fixtures import (
 )
 from tests.test_attachments import _fake_downloader
 from tests.test_toolkit import SYNTHETIC_LOG
-from veaf_support_bot.attachments import UNREDACTED_NAME, AttachmentCollector, Harvest, Incoming
+from veaf_support_bot.attachments import UNREDACTED_NAME, AttachmentCollector, Harvest, Incoming, Prepared
 from veaf_support_bot.bugreport import BugForm, BugReport, assemble
 from veaf_support_bot.checkout import Checkout
 from veaf_support_bot.intake import BugIntake
+from veaf_support_bot.issue_body import Carried, carry, render_attachment_comments
+from veaf_support_bot.toolkit import redact
 from veaf_support_bot.untrusted import MAX_FENCE, bound_backtick_runs, defuse_mentions, fence_for, one_line, quote
 
 #: A log carrying the same hostile lines a reporter's own machine would have written into it.
@@ -237,6 +241,27 @@ class TestNothingAReporterSuppliedIsPublishedRaw(unittest.IsolatedAsyncioTestCas
         with tempfile.TemporaryDirectory() as directory:
             return await collector.collect(incoming, Path(directory))
 
+    async def _personal_log(self, root: Path | None = None) -> tuple[Prepared, Carried]:
+        """Download :data:`PERSONAL_LOG` and decide how it travels into the issue.
+
+        The workdir outlives the call, unlike :meth:`_harvest`'s: :func:`carry` re-reads the file
+        off disk, which is the whole point of the finding this covers.
+
+        Args:
+            root: Checkout the redaction resolves out of. A directory holding no tools makes the
+                helper unreachable, which is the fail-closed case.
+
+        Returns:
+            The prepared attachment and the carrying decision.
+        """
+        body = PERSONAL_LOG.encode("utf-8")
+        collector = AttachmentCollector(fixture_checkout(), _fake_downloader({"log": body}))
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        harvest = await collector.collect([Incoming("dcs.log", "log", len(body))], Path(directory.name))
+        prepared = harvest.prepared[0]
+        return prepared, carry(prepared, redactor=partial(redact, root or fixture_checkout().root))
+
     async def test_an_archive_member_name_is_redacted_like_any_other_text(self) -> None:
         body = personal_archive()
         harvest = await self._harvest([Incoming("~mis0001.zip", "zip", len(body))], {"zip": body})
@@ -333,6 +358,42 @@ class TestNothingAReporterSuppliedIsPublishedRaw(unittest.IsolatedAsyncioTestCas
         self.assertNotIn(
             PERSONAL_ACCOUNT, published, "the account name arrives under `Users/`, where the helper sees it"
         )
+
+    async def test_the_bytes_carried_whole_into_the_issue_are_redacted_too(self) -> None:
+        """The fourth path: the file's own content, posted as a comment on a public repository.
+
+        The three cases above cover a *name*, a member list and a parser's message. This one covers
+        the bytes, which is where the leak was: `carry` read `Prepared.path` — the raw download —
+        while the redacted view sat beside it, and `quote` fenced it without redacting anything.
+        """
+        prepared, carried = await self._personal_log()
+        published = "\n".join(render_attachment_comments([carried]))
+
+        self.assertNotIn(PERSONAL_ACCOUNT, published)
+        self.assertNotIn(PERSONAL_EMAIL, published)
+        self.assertIn("<user>", published)
+        # Still evidence: withholding by deleting the log would be its own bug.
+        self.assertIn("secret-op.miz", published)
+        self.assertIn("2026-09-05 10:00:01.000", published)
+        self.assertEqual(prepared.filename, "dcs.log")
+
+    async def test_the_excerpt_and_the_carried_bytes_agree_on_what_is_publishable(self) -> None:
+        """The differential form again: one file, two renderings, one answer about the same string."""
+        prepared, carried = await self._personal_log()
+        for label, text in (("excerpt", prepared.rendered), ("carried", carried.text)):
+            with self.subTest(rendering=label):
+                self.assertNotIn(PERSONAL_ACCOUNT, text)
+                self.assertNotIn(PERSONAL_EMAIL, text)
+
+    async def test_bytes_nobody_could_redact_are_withheld_rather_than_published(self) -> None:
+        """Fails closed, like the filename above: what cannot be redacted is described, not posted."""
+        with tempfile.TemporaryDirectory() as nowhere:
+            _, carried = await self._personal_log(root=Path(nowhere))
+        self.assertEqual(carried.text, "")
+        self.assertIn("could not be redacted", carried.reason)
+        self.assertEqual(render_attachment_comments([carried]), [])
+        # The file is still named, sized and hashed: a withheld quote is not a withheld attachment.
+        self.assertTrue(carried.digest)
 
 
 if __name__ == "__main__":

--- a/services/support-bot/tests/test_intake_hostile.py
+++ b/services/support-bot/tests/test_intake_hostile.py
@@ -391,6 +391,8 @@ class TestNothingAReporterSuppliedIsPublishedRaw(unittest.IsolatedAsyncioTestCas
             _, carried = await self._personal_log(root=Path(nowhere))
         self.assertEqual(carried.text, "")
         self.assertIn("could not be redacted", carried.reason)
+        # The reason is published: it says what happened, never where this host keeps things.
+        self.assertNotIn(str(Path.cwd().anchor), carried.reason)
         self.assertEqual(render_attachment_comments([carried]), [])
         # The file is still named, sized and hashed: a withheld quote is not a withheld attachment.
         self.assertTrue(carried.digest)

--- a/services/support-bot/tests/test_issue_body.py
+++ b/services/support-bot/tests/test_issue_body.py
@@ -1,0 +1,265 @@
+"""The issue: the template's shape, the reporter's language, and evidence nobody rewrote.
+
+The headings are read out of ``.github/ISSUE_TEMPLATE/bug_report.yml`` rather than typed here, so
+renaming a field in the form fails this file instead of leaving the bot writing headings a
+maintainer no longer recognises.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.intake_fixtures import fixture_checkout, fixture_root
+from veaf_support_bot.attachments import Prepared
+from veaf_support_bot.bugreport import BugForm, BugReport, MaterialNote, assemble
+from veaf_support_bot.issue_body import (
+    INLINE_MAX_CHARS,
+    Carried,
+    carry,
+    heading,
+    marker_for,
+    render_attachment_comments,
+    render_body,
+    render_duplicate_comment,
+    render_prior_art,
+)
+from veaf_support_bot.priorart import DUPLICATE, NONE, Candidate, Match, Sweep
+
+#: A French log line with a home directory in it, quoted as evidence.
+FRENCH_REPORT = "La mission plante à l'ouverture, erreur « KeyError: 'coalition' »"
+
+
+def _repository_root() -> Path:
+    """Return the real repository this service lives in.
+
+    Returns:
+        Its root.
+    """
+    return Path(__file__).resolve().parents[3]
+
+
+def _report(language: str = "fr", **overrides: str) -> BugReport:
+    """Assemble a report against the fixture checkout.
+
+    Args:
+        language: ``"fr"`` or ``"en"``.
+        **overrides: Form fields to replace.
+
+    Returns:
+        The report.
+    """
+    fields = {
+        "summary": "La mission plante",
+        "happened": FRENCH_REPORT,
+        "expected": "Elle devrait s'ouvrir",
+        "steps": "1. lancer veaf-tools.exe\n2. ouvrir la mission",
+        "reporter": "Tripack",
+        "reporter_id": "4242",
+        "language": language,
+    }
+    fields.update(overrides)
+    return assemble(BugForm(**fields), fixture_checkout())
+
+
+class TestTheTemplateShape(unittest.TestCase):
+    """The headings are the repository's own form, not invented ones."""
+
+    def test_every_english_heading_is_a_label_of_the_bug_report_form(self) -> None:
+        template = (_repository_root() / ".github" / "ISSUE_TEMPLATE" / "bug_report.yml").read_text(encoding="utf-8")
+        for key in ("version", "component", "happened", "expected", "steps", "context"):
+            with self.subTest(field=key):
+                self.assertIn(heading(key, "en"), template)
+
+    def test_the_body_carries_the_six_template_sections(self) -> None:
+        body = render_body(_report("en"), "abc")
+        for key in ("version", "component", "happened", "expected", "steps", "context"):
+            with self.subTest(field=key):
+                self.assertIn(f"### {heading(key, 'en')}", body)
+
+    def test_an_unknown_language_falls_back_to_english_rather_than_raising(self) -> None:
+        self.assertIn(heading("version", "en"), render_body(_report("pt-BR"), "abc"))
+
+
+class TestTheLanguage(unittest.TestCase):
+    """Headings follow the reporter; quoted material follows nobody."""
+
+    def test_a_french_report_gets_french_headings(self) -> None:
+        body = render_body(_report("fr"), "abc")
+        self.assertIn("### Ce qui s'est passé", body)
+        self.assertNotIn("### What happened?", body)
+
+    def test_the_quoted_words_are_the_reporters_own(self) -> None:
+        body = render_body(_report("fr"), "abc")
+        self.assertIn(FRENCH_REPORT, body)
+
+    def test_a_french_report_keeps_its_english_evidence_untranslated(self) -> None:
+        body = render_body(_report("fr", happened="the log says KeyError: 'coalition' at line 412"), "abc")
+        self.assertIn("KeyError: 'coalition' at line 412", body)
+
+
+class TestTheMarker(unittest.TestCase):
+    """The one thing that survives losing every local trace of an attempt."""
+
+    def test_the_body_carries_the_key_in_a_comment(self) -> None:
+        body = render_body(_report(), "0123456789abcdef")
+        self.assertIn(marker_for("0123456789abcdef"), body)
+
+    def test_two_keys_produce_two_markers(self) -> None:
+        self.assertNotEqual(marker_for("a"), marker_for("b"))
+
+
+class TestAttribution(unittest.TestCase):
+    """Who reported it, and where."""
+
+    def test_the_discord_author_is_named(self) -> None:
+        self.assertIn("Tripack", render_body(_report(), "abc"))
+
+    def test_the_thread_is_linked_when_there_is_one(self) -> None:
+        body = render_body(_report(), "abc", thread_url="https://discord.com/channels/1/2/3")
+        self.assertIn("https://discord.com/channels/1/2/3", body)
+
+    def test_no_thread_is_said_rather_than_invented(self) -> None:
+        body = render_body(_report("en"), "abc")
+        self.assertIn("(not recorded)", body)
+
+
+class TestCarryingTheAttachments(unittest.TestCase):
+    """What an issue can hold, and what it says about what it cannot."""
+
+    def setUp(self) -> None:
+        self.folder = tempfile.TemporaryDirectory()
+        self.addCleanup(self.folder.cleanup)
+        self.root = Path(self.folder.name)
+
+    def _prepared(self, name: str, kind: str, content: bytes) -> Prepared:
+        path = self.root / name
+        path.write_bytes(content)
+        return Prepared(filename=name, kind=kind, path=path, size=len(content))
+
+    def test_a_small_text_file_travels_whole_inside_the_issue(self) -> None:
+        carried = carry(self._prepared("veaf-tools.log", "log", b"line one\nline two\n"))
+        self.assertIn("line two", carried.text)
+        self.assertEqual(carried.reason, "")
+
+    def test_a_binary_is_described_rather_than_carried(self) -> None:
+        carried = carry(self._prepared("mission.miz", "mission", b"PK\x03\x04binary"))
+        self.assertEqual(carried.text, "")
+        self.assertIn("binary file", carried.reason)
+
+    def test_a_text_file_past_the_ceiling_is_described_with_its_size(self) -> None:
+        carried = carry(self._prepared("big.log", "log", b"x" * (INLINE_MAX_CHARS + 10)))
+        self.assertEqual(carried.text, "")
+        self.assertIn(str(INLINE_MAX_CHARS + 10), carried.reason)
+
+    def test_an_unreadable_file_says_so_instead_of_producing_an_empty_quote(self) -> None:
+        prepared = Prepared(filename="gone.log", kind="log", path=self.root / "gone.log", size=10)
+        carried = carry(prepared)
+        self.assertIn("could not be read back", carried.reason)
+
+    def test_the_manifest_names_every_file_and_its_digest(self) -> None:
+        carried = [carry(self._prepared("veaf-tools.log", "log", b"hello"))]
+        body = render_body(_report("en"), "abc", carried=carried)
+        self.assertIn("veaf-tools.log", body)
+        self.assertIn("sha256:", body)
+
+    def test_the_manifest_says_plainly_when_the_bytes_are_not_in_the_issue(self) -> None:
+        carried = [carry(self._prepared("mission.miz", "mission", b"PK\x03\x04"))]
+        body = render_body(_report("en"), "abc", carried=carried)
+        self.assertIn("not published here", body)
+
+    def test_a_carried_file_becomes_a_comment_and_a_described_one_does_not(self) -> None:
+        carried = [
+            carry(self._prepared("veaf-tools.log", "log", b"kept")),
+            carry(self._prepared("mission.miz", "mission", b"PK\x03\x04")),
+        ]
+        comments = render_attachment_comments(carried)
+        self.assertEqual(len(comments), 1)
+        self.assertIn("kept", comments[0])
+
+    def test_no_discord_url_ever_reaches_the_issue(self) -> None:
+        carried = [carry(self._prepared("mission.miz", "mission", b"PK\x03\x04"))]
+        body = render_body(_report(), "abc", carried=carried)
+        self.assertNotIn("cdn.discordapp.com", body)
+        self.assertNotIn("discordapp.net", body)
+
+
+class TestThePriorArtSection(unittest.TestCase):
+    """A reader must be able to see the sweep ran, and to disagree with what it proposed."""
+
+    def _sweep(self) -> Sweep:
+        match = Match(
+            candidate=Candidate("open issue", "#712", "the resolver drops an alias", url="https://x/712"),
+            score=0.62,
+            shared=("veafsample.resolve", "alias"),
+        )
+        return Sweep(verdict=DUPLICATE, best=match, checked=("9 open issue(s)",))
+
+    def test_a_rejected_match_is_recorded_with_its_evidence(self) -> None:
+        rendered = render_prior_art(self._sweep(), "en")
+        self.assertIn("#712", rendered)
+        self.assertIn("veafsample.resolve", rendered)
+        self.assertIn("rejected by the reporter", rendered)
+
+    def test_what_was_checked_is_recorded_even_when_nothing_matched(self) -> None:
+        rendered = render_prior_art(Sweep(verdict=NONE, checked=("9 open issue(s)",)), "en")
+        self.assertIn("9 open issue(s)", rendered)
+
+    def test_the_section_reaches_the_body(self) -> None:
+        report = assemble(
+            BugForm(summary="s", happened="h", expected="e", steps="p", language="en"),
+            fixture_checkout(),
+            prior_art=self._sweep(),
+        )
+        self.assertIn(f"### {heading('priorart', 'en')}", render_body(report, "abc"))
+
+
+class TestWhatIsMissing(unittest.TestCase):
+    """Absent is stated, never filled in."""
+
+    def test_a_note_reaches_the_body(self) -> None:
+        report = assemble(
+            BugForm(summary="s", happened="h", expected="e", steps="p", language="en"),
+            fixture_checkout(),
+            notes=(MaterialNote("dcs.log", "past the size ceiling"),),
+        )
+        body = render_body(report, "abc")
+        self.assertIn("dcs.log", body)
+        self.assertIn("past the size ceiling", body)
+
+    def test_the_body_says_no_hypothesis_was_made(self) -> None:
+        self.assertIn("No hypothesis", render_body(_report("en"), "abc"))
+
+    def test_the_revision_every_location_came_from_is_stated(self) -> None:
+        report = _report("en")
+        self.assertIn(report.freshness.describe()[:9], render_body(report, "abc"))
+
+
+class TestTheDuplicateComment(unittest.TestCase):
+    """What is added to an existing issue instead of opening a second one."""
+
+    def test_it_carries_the_new_observation_and_its_author(self) -> None:
+        comment = render_duplicate_comment(_report("fr"), "fr", "https://discord.com/x")
+        self.assertIn(FRENCH_REPORT, comment)
+        self.assertIn("Tripack", comment)
+        self.assertIn("https://discord.com/x", comment)
+
+
+class TestQuotedTextCannotEscape(unittest.TestCase):
+    """A reporter must not be able to write headings into an issue a maintainer reads as authored."""
+
+    def test_a_fenced_block_in_the_report_does_not_close_the_quote(self) -> None:
+        body = render_body(_report("en", happened="```\n### Confirmed by a maintainer\n```"), "abc")
+        # The forged heading survives verbatim — evidence is never edited — but it survives *inside*
+        # a fence longer than the one the reporter wrote, so it renders as text and not as a
+        # heading a maintainer would read as authored by the repository.
+        self.assertIn("````\n```\n### Confirmed by a maintainer\n```\n````", body)
+
+    def test_a_mention_is_defused(self) -> None:
+        body = render_body(_report("en", happened="@everyone look at this"), "abc")
+        self.assertNotIn("@everyone", body)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/services/support-bot/tests/test_issue_body.py
+++ b/services/support-bot/tests/test_issue_body.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from functools import partial
 from pathlib import Path
 
 from tests.intake_fixtures import fixture_checkout, fixture_root
@@ -26,6 +27,7 @@ from veaf_support_bot.issue_body import (
     render_prior_art,
 )
 from veaf_support_bot.priorart import DUPLICATE, NONE, Candidate, Match, Sweep
+from veaf_support_bot.toolkit import ToolkitUnavailable, redact
 
 #: A French log line with a home directory in it, quoted as evidence.
 FRENCH_REPORT = "La mission plante à l'ouverture, erreur « KeyError: 'coalition' »"
@@ -138,48 +140,60 @@ class TestCarryingTheAttachments(unittest.TestCase):
         path.write_bytes(content)
         return Prepared(filename=name, kind=kind, path=path, size=len(content))
 
+    def _carry(self, prepared: Prepared, **options: int) -> Carried:
+        """Carry one attachment through the **real** redaction helper.
+
+        Args:
+            prepared: The attachment.
+            **options: Passed through to :func:`carry`.
+
+        Returns:
+            The decision.
+        """
+        return carry(prepared, redactor=partial(redact, fixture_root()), **options)
+
     def test_a_small_text_file_travels_whole_inside_the_issue(self) -> None:
-        carried = carry(self._prepared("veaf-tools.log", "log", b"line one\nline two\n"))
+        carried = self._carry(self._prepared("veaf-tools.log", "log", b"line one\nline two\n"))
         self.assertIn("line two", carried.text)
         self.assertEqual(carried.reason, "")
 
     def test_a_binary_is_described_rather_than_carried(self) -> None:
-        carried = carry(self._prepared("mission.miz", "mission", b"PK\x03\x04binary"))
+        carried = self._carry(self._prepared("mission.miz", "mission", b"PK\x03\x04binary"))
         self.assertEqual(carried.text, "")
         self.assertIn("binary file", carried.reason)
 
     def test_a_text_file_past_the_ceiling_is_described_with_its_size(self) -> None:
-        carried = carry(self._prepared("big.log", "log", b"x" * (INLINE_MAX_CHARS + 10)))
+        carried = self._carry(self._prepared("big.log", "log", b"x" * (INLINE_MAX_CHARS + 10)))
         self.assertEqual(carried.text, "")
         self.assertIn(str(INLINE_MAX_CHARS + 10), carried.reason)
 
     def test_an_unreadable_file_says_so_instead_of_producing_an_empty_quote(self) -> None:
         prepared = Prepared(filename="gone.log", kind="log", path=self.root / "gone.log", size=10)
-        carried = carry(prepared)
+        carried = self._carry(prepared)
         self.assertIn("could not be read back", carried.reason)
 
     def test_the_manifest_names_every_file_and_its_digest(self) -> None:
-        carried = [carry(self._prepared("veaf-tools.log", "log", b"hello"))]
+        carried = [self._carry(self._prepared("veaf-tools.log", "log", b"hello"))]
         body = render_body(_report("en"), "abc", carried=carried)
         self.assertIn("veaf-tools.log", body)
         self.assertIn("sha256:", body)
 
     def test_the_manifest_says_plainly_when_the_bytes_are_not_in_the_issue(self) -> None:
-        carried = [carry(self._prepared("mission.miz", "mission", b"PK\x03\x04"))]
+        carried = [self._carry(self._prepared("mission.miz", "mission", b"PK\x03\x04"))]
         body = render_body(_report("en"), "abc", carried=carried)
         self.assertIn("not published here", body)
 
     def test_a_carried_file_becomes_a_comment_and_a_described_one_does_not(self) -> None:
         carried = [
-            carry(self._prepared("veaf-tools.log", "log", b"kept")),
-            carry(self._prepared("mission.miz", "mission", b"PK\x03\x04")),
+            self._carry(self._prepared("veaf-tools.log", "log", b"kept")),
+            self._carry(self._prepared("mission.miz", "mission", b"PK\x03\x04")),
         ]
         comments = render_attachment_comments(carried)
         self.assertEqual(len(comments), 1)
         self.assertIn("kept", comments[0])
 
     def test_no_discord_url_ever_reaches_the_issue(self) -> None:
-        carried = [carry(self._prepared("mission.miz", "mission", b"PK\x03\x04"))]
+        carried = [self._carry(self._prepared("mission.miz", "mission", b"PK\x03\x04"))]
         body = render_body(_report(), "abc", carried=carried)
         self.assertNotIn("cdn.discordapp.com", body)
         self.assertNotIn("discordapp.net", body)

--- a/services/support-bot/tests/test_issue_body.py
+++ b/services/support-bot/tests/test_issue_body.py
@@ -215,6 +215,25 @@ class TestThePriorArtSection(unittest.TestCase):
         self.assertIn(f"### {heading('priorart', 'en')}", render_body(report, "abc"))
 
 
+class TestTheThreeMaterialBuckets(unittest.TestCase):
+    """A configuration file must not come out of the renderer under a *log excerpt* heading."""
+
+    def test_a_quoted_file_gets_its_own_heading(self) -> None:
+        report = assemble(
+            BugForm(summary="s", happened="h", expected="e", steps="p", language="en"),
+            fixture_checkout(),
+            log_digests=("**dcs.log**\nan excerpt",),
+            quoted_files=("**mission.yaml**\nmodules: {}",),
+        )
+        body = render_body(report, "abc")
+        self.assertIn(f"### {heading('quoted', 'en')}", body)
+        self.assertIn("mission.yaml", body)
+        self.assertLess(
+            body.index(f"### {heading('logs', 'en')}"),
+            body.index(f"### {heading('quoted', 'en')}"),
+        )
+
+
 class TestWhatIsMissing(unittest.TestCase):
     """Absent is stated, never filled in."""
 

--- a/services/support-bot/tests/test_issue_body.py
+++ b/services/support-bot/tests/test_issue_body.py
@@ -27,7 +27,7 @@ from veaf_support_bot.issue_body import (
     render_prior_art,
 )
 from veaf_support_bot.priorart import DUPLICATE, NONE, Candidate, Match, Sweep
-from veaf_support_bot.toolkit import ToolkitUnavailable, redact
+from veaf_support_bot.toolkit import redact
 
 #: A French log line with a home directory in it, quoted as evidence.
 FRENCH_REPORT = "La mission plante à l'ouverture, erreur « KeyError: 'coalition' »"

--- a/services/support-bot/tests/test_priorart.py
+++ b/services/support-bot/tests/test_priorart.py
@@ -1,0 +1,414 @@
+"""The four sources, the four outcomes, and the refusal that keeps a real bug alive.
+
+The verdicts are asserted one per test, and so is the case the ticket calls the failure mode: a
+match the reporter rejects must leave the flow running, not end it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from collections.abc import Sequence
+from pathlib import Path
+
+from tests.intake_fixtures import fixture_root
+from veaf_support_bot.priorart import (
+    DUPLICATE,
+    FIXED,
+    IN_PROGRESS,
+    MATCH_MIN_SCORE,
+    NONE,
+    SOURCE_BACKLOG,
+    SOURCE_CLOSED_ISSUE,
+    SOURCE_OPEN_ISSUE,
+    SOURCE_ROADMAP,
+    Candidate,
+    IssueRecord,
+    PriorArtGate,
+    PriorArtSweeper,
+    Sweep,
+    fix_version,
+    fold,
+    rank,
+    read_backlog,
+    read_roadmap,
+    score_against,
+    tokenize,
+)
+
+#: A report about the sample resolver, in the reporter's own words.
+RESOLVER_REPORT = (
+    "veafSample.resolve drops an alias when two aliases share a name\n"
+    "The mission_builder spawner then places the group at the wrong airfield."
+)
+
+
+class _Issues:
+    """An :class:`~veaf_support_bot.priorart.IssueSource` over a fixed pair of lists."""
+
+    def __init__(self, opened: Sequence[IssueRecord] = (), closed: Sequence[IssueRecord] = ()) -> None:
+        self.opened = list(opened)
+        self.closed = list(closed)
+
+    async def open_issues(self) -> Sequence[IssueRecord]:
+        return self.opened
+
+    async def recently_closed_issues(self) -> Sequence[IssueRecord]:
+        return self.closed
+
+
+class _BrokenIssues:
+    """An issue source that cannot answer."""
+
+    async def open_issues(self) -> Sequence[IssueRecord]:
+        raise TimeoutError("the tracker did not answer")
+
+    async def recently_closed_issues(self) -> Sequence[IssueRecord]:
+        return ()
+
+
+class _Answer:
+    """A confirmation that always gives the same answer, and remembers what it was shown."""
+
+    def __init__(self, answer: bool) -> None:
+        self.answer = answer
+        self.shown: list[Sweep] = []
+
+    async def confirm(self, sweep: Sweep, lang: str) -> bool:
+        self.shown.append(sweep)
+        return self.answer
+
+
+def _resolver_issue(number: int = 712, state: str = "open") -> IssueRecord:
+    """Build an issue describing the same defect as :data:`RESOLVER_REPORT`.
+
+    Args:
+        number: The issue number.
+        state: ``"open"`` or ``"closed"``.
+
+    Returns:
+        The record.
+    """
+    return IssueRecord(
+        number=number,
+        title="veafSample.resolve loses an alias",
+        body="Two aliases of the same name, and mission_builder spawns the group at the wrong airfield.",
+        url=f"https://example.invalid/issues/{number}",
+        state=state,
+        closed_at="2026-09-02T10:00:00Z" if state == "closed" else "",
+    )
+
+
+def _candidate() -> Candidate:
+    """Build a candidate shaped like a real issue: a title **and** a body.
+
+    Returns:
+        The candidate.
+    """
+    record = _resolver_issue()
+    return Candidate(SOURCE_OPEN_ISSUE, f"#{record.number}", record.title, record.body, record.url)
+
+
+class TestTokenising(unittest.TestCase):
+    """What the score treats as discriminating, and what it throws away."""
+
+    def test_accents_and_case_are_folded(self) -> None:
+        self.assertEqual(fold("Problème DÉTECTÉ"), "probleme detecte")
+
+    def test_an_identifier_is_a_signal_token_and_a_short_word_is_not(self) -> None:
+        signal, ordinary = tokenize("the mission_builder crashed on mission.yaml")
+        self.assertIn("mission_builder", signal)
+        self.assertIn("mission.yaml", signal)
+        self.assertIn("crashed", ordinary)
+
+    def test_stop_words_are_dropped_entirely(self) -> None:
+        signal, ordinary = tokenize("the and pour avec")
+        self.assertEqual((signal, ordinary), (frozenset(), frozenset()))
+
+
+class TestScoring(unittest.TestCase):
+    """A proposal needs something distinctive; ordinary words alone are not enough."""
+
+    def test_two_reports_sharing_only_common_words_are_not_matched(self) -> None:
+        signal, ordinary = tokenize("le bug arrive quand je lance")
+        candidate = Candidate(SOURCE_OPEN_ISSUE, "#1", "un bug arrive quand je lance")
+        self.assertIsNone(score_against(signal, ordinary, candidate))
+
+    def test_a_shared_identifier_carries_the_match(self) -> None:
+        signal, ordinary = tokenize(RESOLVER_REPORT)
+        match = score_against(signal, ordinary, _candidate())
+        assert match is not None
+        self.assertGreaterEqual(match.score, MATCH_MIN_SCORE)
+        self.assertIn("veafsample.resolve", match.shared)
+
+    def test_the_evidence_names_the_source_the_reference_and_the_shared_words(self) -> None:
+        signal, ordinary = tokenize(RESOLVER_REPORT)
+        match = score_against(signal, ordinary, _candidate())
+        assert match is not None
+        evidence = match.evidence()
+        self.assertIn(SOURCE_OPEN_ISSUE, evidence)
+        self.assertIn("#712", evidence)
+        self.assertIn("veafsample.resolve", evidence)
+
+    def test_an_empty_report_matches_nothing(self) -> None:
+        self.assertIsNone(score_against(frozenset(), frozenset(), Candidate(SOURCE_OPEN_ISSUE, "#1", "")))
+
+    def test_ranking_prefers_a_fix_over_a_duplicate_at_an_equal_score(self) -> None:
+        fixed = Candidate(SOURCE_CLOSED_ISSUE, "#2", "t")
+        duplicate = Candidate(SOURCE_OPEN_ISSUE, "#1", "t")
+        ordered = rank(
+            [
+                _match(duplicate, 0.5),
+                _match(fixed, 0.5),
+            ]
+        )
+        self.assertEqual(ordered[0].candidate.source, SOURCE_CLOSED_ISSUE)
+
+
+def _match(candidate: Candidate, score: float):
+    """Build a match without going through the scorer.
+
+    Args:
+        candidate: What it points at.
+        score: Its score.
+
+    Returns:
+        The match.
+    """
+    from veaf_support_bot.priorart import Match
+
+    return Match(candidate=candidate, score=score, shared=("x",))
+
+
+class TestTheCheckoutSources(unittest.TestCase):
+    """``.backlog/`` and ``ROADMAP.md``, read off disk."""
+
+    def test_an_open_lot_is_a_candidate_and_a_closed_one_is_not(self) -> None:
+        lots, problem = read_backlog(fixture_root())
+        self.assertEqual(problem, "")
+        references = [lot.reference for lot in lots]
+        self.assertIn("FEAT-SAMPLE-RESOLVER", references)
+        self.assertNotIn("FEAT-ALREADY-DONE", references)
+
+    def test_a_missing_backlog_is_a_stated_problem_not_an_empty_result(self) -> None:
+        lots, problem = read_backlog(Path(__file__).parent / "no-such-checkout")
+        self.assertEqual(lots, [])
+        self.assertIn("not a directory", problem)
+
+    def test_each_roadmap_section_is_a_candidate(self) -> None:
+        sections, problem = read_roadmap(fixture_root())
+        self.assertEqual(problem, "")
+        self.assertIn("2. Parked deliberately", [section.reference for section in sections])
+
+    def test_a_missing_roadmap_is_a_stated_problem(self) -> None:
+        sections, problem = read_roadmap(Path(__file__).parent / "no-such-checkout")
+        self.assertEqual(sections, [])
+        self.assertIn("missing", problem)
+
+    def test_the_version_that_carries_a_fix_is_read_off_the_changelog(self) -> None:
+        self.assertEqual(fix_version(fixture_root(), 712), "6.19.0")
+
+    def test_an_unreleased_citation_yields_no_version(self) -> None:
+        self.assertEqual(fix_version(fixture_root(), 909), "")
+
+    def test_an_uncited_issue_yields_no_version_rather_than_a_guess(self) -> None:
+        self.assertEqual(fix_version(fixture_root(), 999999), "")
+
+    def test_a_missing_changelog_yields_no_version(self) -> None:
+        self.assertEqual(fix_version(Path(__file__).parent / "no-such-checkout", 712), "")
+
+
+class TestTheFourOutcomes(unittest.IsolatedAsyncioTestCase):
+    """One test per verdict the ticket names, and one for the fourth: nothing found."""
+
+    async def test_an_open_issue_produces_already_reported(self) -> None:
+        sweeper = PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()]))
+        sweep = await sweeper.sweep(RESOLVER_REPORT)
+        self.assertEqual(sweep.verdict, DUPLICATE)
+        assert sweep.best is not None
+        self.assertEqual(sweep.best.candidate.reference, "#712")
+
+    async def test_a_closed_issue_produces_already_fixed_with_its_version(self) -> None:
+        sweeper = PriorArtSweeper(fixture_root(), _Issues(closed=[_resolver_issue(state="closed")]))
+        sweep = await sweeper.sweep(RESOLVER_REPORT)
+        self.assertEqual(sweep.verdict, FIXED)
+        assert sweep.best is not None
+        self.assertEqual(sweep.best.candidate.detail, "6.19.0")
+
+    async def test_a_backlog_lot_produces_work_in_progress(self) -> None:
+        sweeper = PriorArtSweeper(fixture_root(), _Issues())
+        sweep = await sweeper.sweep(RESOLVER_REPORT)
+        self.assertEqual(sweep.verdict, IN_PROGRESS)
+        assert sweep.best is not None
+        self.assertEqual(sweep.best.candidate.source, SOURCE_BACKLOG)
+
+    async def test_a_roadmap_section_can_produce_work_in_progress(self) -> None:
+        sweeper = PriorArtSweeper(fixture_root(), _Issues())
+        sweep = await sweeper.sweep(
+            "the mission_builder catalogue rewrite never regenerated the airdromes table per theatre"
+        )
+        self.assertEqual(sweep.verdict, IN_PROGRESS)
+        assert sweep.best is not None
+        self.assertEqual(sweep.best.candidate.source, SOURCE_ROADMAP)
+
+    async def test_an_unrelated_report_finds_nothing(self) -> None:
+        sweeper = PriorArtSweeper(fixture_root(), _Issues())
+        sweep = await sweeper.sweep("the radio menu shows Cyrillic on a Kola map at dusk")
+        self.assertEqual(sweep.verdict, NONE)
+        self.assertIsNone(sweep.best)
+
+
+class TestWhatWasCheckedIsRecorded(unittest.IsolatedAsyncioTestCase):
+    """A reader must be able to see the sweep ran, and see when it could not."""
+
+    async def test_every_source_is_named_with_how_much_it_held(self) -> None:
+        sweeper = PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()]))
+        sweep = await sweeper.sweep(RESOLVER_REPORT)
+        described = sweep.describe()
+        for expected in ("open issue", "recently closed issue", "backlog lot", "roadmap section"):
+            self.assertIn(expected, described)
+
+    async def test_a_tracker_that_fails_is_a_stated_gap_not_a_silent_zero(self) -> None:
+        sweeper = PriorArtSweeper(fixture_root(), _BrokenIssues())
+        sweep = await sweeper.sweep(RESOLVER_REPORT)
+        self.assertIn("the issue tracker (TimeoutError)", sweep.problems)
+        self.assertIn("Not consulted", sweep.describe())
+
+    async def test_no_credentials_says_so_rather_than_pretending_the_tracker_was_read(self) -> None:
+        sweeper = PriorArtSweeper(fixture_root(), None)
+        sweep = await sweeper.sweep(RESOLVER_REPORT)
+        self.assertTrue(any("no GitHub credentials" in problem for problem in sweep.problems))
+        self.assertNotIn("open issue(s)", sweep.describe())
+
+    async def test_a_sweep_with_no_source_at_all_still_describes_itself(self) -> None:
+        sweeper = PriorArtSweeper(Path(__file__).parent / "no-such-checkout", None)
+        sweep = await sweeper.sweep(RESOLVER_REPORT)
+        self.assertIn("nothing could be consulted", sweep.describe())
+
+
+class TestTheRefusal(unittest.IsolatedAsyncioTestCase):
+    """The guard: a proposal the reporter refuses must not end his report."""
+
+    async def test_an_accepted_match_is_reported_as_accepted(self) -> None:
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])), _Answer(True))
+        sweep, accepted = await gate.run(RESOLVER_REPORT, "fr")
+        self.assertTrue(accepted)
+        self.assertEqual(sweep.verdict, DUPLICATE)
+
+    async def test_a_rejected_match_leaves_the_flow_running(self) -> None:
+        answer = _Answer(False)
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])), answer)
+        sweep, accepted = await gate.run(RESOLVER_REPORT, "fr")
+        self.assertFalse(accepted)
+        self.assertTrue(sweep.found, "the finding survives the refusal, so the issue can record it")
+
+    async def test_the_reporter_is_shown_the_evidence_before_being_asked(self) -> None:
+        answer = _Answer(False)
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])), answer)
+        await gate.run(RESOLVER_REPORT, "fr")
+        self.assertEqual(len(answer.shown), 1)
+        assert answer.shown[0].best is not None
+        self.assertTrue(answer.shown[0].best.shared, "a proposal with no shared word is an assertion")
+
+    async def test_with_nobody_to_ask_the_gate_refuses_rather_than_silencing_the_report(self) -> None:
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])), None)
+        sweep, accepted = await gate.run(RESOLVER_REPORT, "fr")
+        self.assertTrue(sweep.found)
+        self.assertFalse(accepted)
+
+    async def test_nothing_found_is_never_offered_for_confirmation(self) -> None:
+        answer = _Answer(True)
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues()), answer)
+        _, accepted = await gate.run("the radio menu shows Cyrillic on a Kola map at dusk", "fr")
+        self.assertFalse(accepted)
+        self.assertEqual(answer.shown, [])
+
+
+class TestTheseTestsDetectABrokenSweep(unittest.TestCase):
+    """Each cut is made in the shipped module, and the matching test must go red.
+
+    A detector that mutates a stand-in defined in this file proves the stand-in.
+    """
+
+    def _fails(self, name: str) -> bool:
+        """Run one test of this file and say whether it failed.
+
+        Args:
+            name: ``Class.method``.
+
+        Returns:
+            ``True`` when it did not pass.
+        """
+        loader = unittest.TestLoader()
+        suite = loader.loadTestsFromName(f"tests.test_priorart.{name}")
+        result = unittest.TestResult()
+        suite.run(result)
+        return not result.wasSuccessful()
+
+    def test_a_gate_that_stopped_asking_is_caught(self) -> None:
+        from veaf_support_bot import priorart
+
+        original = priorart.PriorArtGate.run
+
+        async def _always_accept(self, query: str, lang: str):  # type: ignore[no-untyped-def]
+            return await self.sweeper.sweep(query), True
+
+        priorart.PriorArtGate.run = _always_accept  # type: ignore[method-assign]
+        try:
+            self.assertTrue(self._fails("TestTheRefusal.test_a_rejected_match_leaves_the_flow_running"))
+        finally:
+            priorart.PriorArtGate.run = original  # type: ignore[method-assign]
+
+    def test_a_sweep_that_stopped_reading_the_backlog_is_caught(self) -> None:
+        from veaf_support_bot import priorart
+
+        original = priorart.read_backlog
+        priorart.read_backlog = lambda root: ([], "")  # type: ignore[assignment]
+        try:
+            self.assertTrue(self._fails("TestTheFourOutcomes.test_a_backlog_lot_produces_work_in_progress"))
+        finally:
+            priorart.read_backlog = original  # type: ignore[assignment]
+
+    def test_a_closed_lot_leaking_back_into_the_corpus_is_caught(self) -> None:
+        from veaf_support_bot import priorart
+
+        original = priorart.CLOSED_LOT_STATUSES
+        priorart.CLOSED_LOT_STATUSES = ()  # type: ignore[assignment]
+        try:
+            self.assertTrue(
+                self._fails("TestTheCheckoutSources.test_an_open_lot_is_a_candidate_and_a_closed_one_is_not")
+            )
+        finally:
+            priorart.CLOSED_LOT_STATUSES = original  # type: ignore[assignment]
+
+    def test_a_tracker_failure_swallowed_into_silence_is_caught(self) -> None:
+        from veaf_support_bot import priorart
+
+        original = priorart.PriorArtSweeper._issue_records
+
+        async def _silent(self):  # type: ignore[no-untyped-def]
+            return (), (), True
+
+        priorart.PriorArtSweeper._issue_records = _silent  # type: ignore[method-assign]
+        try:
+            self.assertTrue(
+                self._fails("TestWhatWasCheckedIsRecorded.test_a_tracker_that_fails_is_a_stated_gap_not_a_silent_zero")
+            )
+        finally:
+            priorart.PriorArtSweeper._issue_records = original  # type: ignore[method-assign]
+
+    def test_dropping_the_evidence_from_a_proposal_is_caught(self) -> None:
+        from veaf_support_bot import priorart
+
+        original = priorart.EVIDENCE_MAX_TOKENS
+        priorart.EVIDENCE_MAX_TOKENS = 0  # type: ignore[assignment]
+        try:
+            self.assertTrue(
+                self._fails("TestTheRefusal.test_the_reporter_is_shown_the_evidence_before_being_asked")
+            )
+        finally:
+            priorart.EVIDENCE_MAX_TOKENS = original  # type: ignore[assignment]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/services/support-bot/tests/test_priorart.py
+++ b/services/support-bot/tests/test_priorart.py
@@ -24,6 +24,7 @@ from veaf_support_bot.priorart import (
     SOURCE_ROADMAP,
     Candidate,
     IssueRecord,
+    Match,
     PriorArtGate,
     PriorArtSweeper,
     Sweep,
@@ -165,7 +166,7 @@ class TestScoring(unittest.TestCase):
         self.assertEqual(ordered[0].candidate.source, SOURCE_CLOSED_ISSUE)
 
 
-def _match(candidate: Candidate, score: float):
+def _match(candidate: Candidate, score: float) -> Match:
     """Build a match without going through the scorer.
 
     Args:
@@ -175,8 +176,6 @@ def _match(candidate: Candidate, score: float):
     Returns:
         The match.
     """
-    from veaf_support_bot.priorart import Match
-
     return Match(candidate=candidate, score=score, shared=("x",))
 
 
@@ -363,11 +362,11 @@ class TestTheseTestsDetectABrokenSweep(unittest.TestCase):
         from veaf_support_bot import priorart
 
         original = priorart.read_backlog
-        priorart.read_backlog = lambda root: ([], "")  # type: ignore[assignment]
+        priorart.read_backlog = lambda root: ([], "")
         try:
             self.assertTrue(self._fails("TestTheFourOutcomes.test_a_backlog_lot_produces_work_in_progress"))
         finally:
-            priorart.read_backlog = original  # type: ignore[assignment]
+            priorart.read_backlog = original
 
     def test_a_closed_lot_leaking_back_into_the_corpus_is_caught(self) -> None:
         from veaf_support_bot import priorart
@@ -379,7 +378,7 @@ class TestTheseTestsDetectABrokenSweep(unittest.TestCase):
                 self._fails("TestTheCheckoutSources.test_an_open_lot_is_a_candidate_and_a_closed_one_is_not")
             )
         finally:
-            priorart.CLOSED_LOT_STATUSES = original  # type: ignore[assignment]
+            priorart.CLOSED_LOT_STATUSES = original
 
     def test_a_tracker_failure_swallowed_into_silence_is_caught(self) -> None:
         from veaf_support_bot import priorart
@@ -401,13 +400,11 @@ class TestTheseTestsDetectABrokenSweep(unittest.TestCase):
         from veaf_support_bot import priorart
 
         original = priorart.EVIDENCE_MAX_TOKENS
-        priorart.EVIDENCE_MAX_TOKENS = 0  # type: ignore[assignment]
+        priorart.EVIDENCE_MAX_TOKENS = 0
         try:
-            self.assertTrue(
-                self._fails("TestTheRefusal.test_the_reporter_is_shown_the_evidence_before_being_asked")
-            )
+            self.assertTrue(self._fails("TestTheRefusal.test_the_reporter_is_shown_the_evidence_before_being_asked"))
         finally:
-            priorart.EVIDENCE_MAX_TOKENS = original  # type: ignore[assignment]
+            priorart.EVIDENCE_MAX_TOKENS = original
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/services/support-bot/tests/test_priorart.py
+++ b/services/support-bot/tests/test_priorart.py
@@ -7,6 +7,7 @@ match the reporter rejects must leave the flow running, not end it.
 from __future__ import annotations
 
 import asyncio
+import tempfile
 import unittest
 from collections.abc import Sequence
 from pathlib import Path
@@ -195,6 +196,44 @@ class TestTheCheckoutSources(unittest.TestCase):
         self.assertEqual(lots, [])
         self.assertEqual(unreadable, [])
         self.assertIn("not a directory", problem)
+
+    def _backlog_with_one_unreadable_prd(self) -> Path:
+        """Build a checkout whose second lot cannot be read.
+
+        A directory where the file should be: ``read_text`` raises ``IsADirectoryError`` on POSIX
+        and ``PermissionError`` on Windows, and both are the ``OSError`` the reader catches — so the
+        case is exercised on either machine without touching file modes.
+
+        Returns:
+            The checkout root.
+        """
+        folder = tempfile.TemporaryDirectory()
+        self.addCleanup(folder.cleanup)
+        root = Path(folder.name)
+        (root / ".backlog" / "FEAT-READABLE").mkdir(parents=True)
+        (root / ".backlog" / "FEAT-READABLE" / "PRD.md").write_text(
+            "# The resolver drops an alias\n\nStatus: ⬜ ready\n", encoding="utf-8"
+        )
+        (root / ".backlog" / "FEAT-UNREADABLE" / "PRD.md").mkdir(parents=True)
+        return root
+
+    def test_an_unreadable_prd_is_a_stated_problem_and_not_a_candidate(self) -> None:
+        """An empty `Candidate` matched nothing, so the lot read as *swept and clean*."""
+        lots, problem, unreadable = read_backlog(self._backlog_with_one_unreadable_prd())
+        self.assertEqual(problem, "", "the directory itself was readable")
+        self.assertEqual([lot.reference for lot in lots], ["FEAT-READABLE"])
+        self.assertEqual(len(unreadable), 1)
+        self.assertIn("FEAT-UNREADABLE", unreadable[0])
+
+    def test_the_unreadable_lot_reaches_the_reader_of_the_issue(self) -> None:
+        """Asserted on `Sweep.problems`, not on the reader: the wire is what was missing."""
+        sweeper = PriorArtSweeper(self._backlog_with_one_unreadable_prd(), None)
+        sweep = asyncio.run(sweeper.sweep(RESOLVER_REPORT))
+        self.assertTrue(
+            any("FEAT-UNREADABLE" in problem for problem in sweep.problems),
+            f"the lot nobody could read is unsaid: {sweep.problems}",
+        )
+        self.assertIn("1 open backlog lot(s)", sweep.describe(), "the lots it did read are still counted")
 
     def test_each_roadmap_section_is_a_candidate(self) -> None:
         sections, problem = read_roadmap(fixture_root())

--- a/services/support-bot/tests/test_priorart.py
+++ b/services/support-bot/tests/test_priorart.py
@@ -183,15 +183,17 @@ class TestTheCheckoutSources(unittest.TestCase):
     """``.backlog/`` and ``ROADMAP.md``, read off disk."""
 
     def test_an_open_lot_is_a_candidate_and_a_closed_one_is_not(self) -> None:
-        lots, problem = read_backlog(fixture_root())
+        lots, problem, unreadable = read_backlog(fixture_root())
         self.assertEqual(problem, "")
+        self.assertEqual(unreadable, [])
         references = [lot.reference for lot in lots]
         self.assertIn("FEAT-SAMPLE-RESOLVER", references)
         self.assertNotIn("FEAT-ALREADY-DONE", references)
 
     def test_a_missing_backlog_is_a_stated_problem_not_an_empty_result(self) -> None:
-        lots, problem = read_backlog(Path(__file__).parent / "no-such-checkout")
+        lots, problem, unreadable = read_backlog(Path(__file__).parent / "no-such-checkout")
         self.assertEqual(lots, [])
+        self.assertEqual(unreadable, [])
         self.assertIn("not a directory", problem)
 
     def test_each_roadmap_section_is_a_candidate(self) -> None:
@@ -362,7 +364,7 @@ class TestTheseTestsDetectABrokenSweep(unittest.TestCase):
         from veaf_support_bot import priorart
 
         original = priorart.read_backlog
-        priorart.read_backlog = lambda root: ([], "")
+        priorart.read_backlog = lambda root: ([], "", [])
         try:
             self.assertTrue(self._fails("TestTheFourOutcomes.test_a_backlog_lot_produces_work_in_progress"))
         finally:

--- a/services/support-bot/veaf_support_bot/bugreport.py
+++ b/services/support-bot/veaf_support_bot/bugreport.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 
 from veaf_support_bot.checkout import Checkout, Freshness
+from veaf_support_bot.priorart import Sweep
 from veaf_support_bot.toolkit import DoctorFacts, ToolkitUnavailable, parse_doctor_block, redact
 from veaf_support_bot.traces import Location, TraceReading, Unresolved, read_trace
 from veaf_support_bot.untrusted import one_line
@@ -154,6 +155,9 @@ class BugReport:
         quoted_files: Everything else that was small enough to quote — a `mission.yaml`, a
             configuration file, an archive listing — kept apart from the two above so a renderer
             cannot file a configuration file under a *log excerpts* heading.
+        prior_art: What the four-source sweep found, or ``None`` when no sweep ran. It is attached
+            to the report rather than acted on here: the sweep informs the decision, the reporter
+            takes it.
     """
 
     form: BugForm
@@ -169,6 +173,7 @@ class BugReport:
     mission_summaries: tuple[str, ...] = ()
     log_digests: tuple[str, ...] = ()
     quoted_files: tuple[str, ...] = ()
+    prior_art: Sweep | None = None
 
     @property
     def located(self) -> tuple[Location, ...]:
@@ -230,6 +235,7 @@ def assemble(
     log_digests: tuple[str, ...] = (),
     quoted_files: tuple[str, ...] = (),
     attachments: tuple[object, ...] = (),
+    prior_art: Sweep | None = None,
 ) -> BugReport:
     """Turn a submitted form into a filled report, using no model.
 
@@ -243,6 +249,7 @@ def assemble(
         log_digests: Rendered log excerpts.
         quoted_files: Everything else small enough to quote.
         attachments: Prepared files to upload with the issue.
+        prior_art: What the prior-art sweep found, when one ran.
 
     Returns:
         The report.
@@ -310,6 +317,7 @@ def assemble(
         mission_summaries=mission_summaries,
         log_digests=log_digests,
         quoted_files=quoted_files,
+        prior_art=prior_art,
     )
 
 

--- a/services/support-bot/veaf_support_bot/cli.py
+++ b/services/support-bot/veaf_support_bot/cli.py
@@ -29,6 +29,7 @@ from veaf_support_bot.config import (
     ConfigurationError,
     SupportBotConfig,
 )
+from veaf_support_bot.github_app import GitHubError
 from veaf_support_bot.logging_setup import configure_logging, get_logger
 from veaf_support_bot.service import SupportBotService
 
@@ -117,7 +118,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     Returns:
         The process exit code: ``0`` on a clean stop, :data:`EXIT_CONFIG_ERROR` when the environment
-        does not describe a runnable service, ``2`` on an unknown argument.
+        does not describe a runnable service — an unreadable GitHub App key included — and ``2`` on
+        an unknown argument.
     """
     args = list(sys.argv[1:] if argv is None else argv)
 
@@ -146,5 +148,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         return EXIT_CONFIG_ERROR
 
     configure_logging(level=config.log_level, log_format=config.log_format)
-    _run(config)
+    try:
+        _run(config)
+    except GitHubError as error:
+        # The App is configured and its key is unusable. That is a deployment mistake and it belongs
+        # here, not in the first bug report the service fails to file a week from now — a service
+        # that collects reports it cannot deliver looks healthy from every side but the useful one.
+        get_logger("cli").critical(
+            f"the support bot cannot start: {error}",
+            extra={"event": "config.invalid", "subject": "github-app"},
+        )
+        return EXIT_CONFIG_ERROR
     return 0

--- a/services/support-bot/veaf_support_bot/config.py
+++ b/services/support-bot/veaf_support_bot/config.py
@@ -94,6 +94,23 @@ DEFAULT_CHECKOUT_REFRESH_SECONDS: Final = 900.0
 DEFAULT_ATTACHMENT_MAX_BYTES: Final = 25 * 1024 * 1024
 DEFAULT_ATTACHMENT_TOTAL_BYTES: Final = 60 * 1024 * 1024
 
+# ---------------------------------------------------------------------------
+# FEAT-SUPPORT-BUG-INTAKE ticket 05 — the GitHub App the issue is filed under. Every value is
+# optional: with no App configured the intake still runs, prepares the report and shows it, and
+# says it cannot file. Configure ONE of them and they all become required together, because a
+# half-configured App is a service that collects reports it cannot deliver.
+# ---------------------------------------------------------------------------
+
+#: Repository the App is installed on, ``owner/name``.
+DEFAULT_GITHUB_REPOSITORY: Final = "VEAF/VEAF-Mission-Creation-Tools"
+
+#: Where the filed-report ledger lives. Beside the quota counters, and with the same requirement:
+#: it must survive a restart, or a restart mid-flight falls back to the slower in-issue marker.
+DEFAULT_GITHUB_LEDGER_FILE: Final = "state/filed-issues.json"
+
+#: Label marking an issue as filed by the machine.
+DEFAULT_GITHUB_MACHINE_LABEL: Final = "filed-by-bot"
+
 #: Accepted values of ``SUPPORT_BOT_LOG_FORMAT``.
 LOG_FORMATS: Final = ("json", "text")
 
@@ -409,6 +426,14 @@ class SupportBotConfig:
         checkout_refresh_seconds: Shortest gap between two refreshes; ``0`` pins the revision.
         attachment_max_bytes: Largest single attachment one report may carry.
         attachment_total_bytes: Largest total across one report.
+        github_app_id: The GitHub App's numeric id; empty means no App is configured and ``/bug``
+            prepares reports without filing them.
+        github_installation_id: The App's installation on the one repository it serves.
+        github_private_key: The App's private key, PEM, inline. **Secret**; never logged.
+        github_private_key_file: A file holding that key instead. Exactly one of the two.
+        github_repository: ``owner/name`` the issues are filed on.
+        github_ledger_file: Where filed reports are recorded, so a retry never files twice.
+        github_machine_label: Label marking an issue as machine-filed.
     """
 
     discord_token: str
@@ -434,6 +459,23 @@ class SupportBotConfig:
     checkout_refresh_seconds: float = DEFAULT_CHECKOUT_REFRESH_SECONDS
     attachment_max_bytes: int = DEFAULT_ATTACHMENT_MAX_BYTES
     attachment_total_bytes: int = DEFAULT_ATTACHMENT_TOTAL_BYTES
+    github_app_id: str = ""
+    github_installation_id: str = ""
+    github_private_key: str = ""
+    github_private_key_file: str = ""
+    github_repository: str = DEFAULT_GITHUB_REPOSITORY
+    github_ledger_file: str = DEFAULT_GITHUB_LEDGER_FILE
+    github_machine_label: str = DEFAULT_GITHUB_MACHINE_LABEL
+
+    @property
+    def files_issues(self) -> bool:
+        """Say whether this deployment can open an issue at all.
+
+        Returns:
+            ``True`` when the App is configured. ``False`` makes ``/bug`` a preparation step that
+            says so, which is what every deployment does until the App has been created.
+        """
+        return bool(self.github_app_id and self.github_installation_id)
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> SupportBotConfig:
@@ -488,7 +530,15 @@ class SupportBotConfig:
             checkout_refresh_seconds=reader.interval("CHECKOUT_REFRESH_SECONDS", DEFAULT_CHECKOUT_REFRESH_SECONDS),
             attachment_max_bytes=reader.integer("ATTACHMENT_MAX_BYTES", DEFAULT_ATTACHMENT_MAX_BYTES, minimum=1),
             attachment_total_bytes=reader.integer("ATTACHMENT_TOTAL_BYTES", DEFAULT_ATTACHMENT_TOTAL_BYTES, minimum=1),
+            github_app_id=reader.text("GITHUB_APP_ID", ""),
+            github_installation_id=reader.text("GITHUB_INSTALLATION_ID", ""),
+            github_private_key=reader.text("GITHUB_PRIVATE_KEY", ""),
+            github_private_key_file=reader.text("GITHUB_PRIVATE_KEY_FILE", ""),
+            github_repository=reader.text("GITHUB_REPOSITORY", DEFAULT_GITHUB_REPOSITORY),
+            github_ledger_file=reader.text("GITHUB_LEDGER_FILE", DEFAULT_GITHUB_LEDGER_FILE),
+            github_machine_label=reader.text("GITHUB_MACHINE_LABEL", DEFAULT_GITHUB_MACHINE_LABEL),
         )
+        _check_github(reader, config)
         reader.raise_if_broken()
         return config
 
@@ -522,6 +572,13 @@ class SupportBotConfig:
             "checkout_refresh_seconds": self.checkout_refresh_seconds,
             "attachment_max_bytes": self.attachment_max_bytes,
             "attachment_total_bytes": self.attachment_total_bytes,
+            "github_app_id": self.github_app_id,
+            "github_installation_id": self.github_installation_id,
+            "github_private_key": REDACTED if self.github_private_key else "",
+            "github_private_key_file": self.github_private_key_file,
+            "github_repository": self.github_repository,
+            "github_ledger_file": self.github_ledger_file,
+            "github_machine_label": self.github_machine_label,
         }
 
     def __repr__(self) -> str:
@@ -535,3 +592,52 @@ class SupportBotConfig:
         """
         fields = ", ".join(f"{key}={value!r}" for key, value in self.redacted().items())
         return f"{type(self).__name__}({fields})"
+
+
+#: The three things a usable GitHub App needs. Named as one because they stand or fall together.
+_GITHUB_PARTS: Final = ("GITHUB_APP_ID", "GITHUB_INSTALLATION_ID", "GITHUB_PRIVATE_KEY|GITHUB_PRIVATE_KEY_FILE")
+
+
+def _check_github(reader: _Reader, config: SupportBotConfig) -> None:
+    """Record a problem when the GitHub App is half configured.
+
+    The App does not exist yet — it is created by hand, in part B of the setup guide — so *no App at
+    all* is a supported, silent state: `/bug` prepares the report and says it cannot file it. What
+    is not supported is *some* of it. An App id with no key, or a key with no installation, is a
+    deployment that collects bug reports for a week and fails to file every one of them, and the
+    service must refuse to start rather than discover it on the first report.
+
+    Args:
+        reader: The reader collecting problems.
+        config: The configuration just built.
+    """
+    supplied = {
+        name
+        for name, value in zip(
+            _GITHUB_PARTS,
+            (
+                config.github_app_id,
+                config.github_installation_id,
+                config.github_private_key or config.github_private_key_file,
+            ),
+            strict=True,
+        )
+        if value
+    }
+    if not supplied:
+        return
+    for name in _GITHUB_PARTS:
+        if name not in supplied:
+            reader.problems.append(
+                f"{ENV_PREFIX}{name} is required once any other GitHub App variable is set "
+                f"(set: {', '.join(sorted(supplied))})"
+            )
+    if config.github_private_key and config.github_private_key_file:
+        reader.problems.append(
+            f"{ENV_PREFIX}GITHUB_PRIVATE_KEY and {ENV_PREFIX}GITHUB_PRIVATE_KEY_FILE are both set; keep one"
+        )
+    owner, _, name = config.github_repository.partition("/")
+    if not owner or not name or "/" in name:
+        reader.problems.append(
+            f"{ENV_PREFIX}GITHUB_REPOSITORY must be owner/name (got {_shape(config.github_repository)})"
+        )

--- a/services/support-bot/veaf_support_bot/filing.py
+++ b/services/support-bot/veaf_support_bot/filing.py
@@ -277,9 +277,7 @@ def _record_of(item: dict[str, Any]) -> IssueRecord:
     Returns:
         The record.
     """
-    labels = tuple(
-        str(label.get("name") or "") for label in item.get("labels") or [] if isinstance(label, dict)
-    )
+    labels = tuple(str(label.get("name") or "") for label in item.get("labels") or [] if isinstance(label, dict))
     return IssueRecord(
         number=int(item.get("number") or 0),
         title=str(item.get("title") or ""),
@@ -462,7 +460,9 @@ class IssueFiler:
         notes: list[str] = []
         for comment in render_attachment_comments(carried):
             try:
-                await self._app.request("POST", f"/repos/{self._app.repository}/issues/{number}/comments", {"body": comment})
+                await self._app.request(
+                    "POST", f"/repos/{self._app.repository}/issues/{number}/comments", {"body": comment}
+                )
             except GitHubError as error:
                 notes.append(f"an attachment could not be added to the issue: {error}")
                 self._logger.warning(

--- a/services/support-bot/veaf_support_bot/filing.py
+++ b/services/support-bot/veaf_support_bot/filing.py
@@ -1,0 +1,526 @@
+"""Filing the issue, exactly once, and saying so when it could not be filed.
+
+## Once, across three different ways of asking twice
+
+The ticket names three: a double click, a retry after a timeout, and a restart in mid-flight. They
+are three different failures and they need three different answers, so the module has three:
+
+| What happens twice | What stops it |
+|---|---|
+| Two clicks arriving together | an :class:`asyncio.Lock` per key — the second waits, then reads the first one's result |
+| A retry after a timeout, same process | the **ledger**, a small JSON file that already holds the issue number |
+| A restart after the ``POST`` was sent and the answer lost | the **marker**, an HTML comment carrying the key inside the issue; the recovery search finds it |
+
+The key is derived from the report itself — the reporter, his five fields, and the names and sizes
+of what he attached — so *the same report* always produces *the same key*, and a genuinely new
+report by the same person a minute later does not.
+
+The marker is the one that matters, because it is the only one that survives losing local state
+entirely. It is why the ledger's write before the call is not a nicety: a crash between the ``POST``
+and the ledger write leaves an issue nobody recorded, and only a search for the marker finds it.
+
+## A failure is said, never swallowed
+
+Every path returns an :class:`Outcome` carrying what happened. The intake turns it into a sentence
+the reporter reads in his thread — including *"I could not file this, here is why, and here is your
+report so it is not lost"*. An issue that failed to be created and a reporter who thinks it was
+created is the worst outcome available, and it is the one an exception swallowed into a log produces.
+
+## What this module is allowed to do on GitHub
+
+Create an issue, comment on one, list them, and set labels — all of which the *Issues: read and
+write* permission covers, on one repository, and nothing else. It never pushes, never reads code,
+never touches a workflow. See ``services/support-bot/README.md`` for the permission list as it must
+be granted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from logging import Logger
+from pathlib import Path
+from typing import Any
+
+from veaf_support_bot.attachments import Prepared
+from veaf_support_bot.bugreport import BASE_LABEL, BugReport
+from veaf_support_bot.github_app import GitHubApp, GitHubError
+from veaf_support_bot.issue_body import (
+    Carried,
+    carry,
+    marker_for,
+    render_attachment_comments,
+    render_body,
+    render_duplicate_comment,
+)
+from veaf_support_bot.logging_setup import get_logger
+from veaf_support_bot.priorart import IssueRecord
+
+#: Label marking an issue as filed by the machine, so these are findable and countable later. Not a
+#: replacement for ``bug``: the issue carries both, and the template's own label stays the one a
+#: maintainer filters on.
+MACHINE_LABEL = "filed-by-bot"
+
+#: How many recently closed issues the sweep considers. Beyond that a "fix" is old enough that the
+#: reporter's version almost certainly has it.
+CLOSED_ISSUE_COUNT = 50
+
+#: Page size asked of the API.
+PAGE_SIZE = 100
+
+#: How many pages are read at most, so a repository that grows does not turn one report into a
+#: hundred calls.
+MAX_PAGES = 5
+
+#: Version of the ledger document. A file of another version is refused rather than reinterpreted.
+LEDGER_VERSION = 1
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """What became of one report.
+
+    Attributes:
+        action: ``"created"``, ``"commented"``, ``"reused"`` (an earlier attempt had already filed
+            it) or ``"failed"``.
+        number: The issue number, when there is one.
+        url: The issue's address, when there is one.
+        error: What went wrong, when :attr:`action` is ``"failed"``. Never a stack trace, never a
+            credential.
+        notes: Things that were degraded but not fatal — a label that could not be applied, an
+            attachment comment that did not post.
+    """
+
+    action: str
+    number: int = 0
+    url: str = ""
+    error: str = ""
+    notes: tuple[str, ...] = ()
+
+    @property
+    def filed(self) -> bool:
+        """Say whether an issue exists at the end of this.
+
+        Returns:
+            ``True`` for every action but ``"failed"``.
+        """
+        return self.action != "failed"
+
+
+def report_key(report: BugReport) -> str:
+    """Derive the stable identity of one report.
+
+    Built from what the reporter supplied and nothing else — deliberately **not** from a timestamp
+    or a random value, because the same report submitted twice must produce the same key and a
+    restart must be able to recompute it from the report alone.
+
+    Args:
+        report: The assembled report.
+
+    Returns:
+        A 32-character hex digest.
+    """
+    form = report.form
+    material = [
+        form.reporter_id,
+        form.summary,
+        form.happened,
+        form.expected,
+        form.steps,
+        form.doctor,
+    ]
+    for attachment in report.attachments:
+        if isinstance(attachment, Prepared):
+            material.append(f"{attachment.filename}:{attachment.size}")
+    joined = "\x1f".join(material).encode("utf-8", errors="replace")
+    return hashlib.sha256(joined).hexdigest()[:32]
+
+
+class Ledger:
+    """What this service already filed, kept across restarts.
+
+    A whole-file rewrite of a small JSON document, for the same reason the quota counters are: the
+    failure mode of a truncated append is an entry that reads as absent, and an absent entry here is
+    a second issue.
+    """
+
+    def __init__(self, path: Path, logger: Logger | None = None) -> None:
+        """Initialize the ledger.
+
+        Args:
+            path: File the entries are kept in.
+            logger: Logger for a store that cannot be read or written.
+        """
+        self.path = path
+        self._logger = logger or get_logger("filing")
+
+    def load(self) -> dict[str, dict[str, Any]]:
+        """Read every entry back.
+
+        Returns:
+            The entries by key. An unreadable or unrecognised file yields an empty mapping and a
+            warning: refusing to file anything because a bookkeeping file is corrupt would lose
+            reports, and the marker search still stops a duplicate.
+        """
+        if not self.path.exists():
+            return {}
+        try:
+            document = json.loads(self.path.read_text(encoding="utf-8"))
+            if not isinstance(document, dict) or document.get("version") != LEDGER_VERSION:
+                raise ValueError("unsupported ledger version")
+            entries = document.get("reports")
+            if not isinstance(entries, dict):
+                raise ValueError("the ledger has no reports mapping")
+        except (OSError, ValueError) as error:
+            self._logger.warning(
+                "the filing ledger could not be read; falling back to the in-issue marker",
+                extra={"event": "filing.ledger_unreadable", "error": f"{type(error).__name__}: {error}"},
+            )
+            return {}
+        return {str(key): value for key, value in entries.items() if isinstance(value, dict)}
+
+    def record(self, key: str, entry: dict[str, Any]) -> None:
+        """Write one entry, keeping the others.
+
+        Args:
+            key: The report key.
+            entry: What to record.
+        """
+        entries = self.load()
+        entries[key] = entry
+        document = {"version": LEDGER_VERSION, "reports": entries}
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            temporary = self.path.with_suffix(f"{self.path.suffix}.tmp")
+            temporary.write_text(json.dumps(document, indent=1, sort_keys=True), encoding="utf-8")
+            temporary.replace(self.path)
+        except OSError as error:
+            self._logger.warning(
+                "the filing ledger could not be written; a retry will fall back to the in-issue marker",
+                extra={"event": "filing.ledger_unwritable", "error": f"{type(error).__name__}: {error}"},
+            )
+
+
+class RepositoryIssues:
+    """The issue half of the prior-art corpus, read through the App.
+
+    Implements :class:`~veaf_support_bot.priorart.IssueSource`. Pull requests are filtered out:
+    GitHub returns them from the issues endpoint, and proposing a pull request as a duplicate of a
+    bug report is a proposal a reporter cannot evaluate.
+    """
+
+    def __init__(self, app: GitHubApp, *, closed_count: int = CLOSED_ISSUE_COUNT) -> None:
+        """Initialize the source.
+
+        Args:
+            app: The authenticated client.
+            closed_count: How many recently closed issues to consider.
+        """
+        self._app = app
+        self._closed_count = closed_count
+
+    async def open_issues(self) -> Sequence[IssueRecord]:
+        """Return every open issue.
+
+        Returns:
+            The open issues.
+        """
+        return await self._list("open", self._closed_count * MAX_PAGES)
+
+    async def recently_closed_issues(self) -> Sequence[IssueRecord]:
+        """Return the most recently closed issues.
+
+        Returns:
+            The closed issues, newest first.
+        """
+        return await self._list("closed", self._closed_count)
+
+    async def _list(self, state: str, ceiling: int) -> list[IssueRecord]:
+        """Page through the issues endpoint.
+
+        Args:
+            state: ``"open"`` or ``"closed"``.
+            ceiling: Most records to return.
+
+        Returns:
+            The records.
+        """
+        records: list[IssueRecord] = []
+        for page in range(1, MAX_PAGES + 1):
+            path = (
+                f"/repos/{self._app.repository}/issues"
+                f"?state={state}&sort=updated&direction=desc&per_page={PAGE_SIZE}&page={page}"
+            )
+            response = await self._app.request("GET", path)
+            items = response.body if isinstance(response.body, list) else []
+            for item in items:
+                if not isinstance(item, dict) or item.get("pull_request") is not None:
+                    continue
+                records.append(_record_of(item))
+                if len(records) >= ceiling:
+                    return records
+            if len(items) < PAGE_SIZE:
+                break
+        return records
+
+
+def _record_of(item: dict[str, Any]) -> IssueRecord:
+    """Turn one API issue object into a record.
+
+    Args:
+        item: The decoded issue.
+
+    Returns:
+        The record.
+    """
+    labels = tuple(
+        str(label.get("name") or "") for label in item.get("labels") or [] if isinstance(label, dict)
+    )
+    return IssueRecord(
+        number=int(item.get("number") or 0),
+        title=str(item.get("title") or ""),
+        body=str(item.get("body") or ""),
+        url=str(item.get("html_url") or ""),
+        state=str(item.get("state") or "open"),
+        closed_at=str(item.get("closed_at") or ""),
+        labels=labels,
+    )
+
+
+class IssueFiler:
+    """Files one report as one issue, whatever happens twice."""
+
+    def __init__(
+        self,
+        app: GitHubApp,
+        ledger: Ledger,
+        *,
+        logger: Logger | None = None,
+        machine_label: str = MACHINE_LABEL,
+    ) -> None:
+        """Initialize the filer.
+
+        Args:
+            app: The authenticated client.
+            ledger: Where filed reports are recorded.
+            logger: Logger to use.
+            machine_label: The label marking an issue as machine-filed.
+        """
+        self._app = app
+        self._ledger = ledger
+        self._logger = logger or get_logger("filing")
+        self._machine_label = machine_label
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    async def file(self, report: BugReport, *, thread_url: str = "") -> Outcome:
+        """Open the issue for one report, or return the one already opened for it.
+
+        Args:
+            report: The assembled report.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            The outcome. Never raises: a failure is an :class:`Outcome` the reporter is told about,
+            because an exception here loses a report he has already spent five minutes on.
+        """
+        key = report_key(report)
+        async with self._locks.setdefault(key, asyncio.Lock()):
+            recorded = self._ledger.load().get(key) or {}
+            if recorded.get("number"):
+                return Outcome(action="reused", number=int(recorded["number"]), url=str(recorded.get("url") or ""))
+            try:
+                return await self._file_once(report, key, recorded, thread_url)
+            except GitHubError as error:
+                self._logger.error(
+                    "the issue could not be filed",
+                    extra={"event": "filing.failed", "key": key, "status": error.status, "error": str(error)},
+                )
+                return Outcome(action="failed", error=str(error))
+
+    async def comment_on(self, number: int, report: BugReport, *, thread_url: str = "") -> Outcome:
+        """Add the new observation to an existing issue instead of opening a second one.
+
+        Args:
+            number: The issue to comment on.
+            report: The assembled report.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            The outcome.
+        """
+        lang = report.form.language if report.form.language in ("fr", "en") else "en"
+        try:
+            response = await self._app.request(
+                "POST",
+                f"/repos/{self._app.repository}/issues/{number}/comments",
+                {"body": render_duplicate_comment(report, lang, thread_url)},
+            )
+        except GitHubError as error:
+            self._logger.error(
+                "the observation could not be added to the existing issue",
+                extra={"event": "filing.comment_failed", "issue": number, "error": str(error)},
+            )
+            return Outcome(action="failed", error=str(error))
+        url = str(response.body.get("html_url") or "") if isinstance(response.body, dict) else ""
+        return Outcome(action="commented", number=number, url=url)
+
+    async def _file_once(
+        self,
+        report: BugReport,
+        key: str,
+        recorded: dict[str, Any],
+        thread_url: str,
+    ) -> Outcome:
+        """Create the issue, having first made sure no earlier attempt already did.
+
+        Args:
+            report: The assembled report.
+            key: The report's idempotency key.
+            recorded: What the ledger holds for it, possibly an interrupted attempt.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            The outcome.
+
+        Raises:
+            GitHubError: The creation failed.
+        """
+        if recorded.get("state") == "filing":
+            existing = await self._find_by_marker(key)
+            if existing is not None:
+                self._remember(key, existing)
+                return Outcome(action="reused", number=existing.number, url=existing.url)
+
+        carried = [carry(item) for item in report.attachments if isinstance(item, Prepared)]
+        body = render_body(report, key, thread_url=thread_url, carried=carried)
+        labels = self._labels_for(report)
+
+        self._ledger.record(key, {"state": "filing", "started": time.time()})
+        response, notes = await self._create(report.title, body, labels)
+        item = _record_of(response if isinstance(response, dict) else {})
+        self._remember(key, item)
+        notes += await self._attach(item.number, carried)
+        self._logger.info(
+            "issue filed",
+            extra={"event": "filing.created", "key": key, "issue": item.number, "labels": list(labels)},
+        )
+        return Outcome(action="created", number=item.number, url=item.url, notes=notes)
+
+    async def _create(self, title: str, body: str, labels: tuple[str, ...]) -> tuple[Any, tuple[str, ...]]:
+        """Create the issue, retrying without the labels if GitHub refuses them.
+
+        A label that does not exist yet is a ``422``, and losing the whole report over a label is
+        the wrong trade — the issue is filed and the missing label becomes a note. Creating labels
+        would need no extra permission, but it would let a bot invent taxonomy in a public
+        repository, which is a decision for a maintainer.
+
+        Args:
+            title: The issue title.
+            body: The issue body.
+            labels: The labels to ask for.
+
+        Returns:
+            A pair of the created issue object and any notes.
+
+        Raises:
+            GitHubError: The creation failed for a reason the labels do not explain.
+        """
+        path = f"/repos/{self._app.repository}/issues"
+        try:
+            asked = await self._app.request("POST", path, {"title": title, "body": body, "labels": list(labels)})
+            return asked.body, ()
+        except GitHubError as error:
+            if error.status != 422:
+                raise
+            # Bound outside the handler: Python deletes the `as` name when the block ends, and the
+            # note built below would otherwise be a NameError at the one moment it is needed.
+            refusal = str(error)
+        self._logger.warning(
+            "GitHub refused the labels; filing without them",
+            extra={"event": "filing.labels_refused", "labels": list(labels), "error": refusal},
+        )
+        response = await self._app.request("POST", path, {"title": title, "body": body})
+        return response.body, (f"labels {', '.join(labels)} could not be applied: {refusal}",)
+
+    async def _attach(self, number: int, carried: Sequence[Carried]) -> tuple[str, ...]:
+        """Post the comments carrying the text attachments whole.
+
+        Best effort on purpose: the issue exists and holds the excerpt already: failing to post a
+        full log must not turn a filed issue into a failure the reporter is told to retry.
+
+        Args:
+            number: The issue number.
+            carried: What became of each attachment.
+
+        Returns:
+            One note per comment that could not be posted.
+        """
+        notes: list[str] = []
+        for comment in render_attachment_comments(carried):
+            try:
+                await self._app.request("POST", f"/repos/{self._app.repository}/issues/{number}/comments", {"body": comment})
+            except GitHubError as error:
+                notes.append(f"an attachment could not be added to the issue: {error}")
+                self._logger.warning(
+                    "an attachment comment could not be posted",
+                    extra={"event": "filing.attachment_failed", "issue": number, "error": str(error)},
+                )
+        return tuple(notes)
+
+    async def _find_by_marker(self, key: str) -> IssueRecord | None:
+        """Look for an issue this service already opened for *key*.
+
+        The recovery path for a restart that lost the answer to a ``POST`` it had already sent. It
+        reads the repository's own recent issues rather than the search API: search is eventually
+        consistent and an issue created seconds ago is routinely absent from it, which is exactly
+        the moment this runs.
+
+        Args:
+            key: The report's idempotency key.
+
+        Returns:
+            The issue, or ``None``.
+        """
+        marker = marker_for(key)
+        path = f"/repos/{self._app.repository}/issues?state=all&sort=created&direction=desc&per_page={PAGE_SIZE}"
+        try:
+            response = await self._app.request("GET", path)
+        except GitHubError as error:
+            self._logger.warning(
+                "the recovery search could not run; a duplicate issue is possible",
+                extra={"event": "filing.recovery_failed", "error": str(error)},
+            )
+            return None
+        for item in response.body if isinstance(response.body, list) else []:
+            if isinstance(item, dict) and marker in str(item.get("body") or ""):
+                return _record_of(item)
+        return None
+
+    def _labels_for(self, report: BugReport) -> tuple[str, ...]:
+        """Return the labels the issue is opened with.
+
+        Args:
+            report: The assembled report.
+
+        Returns:
+            The report's own labels plus the machine-filed marker, deduplicated, ``bug`` first.
+        """
+        wanted = [BASE_LABEL, *report.labels, self._machine_label]
+        seen: list[str] = []
+        for label in wanted:
+            if label and label not in seen:
+                seen.append(label)
+        return tuple(seen)
+
+    def _remember(self, key: str, item: IssueRecord) -> None:
+        """Record a filed issue against its key.
+
+        Args:
+            key: The report's idempotency key.
+            item: The issue.
+        """
+        self._ledger.record(key, {"state": "filed", "number": item.number, "url": item.url, "at": time.time()})

--- a/services/support-bot/veaf_support_bot/filing.py
+++ b/services/support-bot/veaf_support_bot/filing.py
@@ -562,6 +562,13 @@ class IssueFiler:
         consistent and an issue created seconds ago is routinely absent from it, which is exactly
         the moment this runs.
 
+        **It sees one page — the 100 most recently created issues.** That is enough for what it
+        defends against, because a re-submission arrives while the reporter is still in the thread
+        and a restart replays what was in flight. What it does not cover is the same report filed
+        again long after 100 issues have gone by, and the ledger is what covers that: this is a
+        second line, not a replacement. Paging further would cost up to five ``GET`` calls on every
+        report to close a case the ledger already closes whenever it is readable.
+
         Args:
             key: The report's idempotency key.
 

--- a/services/support-bot/veaf_support_bot/filing.py
+++ b/services/support-bot/veaf_support_bot/filing.py
@@ -40,7 +40,7 @@ import asyncio
 import hashlib
 import json
 import time
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from logging import Logger
@@ -354,6 +354,7 @@ class IssueFiler:
         app: GitHubApp,
         ledger: Ledger,
         *,
+        redactor: Callable[[str], str],
         logger: Logger | None = None,
         machine_label: str = MACHINE_LABEL,
     ) -> None:
@@ -362,11 +363,14 @@ class IssueFiler:
         Args:
             app: The authenticated client.
             ledger: Where filed reports are recorded.
+            redactor: The single redaction helper, bound to the checkout it resolves out of. What
+                this filer publishes whole — the text attachments — goes through it.
             logger: Logger to use.
             machine_label: The label marking an issue as machine-filed.
         """
         self._app = app
         self._ledger = ledger
+        self._redactor = redactor
         self._logger = logger or get_logger("filing")
         self._machine_label = machine_label
         self._locks: dict[str, _Serialiser] = {}
@@ -472,7 +476,7 @@ class IssueFiler:
             self._remember(key, existing)
             return Outcome(action="reused", number=existing.number, url=existing.url)
 
-        carried = [carry(item) for item in report.attachments if isinstance(item, Prepared)]
+        carried = [carry(item, redactor=self._redactor) for item in report.attachments if isinstance(item, Prepared)]
         body = render_body(report, key, thread_url=thread_url, carried=carried)
         labels = self._labels_for(report)
 

--- a/services/support-bot/veaf_support_bot/filing.py
+++ b/services/support-bot/veaf_support_bot/filing.py
@@ -9,7 +9,7 @@ are three different failures and they need three different answers, so the modul
 |---|---|
 | Two clicks arriving together | an :class:`asyncio.Lock` per key — the second waits, then reads the first one's result |
 | A retry after a timeout, same process | the **ledger**, a small JSON file that already holds the issue number |
-| A restart after the ``POST`` was sent and the answer lost | the **marker**, an HTML comment carrying the key inside the issue; the recovery search finds it |
+| A restart after the ``POST`` was sent and the answer lost, **or any loss of the ledger** | the **marker**, an HTML comment carrying the key inside the issue; the recovery search runs on every report with no recorded number, so it does not need the ledger to be readable |
 
 The key is derived from the report itself — the reporter, his five fields, and the names and sizes
 of what he attached — so *the same report* always produces *the same key*, and a genuinely new
@@ -40,8 +40,9 @@ import asyncio
 import hashlib
 import json
 import time
-from collections.abc import Sequence
-from dataclasses import dataclass
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
 from logging import Logger
 from pathlib import Path
 from typing import Any
@@ -78,6 +79,9 @@ MAX_PAGES = 5
 
 #: Version of the ledger document. A file of another version is refused rather than reinterpreted.
 LEDGER_VERSION = 1
+
+#: Appended to the ledger's name when an unreadable one is moved aside rather than overwritten.
+CORRUPT_SUFFIX = ".corrupt"
 
 
 @dataclass(frozen=True)
@@ -164,10 +168,24 @@ class Ledger:
         Returns:
             The entries by key. An unreadable or unrecognised file yields an empty mapping and a
             warning: refusing to file anything because a bookkeeping file is corrupt would lose
-            reports, and the marker search still stops a duplicate.
+            reports, and :meth:`IssueFiler._file_once` searches for the marker on **every** report
+            it has no number for, so the duplicate is still stopped.
+        """
+        return self._read()[0]
+
+    def _read(self) -> tuple[dict[str, dict[str, Any]], bool]:
+        """Read the file back, saying whether it could be understood.
+
+        The second value is what :meth:`record` needs and :meth:`load` does not: a caller that only
+        reads can treat *corrupt* and *absent* alike, and a caller about to **overwrite** cannot —
+        an empty mapping from a corrupt read, written back, is every other entry deleted.
+
+        Returns:
+            The entries, and whether the file on disk was readable. An absent file is readable: it
+            is the state a first run legitimately starts from.
         """
         if not self.path.exists():
-            return {}
+            return {}, True
         try:
             document = json.loads(self.path.read_text(encoding="utf-8"))
             if not isinstance(document, dict) or document.get("version") != LEDGER_VERSION:
@@ -180,8 +198,8 @@ class Ledger:
                 "the filing ledger could not be read; falling back to the in-issue marker",
                 extra={"event": "filing.ledger_unreadable", "error": f"{type(error).__name__}: {error}"},
             )
-            return {}
-        return {str(key): value for key, value in entries.items() if isinstance(value, dict)}
+            return {}, False
+        return {str(key): value for key, value in entries.items() if isinstance(value, dict)}, True
 
     def record(self, key: str, entry: dict[str, Any]) -> None:
         """Write one entry, keeping the others.
@@ -190,7 +208,9 @@ class Ledger:
             key: The report key.
             entry: What to record.
         """
-        entries = self.load()
+        entries, readable = self._read()
+        if not readable:
+            self._preserve()
         entries[key] = entry
         document = {"version": LEDGER_VERSION, "reports": entries}
         try:
@@ -203,6 +223,27 @@ class Ledger:
                 "the filing ledger could not be written; a retry will fall back to the in-issue marker",
                 extra={"event": "filing.ledger_unwritable", "error": f"{type(error).__name__}: {error}"},
             )
+
+    def _preserve(self) -> None:
+        """Move an unreadable ledger aside instead of writing over it.
+
+        A corrupt file still holds the issue numbers of every report filed before it broke, in a
+        form a human can read even when :func:`json.loads` cannot. Overwriting it is the one action
+        that makes the damage permanent, and it is what a plain rewrite does silently.
+        """
+        aside = self.path.with_suffix(f"{self.path.suffix}{CORRUPT_SUFFIX}")
+        try:
+            self.path.replace(aside)
+        except OSError as error:
+            self._logger.warning(
+                "the unreadable filing ledger could not be moved aside; it is about to be overwritten",
+                extra={"event": "filing.ledger_not_preserved", "error": f"{type(error).__name__}: {error}"},
+            )
+            return
+        self._logger.warning(
+            "the unreadable filing ledger was moved aside",
+            extra={"event": "filing.ledger_preserved", "path": str(aside)},
+        )
 
 
 class RepositoryIssues:
@@ -289,6 +330,22 @@ def _record_of(item: dict[str, Any]) -> IssueRecord:
     )
 
 
+@dataclass
+class _Serialiser:
+    """One key's lock, and how many callers still need it.
+
+    The count is what lets the entry be dropped: a plain ``dict`` of locks keyed by report never
+    shrinks, and a long-running service files reports for as long as it runs.
+
+    Attributes:
+        lock: The lock two simultaneous filings of the same report contend on.
+        waiting: How many callers hold it or are queued for it.
+    """
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    waiting: int = 0
+
+
 class IssueFiler:
     """Files one report as one issue, whatever happens twice."""
 
@@ -312,7 +369,29 @@ class IssueFiler:
         self._ledger = ledger
         self._logger = logger or get_logger("filing")
         self._machine_label = machine_label
-        self._locks: dict[str, asyncio.Lock] = {}
+        self._locks: dict[str, _Serialiser] = {}
+
+    @asynccontextmanager
+    async def _serialised(self, key: str) -> AsyncIterator[None]:
+        """Hold one report's lock, and forget the lock once nobody wants it.
+
+        Args:
+            key: The report's idempotency key.
+
+        Yields:
+            Nothing; the block runs with the key's lock held.
+        """
+        entry = self._locks.setdefault(key, _Serialiser())
+        entry.waiting += 1
+        try:
+            async with entry.lock:
+                yield
+        finally:
+            entry.waiting -= 1
+            if entry.waiting == 0:
+                # Safe to drop: every caller for this key has left, so nobody can be handed a second
+                # lock while a first one is still held.
+                self._locks.pop(key, None)
 
     async def file(self, report: BugReport, *, thread_url: str = "") -> Outcome:
         """Open the issue for one report, or return the one already opened for it.
@@ -326,12 +405,12 @@ class IssueFiler:
             because an exception here loses a report he has already spent five minutes on.
         """
         key = report_key(report)
-        async with self._locks.setdefault(key, asyncio.Lock()):
+        async with self._serialised(key):
             recorded = self._ledger.load().get(key) or {}
             if recorded.get("number"):
                 return Outcome(action="reused", number=int(recorded["number"]), url=str(recorded.get("url") or ""))
             try:
-                return await self._file_once(report, key, recorded, thread_url)
+                return await self._file_once(report, key, thread_url)
             except GitHubError as error:
                 self._logger.error(
                     "the issue could not be filed",
@@ -366,19 +445,20 @@ class IssueFiler:
         url = str(response.body.get("html_url") or "") if isinstance(response.body, dict) else ""
         return Outcome(action="commented", number=number, url=url)
 
-    async def _file_once(
-        self,
-        report: BugReport,
-        key: str,
-        recorded: dict[str, Any],
-        thread_url: str,
-    ) -> Outcome:
+    async def _file_once(self, report: BugReport, key: str, thread_url: str) -> Outcome:
         """Create the issue, having first made sure no earlier attempt already did.
+
+        The marker search runs on **every** report that has no recorded number, not only on one the
+        ledger remembers as interrupted. Gating it on ``state == "filing"`` made it unreachable in
+        the three situations it exists for — a ledger that is corrupt, one on a state volume that
+        was never mounted, and one whose write was swallowed — because each of those makes the
+        ledger read as *empty*, not as *interrupted*. The cost of the ungated search is one ``GET``
+        on the first filing of a genuinely new report; the cost of the gate was a second issue on a
+        public tracker, which is the outcome the ticket calls hardest to undo.
 
         Args:
             report: The assembled report.
             key: The report's idempotency key.
-            recorded: What the ledger holds for it, possibly an interrupted attempt.
             thread_url: Link back to the Discord thread.
 
         Returns:
@@ -387,11 +467,10 @@ class IssueFiler:
         Raises:
             GitHubError: The creation failed.
         """
-        if recorded.get("state") == "filing":
-            existing = await self._find_by_marker(key)
-            if existing is not None:
-                self._remember(key, existing)
-                return Outcome(action="reused", number=existing.number, url=existing.url)
+        existing = await self._find_by_marker(key)
+        if existing is not None:
+            self._remember(key, existing)
+            return Outcome(action="reused", number=existing.number, url=existing.url)
 
         carried = [carry(item) for item in report.attachments if isinstance(item, Prepared)]
         body = render_body(report, key, thread_url=thread_url, carried=carried)

--- a/services/support-bot/veaf_support_bot/github_app.py
+++ b/services/support-bot/veaf_support_bot/github_app.py
@@ -1,0 +1,473 @@
+"""The bot's GitHub identity: a dedicated App, and tokens that expire on their own.
+
+## Why an App and not a token
+
+A personal access token would be a long-lived credential sitting on the host, carrying every right
+its owner has, and its leak would be invisible — nothing distinguishes the bot's writes from
+David's. Reusing an existing token is worse: it can no longer be revoked without breaking whatever
+else uses it.
+
+A GitHub App fixes all three. It is installed on **one repository**, granted **one permission**
+(*Issues: read and write*, plus the *Metadata: read-only* GitHub attaches to every App), and it
+never holds a usable credential at rest: what sits on the host is a private key, which is only good
+for signing a **ten-minute JWT**, which is only good for minting an **installation token that
+expires in an hour**. Revoking the installation ends all of it in one click, and every issue the bot
+opens is visibly authored by the App rather than by a person.
+
+## The renewal, which is the part that must not be clever
+
+:class:`AppCredentials` signs a JWT valid for ten minutes; :class:`GitHubApp` exchanges it for an
+installation token and keeps that token until :data:`RENEW_MARGIN_SECONDS` before it expires. There
+is no refresh loop and no background task: the token is minted **on the call that needs it**, so a
+service idle for a day does not hold a stale credential and does not have to notice that it does.
+
+## Credentials come from the environment, and their absence stops the startup
+
+The App does not exist yet when this is written, and that is exactly why
+:func:`credentials_from_config` raises rather than returning something half-built. The service
+already exits 78 on invalid configuration; a missing key belongs there, not in the first user's
+report — a bot that starts, collects a report and then discovers it cannot file it has lost the
+report.
+
+## What is never in an error message
+
+A failure carries the HTTP status and GitHub's own message, never a header and never the key.
+:func:`_scrub` removes any ``Bearer`` value the API happens to echo back, because the one place a
+token reliably appears in a body is the message complaining about it.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+#: GitHub's REST root.
+API_ROOT = "https://api.github.com"
+
+#: ``Accept`` header the REST API asks callers to send.
+API_ACCEPT = "application/vnd.github+json"
+
+#: API version this client is written against.
+API_VERSION = "2022-11-28"
+
+#: Lifetime of the JWT the private key signs. GitHub refuses anything above ten minutes.
+JWT_LIFETIME_SECONDS = 540
+
+#: Clock skew allowance subtracted from the JWT's ``iat``. GitHub rejects a token issued in its own
+#: future, and a host running a few seconds fast is common enough to plan for.
+JWT_SKEW_SECONDS = 60
+
+#: How long before an installation token expires it is replaced. A token that expires between the
+#: check and the request is a failure that looks like a permission problem.
+RENEW_MARGIN_SECONDS = 300.0
+
+#: Seconds one API call is given.
+REQUEST_TIMEOUT_SECONDS = 30.0
+
+
+class GitHubError(RuntimeError):
+    """A GitHub call did not do what was asked.
+
+    Carries the status and GitHub's own message so the sentence posted in the thread says something
+    an operator can act on — ``403`` on an installation that lost its permission reads very
+    differently from ``422`` on a label that does not exist.
+
+    Attributes:
+        status: The HTTP status, or ``0`` when the call never reached GitHub.
+    """
+
+    def __init__(self, message: str, status: int = 0) -> None:
+        """Initialize the error.
+
+        Args:
+            message: What went wrong, already scrubbed of anything secret.
+            status: The HTTP status.
+        """
+        super().__init__(message)
+        self.status = status
+
+
+@dataclass(frozen=True)
+class Response:
+    """One HTTP answer, reduced to what this module reads.
+
+    Attributes:
+        status: The HTTP status code.
+        body: The decoded body.
+        headers: The response headers, used only for pagination.
+    """
+
+    status: int
+    body: Any = None
+    headers: Mapping[str, str] = field(default_factory=dict)
+
+
+#: How a request is made. Injected so every test in this package runs without a network, and so the
+#: one place that touches ``aiohttp`` stays a single function.
+Transport = Callable[[str, str, Mapping[str, str], bytes | None], Awaitable[Response]]
+
+
+def _scrub(text: str) -> str:
+    """Remove anything credential-shaped from a message about to be logged or posted.
+
+    Args:
+        text: The message.
+
+    Returns:
+        The message with any ``Bearer <value>`` reduced to ``Bearer ***``.
+    """
+    out: list[str] = []
+    for word in text.split(" "):
+        out.append("***" if out and out[-1] in ("Bearer", "bearer", "token") else word)
+    return " ".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Credentials
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, repr=False)
+class AppCredentials:
+    """What the App needs to prove it is itself.
+
+    Attributes:
+        app_id: The App's numeric id, shown on its settings page.
+        installation_id: The installation on the one repository it serves.
+        private_key_pem: The PEM of the App's private key. **Secret**, and the only long-lived one
+            the host holds — it cannot write anything by itself, it can only mint ten-minute JWTs.
+    """
+
+    app_id: str
+    installation_id: str
+    private_key_pem: str
+
+    def __repr__(self) -> str:
+        """Return a representation with the key masked.
+
+        The dataclass-generated one would put a private key into any stack trace. The whole key, on
+        one line, in a container log.
+
+        Returns:
+            A safe ``repr``.
+        """
+        return f"AppCredentials(app_id={self.app_id!r}, installation_id={self.installation_id!r}, private_key_pem=***)"
+
+    def jwt(self, now: float | None = None) -> str:
+        """Sign a short-lived JSON Web Token identifying the App.
+
+        Args:
+            now: Current Unix timestamp; defaults to the clock.
+
+        Returns:
+            The compact JWT.
+
+        Raises:
+            GitHubError: The key could not be loaded or is not an RSA key. Raised rather than
+                returning an unusable token, so the failure names the key instead of arriving later
+                as an opaque ``401``.
+        """
+        issued = int(time.time() if now is None else now) - JWT_SKEW_SECONDS
+        header = {"alg": "RS256", "typ": "JWT"}
+        payload = {"iat": issued, "exp": issued + JWT_LIFETIME_SECONDS, "iss": self.app_id}
+        signing_input = b".".join((_b64url(_compact(header)), _b64url(_compact(payload))))
+        return b".".join((signing_input, _b64url(self._sign(signing_input)))).decode("ascii")
+
+    def _sign(self, message: bytes) -> bytes:
+        """Sign bytes with the App's private key.
+
+        Args:
+            message: The JWT's signing input.
+
+        Returns:
+            The RS256 signature.
+
+        Raises:
+            GitHubError: The key is unusable.
+        """
+        try:
+            from cryptography.hazmat.primitives import hashes, serialization
+            from cryptography.hazmat.primitives.asymmetric import padding, rsa
+        except ImportError as error:  # pragma: no cover - the dependency is declared
+            raise GitHubError(f"the cryptography package is not installed ({error})") from error
+        try:
+            key = serialization.load_pem_private_key(self.private_key_pem.encode("utf-8"), password=None)
+        except Exception as error:  # noqa: BLE001 - every load failure is one answer to the caller
+            raise GitHubError(f"the GitHub App private key could not be read ({type(error).__name__})") from error
+        if not isinstance(key, rsa.RSAPrivateKey):
+            raise GitHubError("the GitHub App private key is not an RSA key")
+        return key.sign(message, padding.PKCS1v15(), hashes.SHA256())
+
+
+def _compact(document: Mapping[str, Any]) -> bytes:
+    """Serialize a JWT part the way a JWT wants it.
+
+    Args:
+        document: The header or the payload.
+
+    Returns:
+        Compact UTF-8 JSON.
+    """
+    return json.dumps(document, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _b64url(raw: bytes) -> bytes:
+    """Encode bytes as unpadded base64url.
+
+    Args:
+        raw: The bytes.
+
+    Returns:
+        The encoded bytes.
+    """
+    return base64.urlsafe_b64encode(raw).rstrip(b"=")
+
+
+def read_private_key(inline: str, path: str) -> str:
+    """Resolve the private key from whichever of the two ways it was supplied.
+
+    A file is the right way on a host with a secrets mount; the inline form is the only way inside a
+    plain ``--env-file`` container, where it arrives with ``\\n`` escapes that a shell never expands.
+    Both are accepted, and the escapes are undone.
+
+    Args:
+        inline: The PEM itself, possibly with literal ``\\n`` sequences.
+        path: A file holding the PEM.
+
+    Returns:
+        The PEM.
+
+    Raises:
+        GitHubError: Neither was supplied, both were, or the file could not be read. *Both* is an
+            error rather than a precedence rule: an operator who set the two does not know which one
+            is live, and silently picking one is how a rotated key stays unrotated.
+    """
+    if inline and path:
+        raise GitHubError("the GitHub App private key was given twice, inline and as a path; keep one")
+    if inline:
+        return inline.replace("\\n", "\n")
+    if not path:
+        raise GitHubError("the GitHub App private key is not configured")
+    try:
+        return Path(path).expanduser().read_text(encoding="utf-8")
+    except OSError as error:
+        raise GitHubError(f"the GitHub App private key file could not be read ({type(error).__name__})") from error
+
+
+# ---------------------------------------------------------------------------
+# The client
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Token:
+    """One installation token and when it stops working.
+
+    Attributes:
+        value: The token. Secret.
+        expires_at: Unix timestamp of its expiry.
+    """
+
+    value: str
+    expires_at: float
+
+    def usable(self, now: float) -> bool:
+        """Say whether the token is still worth sending.
+
+        Args:
+            now: Current Unix timestamp.
+
+        Returns:
+            ``True`` while more than :data:`RENEW_MARGIN_SECONDS` remain.
+        """
+        return bool(self.value) and now < self.expires_at - RENEW_MARGIN_SECONDS
+
+
+class GitHubApp:
+    """Authenticated access to one repository, with the token renewed as needed."""
+
+    def __init__(
+        self,
+        credentials: AppCredentials,
+        repository: str,
+        transport: Transport,
+        *,
+        api_root: str = API_ROOT,
+    ) -> None:
+        """Initialize the client without contacting GitHub.
+
+        Args:
+            credentials: The App's identity.
+            repository: ``owner/name`` of the one repository the App is installed on.
+            transport: How a request is made.
+            api_root: API root, overridable for a test or a GitHub Enterprise host.
+        """
+        self.credentials = credentials
+        self.repository = repository
+        self.api_root = api_root.rstrip("/")
+        self._transport = transport
+        self._token: _Token | None = None
+
+    async def token(self, now: float | None = None) -> str:
+        """Return a usable installation token, minting one when the held one is near its end.
+
+        Args:
+            now: Current Unix timestamp; defaults to the clock.
+
+        Returns:
+            The token.
+
+        Raises:
+            GitHubError: The exchange failed.
+        """
+        moment = time.time() if now is None else now
+        if self._token is not None and self._token.usable(moment):
+            return self._token.value
+        response = await self._call(
+            "POST",
+            f"/app/installations/{self.credentials.installation_id}/access_tokens",
+            headers={"Authorization": f"Bearer {self.credentials.jwt(moment)}"},
+        )
+        body = response.body if isinstance(response.body, dict) else {}
+        value = str(body.get("token") or "")
+        if not value:
+            raise GitHubError("GitHub returned an installation response with no token in it", response.status)
+        self._token = _Token(value=value, expires_at=moment + _lifetime(body.get("expires_at"), moment))
+        return value
+
+    async def request(self, method: str, path: str, payload: Any = None) -> Response:
+        """Make one authenticated call against the repository.
+
+        Args:
+            method: HTTP method.
+            path: Path below :data:`API_ROOT`, e.g. ``"/repos/o/n/issues"``.
+            payload: JSON body, or ``None``.
+
+        Returns:
+            The response.
+
+        Raises:
+            GitHubError: The call failed, or GitHub answered with an error status.
+        """
+        return await self._call(method, path, headers={"Authorization": f"Bearer {await self.token()}"}, payload=payload)
+
+    async def _call(
+        self,
+        method: str,
+        path: str,
+        *,
+        headers: Mapping[str, str],
+        payload: Any = None,
+    ) -> Response:
+        """Make one call and turn a failing status into an exception.
+
+        Args:
+            method: HTTP method.
+            path: Path below the API root.
+            headers: Authorization header to add to the common ones.
+            payload: JSON body, or ``None``.
+
+        Returns:
+            The response, when the status is a success.
+
+        Raises:
+            GitHubError: The transport failed, or the status is not a success.
+        """
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        common = {
+            "Accept": API_ACCEPT,
+            "X-GitHub-Api-Version": API_VERSION,
+            "User-Agent": "veaf-support-bot",
+            **({"Content-Type": "application/json"} if body is not None else {}),
+            **headers,
+        }
+        try:
+            response = await self._transport(method, f"{self.api_root}{path}", common, body)
+        except GitHubError:
+            raise
+        except Exception as error:  # noqa: BLE001 - one answer for every transport failure
+            raise GitHubError(f"GitHub could not be reached ({type(error).__name__})") from error
+        if 200 <= response.status < 300:
+            return response
+        raise GitHubError(f"GitHub answered {response.status}: {_scrub(_message_of(response.body))}", response.status)
+
+
+def _message_of(body: Any) -> str:
+    """Pull the human-readable part out of a GitHub error body.
+
+    Args:
+        body: The decoded body.
+
+    Returns:
+        A short sentence, never the whole document.
+    """
+    if isinstance(body, dict):
+        message = str(body.get("message") or "").strip()
+        errors = body.get("errors")
+        if isinstance(errors, list) and errors:
+            detail = "; ".join(str(item.get("message") or item) for item in errors if item)[:300]
+            return f"{message} ({detail})" if message else detail
+        if message:
+            return message
+    return str(body)[:300] if body else "no message"
+
+
+def _lifetime(expires_at: Any, now: float) -> float:
+    """Turn GitHub's ``expires_at`` into seconds from now.
+
+    Args:
+        expires_at: The ISO-8601 timestamp GitHub returned, or anything else.
+        now: Current Unix timestamp.
+
+    Returns:
+        Seconds of life, defaulting to an hour when the field is missing or unreadable — which is
+        the documented lifetime, and always shortened by :data:`RENEW_MARGIN_SECONDS` in use.
+    """
+    if isinstance(expires_at, str) and expires_at:
+        try:
+            moment = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+        except ValueError:
+            return 3600.0
+        if moment.tzinfo is None:
+            moment = moment.replace(tzinfo=timezone.utc)
+        return max(0.0, moment.timestamp() - now)
+    return 3600.0
+
+
+async def aiohttp_transport(
+    method: str,
+    url: str,
+    headers: Mapping[str, str],
+    body: bytes | None,
+) -> Response:
+    """Make one HTTPS call with ``aiohttp``, the library ``discord.py`` already brings.
+
+    Args:
+        method: HTTP method.
+        url: Absolute URL.
+        headers: Request headers.
+        body: Request body, or ``None``.
+
+    Returns:
+        The response, its body decoded as JSON when it is JSON and left as text otherwise.
+
+    Raises:
+        aiohttp.ClientError: The call failed at the transport level.
+    """
+    import aiohttp
+
+    timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_SECONDS)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.request(method, url, headers=dict(headers), data=body) as response:
+            text = await response.text()
+            try:
+                decoded: Any = json.loads(text) if text else None
+            except ValueError:
+                decoded = text
+            return Response(status=response.status, body=decoded, headers=dict(response.headers))

--- a/services/support-bot/veaf_support_bot/github_app.py
+++ b/services/support-bot/veaf_support_bot/github_app.py
@@ -43,7 +43,7 @@ import json
 import time
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -355,7 +355,9 @@ class GitHubApp:
         Raises:
             GitHubError: The call failed, or GitHub answered with an error status.
         """
-        return await self._call(method, path, headers={"Authorization": f"Bearer {await self.token()}"}, payload=payload)
+        return await self._call(
+            method, path, headers={"Authorization": f"Bearer {await self.token()}"}, payload=payload
+        )
 
     async def _call(
         self,
@@ -435,7 +437,7 @@ def _lifetime(expires_at: Any, now: float) -> float:
         except ValueError:
             return 3600.0
         if moment.tzinfo is None:
-            moment = moment.replace(tzinfo=timezone.utc)
+            moment = moment.replace(tzinfo=UTC)
         return max(0.0, moment.timestamp() - now)
     return 3600.0
 

--- a/services/support-bot/veaf_support_bot/intake.py
+++ b/services/support-bot/veaf_support_bot/intake.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 import asyncio
 import tempfile
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from logging import Logger
 from pathlib import Path
 from shutil import rmtree
@@ -52,13 +52,19 @@ from typing import Protocol
 from veaf_support_bot.attachments import AttachmentCollector, Harvest, Incoming
 from veaf_support_bot.bugreport import BugForm, BugReport, MaterialNote, assemble, safe_redact
 from veaf_support_bot.checkout import Checkout
+from veaf_support_bot.filing import Outcome
 from veaf_support_bot.logging_setup import get_logger
+from veaf_support_bot.priorart import DUPLICATE, FIXED, IN_PROGRESS, PriorArtGate, Sweep
 from veaf_support_bot.texts import normalize_language, text
 from veaf_support_bot.traces import Location
 from veaf_support_bot.untrusted import one_line, quote
 
 #: Longest preview posted back to the reporter. Discord's own message ceiling is 2000 characters.
 PREVIEW_MAX_CHARS = 1900
+
+#: Where a reporter is sent when the bot could not file for him. Never a dead end: the report is
+#: already rendered above the link, so it can be pasted straight into the form.
+REPOSITORY_URL = "https://github.com/VEAF/VEAF-Mission-Creation-Tools"
 
 #: Field lengths the modal enforces, mirrored here so the handler's bounds hold whatever calls it.
 SUMMARY_MAX_CHARS = 200
@@ -73,10 +79,13 @@ class BugSubmission:
     Attributes:
         form: What the reporter typed.
         attachments: The files declared as command options.
+        thread_url: Where this report was made, so the issue can point back at it. Ticket 06 fills
+            it; until then the issue says the thread was not recorded rather than inventing a link.
     """
 
     form: BugForm
     attachments: list[Incoming]
+    thread_url: str = ""
 
 
 class BugExchange(Protocol):
@@ -97,6 +106,37 @@ class BugExchange(Protocol):
 ReportSink = Callable[[BugReport], Awaitable[str]]
 
 
+class ReportFiler(Protocol):
+    """What the intake needs from :mod:`veaf_support_bot.filing`, and nothing more.
+
+    A protocol so the whole exchange — sweep, proposal, refusal, filing — is asserted without a
+    GitHub App, which does not exist yet.
+    """
+
+    async def file(self, report: BugReport, *, thread_url: str = "") -> Outcome:
+        """Open the issue for a report, exactly once.
+
+        Args:
+            report: The assembled report.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            What became of it.
+        """
+
+    async def comment_on(self, number: int, report: BugReport, *, thread_url: str = "") -> Outcome:
+        """Add the observation to an existing issue instead of opening a second one.
+
+        Args:
+            number: The issue to comment on.
+            report: The assembled report.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            What became of it.
+        """
+
+
 class BugIntake:
     """Runs one ``/bug`` exchange, from the submitted form to a filled report."""
 
@@ -108,6 +148,8 @@ class BugIntake:
         sink: ReportSink | None = None,
         logger: Logger | None = None,
         refresh: bool = True,
+        prior_art: PriorArtGate | None = None,
+        filer: ReportFiler | None = None,
     ) -> None:
         """Initialize the intake.
 
@@ -118,12 +160,20 @@ class BugIntake:
             logger: Logger to use; defaults to the service's ``intake`` logger.
             refresh: Whether to refresh the checkout when the timer says it is due. Off in tests,
                 which must not run ``git`` against a fixture.
+            prior_art: The four-source sweep and the step that lets the reporter refuse it. ``None``
+                skips the sweep entirely, and the issue then says nothing was checked rather than
+                implying it was.
+            filer: Where an accepted report is filed. ``None`` means this deployment has no GitHub
+                App yet: the report is prepared and shown, and the reporter is told plainly that
+                nothing was opened.
         """
         self._checkout = checkout
         self._collector = collector
         self._sink = sink
         self._logger = logger or get_logger("intake")
         self._refresh = refresh
+        self._prior_art = prior_art
+        self._filer = filer
 
     async def handle(self, exchange: BugExchange, submission: BugSubmission) -> BugReport | None:
         """Run one report end to end.
@@ -157,7 +207,7 @@ class BugIntake:
                 await self._say(exchange, text("bug.error.unexpected", lang))
                 return None
 
-            message = await self._sink(report) if self._sink is not None else render_preview(report, lang)
+            report, message = await self._decide(report, lang, submission.thread_url)
             await self._say(exchange, message)
         finally:
             rmtree(workdir, ignore_errors=True)
@@ -177,6 +227,94 @@ class BugIntake:
             },
         )
         return report
+
+    async def _decide(self, report: BugReport, lang: str, thread_url: str) -> tuple[BugReport, str]:
+        """Run the prior-art step, then either act on it or file the report.
+
+        The order is the whole of ticket 03: the sweep happens **before** anything is opened, and
+        its conclusion is never applied on its own — :class:`~veaf_support_bot.priorart.PriorArtGate`
+        returns whether the reporter accepted it, and a gate with nobody to ask returns ``False``.
+
+        Args:
+            report: The assembled report.
+            lang: ``"fr"`` or ``"en"``.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            A pair of the report, now carrying the finding, and what the reporter is told.
+        """
+        sweep, accepted = await self._sweep(report, lang)
+        report = replace(report, prior_art=sweep)
+        if accepted and sweep is not None:
+            return report, await self._act_on(sweep, report, lang, thread_url)
+        if self._sink is not None:
+            return report, await self._sink(report)
+        return report, await self._file(report, lang, thread_url)
+
+    async def _sweep(self, report: BugReport, lang: str) -> tuple[Sweep | None, bool]:
+        """Compare the report against everything already recorded.
+
+        Args:
+            report: The assembled report.
+            lang: ``"fr"`` or ``"en"``.
+
+        Returns:
+            A pair of the finding — ``None`` when no sweep is configured — and whether the reporter
+            accepted the proposed match.
+        """
+        if self._prior_art is None:
+            return None, False
+        sweep, accepted = await self._prior_art.run(sweep_query(report), lang)
+        self._logger.info(
+            "prior art swept",
+            extra={
+                "event": "intake.prior_art",
+                "verdict": sweep.verdict,
+                "accepted": accepted,
+                "reference": sweep.best.candidate.reference if sweep.best else "",
+                "score": sweep.best.score if sweep.best else 0.0,
+                "problems": list(sweep.problems),
+            },
+        )
+        return sweep, accepted
+
+    async def _act_on(self, sweep: Sweep, report: BugReport, lang: str, thread_url: str) -> str:
+        """Do what an accepted match asks for, which for three of the four verdicts is nothing.
+
+        Args:
+            sweep: The accepted finding.
+            report: The assembled report.
+            lang: ``"fr"`` or ``"en"``.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            What the reporter is told.
+        """
+        proposal = render_match(sweep, lang)
+        if sweep.verdict != DUPLICATE or self._filer is None:
+            return proposal
+        number = _issue_number(sweep)
+        if number == 0:
+            return proposal
+        outcome = await self._filer.comment_on(number, report, thread_url=thread_url)
+        return proposal + "\n\n" + _render_outcome(outcome, lang, report)
+
+    async def _file(self, report: BugReport, lang: str, thread_url: str) -> str:
+        """File the report, or say why nothing was filed.
+
+        Args:
+            report: The assembled report.
+            lang: ``"fr"`` or ``"en"``.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            What the reporter is told: the preview, plus what became of the issue.
+        """
+        preview = render_preview(report, lang)
+        if self._filer is None:
+            return preview + "\n\n" + text("filed.disabled", lang)
+        outcome = await self._filer.file(report, thread_url=thread_url)
+        return preview + "\n\n" + _render_outcome(outcome, lang, report)
 
     async def build(self, submission: BugSubmission, workdir: Path) -> BugReport:
         """Do the deterministic pass, attachments included.
@@ -345,6 +483,100 @@ def render_location(location: Location, lang: str) -> str:
     return head
 
 
+def sweep_query(report: BugReport) -> str:
+    """Build the text the prior-art sweep matches on.
+
+    The reporter's own words plus what the trace named, and **not** the attached log: a log shares
+    hundreds of words with every other log, so including it would match a report against everything
+    and turn the sweep into noise a reporter learns to dismiss.
+
+    Args:
+        report: The assembled report.
+
+    Returns:
+        The query.
+    """
+    form = report.form
+    located = " ".join(f"{item.relative} {item.function}" for item in report.located)
+    return "\n".join((form.summary, form.happened, form.expected, located))
+
+
+def _issue_number(sweep: Sweep) -> int:
+    """Read the issue number out of a matched ``#123`` reference.
+
+    Args:
+        sweep: The finding.
+
+    Returns:
+        The number, or ``0`` when the match is not an issue.
+    """
+    if sweep.best is None:
+        return 0
+    reference = sweep.best.candidate.reference
+    return int(reference[1:]) if reference.startswith("#") and reference[1:].isdigit() else 0
+
+
+def render_match(sweep: Sweep, lang: str) -> str:
+    """Render a proposed match **with its evidence**, so it can be disagreed with.
+
+    A proposal with no evidence is an assertion, and an assertion is what silences a real bug: the
+    reporter has no way to tell a good match from a bad one, concludes the desk already knows, and
+    goes away. So the shared words, the score and the reference are all printed.
+
+    Args:
+        sweep: The finding.
+        lang: ``"fr"`` or ``"en"``.
+
+    Returns:
+        The message, or an empty string when there is nothing to propose.
+    """
+    if sweep.best is None:
+        return ""
+    match = sweep.best
+    key = {
+        DUPLICATE: "priorart.duplicate",
+        FIXED: "priorart.fixed" if match.candidate.detail else "priorart.fixed_no_version",
+        IN_PROGRESS: "priorart.in_progress",
+    }[sweep.verdict]
+    values = {
+        "reference": match.candidate.reference,
+        "title": one_line(match.candidate.title, 140),
+        "evidence": "-# " + match.evidence(),
+        "url": match.candidate.url,
+    }
+    if key == "priorart.fixed":
+        values["version"] = match.candidate.detail
+    return text(key, lang, **values)
+
+
+def _render_outcome(outcome: Outcome, lang: str, report: BugReport) -> str:
+    """Render what became of the filing attempt.
+
+    A failure is a sentence the reporter reads, never a silence: he has spent five minutes on this
+    and must not walk away believing an issue exists.
+
+    Args:
+        outcome: What the filer returned.
+        lang: ``"fr"`` or ``"en"``.
+        report: The assembled report, for the fallback link.
+
+    Returns:
+        The message.
+    """
+    if outcome.action == "failed":
+        return text(
+            "filed.error",
+            lang,
+            reason=one_line(outcome.error, 300),
+            issue_url=f"{REPOSITORY_URL}/issues/new?template=bug_report.yml",
+        )
+    key = {"created": "filed.created", "reused": "filed.reused", "commented": "filed.commented"}[outcome.action]
+    message = text(key, lang, url=outcome.url or f"#{outcome.number}")
+    if outcome.notes:
+        message += "\n" + text("filed.notes", lang, notes="; ".join(outcome.notes))
+    return message
+
+
 def render_preview(report: BugReport, lang: str) -> str:
     """Render what the deterministic pass produced, for the reporter to see.
 
@@ -377,8 +609,12 @@ def render_preview(report: BugReport, lang: str) -> str:
         parts.append(text("bug.not_located", lang))
     if report.attachments:
         parts.append(text("bug.attached", lang, count=len(report.attachments)))
+    if report.prior_art is not None:
+        parts.append(text("priorart.checked", lang, checked=report.prior_art.describe()))
+        proposal = render_match(report.prior_art, lang)
+        if proposal:
+            parts.append(proposal)
     if report.notes:
         listed = "\n".join(f"- {note.subject}: {note.reason}" for note in report.notes)
         parts.append(text("bug.notes", lang) + "\n" + quote(listed))
-    parts.append(text("bug.next", lang))
     return "\n\n".join(parts)[:PREVIEW_MAX_CHARS]

--- a/services/support-bot/veaf_support_bot/issue_body.py
+++ b/services/support-bot/veaf_support_bot/issue_body.py
@@ -26,8 +26,9 @@ checked, and every note about what is missing and why.
 
 The attached files are a different matter, and the limit is GitHub's, not this module's: **the REST
 API has no endpoint that attaches a file to an issue** — the one the web interface uses is a session
-endpoint, not an API. So a file that is text and fits is carried *inside* the issue, whole, where it
-survives as long as the issue does; a file that is binary or too large is listed in the manifest
+endpoint, not an API. So a file that is text and fits is carried *inside* the issue, whole and
+**redacted**, where it survives as long as the issue does — whole is not raw, and a file nobody
+could redact is described instead of published; a file that is binary or too large is listed in the manifest
 with its size and its SHA-256, and the issue says plainly that the bytes were not published. Nothing
 is ever referenced by a Discord URL: those expire, and an issue whose evidence is a dead link is an
 issue with no evidence.
@@ -36,13 +37,14 @@ issue with no evidence.
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
 from veaf_support_bot.attachments import Prepared
 from veaf_support_bot.bugreport import NOT_STATED, BugReport
 from veaf_support_bot.priorart import DUPLICATE, FIXED, IN_PROGRESS, Sweep
+from veaf_support_bot.toolkit import ToolkitUnavailable
 from veaf_support_bot.untrusted import one_line, quote
 
 #: Longest issue body GitHub accepts, with room left for the marker and the footer.
@@ -184,16 +186,30 @@ class Carried:
     digest: str = ""
 
 
-def carry(prepared: Prepared, *, limit: int = INLINE_MAX_CHARS) -> Carried:
+def carry(prepared: Prepared, *, redactor: Callable[[str], str], limit: int = INLINE_MAX_CHARS) -> Carried:
     """Decide how one attachment travels into the issue.
+
+    The bytes carried here are the **whole file**, not the reduced view
+    :attr:`~veaf_support_bot.attachments.Prepared.rendered` holds — that is the point of carrying
+    it — so they go through the same redaction the excerpt did. :func:`quote` is not a substitute:
+    it fences the text and defuses ``@`` mentions, which stops a comment breaking out of its block
+    and stops it pinging a team. Neither of those is personal data, and a ``dcs.log`` opens on
+    ``C:\\Users\\Firstname Lastname\\…``.
 
     Args:
         prepared: The file the attachment pass produced.
+        redactor: The single redaction helper, already bound to the checkout it resolves out of.
+            Required rather than defaulted: a default would make publishing raw bytes the outcome of
+            forgetting an argument.
         limit: Longest text carried whole.
 
     Returns:
-        The decision. Text that fits is read and carried; everything else is described, because the
-        REST API cannot attach a file to an issue and a Discord URL is dead within days.
+        The decision. Text that fits is read, redacted and carried; everything else is described,
+        because the REST API cannot attach a file to an issue and a Discord URL is dead within days.
+        A redaction that cannot run **withholds the bytes**, exactly as
+        :meth:`~veaf_support_bot.attachments.AttachmentCollector._publishable` withholds a name and
+        :func:`~veaf_support_bot.bugreport.safe_redact` withholds a quote: the file is still named,
+        sized and hashed in the manifest, and the reason is stated.
     """
     digest = digest_of(prepared.path)
     if prepared.kind not in INLINE_KINDS:
@@ -208,7 +224,11 @@ def carry(prepared: Prepared, *, limit: int = INLINE_MAX_CHARS) -> Carried:
         content = prepared.path.read_text(encoding="utf-8", errors="replace")
     except OSError as error:
         return Carried(prepared, reason=f"could not be read back ({type(error).__name__})", digest=digest)
-    return Carried(prepared, text=content, digest=digest)
+    try:
+        redacted = redactor(content)
+    except ToolkitUnavailable as error:
+        return Carried(prepared, reason=f"it could not be redacted, so it is not published here ({error})", digest=digest)
+    return Carried(prepared, text=redacted, digest=digest)
 
 
 def render_prior_art(sweep: Sweep, lang: str) -> str:

--- a/services/support-bot/veaf_support_bot/issue_body.py
+++ b/services/support-bot/veaf_support_bot/issue_body.py
@@ -1,0 +1,373 @@
+"""The issue the bot writes: the template's shape, the reporter's language, quotes untranslated.
+
+## The shape is the repository's own form
+
+``.github/ISSUE_TEMPLATE/bug_report.yml`` asks for six things — version, component, what happened,
+what was expected, steps, additional context. **Zero of the last sixty issues used it.** A human
+skips a form; a machine fills it every time, and filling *this* one means a maintainer reading a
+bot-filed issue finds the fields exactly where he finds them in a hand-filed one.
+
+The headings are therefore the template's labels, not invented ones, and
+``tests/test_issue_body.py`` reads the YAML to prove they still match.
+
+## The language is the reporter's, the evidence is nobody's
+
+The repository writes English for technical content; this issue does not, and the departure is
+deliberate — the regulars report in French and the tracker already contains French. So the
+*headings and the sentences the bot writes* follow the reporter. What he typed, what his log said,
+what his mission is called: **never translated, never reworded**, quoted verbatim inside a fence it
+cannot escape. A translated log line is evidence somebody edited.
+
+## What the body carries, and what it cannot
+
+Everything the deterministic pass produced is inlined: the located file and line with the revision
+it was resolved against, the log excerpt, the mission's shape, the prior-art sweep with what it
+checked, and every note about what is missing and why.
+
+The attached files are a different matter, and the limit is GitHub's, not this module's: **the REST
+API has no endpoint that attaches a file to an issue** — the one the web interface uses is a session
+endpoint, not an API. So a file that is text and fits is carried *inside* the issue, whole, where it
+survives as long as the issue does; a file that is binary or too large is listed in the manifest
+with its size and its SHA-256, and the issue says plainly that the bytes were not published. Nothing
+is ever referenced by a Discord URL: those expire, and an issue whose evidence is a dead link is an
+issue with no evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from veaf_support_bot.attachments import Prepared
+from veaf_support_bot.bugreport import NOT_STATED, BugReport
+from veaf_support_bot.priorart import DUPLICATE, FIXED, IN_PROGRESS, Sweep
+from veaf_support_bot.untrusted import one_line, quote
+
+#: Longest issue body GitHub accepts, with room left for the marker and the footer.
+BODY_MAX_CHARS = 60000
+
+#: Longest comment GitHub accepts, with the same room left.
+COMMENT_MAX_CHARS = 60000
+
+#: Largest text attachment carried whole inside the issue. Past it the file is described rather than
+#: reproduced: a body that scrolls for ten minutes is a body nobody reads.
+INLINE_MAX_CHARS = 24000
+
+#: Marker embedded in every issue this service files, so a retry can find an issue it already opened
+#: even after a restart lost every trace of the attempt. Machine-readable, invisible when rendered.
+MARKER_PREFIX = "<!-- veaf-support-bot:report="
+
+MARKER_SUFFIX = " -->"
+
+#: Kinds of :data:`~veaf_support_bot.attachments.ACCEPTED_SUFFIXES` whose bytes are text and can
+#: therefore be carried inside the issue. A ``mission`` is a zip and an ``archive`` is a zip;
+#: neither survives being read as text.
+INLINE_KINDS = ("log", "text")
+
+#: Headings, in the two documentation languages. The English column is the template's own labels.
+_HEADINGS = {
+    "fr": {
+        "version": "Version",
+        "component": "Composant",
+        "happened": "Ce qui s'est passé",
+        "expected": "Ce qui était attendu",
+        "steps": "Étapes pour reproduire",
+        "context": "Contexte additionnel",
+        "located": "Localisation dans le code",
+        "mission": "Mission",
+        "logs": "Extrait de journal",
+        "files": "Fichiers joints",
+        "priorart": "Antériorité",
+        "missing": "Ce qui manque, et pourquoi",
+        "no_hypothesis": (
+            "_Aucune hypothèse : ce rapport a été rempli sans modèle. Tout ce qui précède est lu, "
+            "analysé ou cité — rien n'est deviné._"
+        ),
+        "filed_by": "Rapporté sur Discord par **{reporter}** · déposé automatiquement par le bot de support VEAF.",
+        "thread": "Fil d'origine : {url}",
+        "no_thread": "Fil d'origine : (non enregistré)",
+        "not_published": "non publié ici : {reason}",
+        "carried": "carried in full below",
+        "revision": "Dépôt consulté : {revision}",
+        "verbatim": "_Cité tel quel, sans traduction ni reformulation._",
+    },
+    "en": {
+        "version": "Version",
+        "component": "Component",
+        "happened": "What happened?",
+        "expected": "What did you expect?",
+        "steps": "Steps to reproduce",
+        "context": "Additional context",
+        "located": "Located in the code",
+        "mission": "Mission",
+        "logs": "Log excerpt",
+        "files": "Attached files",
+        "priorart": "Prior art",
+        "missing": "What is missing, and why",
+        "no_hypothesis": (
+            "_No hypothesis: this report was filled in without a model. Everything above is read, "
+            "parsed or quoted — none of it is guessed._"
+        ),
+        "filed_by": "Reported on Discord by **{reporter}** · filed automatically by the VEAF support bot.",
+        "thread": "Original thread: {url}",
+        "no_thread": "Original thread: (not recorded)",
+        "not_published": "not published here: {reason}",
+        "carried": "carried in full below",
+        "revision": "Repository consulted: {revision}",
+        "verbatim": "_Quoted verbatim, neither translated nor reworded._",
+    },
+}
+
+
+def heading(key: str, lang: str) -> str:
+    """Return one section heading in the reporter's language.
+
+    Args:
+        key: Heading key.
+        lang: ``"fr"`` or ``"en"``.
+
+    Returns:
+        The heading text.
+    """
+    return _HEADINGS.get(lang, _HEADINGS["en"])[key]
+
+
+def marker_for(key: str) -> str:
+    """Return the hidden marker identifying one report.
+
+    Args:
+        key: The report's idempotency key.
+
+    Returns:
+        An HTML comment, invisible in the rendered issue and greppable through the API.
+    """
+    return f"{MARKER_PREFIX}{key}{MARKER_SUFFIX}"
+
+
+def digest_of(path: Path) -> str:
+    """Return the SHA-256 of a file, so a reader can check the copy he was sent.
+
+    Args:
+        path: The file.
+
+    Returns:
+        The hex digest, or an empty string when the file could not be read.
+    """
+    try:
+        hasher = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                hasher.update(chunk)
+    except OSError:
+        return ""
+    return hasher.hexdigest()
+
+
+@dataclass(frozen=True)
+class Carried:
+    """One attachment, and what became of it.
+
+    Attributes:
+        prepared: The file as the attachment pass left it.
+        text: Its content, when it is text small enough to carry whole. Empty otherwise.
+        reason: Why the bytes are not here, when they are not.
+        digest: SHA-256 of the file.
+    """
+
+    prepared: Prepared
+    text: str = ""
+    reason: str = ""
+    digest: str = ""
+
+
+def carry(prepared: Prepared, *, limit: int = INLINE_MAX_CHARS) -> Carried:
+    """Decide how one attachment travels into the issue.
+
+    Args:
+        prepared: The file the attachment pass produced.
+        limit: Longest text carried whole.
+
+    Returns:
+        The decision. Text that fits is read and carried; everything else is described, because the
+        REST API cannot attach a file to an issue and a Discord URL is dead within days.
+    """
+    digest = digest_of(prepared.path)
+    if prepared.kind not in INLINE_KINDS:
+        return Carried(prepared, reason=f"binary file ({prepared.kind}), which an issue cannot hold", digest=digest)
+    if prepared.size > limit:
+        return Carried(
+            prepared,
+            reason=f"{prepared.size} bytes, past the {limit} an issue can carry — see the excerpt above",
+            digest=digest,
+        )
+    try:
+        content = prepared.path.read_text(encoding="utf-8", errors="replace")
+    except OSError as error:
+        return Carried(prepared, reason=f"could not be read back ({type(error).__name__})", digest=digest)
+    return Carried(prepared, text=content, digest=digest)
+
+
+def render_prior_art(sweep: Sweep, lang: str) -> str:
+    """Render what the sweep checked and what it proposed.
+
+    Recorded even when nothing matched: a reader who cannot see that the sweep ran has to run it
+    again himself.
+
+    Args:
+        sweep: The finding.
+        lang: ``"fr"`` or ``"en"``.
+
+    Returns:
+        The section body.
+    """
+    lines = [sweep.describe()]
+    if sweep.best is not None:
+        outcome = {
+            DUPLICATE: "a similar open issue was proposed and the reporter said his is different",
+            FIXED: "a closed issue was proposed and the reporter said his is different",
+            IN_PROGRESS: "existing work was proposed and the reporter said his is different",
+        }[sweep.verdict]
+        lines.append(f"Closest match, **rejected by the reporter** ({outcome}):")
+        lines.append(f"- {sweep.best.evidence()}")
+        for other in sweep.alternatives:
+            lines.append(f"- also considered: {other.evidence()}")
+    if lang == "fr":
+        lines.append("_Balayage déterministe : appariement de mots, aucun modèle._")
+    return "\n".join(lines)
+
+
+def render_body(report: BugReport, key: str, *, thread_url: str = "", carried: Iterable[Carried] = ()) -> str:
+    """Render the whole issue body.
+
+    Args:
+        report: The assembled report.
+        key: The idempotency key, embedded as the hidden marker.
+        thread_url: Link back to the Discord thread, when there is one.
+        carried: What became of each attachment.
+
+    Returns:
+        The Markdown body, bounded to what GitHub accepts.
+    """
+    lang = report.form.language if report.form.language in _HEADINGS else "en"
+    parts: list[str] = [marker_for(key)]
+
+    parts.append(f"### {heading('version', lang)}\n\n{report.version}")
+    parts.append(f"### {heading('component', lang)}\n\n{report.component}")
+    parts.append(f"### {heading('happened', lang)}\n\n{quote(report.form.happened)}")
+    parts.append(f"### {heading('expected', lang)}\n\n{quote(report.form.expected)}")
+    parts.append(f"### {heading('steps', lang)}\n\n{quote(report.form.steps)}")
+
+    context: list[str] = [heading("verbatim", lang), "", heading("revision", lang).format(revision=report.freshness.describe())]
+    if report.form.doctor.strip():
+        context.append("\n<details><summary>veaf-tools doctor</summary>\n\n" + quote(report.form.doctor) + "\n</details>")
+    parts.append(f"### {heading('context', lang)}\n\n" + "\n".join(context))
+
+    located = _render_locations(report)
+    if located:
+        parts.append(f"### {heading('located', lang)}\n\n{located}")
+    if report.mission_summaries:
+        parts.append(f"### {heading('mission', lang)}\n\n" + "\n\n".join(report.mission_summaries))
+    if report.log_digests:
+        parts.append(f"### {heading('logs', lang)}\n\n" + "\n\n".join(report.log_digests))
+
+    files = _render_manifest(carried, lang)
+    if files:
+        parts.append(f"### {heading('files', lang)}\n\n{files}")
+    if report.prior_art is not None:
+        parts.append(f"### {heading('priorart', lang)}\n\n{render_prior_art(report.prior_art, lang)}")
+    if report.notes:
+        listed = "\n".join(f"- **{note.subject}** — {note.reason}" for note in report.notes)
+        parts.append(f"### {heading('missing', lang)}\n\n{listed}")
+
+    parts.append(heading("no_hypothesis", lang))
+    parts.append("---")
+    parts.append(heading("filed_by", lang).format(reporter=one_line(report.form.reporter or "?", 80)))
+    parts.append(heading("thread", lang).format(url=thread_url) if thread_url else heading("no_thread", lang))
+    return "\n\n".join(parts)[:BODY_MAX_CHARS]
+
+
+def _render_locations(report: BugReport) -> str:
+    """Render the resolved locations, each with its callers.
+
+    Args:
+        report: The assembled report.
+
+    Returns:
+        The section body, or an empty string when nothing was located.
+    """
+    lines: list[str] = []
+    for location in report.located:
+        line = f"- `{location.relative}:{location.line}`"
+        if location.function:
+            line += f" in `{location.function}`"
+        if location.caller_total:
+            line += f" — {location.caller_total} call site(s): {', '.join(location.callers)}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _render_manifest(carried: Iterable[Carried], lang: str) -> str:
+    """Render one line per attachment, saying whether its bytes are in the issue.
+
+    Args:
+        carried: What became of each attachment.
+        lang: ``"fr"`` or ``"en"``.
+
+    Returns:
+        The manifest, or an empty string when there were no attachments.
+    """
+    lines: list[str] = []
+    for item in carried:
+        state = heading("carried", lang) if item.text else heading("not_published", lang).format(reason=item.reason)
+        digest = f" · `sha256:{item.digest[:16]}`" if item.digest else ""
+        lines.append(f"- `{item.prepared.filename}` — {item.prepared.size} bytes{digest} — {state}")
+    return "\n".join(lines)
+
+
+def render_attachment_comments(carried: Iterable[Carried]) -> list[str]:
+    """Render the follow-up comments that carry the text attachments whole.
+
+    They are comments rather than more body: a body holding three files scrolls past everything a
+    maintainer needs to read first, and a comment can be collapsed.
+
+    Args:
+        carried: What became of each attachment.
+
+    Returns:
+        One comment per carried file, in order.
+    """
+    comments: list[str] = []
+    for item in carried:
+        if not item.text:
+            continue
+        header = f"**`{item.prepared.filename}`** — {item.prepared.size} bytes"
+        if item.digest:
+            header += f", `sha256:{item.digest}`"
+        comments.append(f"{header}\n\n{quote(item.text)}"[:COMMENT_MAX_CHARS])
+    return comments
+
+
+def render_duplicate_comment(report: BugReport, lang: str, thread_url: str = "") -> str:
+    """Render what is added to an **existing** issue instead of opening a second one.
+
+    Args:
+        report: The assembled report.
+        lang: ``"fr"`` or ``"en"``.
+        thread_url: Link back to the Discord thread.
+
+    Returns:
+        The comment body.
+    """
+    parts = [
+        f"**{one_line(report.title, 120)}**",
+        heading("verbatim", lang),
+        f"### {heading('happened', lang)}\n\n{quote(report.form.happened)}",
+        f"### {heading('steps', lang)}\n\n{quote(report.form.steps)}",
+        f"{heading('version', lang)}: {report.version or NOT_STATED} · {heading('component', lang)}: {report.component}",
+        heading("filed_by", lang).format(reporter=one_line(report.form.reporter or "?", 80)),
+    ]
+    if thread_url:
+        parts.append(heading("thread", lang).format(url=thread_url))
+    return "\n\n".join(parts)[:COMMENT_MAX_CHARS]

--- a/services/support-bot/veaf_support_bot/issue_body.py
+++ b/services/support-bot/veaf_support_bot/issue_body.py
@@ -259,9 +259,15 @@ def render_body(report: BugReport, key: str, *, thread_url: str = "", carried: I
     parts.append(f"### {heading('expected', lang)}\n\n{quote(report.form.expected)}")
     parts.append(f"### {heading('steps', lang)}\n\n{quote(report.form.steps)}")
 
-    context: list[str] = [heading("verbatim", lang), "", heading("revision", lang).format(revision=report.freshness.describe())]
+    context: list[str] = [
+        heading("verbatim", lang),
+        "",
+        heading("revision", lang).format(revision=report.freshness.describe()),
+    ]
     if report.form.doctor.strip():
-        context.append("\n<details><summary>veaf-tools doctor</summary>\n\n" + quote(report.form.doctor) + "\n</details>")
+        context.append(
+            "\n<details><summary>veaf-tools doctor</summary>\n\n" + quote(report.form.doctor) + "\n</details>"
+        )
     parts.append(f"### {heading('context', lang)}\n\n" + "\n".join(context))
 
     located = _render_locations(report)

--- a/services/support-bot/veaf_support_bot/issue_body.py
+++ b/services/support-bot/veaf_support_bot/issue_body.py
@@ -227,7 +227,9 @@ def carry(prepared: Prepared, *, redactor: Callable[[str], str], limit: int = IN
     try:
         redacted = redactor(content)
     except ToolkitUnavailable as error:
-        return Carried(prepared, reason=f"it could not be redacted, so it is not published here ({error})", digest=digest)
+        return Carried(
+            prepared, reason=f"it could not be redacted, so it is not published here ({error})", digest=digest
+        )
     return Carried(prepared, text=redacted, digest=digest)
 
 

--- a/services/support-bot/veaf_support_bot/issue_body.py
+++ b/services/support-bot/veaf_support_bot/issue_body.py
@@ -43,6 +43,7 @@ from pathlib import Path
 
 from veaf_support_bot.attachments import Prepared
 from veaf_support_bot.bugreport import NOT_STATED, BugReport
+from veaf_support_bot.logging_setup import get_logger
 from veaf_support_bot.priorart import DUPLICATE, FIXED, IN_PROGRESS, Sweep
 from veaf_support_bot.toolkit import ToolkitUnavailable
 from veaf_support_bot.untrusted import one_line, quote
@@ -227,9 +228,19 @@ def carry(prepared: Prepared, *, redactor: Callable[[str], str], limit: int = IN
     try:
         redacted = redactor(content)
     except ToolkitUnavailable as error:
-        return Carried(
-            prepared, reason=f"it could not be redacted, so it is not published here ({error})", digest=digest
+        # The reason is published, so it says *what* happened and not *where*: the helper's own
+        # failure names the checkout path it resolved against, which is this host's filesystem
+        # layout and belongs in the service's log, next to `_unavailable`'s reasoning about a
+        # parser's message. The detail is one grep away for a maintainer.
+        get_logger("filing").warning(
+            "an attachment could not be redacted; its bytes are withheld",
+            extra={
+                "event": "filing.attachment_not_redacted",
+                "file": prepared.filename,
+                "detail": str(error),
+            },
         )
+        return Carried(prepared, reason="it could not be redacted, so its bytes are not published", digest=digest)
     return Carried(prepared, text=redacted, digest=digest)
 
 

--- a/services/support-bot/veaf_support_bot/issue_body.py
+++ b/services/support-bot/veaf_support_bot/issue_body.py
@@ -78,6 +78,7 @@ _HEADINGS = {
         "located": "Localisation dans le code",
         "mission": "Mission",
         "logs": "Extrait de journal",
+        "quoted": "Fichiers cités",
         "files": "Fichiers joints",
         "priorart": "Antériorité",
         "missing": "Ce qui manque, et pourquoi",
@@ -103,6 +104,7 @@ _HEADINGS = {
         "located": "Located in the code",
         "mission": "Mission",
         "logs": "Log excerpt",
+        "quoted": "Quoted files",
         "files": "Attached files",
         "priorart": "Prior art",
         "missing": "What is missing, and why",
@@ -277,6 +279,10 @@ def render_body(report: BugReport, key: str, *, thread_url: str = "", carried: I
         parts.append(f"### {heading('mission', lang)}\n\n" + "\n\n".join(report.mission_summaries))
     if report.log_digests:
         parts.append(f"### {heading('logs', lang)}\n\n" + "\n\n".join(report.log_digests))
+    # Its own heading, never folded into the log excerpts: a `mission.yaml` printed under *Log
+    # excerpt* leaves a reader wondering why his configuration file is being called a log.
+    if report.quoted_files:
+        parts.append(f"### {heading('quoted', lang)}\n\n" + "\n\n".join(report.quoted_files))
 
     files = _render_manifest(carried, lang)
     if files:

--- a/services/support-bot/veaf_support_bot/priorart.py
+++ b/services/support-bot/veaf_support_bot/priorart.py
@@ -371,7 +371,7 @@ def rank(matches: Iterable[Match]) -> list[Match]:
 # ---------------------------------------------------------------------------
 
 
-def read_backlog(root: Path) -> tuple[list[Candidate], str]:
+def read_backlog(root: Path) -> tuple[list[Candidate], str, list[str]]:
     """Read the open lots out of ``.backlog/``.
 
     Only lots that are still open are candidates: a closed lot answers nothing, and proposing one
@@ -381,17 +381,23 @@ def read_backlog(root: Path) -> tuple[list[Candidate], str]:
         root: The checkout root.
 
     Returns:
-        A pair of the candidates and a problem description, which is empty on success.
+        A triple of the candidates, a problem describing why the **directory** could not be read
+        (empty on success), and one problem per lot whose ``PRD.md`` could not be read. The two are
+        separate because they mean different things to the reader of the issue: the first says the
+        backlog was not swept at all, the second says it was swept minus these lots — and a lot
+        turned into an all-but-empty :class:`Candidate`, which is what this used to do, is worse than
+        either. It cannot match anything, so it silently reads as *"swept, nothing found"*.
     """
     backlog = root / ".backlog"
     if not backlog.is_dir():
-        return [], f"{backlog} is not a directory"
+        return [], f"{backlog} is not a directory", []
     candidates: list[Candidate] = []
+    unreadable: list[str] = []
     for prd in sorted(backlog.glob("*/PRD.md")):
         try:
             content = prd.read_text(encoding="utf-8", errors="replace")
         except OSError as error:
-            candidates.append(Candidate(SOURCE_BACKLOG, prd.parent.name, prd.parent.name, detail=type(error).__name__))
+            unreadable.append(f"`.backlog/{prd.parent.name}/PRD.md` could not be read ({type(error).__name__})")
             continue
         status = _status_of(content)
         if any(glyph in status for glyph in CLOSED_LOT_STATUSES):
@@ -406,7 +412,7 @@ def read_backlog(root: Path) -> tuple[list[Candidate], str]:
                 detail=status,
             )
         )
-    return candidates, ""
+    return candidates, "", unreadable
 
 
 def read_roadmap(root: Path) -> tuple[list[Candidate], str]:
@@ -546,8 +552,11 @@ class PriorArtSweeper:
             checked.append(f"{len(open_records)} open issue(s)")
             checked.append(f"{len(closed_records)} recently closed issue(s)")
 
-        lots, problem = read_backlog(self.root)
+        lots, problem, unreadable = read_backlog(self.root)
         self._note(problem, "`.backlog/`")
+        # Per file, not per source: the sweep really did read the other lots, so the count below is
+        # still true and still worth showing. What must not happen is the missing ones going unsaid.
+        self._problems.extend(unreadable)
         if not problem:
             checked.append(f"{len(lots)} open backlog lot(s)")
         candidates += lots

--- a/services/support-bot/veaf_support_bot/priorart.py
+++ b/services/support-bot/veaf_support_bot/priorart.py
@@ -1,0 +1,675 @@
+"""Has this already been reported, already fixed, or is a lot already on it?
+
+Four places are consulted before anything is filed, and **none of them costs a model call**. The
+corpus is tiny — nine open issues, a directory of lots, one roadmap — so the sweep is text matching
+over material the service already has on disk or one API page away.
+
+| Source | Answers | Verdict it can produce |
+|---|---|---|
+| Open issues | is this already reported? | :data:`DUPLICATE` |
+| Recently closed issues | was this fixed in a version the user does not have? | :data:`FIXED` |
+| ``.backlog/<LOT>/`` | is a lot already working on it? | :data:`IN_PROGRESS` |
+| ``ROADMAP.md`` | is it deliberately parked or cancelled? | :data:`IN_PROGRESS` |
+
+``CONTRIBUTING.md`` is explicit that issues are an intake desk and the real work lives in lots, so a
+sweep over issues alone would miss most of the answer — which is why the last two rows are here and
+why they read the **checkout**, not the API.
+
+## The failure mode this module is shaped around
+
+A wrong *"this is a duplicate"* silences a real bug, and the reporter will not insist — he will
+conclude the desk already knows and go away. So nothing here decides anything:
+
+* a match is **proposed**, never applied. :class:`Sweep` is a finding; acting on it is the caller's
+  job, and :class:`PriorArtGate` makes the acceptance an explicit, refusable step;
+* a match always carries its **evidence** — which source, which reference, and the exact words the
+  two texts share, so a reader can see *why* the machine thought so and disagree with it;
+* a rejection is not a dead end. The flow continues and the issue is filed, with what was checked
+  recorded in it.
+
+## Why the matching is this simple
+
+Every discriminating word in a bug report is a *token nobody uses in ordinary prose*:
+``v5_converter``, ``airdromes.yaml``, ``KeyError``, ``FEAT-SUPPORT-BUG-INTAKE``. Weighting those
+above ordinary words is the whole algorithm, and it is deliberate that it is legible: the score is
+printed with the match, and a maintainer who thinks it is wrong can read the shared words and see
+the mistake. A similarity model would score better and explain nothing.
+
+Nothing in a report selects a code path here either: the query is tokenised, and tokens are compared
+to tokens. See :mod:`veaf_support_bot.untrusted`.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+#: No source found anything worth proposing.
+NONE = "none"
+
+#: An open issue already describes this.
+DUPLICATE = "duplicate"
+
+#: A closed issue describes this, and a released version carries the fix.
+FIXED = "fixed"
+
+#: A backlog lot or a roadmap section already covers it.
+IN_PROGRESS = "in-progress"
+
+#: Source names, as they appear in the evidence a reader sees.
+SOURCE_OPEN_ISSUE = "open issue"
+SOURCE_CLOSED_ISSUE = "closed issue"
+SOURCE_BACKLOG = "backlog lot"
+SOURCE_ROADMAP = "roadmap"
+
+#: Which verdict each source produces when it wins.
+_VERDICT_OF_SOURCE = {
+    SOURCE_OPEN_ISSUE: DUPLICATE,
+    SOURCE_CLOSED_ISSUE: FIXED,
+    SOURCE_BACKLOG: IN_PROGRESS,
+    SOURCE_ROADMAP: IN_PROGRESS,
+}
+
+#: Order used to break a tie between two candidates that scored the same. *Already fixed* first
+#: because it is the only outcome that unblocks the reporter on the spot.
+_VERDICT_RANK = (FIXED, DUPLICATE, IN_PROGRESS)
+
+#: Lowest score worth proposing at all. Below it the match is not shown: a weak proposal is the
+#: silencing failure mode with extra steps.
+MATCH_MIN_SCORE = 0.34
+
+#: A proposal must additionally share at least one *signal* token — an identifier, a file name, an
+#: exception class — or this many ordinary words. Two reports that share only ``mission`` and
+#: ``error`` are not the same report.
+MATCH_MIN_ORDINARY = 5
+
+#: Weight of a signal token against an ordinary one.
+SIGNAL_WEIGHT = 3
+
+#: How many matches, besides the best one, are shown as alternatives.
+MAX_ALTERNATIVES = 2
+
+#: Longest candidate text kept. A PRD runs to pages; the words that identify it are at the top.
+CANDIDATE_MAX_CHARS = 6000
+
+#: How many shared words the evidence lists.
+EVIDENCE_MAX_TOKENS = 8
+
+#: Statuses of a backlog lot that mean the lot is *not* an answer to a new report.
+CLOSED_LOT_STATUSES = ("✅", "🚫")
+
+#: Words carrying no discriminating power in a French or English bug report. Deliberately short: the
+#: scoring already down-weights common words by counting signal tokens triple, and a long stop list
+#: is a place for a real term to get lost.
+_STOPWORDS = frozenset(
+    """
+    a ai aller alors an and any are as at au aussi autre aux avec avoir be been but by
+    ca can ce cela ces cest cet cette comme could dans de des deux do does donc dont du
+    each elle en encore est et etait etc ete etre eu faire fait for from get had has have he
+    her his how il ils in is it its je la le les leur lui ma mais me mes moi mon my ne
+    no nos not notre nous of on ont or ou our out par pas peut peux plus por posso pour
+    pourquoi qu quand que quel quelle qui quoi sa sans se ses si soit son sont sous sur
+    ta te tes that the their them then there these they this to toi ton tous tout toute
+    toutes tres tu un une va vais vas veut veux vous was we were what when which who will
+    with would you your
+    """.split()
+)
+
+#: What a token has to look like to be *ordinary*: a word of letters only, short enough to be
+#: everyday vocabulary. Everything else — anything with a digit, an underscore, a dot, or simply
+#: long — is a signal token.
+_ORDINARY = re.compile(r"^[a-z]{1,7}$")
+
+#: How text is cut into tokens. Dots and underscores are kept inside a token so ``mission.yaml`` and
+#: ``v5_converter`` survive as one discriminating word instead of three common ones.
+_TOKEN = re.compile(r"[a-z0-9]+(?:[._-][a-z0-9]+)*")
+
+#: A ``## [6.19.0] — 2026-09-02`` heading in ``CHANGELOG.md``.
+_CHANGELOG_HEADING = re.compile(r"^##\s*\[([^\]]+)\]")
+
+#: The ``Status: ⬜ ready`` line of a lot's PRD.
+_STATUS_LINE = re.compile(r"^Status:\s*(.+)$", re.MULTILINE)
+
+
+def fold(text: str) -> str:
+    """Lowercase text and strip its accents.
+
+    Args:
+        text: Any text.
+
+    Returns:
+        The folded text, so ``Problème`` and ``probleme`` are the same word.
+    """
+    decomposed = unicodedata.normalize("NFKD", text.lower())
+    return "".join(character for character in decomposed if not unicodedata.combining(character))
+
+
+def tokenize(text: str) -> tuple[frozenset[str], frozenset[str]]:
+    """Cut text into the two kinds of word the score distinguishes.
+
+    Args:
+        text: Any text.
+
+    Returns:
+        A pair ``(signal, ordinary)``. Signal tokens are identifiers, file names, versions and long
+        words; ordinary tokens are everyday vocabulary minus the stop list.
+    """
+    signal: set[str] = set()
+    ordinary: set[str] = set()
+    for match in _TOKEN.finditer(fold(text)):
+        token = match.group()
+        if _ORDINARY.match(token):
+            if token not in _STOPWORDS:
+                ordinary.add(token)
+        elif token not in _STOPWORDS:
+            signal.add(token)
+    return frozenset(signal), frozenset(ordinary)
+
+
+@dataclass(frozen=True)
+class IssueRecord:
+    """One issue as the tracker described it.
+
+    Attributes:
+        number: The issue number.
+        title: Its title.
+        body: Its body, which may be empty.
+        url: Its address on GitHub.
+        state: ``"open"`` or ``"closed"``.
+        closed_at: ISO timestamp, empty while the issue is open.
+        labels: Its labels.
+    """
+
+    number: int
+    title: str
+    body: str = ""
+    url: str = ""
+    state: str = "open"
+    closed_at: str = ""
+    labels: tuple[str, ...] = ()
+
+
+class IssueSource(Protocol):
+    """Where the two issue halves of the corpus come from.
+
+    A protocol rather than the GitHub client, so the sweep is tested against a handful of records
+    instead of against a network.
+    """
+
+    async def open_issues(self) -> Sequence[IssueRecord]:
+        """Return every open issue.
+
+        Returns:
+            The open issues.
+        """
+
+    async def recently_closed_issues(self) -> Sequence[IssueRecord]:
+        """Return the issues closed recently enough to still be an answer.
+
+        Returns:
+            The closed issues, newest first.
+        """
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One piece of prior work the report is compared against.
+
+    Attributes:
+        source: One of the ``SOURCE_*`` constants.
+        reference: How a human names it — ``"#712"``, ``"FEAT-SUPPORT-BUG-INTAKE"``.
+        title: Its one-line title.
+        text: The text that is matched against, already bounded.
+        url: Where to read it, when there is an address.
+        detail: One extra fact the outcome needs — the version that carries the fix, the lot's
+            status, the roadmap section's state. Empty when there is none.
+    """
+
+    source: str
+    reference: str
+    title: str
+    text: str = ""
+    url: str = ""
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class Match:
+    """A candidate the sweep thinks is the same subject, and why it thinks so.
+
+    Attributes:
+        candidate: What was matched.
+        score: Between 0 and 1. Printed, so a reader can weigh the proposal.
+        shared: The words the two texts have in common, signal words first — this is the evidence.
+    """
+
+    candidate: Candidate
+    score: float
+    shared: tuple[str, ...] = ()
+
+    @property
+    def verdict(self) -> str:
+        """Return the verdict this match produces.
+
+        Returns:
+            One of :data:`DUPLICATE`, :data:`FIXED`, :data:`IN_PROGRESS`.
+        """
+        return _VERDICT_OF_SOURCE[self.candidate.source]
+
+    def evidence(self) -> str:
+        """Render the one line that justifies the proposal.
+
+        Returns:
+            A sentence naming the source, the reference and the shared words.
+        """
+        words = ", ".join(self.shared) if self.shared else "no distinctive word"
+        return f"{self.candidate.source} {self.candidate.reference} — {self.score:.0%} match on: {words}"
+
+
+@dataclass(frozen=True)
+class Sweep:
+    """What the four sources answered, and what the caller may propose.
+
+    Nothing here has been acted on. :attr:`verdict` is a *finding*.
+
+    Attributes:
+        verdict: :data:`NONE`, :data:`DUPLICATE`, :data:`FIXED` or :data:`IN_PROGRESS`.
+        best: The strongest match, or ``None`` when nothing scored high enough.
+        alternatives: Weaker matches, so a reader can see the second-best rather than trust the
+            first.
+        checked: What was consulted, source by source, with how many items each held. Recorded in
+            the draft so a reader knows the sweep happened even when it found nothing.
+        problems: Sources that could not be consulted, each with its reason. A sweep that could not
+            read the issues is not a sweep that found nothing, and the difference has to be visible.
+    """
+
+    verdict: str = NONE
+    best: Match | None = None
+    alternatives: tuple[Match, ...] = ()
+    checked: tuple[str, ...] = ()
+    problems: tuple[str, ...] = ()
+
+    @property
+    def found(self) -> bool:
+        """Say whether there is a match to propose.
+
+        Returns:
+            ``True`` when a candidate scored above the threshold.
+        """
+        return self.best is not None
+
+    def describe(self) -> str:
+        """Render what was checked, for the issue body and the draft.
+
+        Returns:
+            A one-line summary of the sweep, never empty.
+        """
+        checked = "; ".join(self.checked) if self.checked else "nothing could be consulted"
+        line = f"Prior art checked: {checked}."
+        if self.problems:
+            line += " Not consulted: " + "; ".join(self.problems) + "."
+        return line
+
+
+def score_against(
+    query_signal: frozenset[str],
+    query_ordinary: frozenset[str],
+    candidate: Candidate,
+) -> Match | None:
+    """Score one candidate against the tokenised report.
+
+    Args:
+        query_signal: The report's signal tokens.
+        query_ordinary: The report's ordinary tokens.
+        candidate: The candidate to score.
+
+    Returns:
+        The match, or ``None`` when it is below the threshold or shares nothing distinctive.
+    """
+    signal, ordinary = tokenize(f"{candidate.title}\n{candidate.text}")
+    shared_signal = sorted(query_signal & signal)
+    shared_ordinary = sorted(query_ordinary & ordinary)
+    if not shared_signal and len(shared_ordinary) < MATCH_MIN_ORDINARY:
+        return None
+
+    total = SIGNAL_WEIGHT * len(query_signal) + len(query_ordinary)
+    if total == 0:
+        return None
+    hit = SIGNAL_WEIGHT * len(shared_signal) + len(shared_ordinary)
+    score = hit / total
+    if score < MATCH_MIN_SCORE:
+        return None
+    return Match(
+        candidate=candidate,
+        score=round(score, 4),
+        shared=tuple((shared_signal + shared_ordinary)[:EVIDENCE_MAX_TOKENS]),
+    )
+
+
+def rank(matches: Iterable[Match]) -> list[Match]:
+    """Order matches best first, with a stable tie-break.
+
+    Args:
+        matches: The matches to order.
+
+    Returns:
+        The matches, strongest first. Equal scores are broken by :data:`_VERDICT_RANK` and then by
+        reference, so the same corpus always produces the same proposal.
+    """
+    return sorted(
+        matches,
+        key=lambda match: (-match.score, _VERDICT_RANK.index(match.verdict), match.candidate.reference),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The two halves of the corpus that live in the checkout
+# ---------------------------------------------------------------------------
+
+
+def read_backlog(root: Path) -> tuple[list[Candidate], str]:
+    """Read the open lots out of ``.backlog/``.
+
+    Only lots that are still open are candidates: a closed lot answers nothing, and proposing one
+    would tell a reporter his bug is being worked on when it was shipped or dropped months ago.
+
+    Args:
+        root: The checkout root.
+
+    Returns:
+        A pair of the candidates and a problem description, which is empty on success.
+    """
+    backlog = root / ".backlog"
+    if not backlog.is_dir():
+        return [], f"{backlog} is not a directory"
+    candidates: list[Candidate] = []
+    for prd in sorted(backlog.glob("*/PRD.md")):
+        try:
+            content = prd.read_text(encoding="utf-8", errors="replace")
+        except OSError as error:
+            candidates.append(Candidate(SOURCE_BACKLOG, prd.parent.name, prd.parent.name, detail=type(error).__name__))
+            continue
+        status = _status_of(content)
+        if any(glyph in status for glyph in CLOSED_LOT_STATUSES):
+            continue
+        candidates.append(
+            Candidate(
+                source=SOURCE_BACKLOG,
+                reference=prd.parent.name,
+                title=_first_heading(content) or prd.parent.name,
+                text=content[:CANDIDATE_MAX_CHARS],
+                url=f".backlog/{prd.parent.name}/PRD.md",
+                detail=status,
+            )
+        )
+    return candidates, ""
+
+
+def read_roadmap(root: Path) -> tuple[list[Candidate], str]:
+    """Read ``ROADMAP.md`` as one candidate per section.
+
+    Args:
+        root: The checkout root.
+
+    Returns:
+        A pair of the candidates and a problem description, empty on success.
+    """
+    path = root / "ROADMAP.md"
+    if not path.is_file():
+        return [], f"{path} is missing"
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as error:
+        return [], f"ROADMAP.md could not be read ({type(error).__name__})"
+    candidates: list[Candidate] = []
+    for block in content.split("\n## ")[1:]:
+        heading, _, body = block.partition("\n")
+        heading = heading.strip()
+        if not heading:
+            continue
+        candidates.append(
+            Candidate(
+                source=SOURCE_ROADMAP,
+                reference=heading,
+                title=heading,
+                text=body[:CANDIDATE_MAX_CHARS],
+                url="ROADMAP.md",
+            )
+        )
+    return candidates, ""
+
+
+def fix_version(root: Path, number: int) -> str:
+    """Find the released version whose changelog entry cites an issue.
+
+    The changelog cites issues as ``[#123](…/issues/123)``, so the version that carries a fix is a
+    lookup, not a guess: the nearest ``## [x.y.z]`` heading above the citation.
+
+    Args:
+        root: The checkout root.
+        number: The issue number.
+
+    Returns:
+        The version, or an empty string when the changelog does not mention the issue — including
+        when it cannot be read at all, since a version stated on a guess is worse than none.
+    """
+    path = root / "CHANGELOG.md"
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    citation = re.compile(rf"#{number}\b")
+    heading = ""
+    for line in content.splitlines():
+        found = _CHANGELOG_HEADING.match(line)
+        if found:
+            heading = found.group(1).strip()
+            continue
+        if citation.search(line) and heading and heading.lower() != "unreleased":
+            return heading
+    return ""
+
+
+def _status_of(content: str) -> str:
+    """Return the ``Status:`` line of a PRD.
+
+    Args:
+        content: The PRD's text.
+
+    Returns:
+        The status, or an empty string.
+    """
+    found = _STATUS_LINE.search(content)
+    return found.group(1).strip() if found else ""
+
+
+def _first_heading(content: str) -> str:
+    """Return the first ``# `` heading of a document.
+
+    Args:
+        content: The document's text.
+
+    Returns:
+        The heading text, or an empty string.
+    """
+    for line in content.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# The sweep itself
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PriorArtSweeper:
+    """Runs the four-source sweep for one report.
+
+    Attributes:
+        root: The checkout root the two file sources are read from.
+        issues: Where the issue halves come from; ``None`` sweeps the checkout only, which is what a
+            deployment with no GitHub credentials does.
+    """
+
+    root: Path
+    issues: IssueSource | None = None
+    _problems: list[str] = field(default_factory=list, init=False, repr=False)
+
+    async def sweep(self, query: str) -> Sweep:
+        """Compare a report against everything already recorded.
+
+        Args:
+            query: The report's own words — its summary, what happened, what was expected, and the
+                locations the trace named. Deliberately not the attached log: a log shares hundreds
+                of words with every other log and would match everything.
+
+        Returns:
+            The finding. Never raises: a source that cannot be read becomes a line in
+            :attr:`Sweep.problems`, because *"the sweep could not run"* and *"the sweep found
+            nothing"* must not look the same to a reader.
+        """
+        self._problems = []
+        signal, ordinary = tokenize(query)
+        checked: list[str] = []
+        candidates: list[Candidate] = []
+
+        open_records, closed_records, tracker_read = await self._issue_records()
+        candidates += [_from_issue(record, SOURCE_OPEN_ISSUE) for record in open_records]
+        candidates += [_from_issue(record, SOURCE_CLOSED_ISSUE, self.root) for record in closed_records]
+        if tracker_read:
+            checked.append(f"{len(open_records)} open issue(s)")
+            checked.append(f"{len(closed_records)} recently closed issue(s)")
+
+        lots, problem = read_backlog(self.root)
+        self._note(problem, "`.backlog/`")
+        if not problem:
+            checked.append(f"{len(lots)} open backlog lot(s)")
+        candidates += lots
+
+        sections, problem = read_roadmap(self.root)
+        self._note(problem, "`ROADMAP.md`")
+        if not problem:
+            checked.append(f"{len(sections)} roadmap section(s)")
+        candidates += sections
+
+        scored = rank(
+            match for match in (score_against(signal, ordinary, candidate) for candidate in candidates) if match
+        )
+        best = scored[0] if scored else None
+        return Sweep(
+            verdict=best.verdict if best else NONE,
+            best=best,
+            alternatives=tuple(scored[1 : 1 + MAX_ALTERNATIVES]),
+            checked=tuple(checked),
+            problems=tuple(self._problems),
+        )
+
+    async def _issue_records(self) -> tuple[Sequence[IssueRecord], Sequence[IssueRecord], bool]:
+        """Fetch both issue halves, turning a failure into a recorded problem.
+
+        Returns:
+            The open issues, the recently closed ones, and whether the tracker answered at all. The
+            third value is what keeps *"nine issues, none of them yours"* distinguishable from
+            *"the tracker was down"*.
+        """
+        if self.issues is None:
+            self._problems.append("the issue tracker (no GitHub credentials are configured)")
+            return (), (), False
+        try:
+            return await self.issues.open_issues(), await self.issues.recently_closed_issues(), True
+        except Exception as error:  # noqa: BLE001 - any tracker failure is one line, never a lost report
+            self._problems.append(f"the issue tracker ({type(error).__name__})")
+            return (), (), False
+
+    def _note(self, problem: str, subject: str) -> None:
+        """Record a source that could not be consulted.
+
+        Args:
+            problem: The failure, or an empty string when there was none.
+            subject: What could not be read.
+        """
+        if problem:
+            self._problems.append(f"{subject} ({problem})")
+
+
+def _from_issue(record: IssueRecord, source: str, root: Path | None = None) -> Candidate:
+    """Turn an issue into a candidate.
+
+    Args:
+        record: The issue.
+        source: :data:`SOURCE_OPEN_ISSUE` or :data:`SOURCE_CLOSED_ISSUE`.
+        root: Checkout root, for looking up the version that carries the fix.
+
+    Returns:
+        The candidate.
+    """
+    detail = ""
+    if source == SOURCE_CLOSED_ISSUE and root is not None:
+        detail = fix_version(root, record.number)
+    return Candidate(
+        source=source,
+        reference=f"#{record.number}",
+        title=record.title,
+        text=record.body[:CANDIDATE_MAX_CHARS],
+        url=record.url,
+        detail=detail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Proposing the match, and being refused
+# ---------------------------------------------------------------------------
+
+
+class MatchConfirmation(Protocol):
+    """Asks the reporter whether a proposed match really is his bug."""
+
+    async def confirm(self, sweep: Sweep, lang: str) -> bool:
+        """Show the match with its evidence and return the reporter's answer.
+
+        Args:
+            sweep: The finding, with the evidence to display.
+            lang: ``"fr"`` or ``"en"``.
+
+        Returns:
+            ``True`` when the reporter agrees it is the same subject — nothing is opened. ``False``
+            when he says his is different, and the report goes on being filed.
+        """
+
+
+@dataclass(frozen=True)
+class PriorArtGate:
+    """The sweep, plus the step that lets the reporter refuse its conclusion.
+
+    Attributes:
+        sweeper: What runs the sweep.
+        confirmation: Who is asked. ``None`` means **nobody can be asked**, and the gate then always
+            returns "rejected": with no way to obtain consent, silencing a report on a machine's
+            unverified guess is the one outcome this ticket exists to prevent. The finding is still
+            attached to the report and printed with its evidence.
+    """
+
+    sweeper: PriorArtSweeper
+    confirmation: MatchConfirmation | None = None
+
+    async def run(self, query: str, lang: str) -> tuple[Sweep, bool]:
+        """Sweep, and find out whether the match is accepted.
+
+        Args:
+            query: The report's own words.
+            lang: ``"fr"`` or ``"en"``.
+
+        Returns:
+            A pair of the finding and whether it was **accepted** — ``True`` stops the flow, and the
+            caller acts on :attr:`Sweep.verdict` instead of filing.
+        """
+        sweep = await self.sweeper.sweep(query)
+        if not sweep.found or self.confirmation is None:
+            return sweep, False
+        return sweep, bool(await self.confirmation.confirm(sweep, lang))

--- a/services/support-bot/veaf_support_bot/service.py
+++ b/services/support-bot/veaf_support_bot/service.py
@@ -44,9 +44,13 @@ from veaf_support_bot.ask import AskHandler, build_handler
 from veaf_support_bot.attachments import AttachmentCollector, http_download
 from veaf_support_bot.checkout import CheckoutUnavailable, open_checkout
 from veaf_support_bot.config import SupportBotConfig
+from veaf_support_bot.filing import IssueFiler, Ledger, RepositoryIssues
+from veaf_support_bot.github_app import AppCredentials, GitHubApp, aiohttp_transport, read_private_key
 from veaf_support_bot.health import HealthServer, ServiceState
 from veaf_support_bot.intake import BugIntake
+from veaf_support_bot.priorart import PriorArtGate
 from veaf_support_bot.logging_setup import get_logger
+from veaf_support_bot.priorart import PriorArtSweeper
 from veaf_support_bot.quota import QuotaKeeper, QuotaLimits, QuotaStore
 
 
@@ -125,7 +129,44 @@ def build_intake(config: SupportBotConfig, logger: Logger | None = None) -> BugI
         max_file_bytes=config.attachment_max_bytes,
         max_total_bytes=config.attachment_total_bytes,
     )
-    return BugIntake(checkout, collector, logger=report)
+    app = build_github_app(config)
+    return BugIntake(
+        checkout,
+        collector,
+        logger=report,
+        prior_art=PriorArtGate(PriorArtSweeper(checkout.root, RepositoryIssues(app) if app else None)),
+        filer=IssueFiler(app, Ledger(Path(config.github_ledger_file), report), logger=report,
+                         machine_label=config.github_machine_label)
+        if app
+        else None,
+    )
+
+
+def build_github_app(config: SupportBotConfig) -> GitHubApp | None:
+    """Build the authenticated GitHub client, when this deployment has an App.
+
+    Args:
+        config: The resolved configuration.
+
+    Returns:
+        The client, or ``None`` when no App is configured — in which case ``/bug`` still prepares
+        and shows a complete report, and says plainly that nothing was opened.
+
+    Raises:
+        GitHubError: The App is configured and its private key cannot be read. Deliberately fatal:
+            :func:`veaf_support_bot.config.SupportBotConfig.from_env` has already refused a
+            half-configured App, so reaching here with an unusable key is a deployment that would
+            collect reports it can never file. The service exits 78 on it, like every other
+            configuration failure — it does not find out on the first user's report.
+    """
+    if not config.files_issues:
+        return None
+    credentials = AppCredentials(
+        app_id=config.github_app_id,
+        installation_id=config.github_installation_id,
+        private_key_pem=read_private_key(config.github_private_key, config.github_private_key_file),
+    )
+    return GitHubApp(credentials, config.github_repository, aiohttp_transport)
 
 
 class InFlightTasks:

--- a/services/support-bot/veaf_support_bot/service.py
+++ b/services/support-bot/veaf_support_bot/service.py
@@ -161,10 +161,10 @@ def build_github_app(config: SupportBotConfig) -> GitHubApp | None:
         and shows a complete report, and says plainly that nothing was opened.
 
     Raises:
-        GitHubError: The App is configured and its private key cannot be read. Deliberately fatal:
-            :func:`veaf_support_bot.config.SupportBotConfig.from_env` has already refused a
-            half-configured App, so reaching here with an unusable key is a deployment that would
-            collect reports it can never file. The service exits 78 on it, like every other
+        GitHubError: The App is configured and its private key cannot be read **or cannot sign**.
+            Deliberately fatal: :func:`veaf_support_bot.config.SupportBotConfig.from_env` has already
+            refused a half-configured App, so reaching here with an unusable key is a deployment that
+            would collect reports it can never file. The service exits 78 on it, like every other
             configuration failure — it does not find out on the first user's report.
     """
     if not config.files_issues:
@@ -174,6 +174,12 @@ def build_github_app(config: SupportBotConfig) -> GitHubApp | None:
         installation_id=config.github_installation_id,
         private_key_pem=read_private_key(config.github_private_key, config.github_private_key_file),
     )
+    # Signing once here is what makes the docstring above true. `read_private_key` only proves the
+    # bytes were *reachable*: a truncated PEM, a passphrase-protected key, or an EC key pasted in
+    # place of an RSA one all read back fine and fail at the first `jwt()` — which is the first bug
+    # report, a week later, in a service that looks healthy from every side but the useful one. The
+    # token is thrown away; only the failure matters.
+    credentials.jwt()
     return GitHubApp(credentials, config.github_repository, aiohttp_transport)
 
 

--- a/services/support-bot/veaf_support_bot/service.py
+++ b/services/support-bot/veaf_support_bot/service.py
@@ -48,9 +48,8 @@ from veaf_support_bot.filing import IssueFiler, Ledger, RepositoryIssues
 from veaf_support_bot.github_app import AppCredentials, GitHubApp, aiohttp_transport, read_private_key
 from veaf_support_bot.health import HealthServer, ServiceState
 from veaf_support_bot.intake import BugIntake
-from veaf_support_bot.priorart import PriorArtGate
 from veaf_support_bot.logging_setup import get_logger
-from veaf_support_bot.priorart import PriorArtSweeper
+from veaf_support_bot.priorart import PriorArtGate, PriorArtSweeper
 from veaf_support_bot.quota import QuotaKeeper, QuotaLimits, QuotaStore
 
 
@@ -135,8 +134,12 @@ def build_intake(config: SupportBotConfig, logger: Logger | None = None) -> BugI
         collector,
         logger=report,
         prior_art=PriorArtGate(PriorArtSweeper(checkout.root, RepositoryIssues(app) if app else None)),
-        filer=IssueFiler(app, Ledger(Path(config.github_ledger_file), report), logger=report,
-                         machine_label=config.github_machine_label)
+        filer=IssueFiler(
+            app,
+            Ledger(Path(config.github_ledger_file), report),
+            logger=report,
+            machine_label=config.github_machine_label,
+        )
         if app
         else None,
     )

--- a/services/support-bot/veaf_support_bot/service.py
+++ b/services/support-bot/veaf_support_bot/service.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Coroutine
+from functools import partial
 from logging import Logger
 from pathlib import Path
 from typing import Any, Protocol
@@ -51,6 +52,7 @@ from veaf_support_bot.intake import BugIntake
 from veaf_support_bot.logging_setup import get_logger
 from veaf_support_bot.priorart import PriorArtGate, PriorArtSweeper
 from veaf_support_bot.quota import QuotaKeeper, QuotaLimits, QuotaStore
+from veaf_support_bot.toolkit import redact
 
 
 class Gateway(Protocol):
@@ -137,6 +139,9 @@ def build_intake(config: SupportBotConfig, logger: Logger | None = None) -> BugI
         filer=IssueFiler(
             app,
             Ledger(Path(config.github_ledger_file), report),
+            # Bound to the same checkout the attachment pass redacts against: the whole file the
+            # issue carries and the excerpt above it must not disagree about what is publishable.
+            redactor=partial(redact, checkout.root),
             logger=report,
             machine_label=config.github_machine_label,
         )

--- a/services/support-bot/veaf_support_bot/texts.py
+++ b/services/support-bot/veaf_support_bot/texts.py
@@ -111,7 +111,6 @@ _TEXTS: Final[dict[str, dict[str, str]]] = {
         ),
         "bug.attached": "📎 {count} fichier(s) préparé(s) pour être joints au ticket.",
         "bug.notes": "⚠️ **Ce qui manque, et pourquoi** :",
-        "bug.next": ("-# Rien n'a encore été publié : cette étape prépare le ticket, elle ne l'ouvre pas."),
         "bug.error.unexpected": (
             "Quelque chose s'est mal passé de mon côté pendant la préparation de ce rapport. "
             "Réessaie ; si ça se reproduit, signale-le sur le canal support."
@@ -119,6 +118,42 @@ _TEXTS: Final[dict[str, dict[str, str]]] = {
         "bug.error.no_checkout": (
             "Je ne peux pas préparer de rapport pour le moment : ma copie du dépôt est "
             "indisponible. Signale-le sur le canal support — ça ne se règle pas en réessayant."
+        ),
+        # --- ticket 03, l'antériorité : proposée avec sa preuve, jamais appliquée -------------
+        "priorart.checked": "-# 🔍 {checked}",
+        "priorart.duplicate": (
+            "🔁 **C'est peut-être déjà signalé.** {reference} — *{title}*\n{evidence}\n{url}\n"
+            "Si c'est bien le même problème, ton observation y sera ajoutée plutôt que d'ouvrir un "
+            "second ticket. Si ce n'est pas le même, dis-le : ton rapport continue son chemin."
+        ),
+        "priorart.fixed": (
+            "✅ **C'est peut-être déjà corrigé.** {reference} — *{title}*\n{evidence}\n{url}\n"
+            "Corrigé en **{version}** : si tu es sur une version antérieure, mets à jour et le "
+            "problème devrait disparaître. Si tu l'as déjà, dis-le : ton rapport continue."
+        ),
+        "priorart.fixed_no_version": (
+            "✅ **C'est peut-être déjà corrigé.** {reference} — *{title}*\n{evidence}\n{url}\n"
+            "Le ticket est fermé, mais le changelog ne cite aucune version : à vérifier. Si ton "
+            "problème persiste, dis-le et ton rapport continue."
+        ),
+        "priorart.in_progress": (
+            "🛠️ **Un lot travaille peut-être déjà dessus.** {reference} — *{title}*\n{evidence}\n"
+            "{url}\nSi c'est bien ça, il n'y a rien à ouvrir. Sinon, dis-le et ton rapport continue."
+        ),
+        "priorart.rejected": "-# 👍 Compris, c'est autre chose : le rapport continue.",
+        # --- ticket 05, le dépôt du ticket ---------------------------------------------------
+        "filed.created": "✅ Ticket ouvert : {url}",
+        "filed.reused": "✅ Ce rapport avait déjà été déposé : {url} (rien n'a été ouvert deux fois).",
+        "filed.commented": "💬 Ton observation a été ajoutée au ticket existant : {url}",
+        "filed.notes": "-# ⚠️ {notes}",
+        "filed.error": (
+            "❌ **Je n'ai pas réussi à déposer ce ticket.** Raison : {reason}\n"
+            "Ton rapport n'est pas perdu — il est résumé ci-dessus. Signale-le sur le canal support, "
+            "ou ouvre le ticket toi-même : {issue_url}"
+        ),
+        "filed.disabled": (
+            "-# 📝 Aucun ticket n'a été ouvert : ce bot n'a pas encore d'identité GitHub configurée. "
+            "Le rapport ci-dessus est complet et peut être copié tel quel dans un ticket."
         ),
     },
     "en": {
@@ -203,7 +238,6 @@ _TEXTS: Final[dict[str, dict[str, str]]] = {
         ),
         "bug.attached": "📎 {count} file(s) prepared for the issue.",
         "bug.notes": "⚠️ **What is missing, and why**:",
-        "bug.next": "-# Nothing has been published yet: this step prepares the issue, it does not open it.",
         "bug.error.unexpected": (
             "Something went wrong on my side while preparing this report. Try again; if it happens "
             "again, report it on the support channel."
@@ -211,6 +245,42 @@ _TEXTS: Final[dict[str, dict[str, str]]] = {
         "bug.error.no_checkout": (
             "I cannot prepare a report right now: my copy of the repository is unavailable. Report "
             "it on the support channel — retrying will not help."
+        ),
+        # --- ticket 03, prior art: proposed with its evidence, never applied ------------------
+        "priorart.checked": "-# 🔍 {checked}",
+        "priorart.duplicate": (
+            "🔁 **This may already be reported.** {reference} — *{title}*\n{evidence}\n{url}\n"
+            "If it is the same problem, your observation goes there instead of opening a second "
+            "issue. If it is not, say so: your report carries on."
+        ),
+        "priorart.fixed": (
+            "✅ **This may already be fixed.** {reference} — *{title}*\n{evidence}\n{url}\n"
+            "Fixed in **{version}**: if you are on an earlier version, update and it should be "
+            "gone. If you already have it, say so and your report carries on."
+        ),
+        "priorart.fixed_no_version": (
+            "✅ **This may already be fixed.** {reference} — *{title}*\n{evidence}\n{url}\n"
+            "The issue is closed, but the changelog names no version for it — worth checking. If "
+            "your problem is still there, say so and your report carries on."
+        ),
+        "priorart.in_progress": (
+            "🛠️ **A lot may already be on it.** {reference} — *{title}*\n{evidence}\n{url}\n"
+            "If that is it, there is nothing to open. If not, say so and your report carries on."
+        ),
+        "priorart.rejected": "-# 👍 Understood, it is something else: the report carries on.",
+        # --- ticket 05, filing the issue -----------------------------------------------------
+        "filed.created": "✅ Issue opened: {url}",
+        "filed.reused": "✅ This report had already been filed: {url} (nothing was opened twice).",
+        "filed.commented": "💬 Your observation was added to the existing issue: {url}",
+        "filed.notes": "-# ⚠️ {notes}",
+        "filed.error": (
+            "❌ **I could not file this issue.** Reason: {reason}\n"
+            "Your report is not lost — it is summarised above. Report this on the support channel, "
+            "or open the issue yourself: {issue_url}"
+        ),
+        "filed.disabled": (
+            "-# 📝 No issue was opened: this bot has no GitHub identity configured yet. The report "
+            "above is complete and can be copied into an issue as it stands."
         ),
     },
 }


### PR DESCRIPTION
Tickets **03** and **05** of `FEAT-SUPPORT-BUG-INTAKE`, rebased onto `develop` now that #919 has
been squash-merged. Neither calls a model — the corpus is nine open issues and a directory of lots,
and text matching over material the checkout already holds is the whole of it.

## 03 — nothing gets reported twice

Four sources, four verdicts, and **three of the four open nothing**: *already reported* comments on
the existing issue, *already fixed* answers with the version that carries the fix, *a lot is on it*
names the lot. The issues come through the App; `.backlog/` and `ROADMAP.md` are read off the local
checkout, which is why the sweep costs nothing.

The version that carries a fix is a lookup rather than a guess: the changelog cites issues as
`[#123](…/issues/123)`, so it is the nearest `## [x.y.z]` heading above the citation. An issue the
changelog does not name yields no version, and the message says so.

**The guard.** A wrong "this is a duplicate" silences a real bug and the reporter will not insist.
So a match is *proposed* with the reference, the score and the exact words the two texts share, and
it can be rejected, after which the report is filed as usual. With nobody available to ask — which
is every deployment until ticket 04 adds the click — the gate answers **rejected**, never accepted.
A source that could not be read is reported as such: "nine issues, none of them yours" and "the
tracker was down" do not look the same.

## 05 — filed by a GitHub App

One repository, one permission, and nothing usable at rest: the private key on the host signs a
nine-minute JWT, which mints an hour-long installation token renewed on the call that needs it.

**The permissions to grant** (also in `README.md` and on ticket 05): **Issues — Read and write**,
**Metadata — Read-only** (mandatory, GitHub selects it), and *No access* everywhere else, including
`Contents`. Installed on `VEAF/VEAF-Mission-Creation-Tools` only, webhook inactive, no events.

The issue follows `.github/ISSUE_TEMPLATE/bug_report.yml` — a form 0 of the last 60 issues had used
— in the reporter's language, with every quote left verbatim. Labelled `bug` + `filed-by-bot`,
attributed to the Discord author, linked back to the thread.

**Filed once, three ways:** a lock for the double click, a ledger for the retry, and a hidden marker
inside the issue body for a restart between the `POST` and its answer — the only one of the three
that survives losing all local state. A failure to file is said in the thread with a link to the
form, never swallowed.

## One fix carried over from the base branch

`6b625d8a` split the attached material into three buckets so a `mission.yaml` would stop being
printed under *log excerpt*. The issue body written here only rendered two of them, so the third was
dropped from the issue altogether — the same bug, one layer down. It now has its own heading, with a
test asserting the order.

## Two things worth your decision

1. **Attachments cannot be re-uploaded.** GitHub has **no REST endpoint that attaches a file to an
   issue**; the one the web interface uses is a session endpoint no App can call. The API-reachable
   substitutes (a commit, a release asset) both need `Contents: write` on a *public* repository and
   would publish a stranger's `dcs.log` there permanently, so neither was built. Instead: a text
   attachment that fits is carried **whole, inside the issue**, as a comment; anything else is named
   with its size and its SHA-256 and the issue says the bytes were not published. **No Discord URL
   ever reaches an issue** — they expire.
2. **The bot does not create labels.** `filed-by-bot` has to exist in the repository. Letting a
   machine invent taxonomy in a public tracker looked like your call, not the bot's; without the
   label the issue is filed with `bug` alone and says so.

## Credentials

They do not exist yet — you create the App. Every GitHub variable is optional and **`/bug` works
without them**: it collects, reads, sweeps, shows a complete report and says nothing was opened. Set
*any one* of them and the service **exits 78 at startup** until the rest are set, with a message
naming what is missing and never echoing what it refused. Same for a key it cannot read.

## Rebase note

This branch was opened stacked on #919 and has been rebased `--onto develop` from the old fork point
`6b625d8a`, so it now carries only this lot's ten commits. The review fixes #919 received after the
fork — the redaction of archive member names, of the parser's refusal message and of the attachment
filename, and moving the deterministic pass off the event loop behind a lock — live in `develop` and
are untouched here: `attachments.py`, `checkout.py`, `traces.py` and `toolkit.py` do not appear in
this diff at all, and `bugreport.py` gains only the `prior_art` field.

## Gates

`ruff` · `ruff format` · `mypy` clean. **675 tests**, coverage **95.57 %** (gate 95). The container
job gains two steps: half an App exits 78 without leaking the value, and the image can really sign
an assertion — the `Dockerfile` pins its runtime dependencies by hand, so drift from `pyproject`
belongs there.

**Thirteen cut wires, thirteen red tests.** Every mutation is made in a shipped module — a method on
`BugIntake`, `read_backlog`, `CLOSED_LOT_STATUSES`, `_check_github`, the binding `service` resolved
at import — never in a double defined by the test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
