### PR TITLE
fix(combatzone): anchor a group spawn on the mission record, not on the live unit 1

### DIFF
--- a/.backlog/FIX-TRIPACK-FIELD-REPORTS/PRD.md
+++ b/.backlog/FIX-TRIPACK-FIELD-REPORTS/PRD.md
@@ -124,9 +124,16 @@ drops `taskSelected`, `uncontrolled`, `frequency`, `modulation`, `communication`
 | 01 | [Skynet's scheduler keeps the promise its docstring makes](tickets/01-skynet-scheduler-floor.md) | fix | 🧑 |
 | 02 | [A zone's naval element looks for water, not for dry land](tickets/02-naval-elements-look-for-water.md) | fix | ✅ |
 | 03 | [Why the terrain check refuses a ship already at sea](tickets/03-measure-the-naval-refusal.md) | fix | ✅ |
-| 04 | [ZU-23s of a combat zone come up kilometres out to sea](tickets/04-units-displaced-out-to-sea.md) | fix | ⬜ |
+| 04 | [ZU-23s of a combat zone come up kilometres out to sea](tickets/04-units-displaced-out-to-sea.md) | fix | 🧑 |
 | 05 | [A cloned group loses the mission task the editor gave it](tickets/05-qra-scrambles-without-engaging.md) | fix | ✅ |
 
 **All five are workable.** Tripack sent `Snowfox_20260903.miz`, its Skynet-off twin and the mission
-sources on 2026-09-05, and the measurements below replaced three open questions with answers. Only
-ticket 04 still lacks a named cause, and it now has a bounded hypothesis to test rather than a blank.
+sources on 2026-09-05, and the measurements below replaced three open questions with answers.
+
+Ticket 04 was worked the same day and the hypothesis held: the offset that translates a zone's group
+is read from **two sources** — the mission record's `units[1]` at one end, `Group:getUnit(1)` at the
+other — and any disagreement between them moves the whole group by the spacing between two different
+units. Measured on the real coordinates: 1 976 m and 3 340 m in the two scenarios that make them
+disagree. The anchor is now read from the record by name, so they cannot. What is **not** established
+is that either scenario occurred in Tripack's mission, which is why the ticket sits at 🧑 with an
+in-game check queued rather than closed.

--- a/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/04-units-displaced-out-to-sea.md
+++ b/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/04-units-displaced-out-to-sea.md
@@ -1,6 +1,6 @@
 # 04 — ZU-23s of a combat zone come up kilometres out to sea
 
-Status: ⬜ ready
+Status: 🧑 waiting-human
 
 Type: fix
 
@@ -41,30 +41,73 @@ spawn translates the *whole group* by one offset measured against its first unit
 which is exactly the observed magnitude, and exactly the trap `referencePositionOf`'s own docstring
 describes for a group straddling a zone edge.
 
-So the candidate is **the anchor**, not the radius. Three readings, none of them conclusive:
+So the candidate is **the anchor**, not the radius.
 
-1. `referencePositionOf` anchors on `Group.getByName(name):getUnit(1)` — the first **live** unit. With
-   `AAA-1` destroyed it returns `AAA-2`, 1 976 m away. But zone elements are built once, in
-   `VeafCombatZone:initialize` via `AddZone`, so a later loss should not re-anchor. *Should* — this is
-   read, not measured.
-2. The record's `units` order comes from `pairs(groupData.units)`
-   ([`veafMissionDb.lua:201`](../../../src/scripts/veaf/veafMissionDb.lua)). The mission's table is a
-   clean sequence here, so `pairs` walks it in order — but a group with a hole in its unit table would
-   fall into the hash part, and the order would then be arbitrary.
-3. Ruled out: CTLD. `CTLDVehicleSpawner` registers this zone's `Hawk` battery and its `Ural-375`, and
-   **not** the ZU-23s, so it is not moving them.
+## What was measured (2026-09-05)
 
-## What is needed
+`test/lua/test_veafCombatZone_displacement.lua` drives the real path — `VeafCombatZone:initialize` →
+`buildGroupElement` → `referencePositionOf` → `spawnElement` → `VeafGroupSpawn:respawn` — with the
+five editor coordinates above as the fixture, and asserts on the unit positions handed to
+`coalition.addGroup`. No run of DCS was available.
 
-A `debug` run: `VeafCombatZone:spawnElement` traces the declared position, the radius and the point
-found, and `_drawOrigin` the offset. Those three numbers turn this into arithmetic. Failing that,
-reproduce here — a zone whose group is deliberately spread over kilometres, activated repeatedly,
-with units killed between activations to exercise reading 1.
+**The defect is real and it is the anchor.** The offset was read from **two different sources**:
+
+| End of the offset | Source | What "unit 1" means there |
+|---|---|---|
+| `VeafGroupSpawn._drawOrigin` (`data.units[1]`) | the mission record | the unit the **Mission Editor** put first |
+| `veafCombatZone.referencePositionOf` | `Group:getUnit(1)` | the first **live** unit; the index shifts as DCS compacts its list |
+
+When the two disagree, the offset becomes the spacing between two different units and every unit of
+the group is translated by it. Measured on the real coordinates, before the fix:
+
+| Scenario | Worst displacement |
+|---|---|
+| Everything alive, units met in editor order (baseline) | ≤ 50 m — the default dispersion, nothing else |
+| `AAA-1` lost **before** `initialize` | **1 975.9 m** — the `AAA-1`→`AAA-2` spacing, on all five |
+| Live list out of editor order, everything alive | **3 340.4 m** — the `AAA-1`→`AAA-4` spacing, on all five |
+| `AAA-1` lost **after** `initialize` | ≤ 50 m — the element holds a position measured once, no re-anchor |
+| Five activate/deactivate cycles in a row | ≤ 50 m — no drift, no compounding |
+| The zone meeting the units out of order (`plainUnits[1]`) | ≤ 50 m — the anchor never was the unit the zone met |
+
+## What was ruled out
+
+- **The spawn radius.** 50 m, and `veaf.findSpawnPoint` bounds every tier to it — tier 1 explicitly
+  distance-tests Disposition's answers, which are not bounded by its radius argument.
+- **Compounding across activations.** The element's position is measured once, in `initialize`; a
+  later death does not re-anchor it and five cycles produced no drift.
+- **`plainUnits[1]`, the first unit the *zone* met.** It only decides the element's coalition. Both
+  the anchor and that list come from DCS's own `getUnits()` order, so the documented fallback cannot
+  disagree with the primary path.
+- **`pairs(groupData.units)` ordering.** The mission's unit table is a clean 1..5 sequence.
+- **CTLD.** `CTLDVehicleSpawner` registers this zone's Hawk battery and its Ural-375, not the ZU-23s.
+
+## The fix
+
+`referencePositionOf` now reads the anchor from the **mission record, by name** — the same unit
+`_drawOrigin` measures against — so both ends name the same unit and the offset is zero by
+construction, whatever DCS's live list looks like. A record whose unit 1 is no longer alive falls
+back on that unit's **editor position** (offset zero, the group comes up where it was drawn) instead
+of on some other unit, which is the defect itself.
+
+## What is still not established
+
+**Which of the two reproducing scenarios happened in Tripack's mission**, if either. Both require
+`Group:getUnit(1)` to differ from the record's `units[1]`, and at mission start, with all five
+ZU-23s alive, they should be the same object. The fix removes the whole family rather than a case
+that was observed — honest framing: the mechanism is proven, the trigger is not.
+
+An in-game check is queued in `DCS-SESSION-TODO.md`. What would settle it in one line is a `debug`
+run of the mission: `spawnElement` traces the declared position and the point found, and
+`_drawOrigin` the offset — three numbers that turn the remaining question into arithmetic.
 
 ## Definition of done
 
-- [ ] The displacement is reproduced, with the numbers that show it
-- [ ] Its cause is named
-- [ ] Fix, plus a test asserting the **built group's** unit positions — a widely spread group keeps
+- [x] The displacement is reproduced, with the numbers that show it
+- [x] Its cause is named — two sources for one offset
+- [x] Fix, plus a test asserting the **built group's** unit positions — a widely spread group keeps
       its shape and every unit lands where the zone put it
-- [ ] `luacheck` + `stylua --check` clean; Lua coverage floor bumped per the ratchet policy
+- [x] `stylua --check` clean; `luacheck` crashes on this workstation (Lua version mismatch in the
+      luarocks install), so the CI Lua gate is the one that answers for it
+- [x] Lua coverage measured at **80.33 %** against a floor of 80 — already inside the ~2-point band,
+      so the floor is left where it is rather than bumped onto a 0.33-point margin
+- [ ] Confirmed in game against Tripack's mission (see `DCS-SESSION-TODO.md`)

--- a/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/04-units-displaced-out-to-sea.md
+++ b/.backlog/FIX-TRIPACK-FIELD-REPORTS/tickets/04-units-displaced-out-to-sea.md
@@ -100,10 +100,38 @@ An in-game check is queued in `DCS-SESSION-TODO.md`. What would settle it in one
 run of the mission: `spawnElement` traces the declared position and the point found, and
 `_drawOrigin` the offset — three numbers that turn the remaining question into arithmetic.
 
+## `#spawnradius=0` is now guaranteed, and the harness had to be pushed to prove it
+
+Tripack asked for a way to keep a zone's elements exactly where he drew them — his Syrian air
+defences sit in revetments the map provides, and a metre of dispersion puts a launcher on the berm
+instead of inside it. `#spawnradius=0` already expressed that request, but on its own it did not
+deliver it, and `veafCombatZone.lua`'s own comment said why:
+
+> Unconditional, including when spawnRadius is 0: the delta is *not* only the dispersion.
+
+The dispersion was one of two terms; the anchor offset was the other, and it applied whatever the
+radius. This ticket makes the second term zero, so `TestAbuMusaFixedPlacement` asserts **exactly
+zero** — to the millimetre, on all five units — rather than "within the radius", and also that
+`findSpawnPoint` is never consulted at all.
+
+**A limit of the harness, found while making that test discriminating.** `dcs_mocks` answers
+`math.random()` with a constant **0**, so `veafGeo.getRandomPointInCircle` lands on the centre
+whatever radius it is given: in this harness *no spawn ever disperses*. A "nothing moved" assertion
+therefore passes with a 50 m radius exactly as it does with a written zero. Measured: with the tag
+removed from the fixture, the test stayed **green** until `dcs_mocks.setRandomSequence({ 0.5 })` was
+fed in, which draws a real `50 * sqrt(0.5)` ≈ 35.36 m and makes all three cases fail as they should.
+
+The same caveat applies to this suite's pre-existing `worst <= 51` assertions: they catch a
+kilometre-scale anchor error, which does not depend on the draw, but they do **not** exercise the
+dispersion. Any future test that means to assert something about dispersion has to drive the
+sequence.
+
 ## Definition of done
 
 - [x] The displacement is reproduced, with the numbers that show it
 - [x] Its cause is named — two sources for one offset
+- [x] `#spawnradius=0` produces an identity spawn, asserted to the millimetre and verified to fail
+      without the tag (three cases, 35.36 m of drift)
 - [x] Fix, plus a test asserting the **built group's** unit positions — a widely spread group keeps
       its shape and every unit lands where the zone put it
 - [x] `stylua --check` clean; `luacheck` crashes on this workstation (Lua version mismatch in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,6 +580,18 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   a `compose.yml` for the VEAF Docker host, a PowerShell launcher for a direct rehearsal, and the
   README section that says where it runs instead of asking.
 
+- **A combat zone's group is anchored on the unit the Mission Editor put first, not on the first one
+  still alive.** Spawning a zone's group translates all of its units by a single offset, and the two
+  ends of that offset were read from two different places: the spawner measures it against the
+  mission record's `units[1]`, while the zone element was anchored on `Group:getUnit(1)` — the first
+  *live* unit, an index DCS shifts as units are lost. Whenever the two disagreed the offset became
+  the spacing between two different units, and the whole group moved by it. On a group spread over
+  kilometres that is kilometres: measured on Tripack's `CMBT_ABU_MUSA_AIRPORT - AAA`, five ZU-23s
+  ringing Abu Musa 4 330 m apart, **1 976 m** with the first ZU-23 lost before the zone was built and
+  **3 340 m** with the live list out of editor order — enough to stand the south-western ones in open
+  water. Both ends now name the same unit, so the offset is zero by construction; a group whose first
+  unit is no longer alive falls back on that unit's editor position rather than on another unit.
+
 ## [6.19.0] — 2026-09-02
 
 ### Fixed

--- a/DCS-SESSION-TODO.md
+++ b/DCS-SESSION-TODO.md
@@ -941,3 +941,37 @@ son scramble, faire pénétrer un intrus dans sa zone d'engagement.
 
 Accessoirement, vérifier au passage que le groupe cloné reste **caché** sur la carte F10 si l'éditeur
 l'avait déclaré `hidden = true` — capture d'écran de Tripack à comparer, plus rapide qu'un vol.
+
+## Zone de combat : un groupe très étalé garde-t-il sa forme ?
+
+Ouvert par `FIX-TRIPACK-FIELD-REPORTS` (ticket 04), correctif du 2026-09-05.
+
+Ce qui est établi sans DCS : le décalage qui translate tout le groupe d'une zone était lu à **deux
+sources différentes** — le spawner le mesure contre `units[1]` de l'enregistrement de mission (l'unité
+que l'éditeur a mise en premier), la zone ancrait l'élément sur `Group:getUnit(1)` (la première unité
+**vivante**, dont l'indice glisse quand DCS compacte sa liste). Dès qu'elles divergent, le décalage
+devient l'écart entre deux unités différentes et tout le groupe se déplace d'autant. Mesuré dans le
+harnais sur les vraies coordonnées de `CMBT_ABU_MUSA_AIRPORT - AAA` (cinq ZU-23 étalées sur 4 330 m) :
+**1 975,9 m** si la première ZU-23 est perdue avant la construction de la zone, **3 340,4 m** si la
+liste vivante n'est pas dans l'ordre de l'éditeur. Après correctif, ≤ 50 m dans les deux cas.
+
+Ce qu'ils ne peuvent pas dire : **lequel des deux scénarios s'est produit chez Tripack**, ni même si
+l'un des deux s'est produit. Au démarrage de la mission les cinq ZU-23 sont vivantes, et les deux
+« unité 1 » devraient donc désigner le même objet. Le correctif supprime toute la famille, il ne
+referme pas un cas observé.
+
+**À faire** : lancer `Snowfox_20260903.miz` avec le niveau de log `debug`, activer
+`CMBT_ABU_MUSA_AIRPORT`, et relever dans `dcs.log` les trois nombres que la zone trace déjà —
+`spawnElement` : `position=[...]` (la position déclarée) puis `found=[...]` (le point retenu), et
+`_drawOrigin` : le décalage. Comparer `position` aux coordonnées éditeur de `AAA-1`
+(`x = -30382,9 ; y = -122247,2`).
+
+- **Attendu après correctif** : `position` tombe sur `AAA-1` à quelques mètres près, le décalage est
+  inférieur à 50 m, et les cinq ZU-23 sont à terre sur la carte F10.
+- **Ce qui rouvrirait le sujet** : `position` tombe sur une **autre** ZU-23 (donc l'ancrage par nom
+  n'a pas suffi), ou les cinq sont bien à leur place et deux restent quand même dans l'eau — ça
+  voudrait dire que le déplacement n'était pas la cause du rapport de Tripack et qu'il faut chercher
+  ailleurs. Candidat restant, non traité ici : la validation de terrain
+  (`veaf.findSpawnPoint` dans `spawnElement`) ne teste que le point d'ancrage, jamais les quatre
+  autres unités du groupe — une unité déjà au bord de l'eau dans l'éditeur peut donc passer dedans
+  sans que rien ne le remarque.

--- a/doc/TESTING.en.md
+++ b/doc/TESTING.en.md
@@ -164,6 +164,7 @@ luaunit.assertIsTrue(ok, err)
 | `test_veafCombatMission.lua` | Base combat mission lifecycle |
 | `test_veafAirbases.lua` | Airbase data lookup |
 | `test_veafCombatZone.lua` | Zone activation, scoring, state machine |
+| `test_veafCombatZone_displacement.lua` | Spawn anchor of a widely spread group: it keeps its shape |
 | `test_veafUnits.lua` | Unit template lookup, category filtering |
 | `test_veafAssets.lua` | Asset registration, state tracking |
 | `test_veafAssist.lua` | Pilot assistance: checklists, progression, menus |

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -164,6 +164,7 @@ luaunit.assertIsTrue(ok, err)
 | `test_veafCombatMission.lua` | Cycle de vie d'une mission de combat |
 | `test_veafAirbases.lua` | Recherche de données aérodromes |
 | `test_veafCombatZone.lua` | Activation de zone, scoring, machine à états |
+| `test_veafCombatZone_displacement.lua` | Ancrage du spawn d'un groupe très étalé : il garde sa forme |
 | `test_veafUnits.lua` | Recherche de templates d'unités, filtrage par catégorie |
 | `test_veafAssets.lua` | Enregistrement d'assets, suivi d'état |
 | `test_veafAssist.lua` | Assistance pilote : checklists, progression, menus |

--- a/src/scripts/veaf/veafCombatZone.lua
+++ b/src/scripts/veaf/veafCombatZone.lua
@@ -562,14 +562,39 @@ end
 --- first one", and a convoy comes up a truck-length down the road from where it was drawn — with
 --- `#spawnradius=0` written and no dispersion asked for.
 ---
---- Falls back on the unit it was handed when DCS cannot produce unit 1, since an element with no
---- position spawns nothing at all, which is worse than spawning thirty metres off.
+--- FIX-TRIPACK-FIELD-REPORTS ticket 04: the anchor is read from the **mission record**, by name, and not
+--- from `Group:getUnit(1)`. Both used to be called "unit 1", and they are not the same unit: the record's
+--- is the one the Mission Editor put first and the one `_drawOrigin` measures the offset against, while
+--- DCS's is the first *live* one — its list compacts as units die. Reading them from two sources made the
+--- offset the spacing between two different units whenever those sources disagreed, which for
+--- `CMBT_ABU_MUSA_AIRPORT - AAA` — five ZU-23s spread over 4 330 m around Abu Musa — moves every unit of
+--- the group by kilometres and puts the south-western ones out to sea. Same source, so the offset is zero
+--- by construction and no divergence is possible.
 ---
---- @param unit the unit the caller had, used as the fallback
+--- The fallbacks, in order: the record's own **editor** position when its unit 1 is not live (offset zero,
+--- so the group comes up exactly where it was drawn — never anchored on some other unit, which is the
+--- defect itself), then DCS's unit 1, then the unit the caller had. The last two carry a group with no
+--- mission record at all: an element with no position spawns nothing, which is worse than an imperfect one.
+---
+--- @param unit the unit the caller had, used as the last fallback
 --- @param group the group, as built by VeafCombatZone:initialize
 --- @return table a runtime vec3
 function veafCombatZone.referencePositionOf(unit, group)
   if not group.isStatic then
+    local record = veaf.getGroupRecord(group.name)
+    local anchor = record and record.units and record.units[1]
+    if anchor then
+      local liveAnchor = anchor.unitName and Unit.getByName(anchor.unitName)
+      if liveAnchor then
+        return liveAnchor:getPosition().p
+      end
+      -- Its editor position, in runtime shape: `x` is the northing, `z` the easting, and the altitude
+      -- is the terrain's — see docs/agents/dcs-coordinates.md.
+      veaf.loggers
+        .get(veafCombatZone.Id)
+        :info("group [%s] has no live [%s]; anchoring on its editor position", veaf.p(group.name), veaf.p(anchor.unitName))
+      return { x = anchor.x, y = land.getHeight({ x = anchor.x, y = anchor.y }), z = anchor.y }
+    end
     local dcsGroup = Group.getByName(group.name)
     local firstUnit = dcsGroup and dcsGroup:getUnit(1)
     if firstUnit then

--- a/test/lua/test_veafCombatZone_displacement.lua
+++ b/test/lua/test_veafCombatZone_displacement.lua
@@ -1,0 +1,374 @@
+--- FIX-TRIPACK-FIELD-REPORTS ticket 04 — a combat zone's widely spread group must keep its shape.
+---
+--- Tripack's `Snowfox_20260903.miz` shows two ZU-23s of `CMBT_ABU_MUSA_AIRPORT` standing in open water
+--- kilometres south-west of Abu Musa, with all five ashore in the Mission Editor. The spawn translates
+--- the **whole group** by one offset (`veafDcsSpawner._drawOrigin`), measured between the point the zone
+--- element declares and the mission record's unit 1. That group is 4 330 m wide, so any mechanism that
+--- anchors the element on a unit other than the record's first one moves every ZU-23 by kilometres.
+---
+--- These tests drive the real path — `VeafCombatZone:initialize` → `buildGroupElement` →
+--- `referencePositionOf` → `spawnElement` → `VeafGroupSpawn:respawn` — with the five real editor
+--- coordinates as the fixture, and assert on the unit positions actually handed to
+--- `coalition.addGroup`. Nothing between the zone and DCS is stubbed.
+local _base = debug.getinfo(1, "S").source:match("^@(.+)[\\/]") or "."
+luaunit = dofile(_base .. "/luaunit.lua")
+dofile(_base .. "/dcs_mocks.lua")
+local src = _base .. "/../../src/scripts/veaf"
+dofile(src .. "/veaf.lua")
+dofile(src .. "/veafScheduler.lua")
+dofile(src .. "/veafMath.lua")
+dofile(src .. "/veafGeo.lua")
+dofile(src .. "/veafMissionDb.lua")
+dofile(src .. "/veafDcsSpawner.lua")
+dofile(src .. "/veafI18n.lua")
+dofile(src .. "/veafCombatZone.lua")
+
+veaf.config.language = "en"
+
+local ZONE_NAME = "CMBT_ABU_MUSA_AIRPORT"
+local GROUP_NAME = ZONE_NAME .. " - AAA"
+local ZONE_CENTRE = { x = -31532.5, z = -121253.0 }
+local ZONE_RADIUS = 4876.8
+
+--- The five ZU-23s as Tripack drew them, in mission-table shape: `x` is the northing, `y` the easting.
+local EDITOR_UNITS = {
+  { name = GROUP_NAME .. "-1", unitId = 9001, x = -30382.9, y = -122247.2 },
+  { name = GROUP_NAME .. "-2", unitId = 9002, x = -29154.8, y = -120699.3 },
+  { name = GROUP_NAME .. "-3", unitId = 9003, x = -31826.8, y = -119503.7 },
+  { name = GROUP_NAME .. "-4", unitId = 9004, x = -33555.6, y = -121202.2 },
+  { name = GROUP_NAME .. "-5", unitId = 9005, x = -32818.9, y = -123007.7 },
+}
+
+-- ---------------------------------------------------------------------------
+-- Fixture
+-- ---------------------------------------------------------------------------
+
+--- The mission table the zone and the spawner both read, rebuilt from EDITOR_UNITS.
+local function buildMissionSnapshot()
+  local units = {}
+  for _, unit in ipairs(EDITOR_UNITS) do
+    table.insert(units, {
+      name = unit.name,
+      unitId = unit.unitId,
+      type = "ZU-23 Closed Insurgent",
+      x = unit.x,
+      y = unit.y,
+      alt = 0,
+      heading = 0,
+      skill = "Average",
+    })
+  end
+  env.mission.coalition.red = env.mission.coalition.red or {}
+  env.mission.coalition.red.country = {
+    [1] = {
+      -- RUSSIA rather than Tripack's Insurgents: `veafDcsSpawner.addGroup` resolves the country against
+      -- the `country` table, and the mocks carry only RUSSIA and USA. Nothing under test reads it.
+      name = "RUSSIA",
+      id = country.id.RUSSIA,
+      vehicle = { group = { { name = GROUP_NAME, groupId = 900, units = units } } },
+    },
+  }
+  veafMissionDb.buildSnapshot()
+end
+
+--- Register the live DCS units and their group.
+---
+--- `liveOrder` is the order `Group:getUnit(n)` answers in — DCS compacts the list as units die, so a
+--- destroyed unit 1 makes unit 2 the first one the API hands back.
+local function registerLiveGroup(liveOrder)
+  local byName = {}
+  for _, unit in ipairs(EDITOR_UNITS) do
+    dcs_mocks.addUnit(unit.name, {
+      _point = { x = unit.x, y = 0, z = unit.y },
+      getPoint = function()
+        return { x = unit.x, y = 0, z = unit.y }
+      end,
+      getCoalition = function()
+        return coalition.side.RED
+      end,
+      getGroup = function()
+        return Group.getByName(GROUP_NAME)
+      end,
+    })
+    byName[unit.name] = Unit.getByName(unit.name)
+  end
+
+  local live = {}
+  for _, name in ipairs(liveOrder) do
+    table.insert(live, byName[name])
+  end
+
+  dcs_mocks.addGroup(GROUP_NAME, {
+    getUnits = function()
+      return live
+    end,
+    getUnit = function(_self, index)
+      return live[index]
+    end,
+    getCategory = function()
+      return Group.Category.GROUND
+    end,
+    getCoalition = function()
+      return coalition.side.RED
+    end,
+  })
+  return byName
+end
+
+--- Everything the zone needs to exist and to find its units, with a flat all-land island.
+local function setUpFixture(liveOrder, unitNamesTheZoneSees)
+  dcs_mocks.reset()
+  dcs_mocks.clearUnitsAndGroups()
+  Disposition = nil
+  land.getHeight = function()
+    return 0
+  end
+  land.getSurfaceType = function()
+    return land.SurfaceType.LAND
+  end
+
+  veaf.triggerZones[ZONE_NAME] = {
+    name = ZONE_NAME,
+    type = 0,
+    x = ZONE_CENTRE.x,
+    y = ZONE_CENTRE.z,
+    radius = ZONE_RADIUS,
+  }
+  dcs_mocks.addZone(ZONE_NAME, ZONE_CENTRE.x, ZONE_CENTRE.z, ZONE_RADIUS)
+
+  buildMissionSnapshot()
+  registerLiveGroup(liveOrder)
+
+  local names = unitNamesTheZoneSees or liveOrder
+  veaf.getUnitsNamesOfCoalition = function()
+    local copy = {}
+    for _, name in ipairs(names) do
+      table.insert(copy, name)
+    end
+    return copy
+  end
+end
+
+local function tearDownFixture()
+  veaf.triggerZones[ZONE_NAME] = nil
+  dcs_mocks.zones[ZONE_NAME] = nil
+  dcs_mocks.clearUnitsAndGroups()
+  dcs_mocks.reset()
+end
+
+--- The names of the five ZU-23s, in editor order.
+local function editorOrder()
+  local names = {}
+  for _, unit in ipairs(EDITOR_UNITS) do
+    table.insert(names, unit.name)
+  end
+  return names
+end
+
+--- The group the zone last handed `coalition.addGroup`, indexed by the editor unit name it came from.
+---
+--- The spawner keeps the record's unit order, so entry `n` is `EDITOR_UNITS[n]` moved.
+local function spawnedPositions()
+  local submitted = dcs_mocks.groupsAdded[#dcs_mocks.groupsAdded]
+  if not submitted then
+    return nil
+  end
+  local positions = {}
+  for index, unit in ipairs(submitted.group.units) do
+    positions[EDITOR_UNITS[index].name] = { x = unit.x, y = unit.y }
+  end
+  return positions
+end
+
+--- How far each spawned unit ended up from where the Mission Editor drew it, in metres.
+local function displacements()
+  local positions = spawnedPositions()
+  if not positions then
+    return nil
+  end
+  local distances = {}
+  for _, unit in ipairs(EDITOR_UNITS) do
+    local spawned = positions[unit.name]
+    local dx, dy = spawned.x - unit.x, spawned.y - unit.y
+    distances[unit.name] = math.sqrt(dx * dx + dy * dy)
+  end
+  return distances
+end
+
+local function worstDisplacement()
+  local worst, worstName = 0, nil
+  for name, distance in pairs(displacements()) do
+    if distance > worst then
+      worst, worstName = distance, name
+    end
+  end
+  return worst, worstName
+end
+
+--- Build the zone as mission start does, then activate it.
+local function activateZone()
+  local zone = VeafCombatZone:new():setFriendlyName("Abu Musa"):setMissionEditorZoneName(ZONE_NAME):initialize()
+  zone:activate()
+  return zone
+end
+
+-- ---------------------------------------------------------------------------
+-- The baseline: nothing wrong, nothing moves
+-- ---------------------------------------------------------------------------
+TestAbuMusaBaseline = {}
+
+function TestAbuMusaBaseline:setUp()
+  setUpFixture(editorOrder())
+end
+
+function TestAbuMusaBaseline:tearDown()
+  tearDownFixture()
+end
+
+function TestAbuMusaBaseline:test_the_zone_builds_one_element_for_the_group()
+  local zone = activateZone()
+  local elements = zone:getZoneElements()
+  luaunit.assertEquals(#elements, 1)
+  luaunit.assertEquals(elements[1]:getName(), GROUP_NAME)
+  luaunit.assertEquals(elements[1]:getSpawnRadius(), 50, "no #spawnradius tag, so the vehicle default")
+end
+
+function TestAbuMusaBaseline:test_the_group_reaches_dcs()
+  activateZone()
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 1)
+  luaunit.assertEquals(#dcs_mocks.groupsAdded[1].group.units, 5)
+end
+
+--- The whole point: with every unit alive and met in editor order, the group keeps its shape and no
+--- unit moves further than the 50 m dispersion the default allows.
+function TestAbuMusaBaseline:test_no_unit_moves_beyond_the_spawn_radius()
+  activateZone()
+  local worst, name = worstDisplacement()
+  luaunit.assertTrue(worst <= 51, string.format("worst displacement %s m, on %s", tostring(worst), tostring(name)))
+end
+
+function TestAbuMusaBaseline:test_the_group_keeps_its_shape()
+  activateZone()
+  local moved = spawnedPositions()
+  -- every unit translated by the same vector, so every spacing is preserved to the metre
+  local reference = EDITOR_UNITS[1]
+  local dx = moved[reference.name].x - reference.x
+  local dy = moved[reference.name].y - reference.y
+  for _, unit in ipairs(EDITOR_UNITS) do
+    luaunit.assertAlmostEquals(moved[unit.name].x - unit.x, dx, 0.001, unit.name .. " northing")
+    luaunit.assertAlmostEquals(moved[unit.name].y - unit.y, dy, 0.001, unit.name .. " easting")
+  end
+end
+
+-- ---------------------------------------------------------------------------
+-- Reading 1 — the anchor is the first *live* unit
+-- ---------------------------------------------------------------------------
+TestAbuMusaDeadFirstUnit = {}
+
+function TestAbuMusaDeadFirstUnit:tearDown()
+  tearDownFixture()
+end
+
+--- `referencePositionOf` anchors on `Group:getUnit(1)`, and DCS compacts that list as units die. If a
+--- ZU-23 is lost before the zone is built, unit 2 becomes "the first one" — 1 976 m from unit 1 — while
+--- the mission record still starts at unit 1. The offset then carries that spacing.
+function TestAbuMusaDeadFirstUnit:test_a_dead_first_unit_at_initialize_time_displaces_the_group()
+  local survivors = { EDITOR_UNITS[2].name, EDITOR_UNITS[3].name, EDITOR_UNITS[4].name, EDITOR_UNITS[5].name }
+  setUpFixture(survivors)
+  activateZone()
+  local worst, name = worstDisplacement()
+  luaunit.assertTrue(
+    worst > 1000,
+    string.format("expected a kilometre-scale displacement, got %s m on %s", tostring(worst), tostring(name))
+  )
+end
+
+--- The same loss **after** the zone was built must change nothing: the element holds a position measured
+--- once, at initialize, and no later death re-anchors it.
+function TestAbuMusaDeadFirstUnit:test_a_unit_lost_after_initialize_does_not_re_anchor_the_element()
+  setUpFixture(editorOrder())
+  local zone = VeafCombatZone:new():setFriendlyName("Abu Musa"):setMissionEditorZoneName(ZONE_NAME):initialize()
+  -- unit 1 is destroyed between the build and the activation
+  local live = {}
+  for index = 2, #EDITOR_UNITS do
+    table.insert(live, Unit.getByName(EDITOR_UNITS[index].name))
+  end
+  local group = Group.getByName(GROUP_NAME)
+  group.getUnit = function(_self, index)
+    return live[index]
+  end
+  group.getUnits = function()
+    return live
+  end
+  dcs_mocks.removeUnit(EDITOR_UNITS[1].name)
+
+  zone:activate()
+  local worst, name = worstDisplacement()
+  luaunit.assertTrue(worst <= 51, string.format("worst displacement %s m, on %s", tostring(worst), tostring(name)))
+end
+
+-- ---------------------------------------------------------------------------
+-- Reading 2 — repeated activations must not compound
+-- ---------------------------------------------------------------------------
+TestAbuMusaRepeatedActivations = {}
+
+function TestAbuMusaRepeatedActivations:setUp()
+  setUpFixture(editorOrder())
+end
+
+function TestAbuMusaRepeatedActivations:tearDown()
+  tearDownFixture()
+end
+
+function TestAbuMusaRepeatedActivations:test_five_cycles_never_drift()
+  local zone = VeafCombatZone:new():setFriendlyName("Abu Musa"):setMissionEditorZoneName(ZONE_NAME):initialize()
+  for cycle = 1, 5 do
+    zone:activate()
+    local worst, name = worstDisplacement()
+    luaunit.assertTrue(
+      worst <= 51,
+      string.format("cycle %d: worst displacement %s m, on %s", cycle, tostring(worst), tostring(name))
+    )
+    zone:desactivate()
+  end
+  luaunit.assertEquals(#dcs_mocks.groupsAdded, 5)
+end
+
+-- ---------------------------------------------------------------------------
+-- Reading 3 — the zone meets the units in an order of its own
+-- ---------------------------------------------------------------------------
+TestAbuMusaUnitOrder = {}
+
+function TestAbuMusaUnitOrder:tearDown()
+  tearDownFixture()
+end
+
+--- `plainUnits[1]` — the first unit the zone happened to meet — must not decide the position: the
+--- element anchors on the group's unit 1 whatever order the zone walked in.
+function TestAbuMusaUnitOrder:test_meeting_the_units_out_of_order_changes_nothing()
+  local reversed = {}
+  for index = #EDITOR_UNITS, 1, -1 do
+    table.insert(reversed, EDITOR_UNITS[index].name)
+  end
+  setUpFixture(editorOrder(), reversed)
+  activateZone()
+  local worst, name = worstDisplacement()
+  luaunit.assertTrue(worst <= 51, string.format("worst displacement %s m, on %s", tostring(worst), tostring(name)))
+end
+
+--- DCS answering its units in an order that is not the editor's, with every unit alive.
+function TestAbuMusaUnitOrder:test_a_live_list_out_of_editor_order_displaces_the_group()
+  local shuffled = {
+    EDITOR_UNITS[4].name,
+    EDITOR_UNITS[1].name,
+    EDITOR_UNITS[2].name,
+    EDITOR_UNITS[3].name,
+    EDITOR_UNITS[5].name,
+  }
+  setUpFixture(shuffled)
+  activateZone()
+  local worst = worstDisplacement()
+  luaunit.assertTrue(worst > 1000, string.format("expected a kilometre-scale displacement, got %s m", tostring(worst)))
+end
+
+os.exit(luaunit.LuaUnit.run())

--- a/test/lua/test_veafCombatZone_displacement.lua
+++ b/test/lua/test_veafCombatZone_displacement.lua
@@ -269,18 +269,18 @@ function TestAbuMusaDeadFirstUnit:tearDown()
   tearDownFixture()
 end
 
---- `referencePositionOf` anchors on `Group:getUnit(1)`, and DCS compacts that list as units die. If a
---- ZU-23 is lost before the zone is built, unit 2 becomes "the first one" — 1 976 m from unit 1 — while
---- the mission record still starts at unit 1. The offset then carries that spacing.
-function TestAbuMusaDeadFirstUnit:test_a_dead_first_unit_at_initialize_time_displaces_the_group()
+--- The regression. `referencePositionOf` used to anchor on `Group:getUnit(1)`, and DCS compacts that
+--- list as units die: with the first ZU-23 lost before the zone is built, unit 2 became "the first one"
+--- — 1 976 m from unit 1 — while the mission record still started at unit 1, so the offset carried that
+--- spacing and translated all five. Measured before the fix: 1 976 m on every unit. The anchor now comes
+--- from the record, so a group that lost its first unit still comes up where it was drawn.
+function TestAbuMusaDeadFirstUnit:test_a_dead_first_unit_at_initialize_time_does_not_displace_the_group()
   local survivors = { EDITOR_UNITS[2].name, EDITOR_UNITS[3].name, EDITOR_UNITS[4].name, EDITOR_UNITS[5].name }
   setUpFixture(survivors)
+  dcs_mocks.removeUnit(EDITOR_UNITS[1].name)
   activateZone()
   local worst, name = worstDisplacement()
-  luaunit.assertTrue(
-    worst > 1000,
-    string.format("expected a kilometre-scale displacement, got %s m on %s", tostring(worst), tostring(name))
-  )
+  luaunit.assertTrue(worst <= 51, string.format("worst displacement %s m, on %s", tostring(worst), tostring(name)))
 end
 
 --- The same loss **after** the zone was built must change nothing: the element holds a position measured
@@ -325,10 +325,7 @@ function TestAbuMusaRepeatedActivations:test_five_cycles_never_drift()
   for cycle = 1, 5 do
     zone:activate()
     local worst, name = worstDisplacement()
-    luaunit.assertTrue(
-      worst <= 51,
-      string.format("cycle %d: worst displacement %s m, on %s", cycle, tostring(worst), tostring(name))
-    )
+    luaunit.assertTrue(worst <= 51, string.format("cycle %d: worst displacement %s m, on %s", cycle, tostring(worst), tostring(name)))
     zone:desactivate()
   end
   luaunit.assertEquals(#dcs_mocks.groupsAdded, 5)
@@ -356,8 +353,10 @@ function TestAbuMusaUnitOrder:test_meeting_the_units_out_of_order_changes_nothin
   luaunit.assertTrue(worst <= 51, string.format("worst displacement %s m, on %s", tostring(worst), tostring(name)))
 end
 
---- DCS answering its units in an order that is not the editor's, with every unit alive.
-function TestAbuMusaUnitOrder:test_a_live_list_out_of_editor_order_displaces_the_group()
+--- The second regression, and the one that needs no death at all: DCS answering its units in an order
+--- that is not the editor's. `Group:getUnit(1)` was then unit 4 — 3 340 m from the record's unit 1 — and
+--- the whole group moved by it (measured before the fix). The anchor is named now, not indexed.
+function TestAbuMusaUnitOrder:test_a_live_list_out_of_editor_order_does_not_displace_the_group()
   local shuffled = {
     EDITOR_UNITS[4].name,
     EDITOR_UNITS[1].name,
@@ -367,8 +366,8 @@ function TestAbuMusaUnitOrder:test_a_live_list_out_of_editor_order_displaces_the
   }
   setUpFixture(shuffled)
   activateZone()
-  local worst = worstDisplacement()
-  luaunit.assertTrue(worst > 1000, string.format("expected a kilometre-scale displacement, got %s m", tostring(worst)))
+  local worst, name = worstDisplacement()
+  luaunit.assertTrue(worst <= 51, string.format("worst displacement %s m, on %s", tostring(worst), tostring(name)))
 end
 
 os.exit(luaunit.LuaUnit.run())

--- a/test/lua/test_veafCombatZone_displacement.lua
+++ b/test/lua/test_veafCombatZone_displacement.lua
@@ -43,6 +43,11 @@ local EDITOR_UNITS = {
 -- Fixture
 -- ---------------------------------------------------------------------------
 
+--- The group name the current fixture uses. Normally `GROUP_NAME`; a fixture that exercises a
+--- `#spawnradius=` tag appends it here, because a combat zone reads its tags from the **names** the
+--- Mission Editor gave the group and its units.
+local activeGroupName = GROUP_NAME
+
 --- The mission table the zone and the spawner both read, rebuilt from EDITOR_UNITS.
 local function buildMissionSnapshot()
   local units = {}
@@ -65,7 +70,7 @@ local function buildMissionSnapshot()
       -- the `country` table, and the mocks carry only RUSSIA and USA. Nothing under test reads it.
       name = "RUSSIA",
       id = country.id.RUSSIA,
-      vehicle = { group = { { name = GROUP_NAME, groupId = 900, units = units } } },
+      vehicle = { group = { { name = activeGroupName, groupId = 900, units = units } } },
     },
   }
   veafMissionDb.buildSnapshot()
@@ -87,7 +92,7 @@ local function registerLiveGroup(liveOrder)
         return coalition.side.RED
       end,
       getGroup = function()
-        return Group.getByName(GROUP_NAME)
+        return Group.getByName(activeGroupName)
       end,
     })
     byName[unit.name] = Unit.getByName(unit.name)
@@ -98,7 +103,7 @@ local function registerLiveGroup(liveOrder)
     table.insert(live, byName[name])
   end
 
-  dcs_mocks.addGroup(GROUP_NAME, {
+  dcs_mocks.addGroup(activeGroupName, {
     getUnits = function()
       return live
     end,
@@ -116,7 +121,11 @@ local function registerLiveGroup(liveOrder)
 end
 
 --- Everything the zone needs to exist and to find its units, with a flat all-land island.
-local function setUpFixture(liveOrder, unitNamesTheZoneSees)
+---
+--- `groupNameOverride` renames the **group** only, so a fixture can carry a `#spawnradius=` tag; the
+--- unit names stay as EDITOR_UNITS holds them, which is what `displacements()` keys on.
+local function setUpFixture(liveOrder, unitNamesTheZoneSees, groupNameOverride)
+  activeGroupName = groupNameOverride or GROUP_NAME
   dcs_mocks.reset()
   dcs_mocks.clearUnitsAndGroups()
   Disposition = nil
@@ -150,6 +159,7 @@ local function setUpFixture(liveOrder, unitNamesTheZoneSees)
 end
 
 local function tearDownFixture()
+  activeGroupName = GROUP_NAME
   veaf.triggerZones[ZONE_NAME] = nil
   dcs_mocks.zones[ZONE_NAME] = nil
   dcs_mocks.clearUnitsAndGroups()
@@ -368,6 +378,76 @@ function TestAbuMusaUnitOrder:test_a_live_list_out_of_editor_order_does_not_disp
   activateZone()
   local worst, name = worstDisplacement()
   luaunit.assertTrue(worst <= 51, string.format("worst displacement %s m, on %s", tostring(worst), tostring(name)))
+end
+
+-- ---------------------------------------------------------------------------
+-- `#spawnradius=0` — "these are placed exactly where I want them"
+-- ---------------------------------------------------------------------------
+
+--- Tripack asked for a way to keep a zone's elements exactly where he drew them: his Syrian air
+--- defences sit in revetments the map provides, and a metre of dispersion puts a launcher on the berm
+--- instead of inside it. `#spawnradius=0` is that request, and it already existed — but on its own it
+--- was not enough, which is what `veafCombatZone.lua`'s own comment said out loud:
+---
+--- > Unconditional, including when spawnRadius is 0: the delta is *not* only the dispersion.
+---
+--- The dispersion was only one of the two terms. The other was the offset between the anchor and the
+--- record's unit 1, and it applied whatever the radius — so a group could move with dispersion switched
+--- off. Ticket 04 makes both terms zero, so this asserts **exactly zero**, not "within the radius":
+--- with no dispersion asked for and every unit alive where the editor put it, a spawn must be the
+--- identity.
+TestAbuMusaFixedPlacement = {}
+
+local FIXED_GROUP_NAME = GROUP_NAME .. " #spawnradius=0"
+
+function TestAbuMusaFixedPlacement:setUp()
+  setUpFixture(editorOrder(), nil, FIXED_GROUP_NAME)
+  -- **This is what makes the suite discriminating.** The mocks answer `math.random()` with 0, so
+  -- `getRandomPointInCircle` lands exactly on the centre whatever the radius — which means a
+  -- "nothing moved" assertion passes with a 50 m radius just as happily as with a zero one, and
+  -- proves nothing at all. Measured: without this line, dropping the tag from FIXED_GROUP_NAME
+  -- leaves `test_not_one_unit_moves_at_all` green. Feeding 0.5 draws a real displacement of
+  -- `50 * sqrt(0.5)` ≈ 35 m for the default radius, while a written zero short-circuits the draw
+  -- before it happens (`veafGeo.getRandomPointInCircle`, `if r <= 0`).
+  dcs_mocks.setRandomSequence({ 0.5 })
+end
+
+function TestAbuMusaFixedPlacement:tearDown()
+  dcs_mocks.setRandomSequence(nil)
+  tearDownFixture()
+end
+
+function TestAbuMusaFixedPlacement:test_the_tag_reaches_the_zone_element()
+  local zone = activateZone()
+  local elements = zone:getZoneElements()
+  luaunit.assertEquals(#elements, 1)
+  luaunit.assertEquals(elements[1]:getSpawnRadius(), 0, "#spawnradius=0 must survive as a written zero")
+end
+
+--- The promise made to a mission maker who writes `#spawnradius=0`: not "less than the radius", but
+--- not one metre. Asserted to the millimetre on all five units.
+function TestAbuMusaFixedPlacement:test_not_one_unit_moves_at_all()
+  activateZone()
+  local moved = spawnedPositions()
+  for _, unit in ipairs(EDITOR_UNITS) do
+    luaunit.assertAlmostEquals(moved[unit.name].x, unit.x, 0.001, unit.name .. " northing moved")
+    luaunit.assertAlmostEquals(moved[unit.name].y, unit.y, 0.001, unit.name .. " easting moved")
+  end
+end
+
+--- And the terrain search must not even be consulted: tier 1 exists to *move* a point, so a zero radius
+--- has to skip it. If `findSpawnPoint` ran, a scenery-aware candidate could displace the group despite
+--- the tag.
+function TestAbuMusaFixedPlacement:test_the_spawn_point_search_is_not_consulted()
+  local searched = false
+  local realFindSpawnPoint = veaf.findSpawnPoint
+  veaf.findSpawnPoint = function(...)
+    searched = true
+    return realFindSpawnPoint(...)
+  end
+  activateZone()
+  veaf.findSpawnPoint = realFindSpawnPoint
+  luaunit.assertFalse(searched, "a zero spawn radius must not search for a spawn point")
 end
 
 os.exit(luaunit.LuaUnit.run())


### PR DESCRIPTION
`FIX-TRIPACK-FIELD-REPORTS` ticket 04. **Investigation first.** The mechanism is proven and fixed; the trigger in Tripack's mission is **not** established, and the ticket says so rather than claiming his report is closed.

## What the offset actually is

Spawning a combat zone's group translates **every one of its units by a single offset**. The two ends of that offset were read from two different places:

| End | Source | What "unit 1" means there |
|---|---|---|
| `VeafGroupSpawn._drawOrigin` (`data.units[1]`) | the mission record | the unit the **Mission Editor** put first |
| `veafCombatZone.referencePositionOf` | `Group:getUnit(1)` | the first **live** unit — an index DCS shifts as its list compacts |

When they disagree the offset becomes the spacing between two *different* units, and the whole group moves by it. On `CMBT_ABU_MUSA_AIRPORT - AAA` — five ZU-23s ringing Abu Musa 4 330 m apart — that is kilometres, which is the order of magnitude of the report.

## Measured, on the real editor coordinates

`test/lua/test_veafCombatZone_displacement.lua` drives the real path (`initialize` → `buildGroupElement` → `referencePositionOf` → `spawnElement` → `VeafGroupSpawn:respawn`) and asserts on the unit positions handed to `coalition.addGroup`. Nothing between the zone and DCS is stubbed.

| Scenario | Before | After |
|---|---|---|
| All alive, editor order (baseline) | ≤ 50 m | ≤ 50 m |
| `AAA-1` lost **before** `initialize` | **1 975.9 m** on all five | ≤ 50 m |
| Live list out of editor order, all alive | **3 340.4 m** on all five | ≤ 50 m |
| `AAA-1` lost **after** `initialize` | ≤ 50 m | ≤ 50 m |
| Five activate/deactivate cycles | ≤ 50 m | ≤ 50 m |
| Zone meeting the units out of order | ≤ 50 m | ≤ 50 m |

1 975.9 m is exactly the `AAA-1`→`AAA-2` spacing and 3 340.4 m the `AAA-1`→`AAA-4` spacing — the arithmetic the ticket asked for. Both reproductions were confirmed to **fail** against the unpatched source before the fix landed.

## The fix

`referencePositionOf` reads the anchor from the mission record **by name** — the same unit `_drawOrigin` measures against — so both ends name the same unit and the offset is zero by construction, whatever DCS's live list looks like. A record whose unit 1 is no longer alive falls back on that unit's **editor position** (offset zero, the group comes up where it was drawn) rather than on some other unit, which is the defect itself.

## Ruled out, and stated as such

The spawn radius (50 m, and `findSpawnPoint` bounds every tier to it, Disposition's overshoot included); compounding across activations; `plainUnits[1]`, the first unit the *zone* met, which only decides the coalition; `pairs(groupData.units)` ordering; CTLD.

## What this PR does **not** claim

That either reproducing scenario happened in Tripack's mission. At mission start all five ZU-23s are alive and the two "unit 1"s should be the same object. The fix removes the family, not an observed case. Ticket 04 stays 🧑 with an in-game check queued in `DCS-SESSION-TODO.md` — including the one remaining candidate this fix does **not** cover: `findSpawnPoint` validates the anchor's terrain only, never the other four units of the group.

## Gates

- `test-lua`: 48 suites, 0 failures (run directly against Lua 5.1 — `poetry` has no environment in this worktree).
- `stylua --check src/scripts/veaf/ test/lua/`: clean.
- `luacheck`: **crashes on this workstation** (the luarocks install is 5.5 and the module tree does not load). Not run, not waved through — the CI Lua gate answers for it.
- Lua coverage measured at **80.33 %** against a floor of 80. Already inside the ~2-point band, so the floor is left where it is rather than bumped onto a 0.33-point margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Anchor combat-zone group spawning consistently to mission-record coordinates so widely spaced groups retain their intended placement and shape.

Bug Fixes:
- Anchor combat-zone group spawns to the mission-record unit selected by the Mission Editor, preventing live-unit ordering or loss from translating the entire group by kilometre-scale offsets.
- Ensure groups with a missing live anchor fall back to its editor position and honor exact-placement spawns with zero radius.

Documentation:
- Document the confirmed displacement mechanism, remaining in-game validation work, and the new displacement test suite in the ticket and session checklist.
- Add the combat-zone displacement test suite to the English and French testing documentation.
- Document the fix in the changelog.

Tests:
- Add end-to-end Lua coverage for widely spaced groups, reordered or missing live anchors, repeated activations, zone unit ordering, and exact zero-radius placement.