### PR TITLE
feat(support-bot): the reporter sees the issue before it is filed, and clicks

### DIFF
--- a/.backlog/FEAT-SUPPORT-BUG-INTAKE/tickets/04-draft-and-consent.md
+++ b/.backlog/FEAT-SUPPORT-BUG-INTAKE/tickets/04-draft-and-consent.md
@@ -1,6 +1,6 @@
 # 04 — The preview, and the click that files it
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: feat
 
@@ -41,10 +41,48 @@ tracker honest, not the consent step.
 
 ## Definition of done
 
-- [ ] Preview rendered in the thread, carrying facts only
-- [ ] File / edit / cancel, with edit reopening the modal and regenerating the preview
-- [ ] Truncation always visible; nothing silently dropped
-- [ ] Preview expiry, announced
-- [ ] `/ask` escalation carries question and unsatisfying answer into the modal
-- [ ] Unit tests: each control, expiry, an over-long draft, the escalation path
-- [ ] Quality gate clean
+- [x] Preview rendered in the thread, carrying facts only
+- [x] File / edit / cancel, with edit reopening the modal and regenerating the preview
+- [x] Truncation always visible; nothing silently dropped
+- [x] Preview expiry, announced
+- [x] `/ask` escalation carries question and unsatisfying answer into the modal
+- [x] Unit tests: each control, expiry, an over-long draft, the escalation path
+- [x] Quality gate clean
+
+## What was built
+
+`veaf_support_bot/draft.py` holds the draft and the two bounds; the buttons live in
+`discord_bot.py`, and the intake never draws one.
+
+**The preview is the issue, not a rendering of it.** `IssueFiler.draft_of` calls the same
+`render_body` the filing path calls, with the same arguments, so a preview that drifts from what
+gets published is a test failure rather than a surprise on a public tracker. The one thing a second
+renderer could never prove is that the issue says what the preview said.
+
+**The question moved onto the exchange.** `decide` and `confirm` are now part of `BugExchange`
+rather than objects built at start-up, because the buttons hang off *this* reporter's own message —
+there is no reporter to ask when the service boots. That is also what finally answers ticket 03's
+open point: `PriorArtGate.run` takes the confirmation as an argument, the gate's own field is gone,
+and the proposal is genuinely put to the reporter with its evidence instead of always answering
+*rejected*.
+
+**Two things publish, and both wait for the click.** The ticket names the issue; the flow also
+writes a *comment* when the reporter accepts a duplicate, carrying the same material onto the same
+public tracker. Recognising an issue as his is not the same act as agreeing to publish twenty lines
+under it, so the comment is previewed and confirmed exactly like the issue, under its own heading.
+
+**Every failure leans the same way.** A silence expires, a Discord error cancels, an answer nobody
+wrote a case for is treated as a refusal — the only path that reaches GitHub is a press of *File the
+issue*. The two waits are five and eight minutes against Discord's fifteen-minute interaction token,
+so the expiry can still be announced on the message it happened to; a timeout the service could no
+longer write to would leave the reporter on a preview that never resolves.
+
+**Truncation states its counts.** `fold` cuts on a line boundary, closes a fenced block it ran
+through, and returns what it dropped so the notice can name it — the long parts are exactly the ones
+the reporter did not write, so a silent cut would misrepresent the part that matters most.
+
+## What ticket 06 still has to pick up
+
+The escalation button carries the `/ask` exchange into the form but **not** the thread it came from:
+`BugSubmission.thread_url` is still empty, so the issue says the thread was not recorded. Ticket 06
+owns that link, and it is the same link the relay needs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -470,6 +470,21 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   candidate that matched nothing, so a lot nobody had read was indistinguishable from a lot swept
   and found irrelevant.
 
+- **Support bot — a `/bug` report is now shown before it is filed, and nothing is published without
+  a click.** The reporter sees the issue itself — the exact title and body that would be created,
+  not a summary of them — with *File the issue*, *Edit* and *Cancel*. He types three fields and
+  twenty lines get published under a machine account, so the click is where he can see the log
+  excerpt, the extracted code and the environment that were added on his behalf, and say *not that*.
+  *Edit* reopens the form with his answers still in it. A draft nobody answers expires after eight
+  minutes and says so, and every other way this step can fail — a silence, a refusal, Discord
+  refusing to show the draft — leaves the tracker untouched. The preview is bounded to what Discord
+  accepts and **states** what it left out, with the counts. The prior-art proposal is now actually
+  put to the reporter with its evidence, where it previously had nobody to ask and always answered
+  *rejected* — and the comment added to an existing issue goes through the same click, since a
+  comment on a public tracker publishes as much as an issue does. And an `/ask` answer that did not
+  help carries a *Report a bug* button that opens the same form, pre-filled with the question and
+  the answer.
+
 ## [6.19.0] — 2026-09-02
 
 ### Fixed

--- a/services/support-bot/README.md
+++ b/services/support-bot/README.md
@@ -56,6 +56,40 @@ texts share — and the reporter can say his is different, after which the repor
 wrong "this is a duplicate" silences a real bug and the reporter will not insist, so the sweep
 informs the decision and never takes it. With nobody to ask, the answer is *rejected*.
 
+### Nothing is filed before the reporter clicks
+
+What he is then shown is **the issue itself** — the exact title and body that would be created, not
+a summary of them — with three buttons:
+
+| Button | What it does |
+|---|---|
+| **File the issue** | the only path that reaches GitHub |
+| **Edit** | reopens the form with his answers still in it, and re-runs the whole pass |
+| **Cancel** | nothing is filed, and nothing is kept |
+
+He typed three fields; twenty lines get published, under a machine account that does not carry his
+name. The log excerpt, the extracted code and the environment are material he never wrote, so the
+click is where he can see the difference and say *not that*.
+
+The **comment** added to an existing issue goes through the same click. Recognising an issue as
+his is not the same act as agreeing to publish twenty lines under it, and a comment on a public
+tracker carries exactly what an issue carries.
+
+A draft nobody answers **expires** after eight minutes and says so — an abandoned draft must never
+turn into an issue later. Both waits, the prior-art proposal and the draft, fit inside the fifteen
+minutes Discord keeps an interaction alive, because the last thing the exchange does is write the
+outcome onto that same message. And every way this step can fail — a silence, a refusal, Discord
+refusing to show the draft at all — leaves the tracker untouched: the irreversible direction is the
+one that needs a click.
+
+The preview is bounded to what a Discord message holds, and what it had to leave out is **stated**,
+with the count of lines and characters that go into the issue anyway. A fenced block the cut ran
+through is closed, so the rest of the message still renders.
+
+An unsatisfying `/ask` answer carries a **Report a bug** button that opens the same form, pre-filled
+with the question and the answer. What was expected and the steps stay empty on purpose: the
+exchange is the observation, the report is still his to make.
+
 **Everything published is redacted first**, through the same `veaf_libs.redaction` the `doctor`
 command uses — the quoted body of a text file, the member names of an attached archive, the file
 name the reporter's own machine gave it, the bytes of an attachment carried whole into the issue,
@@ -123,6 +157,9 @@ live.
    checked against the real `doc/` tree. A title the corpus does not have is dropped. The bot can
    therefore show *fewer* sources than it used — never one that does not exist.
 5. No page cited reads as "the documentation may not cover this", with a route to the support page.
+6. The answer carries a **Report a bug** button for an hour, which opens `/bug`'s form pre-filled
+   with the exchange. An answer that did not help is where somebody gives up, and it is also where a
+   real bug most often surfaces first.
 
 If the bot cannot open a thread — usually a missing **Create Public Threads** permission — it says
 so and answers in the channel anyway. Losing the answer would be worse.

--- a/services/support-bot/tests/fakes.py
+++ b/services/support-bot/tests/fakes.py
@@ -34,6 +34,7 @@ class RecordingExchange:
                 placeholder forever — so it has to be reachable from a test.
         """
         self.calls: list[tuple[str, str]] = []
+        self.escalations: list[tuple[str, str, str]] = []
         self.thread_allowed = thread_allowed
         self._fails_on = set(fails_on)
 
@@ -90,6 +91,21 @@ class RecordingExchange:
             content: The new content.
         """
         self._record("edit", content)
+
+    async def offer_escalation(self, question: str, answer: str, lang: str) -> None:
+        """Record that the report form was offered, and with what.
+
+        The transcript keeps the pair rather than a flag: what the escalation carries into the form
+        is the whole point of it, and a test asserting only that *something* was offered would pass
+        on a button that escalates an empty exchange.
+
+        Args:
+            question: What was asked.
+            answer: What the bot replied.
+            lang: The language it was offered in.
+        """
+        self.escalations.append((question, answer, lang))
+        self._record("offer_escalation", answer)
 
     @property
     def steps(self) -> list[str]:

--- a/services/support-bot/tests/test_ask.py
+++ b/services/support-bot/tests/test_ask.py
@@ -125,7 +125,9 @@ class TestTheOrderOfTheExchange(unittest.IsolatedAsyncioTestCase):
 
         await _handler(FakeWorker(["la réponse"])).handle(exchange, _context())
 
-        self.assertEqual(exchange.steps[-1], "edit")
+        # The escalation offer comes after, and writes nothing: what the asker is left reading is
+        # still the edited answer.
+        self.assertEqual([step for step in exchange.steps if step != "offer_escalation"][-1], "edit")
         self.assertIn("la réponse", exchange.final)
 
 

--- a/services/support-bot/tests/test_discord_consent.py
+++ b/services/support-bot/tests/test_discord_consent.py
@@ -1,0 +1,523 @@
+"""The Discord half of ticket 04: the buttons, what a silence means, and the form that comes back.
+
+The intake is asserted against a protocol elsewhere. What can only break here is the wiring to the
+library: a draft shown without buttons, a click that answers the wrong question, a *File the issue*
+button still sitting on the message after the issue was filed, or an escalation that opens an empty
+form. All of those pass a protocol test and fail a reporter.
+
+Each test drives the real :class:`~discord.ui.View`: the buttons are pressed by calling the callback
+the library would call, so what is asserted is the object that will actually be sent to Discord.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, cast
+
+import discord
+
+from tests.intake_fixtures import fixture_checkout
+from tests.test_attachments import _fake_downloader
+from veaf_support_bot.attachments import AttachmentCollector
+from veaf_support_bot.bugreport import BugForm
+from veaf_support_bot.discord_bot import (
+    ESCALATION_EXPIRY_SECONDS,
+    BugModal,
+    InteractionExchange,
+    ModalExchange,
+    _ChoiceView,
+    _EscalationView,
+)
+from veaf_support_bot.draft import CANCEL, DRAFT_EXPIRY_SECONDS, EDIT, EXPIRED, FILE, MATCH_EXPIRY_SECONDS
+from veaf_support_bot.intake import BugIntake
+from veaf_support_bot.logging_setup import get_logger
+from veaf_support_bot.service import InFlightTasks
+
+
+class _Stub:
+    """A stand-in for the ``aiohttp`` response ``discord.HTTPException`` wants."""
+
+    status = 403
+    reason = "Forbidden"
+
+
+class _User:
+    """The parts of a Discord user the adapter reads."""
+
+    id = 4242
+    display_name = "Tripack"
+
+
+class _Response:
+    """Records how a click was answered."""
+
+    def __init__(self) -> None:
+        """Initialize the recorder."""
+        self.deferred = 0
+        self.modals: list[BugModal] = []
+
+    async def defer(self, **kwargs: Any) -> None:
+        """Record a deferred acknowledgement.
+
+        Args:
+            **kwargs: What it was deferred with.
+        """
+        self.deferred += 1
+
+    async def send_modal(self, modal: BugModal) -> None:
+        """Record a modal being opened.
+
+        Args:
+            modal: The form.
+        """
+        self.modals.append(modal)
+
+
+class _Click:
+    """The interaction a button callback receives."""
+
+    def __init__(self) -> None:
+        """Initialize the click."""
+        self.response = _Response()
+        self.user = _User()
+        self.locale = "en-GB"
+
+
+class _Message:
+    """A posted message whose components can be replaced."""
+
+    def __init__(self) -> None:
+        """Initialize the message."""
+        self.views: list[Any] = []
+        self.edit_error: Exception | None = None
+
+    async def edit(self, content: str | None = None, view: Any = None, allowed_mentions: Any = None) -> _Message:
+        """Record an edit.
+
+        Args:
+            content: The new content, when it changed.
+            view: The components to show, or ``None`` to take them off.
+            allowed_mentions: What the message may ping.
+
+        Returns:
+            The message.
+
+        Raises:
+            Exception: :attr:`edit_error`, when set.
+        """
+        if self.edit_error is not None:
+            raise self.edit_error
+        self.views.append(view)
+        return self
+
+
+class _Interaction:
+    """The parts of ``discord.Interaction`` the consent step touches.
+
+    Attributes:
+        shown: What was written on the reporter's message, with the components it carried.
+        press: Which button label to press as soon as a view is shown, or ``None`` to leave it
+            unanswered — which is how a silence is asserted without waiting eight minutes.
+    """
+
+    def __init__(self, *, press: str | None = None, edit_error: Exception | None = None) -> None:
+        """Initialize the interaction.
+
+        Args:
+            press: The label of the button to press when a view appears.
+            edit_error: Raised instead of showing anything, when given.
+        """
+        self.response = _Response()
+        self.user = _User()
+        self.locale = "en-GB"
+        self.shown: list[tuple[str, Any]] = []
+        self.clicks: list[_Click] = []
+        self.press = press
+        self._edit_error = edit_error
+
+    async def edit_original_response(self, content: str, view: Any = None, allowed_mentions: Any = None) -> _Message:
+        """Record what the reporter was shown, and answer it when the test asked to.
+
+        Args:
+            content: The message content.
+            view: The components.
+            allowed_mentions: What the message may ping.
+
+        Returns:
+            A message.
+
+        Raises:
+            Exception: The one this interaction was built with.
+        """
+        if self._edit_error is not None:
+            raise self._edit_error
+        self.shown.append((content, view))
+        if view is not None and self.press is not None:
+            for item in view.children:
+                if item.label == self.press:
+                    click = _Click()
+                    self.clicks.append(click)
+                    await item.callback(cast(discord.Interaction, cast(object, click)))
+        return _Message()
+
+
+def _intake() -> BugIntake:
+    """Build an intake over the fixture checkout.
+
+    Returns:
+        The intake.
+    """
+    collector = AttachmentCollector(fixture_checkout(), _fake_downloader({}))
+    return BugIntake(fixture_checkout(), collector, refresh=False)
+
+
+def _modal_exchange(interaction: _Interaction, *, reopen: Any = None) -> ModalExchange:
+    """Build the exchange under test.
+
+    Args:
+        interaction: The fake interaction.
+        reopen: What the *Edit* button does.
+
+    Returns:
+        The exchange.
+    """
+    return ModalExchange(cast(discord.Interaction, cast(object, interaction)), reopen, get_logger("test"))
+
+
+class TestTheDraftIsShownWithItsButtons(unittest.IsolatedAsyncioTestCase):
+    async def test_the_draft_is_written_on_the_reporters_own_message(self) -> None:
+        interaction = _Interaction(press="Cancel")
+
+        await _modal_exchange(interaction).decide("the issue as it will be filed", "en")
+
+        self.assertEqual(interaction.shown[0][0], "the issue as it will be filed")
+
+    async def test_pressing_file_answers_file(self) -> None:
+        interaction = _Interaction(press="File the issue")
+
+        self.assertEqual(await _modal_exchange(interaction).decide("draft", "en"), FILE)
+
+    async def test_pressing_cancel_answers_cancel(self) -> None:
+        interaction = _Interaction(press="Cancel")
+
+        self.assertEqual(await _modal_exchange(interaction).decide("draft", "en"), CANCEL)
+
+    async def test_the_buttons_speak_the_reporters_language(self) -> None:
+        interaction = _Interaction(press="Annuler")
+
+        self.assertEqual(await _modal_exchange(interaction).decide("brouillon", "fr"), CANCEL)
+
+    async def test_without_a_form_to_reopen_no_edit_button_is_offered(self) -> None:
+        """A button that leads nowhere is worse than a missing one."""
+        interaction = _Interaction(press="Cancel")
+
+        await _modal_exchange(interaction).decide("draft", "en")
+
+        labels = [item.label for item in interaction.shown[0][1].children]
+        self.assertNotIn("Edit", labels)
+
+    async def test_a_discord_failure_answers_cancel_rather_than_filing(self) -> None:
+        """Fail closed: a draft nobody could be shown must not be published on his behalf."""
+        interaction = _Interaction(edit_error=discord.HTTPException(cast(Any, _Stub()), "gone"))
+
+        self.assertEqual(await _modal_exchange(interaction).decide("draft", "en"), CANCEL)
+
+
+class TestWhatASilenceMeans(unittest.IsolatedAsyncioTestCase):
+    """Both waits end in the answer that publishes nothing, and both fit in one interaction token."""
+
+    async def test_an_unanswered_draft_expires(self) -> None:
+        self.assertEqual(_ChoiceView(default=EXPIRED, timeout=DRAFT_EXPIRY_SECONDS).choice, EXPIRED)
+
+    async def test_the_two_waits_fit_inside_discords_fifteen_minutes(self) -> None:
+        # Past the token the service can no longer edit the message, so the reporter would be left
+        # on a preview that never resolves — the expiry has to be announceable.
+        self.assertLess(MATCH_EXPIRY_SECONDS + DRAFT_EXPIRY_SECONDS, 15 * 60)
+
+
+class TestTheProposalIsPutToTheReporter(unittest.IsolatedAsyncioTestCase):
+    async def test_recognising_the_match_answers_yes(self) -> None:
+        interaction = _Interaction(press="Yes, that is it")
+
+        self.assertTrue(await _modal_exchange(interaction).confirm("#712 looks like yours", "en"))
+
+    async def test_saying_it_is_different_answers_no(self) -> None:
+        interaction = _Interaction(press="No, mine is different")
+
+        self.assertFalse(await _modal_exchange(interaction).confirm("#712 looks like yours", "en"))
+
+    async def test_a_discord_failure_answers_no_rather_than_silencing_the_report(self) -> None:
+        interaction = _Interaction(edit_error=discord.HTTPException(cast(Any, _Stub()), "gone"))
+
+        self.assertFalse(await _modal_exchange(interaction).confirm("#712", "en"))
+
+
+class TestTheButtonsAreTakenAwayWithTheAnswer(unittest.IsolatedAsyncioTestCase):
+    async def test_the_final_message_carries_no_components(self) -> None:
+        """Otherwise *File the issue* is still there to be pressed after the issue was filed."""
+        interaction = _Interaction()
+
+        await _modal_exchange(interaction).post("✅ Issue opened: https://example.invalid/1")
+
+        self.assertEqual(interaction.shown[-1][1], None)
+
+
+class TestEditGivesTheFormBack(unittest.IsolatedAsyncioTestCase):
+    async def test_pressing_edit_reopens_the_form_with_his_answers(self) -> None:
+        opened: list[BugModal] = []
+
+        async def reopen(click: discord.Interaction) -> None:
+            modal = BugModal(_intake(), [], get_logger("test"), prefill=_form())
+            opened.append(modal)
+            await click.response.send_modal(modal)
+
+        interaction = _Interaction(press="Edit")
+
+        answer = await _modal_exchange(interaction, reopen=reopen).decide("draft", "en")
+
+        self.assertEqual(answer, EDIT)
+        self.assertEqual(str(opened[0].summary.default), "convert-v5 crashes")
+
+
+class _Submission(_Interaction):
+    """A modal submission: it can be deferred, and it shows the draft on its own response."""
+
+    async def edit_original_response(self, content: str, view: Any = None, allowed_mentions: Any = None) -> _Message:
+        """Show the reporter something, pressing a button if the test asked for one.
+
+        Args:
+            content: The message content.
+            view: The components.
+            allowed_mentions: What the message may ping.
+
+        Returns:
+            A message.
+        """
+        return await super().edit_original_response(content, view, allowed_mentions)
+
+
+class TestTheSubmissionIsWiredEndToEnd(unittest.IsolatedAsyncioTestCase):
+    """The production ``reopen`` and the production task registry — not stand-ins for them.
+
+    Four bugs shipped green on this repository because a test drove the handler and never the thing
+    that connects it. The *Edit* button is exactly that shape: a modal that reopens empty passes
+    every protocol test in the suite.
+    """
+
+    async def _submit(self, press: str, tasks: Any = None) -> _Submission:
+        """Run one real modal submission.
+
+        Args:
+            press: The button label to press on the draft.
+            tasks: The in-flight registry, when the test is about tracking.
+
+        Returns:
+            The submission interaction, with what it was shown and what it opened.
+        """
+        from tests.test_intake_github_wiring import _Filer
+
+        collector = AttachmentCollector(fixture_checkout(), _fake_downloader({}))
+        intake = BugIntake(fixture_checkout(), collector, refresh=False, filer=_Filer())
+        modal = BugModal(intake, [], get_logger("test"), prefill=_form(), tasks=tasks)
+        interaction = _Submission(press=press)
+        await modal.on_submit(cast(discord.Interaction, cast(object, interaction)))
+        return interaction
+
+    async def test_the_draft_reaches_the_reporter_through_the_real_modal(self) -> None:
+        interaction = await self._submit("Cancel")
+
+        self.assertIn("convert-v5 crashes", interaction.shown[0][0])
+
+    async def test_the_edit_button_reopens_the_form_with_what_he_submitted(self) -> None:
+        interaction = await self._submit("Edit")
+
+        reopened = [modal for click in interaction.clicks for modal in click.response.modals]
+        self.assertTrue(reopened, "the Edit button opened no form at all")
+        self.assertEqual(str(reopened[0].summary.default), "convert-v5 crashes")
+        self.assertEqual(str(reopened[0].steps.default), "run it")
+
+    async def test_the_submission_is_tracked_so_a_shutdown_waits_for_it(self) -> None:
+        tasks = _Registry()
+
+        await self._submit("Cancel", tasks=tasks)
+
+        self.assertEqual(tasks.tracked, ["bug:4242"])
+        self.assertEqual(len(tasks), 0, "a finished exchange must not stay in the registry")
+
+
+class _Registry(InFlightTasks):
+    """The real registry, plus a note of what it was asked to track.
+
+    Subclassed rather than replaced: what has to be asserted is that the **production** registry is
+    handed the submission, under a name a drain can report.
+
+    Attributes:
+        tracked: The names tracked, in order.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the registry."""
+        super().__init__()
+        self.tracked: list[str | None] = []
+
+    def track(self, coro: Any, *, name: str | None = None) -> Any:
+        """Record the name, then track for real.
+
+        Args:
+            coro: The coroutine to run.
+            name: What to call it.
+
+        Returns:
+            The task.
+        """
+        self.tracked.append(name)
+        return super().track(coro, name=name)
+
+
+def _form(**overrides: str) -> BugForm:
+    """Build a submitted form.
+
+    Args:
+        **overrides: Fields to replace.
+
+    Returns:
+        The form.
+    """
+    base = {
+        "summary": "convert-v5 crashes",
+        "happened": "it stopped",
+        "expected": "it should convert",
+        "steps": "run it",
+        "doctor": "",
+        "reporter": "Tripack",
+        "reporter_id": "4242",
+        "language": "en",
+    }
+    base.update(overrides)
+    return BugForm(**base)
+
+
+class TestTheModalIsPrefilledOrEmpty(unittest.TestCase):
+    def test_with_no_prefill_every_field_starts_empty(self) -> None:
+        modal = BugModal(_intake(), [], get_logger("test"))
+
+        self.assertIsNone(modal.summary.default)
+        self.assertIsNone(modal.doctor.default)
+
+    def test_a_prefilled_modal_carries_every_field(self) -> None:
+        modal = BugModal(_intake(), [], get_logger("test"), prefill=_form(doctor="veaf-tools 6.19.0"))
+
+        filled = [modal.summary.default, modal.happened.default, modal.expected.default, modal.steps.default]
+        self.assertEqual(filled, ["convert-v5 crashes", "it stopped", "it should convert", "run it"])
+        self.assertEqual(str(modal.doctor.default), "veaf-tools 6.19.0")
+
+
+class _AnswerMessage:
+    """The public answer message an escalation button is attached to."""
+
+    def __init__(self, *, edit_error: Exception | None = None) -> None:
+        """Initialize the message.
+
+        Args:
+            edit_error: Raised by :meth:`edit`, when given.
+        """
+        self.views: list[Any] = []
+        self.edit_error = edit_error
+
+    async def edit(self, content: str | None = None, view: Any = None, allowed_mentions: Any = None) -> _AnswerMessage:
+        """Record an edit.
+
+        Args:
+            content: The new content.
+            view: The components.
+            allowed_mentions: What the message may ping.
+
+        Returns:
+            The message.
+
+        Raises:
+            Exception: :attr:`edit_error`, when set.
+        """
+        if self.edit_error is not None:
+            raise self.edit_error
+        self.views.append(view)
+        return self
+
+
+def _answered(intake: BugIntake | None, message: _AnswerMessage) -> InteractionExchange:
+    """Build an exchange that has already posted its answer.
+
+    Args:
+        intake: What an escalation would hand its form to.
+        message: The answer message.
+
+    Returns:
+        The exchange.
+    """
+    exchange = InteractionExchange(
+        cast(discord.Interaction, cast(object, _Interaction())),
+        get_logger("test"),
+        intake=intake,
+    )
+    exchange._message = cast(discord.Message, cast(object, message))  # noqa: SLF001 - the seam under test
+    return exchange
+
+
+class TestTheEscalationOffer(unittest.IsolatedAsyncioTestCase):
+    async def test_the_answer_gains_a_report_button(self) -> None:
+        message = _AnswerMessage()
+
+        await _answered(_intake(), message).offer_escalation("how do I set a QRA?", "you cannot", "en")
+
+        labels = [item.label for item in message.views[0].children]
+        self.assertEqual(labels, ["Report a bug"])
+
+    async def test_without_an_intake_nothing_is_offered(self) -> None:
+        """The deployment where ``/bug`` is not published either."""
+        message = _AnswerMessage()
+
+        await _answered(None, message).offer_escalation("q", "a", "en")
+
+        self.assertEqual(message.views, [])
+
+    async def test_pressing_it_opens_the_form_carrying_the_exchange(self) -> None:
+        message = _AnswerMessage()
+        await _answered(_intake(), message).offer_escalation("how do I set a QRA?", "you cannot", "en")
+        click = _Click()
+
+        await message.views[0].children[0].callback(cast(discord.Interaction, cast(object, click)))
+
+        opened = click.response.modals[0]
+        self.assertIn("QRA", str(opened.summary.default))
+        self.assertIn("you cannot", str(opened.happened.default))
+
+    async def test_a_failure_to_offer_it_does_not_lose_the_answer(self) -> None:
+        """The answer is already posted; trading it for a button would be the wrong way round."""
+        message = _AnswerMessage(edit_error=discord.HTTPException(cast(Any, _Stub()), "rate limited"))
+
+        await _answered(_intake(), message).offer_escalation("q", "a", "en")  # must not raise
+
+    async def test_the_button_is_taken_off_when_it_stops_being_live(self) -> None:
+        message = _AnswerMessage()
+        view = _EscalationView(label="Report a bug", open_form=_never, logger=get_logger("test"))
+        view.message = cast(discord.Message, cast(object, message))
+
+        await view.on_timeout()
+
+        self.assertEqual(message.views, [None])
+
+    async def test_it_stays_offered_for_as_long_as_a_thread_is_read(self) -> None:
+        """Not the interaction budget: nobody is waiting on this one."""
+        self.assertGreater(ESCALATION_EXPIRY_SECONDS, DRAFT_EXPIRY_SECONDS)
+
+
+async def _never(click: discord.Interaction) -> None:
+    """Stand in for a button action that is not exercised.
+
+    Args:
+        click: The click.
+    """
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/support-bot/tests/test_draft_consent.py
+++ b/services/support-bot/tests/test_draft_consent.py
@@ -1,0 +1,224 @@
+"""Ticket 04: what the reporter is shown, and what his click does — or does not — publish.
+
+Two properties carry the whole ticket, and both are asserted on the **production** path rather than
+on a rendering helper:
+
+* **Nothing reaches GitHub before the click.** Not a preview that resembles the issue and a filing
+  that happens anyway: the filer is asked for the draft, the reporter is asked, and only then is
+  anything filed. Every other answer — edit, cancel, silence — leaves the tracker untouched.
+* **What he is shown is what will be published.** The draft is the filer's own body, so a preview
+  that drifts from the issue is a test failure rather than a surprise on a public tracker.
+
+The rest is the cutting: a report does not fit in a Discord message, and a preview that cuts
+silently is a preview that lies about the part he did not write.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from tests.test_intake_github_wiring import _Exchange, _Filer, _intake, _submission
+from veaf_support_bot.draft import (
+    CANCEL,
+    DRAFT_MAX_CHARS,
+    EDIT,
+    EXPIRED,
+    FILE,
+    Draft,
+    fold,
+)
+from veaf_support_bot.intake import (
+    ESCALATED_ANSWER_CHARS,
+    ESCALATED_QUESTION_CHARS,
+    PARAGRAPH_MAX_CHARS,
+    SUMMARY_MAX_CHARS,
+    escalation_form,
+)
+from veaf_support_bot.texts import text
+
+
+def _long_body(lines: int = 400) -> str:
+    """Build a body no Discord message can hold.
+
+    Args:
+        lines: How many lines it has.
+
+    Returns:
+        The body.
+    """
+    return "\n".join(f"line {index} of a report that is far too long to preview" for index in range(lines))
+
+
+class TestTheDraftIsTheIssue(unittest.IsolatedAsyncioTestCase):
+    """The preview is the body that will be sent, not a second rendering of it."""
+
+    async def test_what_is_shown_is_the_body_the_filer_would_publish(self) -> None:
+        filer = _Filer()
+        exchange = _Exchange(decision=FILE)
+
+        report = await _intake(filer=filer).handle(exchange, _submission())
+
+        assert report is not None
+        self.assertIn(filer.draft_of(report).body, exchange.drafts[0])
+
+    async def test_the_title_is_shown_with_the_body(self) -> None:
+        exchange = _Exchange(decision=CANCEL)
+
+        report = await _intake(filer=_Filer()).handle(exchange, _submission())
+
+        assert report is not None
+        self.assertIn(report.title, exchange.drafts[0])
+
+
+class TestNothingIsFiledBeforeTheClick(unittest.IsolatedAsyncioTestCase):
+    """The one irreversible step of this flow, and the only gate in front of it."""
+
+    async def test_the_draft_is_shown_before_anything_is_filed(self) -> None:
+        filer = _Filer()
+        exchange = _Exchange(decision=FILE)
+
+        await _intake(filer=filer).handle(exchange, _submission())
+
+        self.assertEqual(len(exchange.drafts), 1)
+        self.assertEqual(len(filer.filed), 1)
+
+    async def test_a_cancelled_draft_files_nothing_and_says_so(self) -> None:
+        filer = _Filer()
+        exchange = _Exchange(decision=CANCEL)
+
+        await _intake(filer=filer).handle(exchange, _submission())
+
+        self.assertEqual(filer.filed, [])
+        self.assertEqual(exchange.messages[0], text("draft.cancelled", "en"))
+
+    async def test_an_expired_draft_files_nothing_and_says_it_expired(self) -> None:
+        filer = _Filer()
+        exchange = _Exchange(decision=EXPIRED)
+
+        await _intake(filer=filer).handle(exchange, _submission())
+
+        self.assertEqual(filer.filed, [])
+        # Distinguished from a cancellation on purpose: a reporter who walked away must be able to
+        # tell that his report lapsed rather than that he dropped it.
+        self.assertEqual(exchange.messages[0], text("draft.expired", "en"))
+        self.assertNotEqual(text("draft.expired", "en"), text("draft.cancelled", "en"))
+
+    async def test_an_edited_draft_files_nothing_and_points_at_the_reopened_form(self) -> None:
+        filer = _Filer()
+        exchange = _Exchange(decision=EDIT)
+
+        await _intake(filer=filer).handle(exchange, _submission())
+
+        self.assertEqual(filer.filed, [])
+        self.assertEqual(exchange.messages[0], text("draft.editing", "en"))
+
+    async def test_an_unknown_answer_is_treated_as_a_refusal(self) -> None:
+        """Fail closed: an answer nobody wrote a case for must not publish."""
+        filer = _Filer()
+        exchange = _Exchange(decision="something the ui never sends")
+
+        await _intake(filer=filer).handle(exchange, _submission())
+
+        self.assertEqual(filer.filed, [])
+
+    async def test_an_accepted_duplicate_shows_the_comment_and_opens_no_issue(self) -> None:
+        """The other thing this flow publishes, and it goes through the same click."""
+        from tests.test_intake_github_wiring import _gate
+        from tests.test_priorart import _resolver_issue
+
+        filer = _Filer()
+        exchange = _Exchange(recognises=True, decision=CANCEL)
+
+        await _intake(prior_art=_gate(opened=[_resolver_issue()]), filer=filer).handle(exchange, _submission())
+
+        # The double renders comments as "observation on <title>", so this is the comment body
+        # and not the issue body — the two are different publications and get different previews.
+        self.assertIn("observation on", exchange.drafts[0])
+        self.assertEqual((filer.filed, filer.commented), ([], []))
+
+
+class TestTruncationIsAnnounced(unittest.TestCase):
+    """A cut nobody is told about is a preview that misrepresents what gets published."""
+
+    def test_a_short_body_is_shown_whole_with_no_notice(self) -> None:
+        rendered = Draft(title="short", body="one line").render("en")
+
+        self.assertIn("one line", rendered)
+        self.assertNotIn("Preview cut here", rendered)
+
+    def test_a_long_body_is_cut_within_discords_ceiling(self) -> None:
+        rendered = Draft(title="long", body=_long_body()).render("en")
+
+        self.assertLessEqual(len(rendered), DRAFT_MAX_CHARS)
+
+    def test_a_long_body_says_how_much_it_left_out(self) -> None:
+        body = _long_body()
+
+        rendered = Draft(title="long", body=body).render("en")
+
+        self.assertIn("more lines", rendered)
+        # The count is the real one, not a placeholder: a notice saying "a few more lines" is the
+        # same lie as no notice at all.
+        kept, lines, chars = fold(body, 500)
+        self.assertEqual(chars, len(body) - len(kept))
+        self.assertEqual(lines, body[len(kept) :].count("\n"))
+
+    def test_the_cut_falls_on_a_line_boundary(self) -> None:
+        kept, _, _ = fold(_long_body(), 500)
+
+        self.assertFalse(kept.endswith(" of a report"), "a mid-sentence cut reads as corruption")
+        self.assertTrue(_long_body().startswith(kept))
+
+    def test_a_fenced_block_the_cut_ran_through_is_closed(self) -> None:
+        body = "before\n```\n" + "\n".join(f"log line {index}" for index in range(200)) + "\n```\n"
+
+        kept, _, _ = fold(body, 400)
+
+        self.assertEqual(kept.count("```") % 2, 0, "an unclosed fence swallows the rest of the message")
+
+    def test_a_body_that_is_all_one_line_is_still_cut(self) -> None:
+        """No line boundary to prefer, and the ceiling still has to hold."""
+        rendered = Draft(title="one line", body="x" * 5000).render("en")
+
+        self.assertLessEqual(len(rendered), DRAFT_MAX_CHARS)
+        self.assertIn("more lines", rendered)
+
+
+class TestTheEscalatedForm(unittest.TestCase):
+    """What ``/ask`` carries into ``/bug`` when its answer did not help."""
+
+    def _form(self, question: str = "how do I set a QRA?", answer: str = "you cannot") -> Any:
+        """Build an escalated form.
+
+        Args:
+            question: What was asked.
+            answer: What the bot replied.
+
+        Returns:
+            The form.
+        """
+        return escalation_form(question, answer, reporter="Tripack", reporter_id="4242", language="en")
+
+    def test_the_exchange_is_carried_into_what_happened(self) -> None:
+        form = self._form()
+
+        self.assertIn("how do I set a QRA?", form.happened)
+        self.assertIn("you cannot", form.happened)
+
+    def test_the_summary_is_the_question(self) -> None:
+        self.assertIn("QRA", self._form().summary)
+
+    def test_what_was_expected_is_left_for_the_reporter_to_write(self) -> None:
+        """The exchange is the observation; the report is still his to make."""
+        form = self._form()
+
+        self.assertEqual((form.expected, form.steps), ("", ""))
+
+    def test_a_long_exchange_stays_inside_what_a_modal_accepts(self) -> None:
+        """Discord refuses a modal whose pre-filled value overflows: too long means *no form*."""
+        form = self._form(question="q" * 4000, answer="a" * 9000)
+
+        self.assertLessEqual(len(form.summary), SUMMARY_MAX_CHARS)
+        self.assertLessEqual(len(form.happened), PARAGRAPH_MAX_CHARS)
+        self.assertLess(ESCALATED_QUESTION_CHARS + ESCALATED_ANSWER_CHARS, PARAGRAPH_MAX_CHARS)

--- a/services/support-bot/tests/test_intake.py
+++ b/services/support-bot/tests/test_intake.py
@@ -20,6 +20,7 @@ from tests.test_toolkit import SYNTHETIC_LOG
 from veaf_support_bot.attachments import AttachmentCollector, Incoming, Prepared
 from veaf_support_bot.bugreport import BugForm
 from veaf_support_bot.checkout import Checkout, Freshness
+from veaf_support_bot.draft import CANCEL
 from veaf_support_bot.intake import (
     PREVIEW_MAX_CHARS,
     BugIntake,
@@ -30,7 +31,11 @@ from veaf_support_bot.intake import (
 
 
 class RecordingExchange:
-    """Records the order the exchange was driven in."""
+    """Records the order the exchange was driven in.
+
+    These tests run without a filer, so the draft is never reached; the two questions are here
+    because the protocol has them, and they answer the way an unreachable reporter would.
+    """
 
     def __init__(self) -> None:
         self.calls: list[str] = []
@@ -42,6 +47,14 @@ class RecordingExchange:
     async def post(self, content: str) -> None:
         self.calls.append("post")
         self.posted.append(content)
+
+    async def decide(self, content: str, lang: str) -> str:
+        self.calls.append("decide")
+        return CANCEL
+
+    async def confirm(self, content: str, lang: str) -> bool:
+        self.calls.append("confirm")
+        return False
 
 
 class _RecordingCollector(AttachmentCollector):

--- a/services/support-bot/tests/test_intake_github_wiring.py
+++ b/services/support-bot/tests/test_intake_github_wiring.py
@@ -29,6 +29,7 @@ from tests.test_priorart import RESOLVER_REPORT, _Issues, _resolver_issue
 from veaf_support_bot.attachments import AttachmentCollector
 from veaf_support_bot.bugreport import BugForm
 from veaf_support_bot.config import ConfigurationError, SupportBotConfig
+from veaf_support_bot.draft import CANCEL, EXPIRED, FILE, Draft
 from veaf_support_bot.filing import Outcome
 from veaf_support_bot.github_app import GitHubError
 from veaf_support_bot.intake import BugIntake, BugSubmission, render_match, sweep_query
@@ -37,17 +38,40 @@ from veaf_support_bot.service import build_github_app, build_intake
 
 
 class _Exchange:
-    """A :class:`~veaf_support_bot.intake.BugExchange` that records what the reporter was told."""
+    """A :class:`~veaf_support_bot.intake.BugExchange` that records what the reporter was told.
 
-    def __init__(self) -> None:
+    It is also who answers the two questions, because ticket 04 put them on the exchange: what the
+    reporter is *shown* and what he *answers* are the same conversation, and a double that split
+    them would not be able to assert that nothing is filed before the answer.
+    """
+
+    def __init__(self, *, decision: str = FILE, recognises: bool = False) -> None:
+        """Initialize the double.
+
+        Args:
+            decision: What the reporter clicks on the draft.
+            recognises: Whether he says a proposed match is his bug.
+        """
         self.deferred = False
         self.messages: list[str] = []
+        self.drafts: list[str] = []
+        self.proposals: list[str] = []
+        self.decision = decision
+        self.recognises = recognises
 
     async def defer(self) -> None:
         self.deferred = True
 
     async def post(self, content: str) -> None:
         self.messages.append(content)
+
+    async def decide(self, content: str, lang: str) -> str:
+        self.drafts.append(content)
+        return self.decision
+
+    async def confirm(self, content: str, lang: str) -> bool:
+        self.proposals.append(content)
+        return self.recognises
 
 
 class _Filer:
@@ -65,6 +89,12 @@ class _Filer:
     async def comment_on(self, number: int, report: Any, *, thread_url: str = "") -> Outcome:
         self.commented.append(number)
         return Outcome(action="commented", number=number, url=f"https://example.invalid/issues/{number}#c")
+
+    def draft_of(self, report: Any, *, thread_url: str = "") -> Draft:
+        return Draft(title=report.title, body=f"body of {report.title}")
+
+    def comment_draft_of(self, report: Any, *, thread_url: str = "") -> Draft:
+        return Draft(title=report.title, body=f"observation on {report.title}")
 
 
 class _Answer:
@@ -115,18 +145,19 @@ def _submission(summary: str = RESOLVER_REPORT.splitlines()[0]) -> BugSubmission
     )
 
 
-def _gate(answer: bool | None, **issues: Any) -> PriorArtGate:
+def _gate(**issues: Any) -> PriorArtGate:
     """Build a gate over the fixture checkout.
 
+    Who answers the proposal is no longer the gate's business: it is the exchange, per report. See
+    :class:`_Exchange`.
+
     Args:
-        answer: What the reporter answers, or ``None`` for nobody to ask.
         **issues: ``opened`` and ``closed`` issue records.
 
     Returns:
         The gate.
     """
-    sweeper = PriorArtSweeper(fixture_root(), _Issues(**issues))
-    return PriorArtGate(sweeper, None if answer is None else _Answer(answer))
+    return PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(**issues)))
 
 
 class TestTheQuery(unittest.TestCase):
@@ -160,8 +191,8 @@ class TestTheSweepRunsBeforeAnythingOpens(unittest.IsolatedAsyncioTestCase):
     """Ticket 03's whole point: the four sources are consulted first."""
 
     async def test_the_finding_is_attached_to_the_report(self) -> None:
-        intake = _intake(prior_art=_gate(False, opened=[_resolver_issue()]), filer=_Filer())
-        report = await intake.handle(_Exchange(), _submission())
+        intake = _intake(prior_art=_gate(opened=[_resolver_issue()]), filer=_Filer())
+        report = await intake.handle(_Exchange(recognises=False), _submission())
         assert report is not None
         assert report.prior_art is not None
         self.assertEqual(report.prior_art.verdict, DUPLICATE)
@@ -177,17 +208,26 @@ class TestWhatAnAcceptedMatchDoes(unittest.IsolatedAsyncioTestCase):
 
     async def test_an_accepted_duplicate_comments_and_opens_nothing(self) -> None:
         filer = _Filer()
-        intake = _intake(prior_art=_gate(True, opened=[_resolver_issue()]), filer=filer)
-        exchange = _Exchange()
+        intake = _intake(prior_art=_gate(opened=[_resolver_issue()]), filer=filer)
+        exchange = _Exchange(recognises=True, decision=FILE)
         await intake.handle(exchange, _submission())
         self.assertEqual(filer.commented, [712])
         self.assertEqual(filer.filed, [])
         self.assertIn("#712", exchange.messages[0])
 
+    async def test_the_observation_is_shown_before_it_is_added(self) -> None:
+        """A comment on a public tracker publishes as much as an issue does."""
+        filer = _Filer()
+        intake = _intake(prior_art=_gate(opened=[_resolver_issue()]), filer=filer)
+        exchange = _Exchange(recognises=True, decision=CANCEL)
+        await intake.handle(exchange, _submission())
+        self.assertEqual(len(exchange.drafts), 1)
+        self.assertEqual(filer.commented, [], "a refused observation must not be added anyway")
+
     async def test_an_accepted_fix_opens_nothing_and_names_the_version(self) -> None:
         filer = _Filer()
-        intake = _intake(prior_art=_gate(True, closed=[_resolver_issue(state="closed")]), filer=filer)
-        exchange = _Exchange()
+        intake = _intake(prior_art=_gate(closed=[_resolver_issue(state="closed")]), filer=filer)
+        exchange = _Exchange(recognises=True)
         await intake.handle(exchange, _submission())
         self.assertEqual(filer.filed, [])
         self.assertEqual(filer.commented, [])
@@ -195,8 +235,8 @@ class TestWhatAnAcceptedMatchDoes(unittest.IsolatedAsyncioTestCase):
 
     async def test_an_accepted_lot_opens_nothing(self) -> None:
         filer = _Filer()
-        intake = _intake(prior_art=_gate(True), filer=filer)
-        exchange = _Exchange()
+        intake = _intake(prior_art=_gate(), filer=filer)
+        exchange = _Exchange(recognises=True)
         await intake.handle(exchange, _submission())
         self.assertEqual((filer.filed, filer.commented), ([], []))
         self.assertIn("FEAT-SAMPLE-RESOLVER", exchange.messages[0])
@@ -207,28 +247,30 @@ class TestTheRefusalDoesNotEndTheReport(unittest.IsolatedAsyncioTestCase):
 
     async def test_a_rejected_duplicate_is_filed_anyway(self) -> None:
         filer = _Filer()
-        intake = _intake(prior_art=_gate(False, opened=[_resolver_issue()]), filer=filer)
-        exchange = _Exchange()
+        intake = _intake(prior_art=_gate(opened=[_resolver_issue()]), filer=filer)
+        exchange = _Exchange(recognises=False)
         await intake.handle(exchange, _submission())
         self.assertEqual(len(filer.filed), 1)
         self.assertEqual(filer.commented, [])
         self.assertIn("https://example.invalid/issues/901", exchange.messages[0])
 
-    async def test_with_nobody_to_ask_the_report_is_filed_and_the_finding_recorded(self) -> None:
+    async def test_a_refused_match_still_records_the_finding_on_the_report(self) -> None:
         filer = _Filer()
-        intake = _intake(prior_art=_gate(None, opened=[_resolver_issue()]), filer=filer)
-        exchange = _Exchange()
+        intake = _intake(prior_art=_gate(opened=[_resolver_issue()]), filer=filer)
+        exchange = _Exchange(recognises=False)
         report = await intake.handle(exchange, _submission())
         self.assertEqual(len(filer.filed), 1)
         assert report is not None and report.prior_art is not None
         self.assertTrue(report.prior_art.found)
 
-    async def test_the_proposal_shown_to_the_reporter_carries_its_evidence(self) -> None:
-        intake = _intake(prior_art=_gate(None, opened=[_resolver_issue()]), filer=_Filer())
-        exchange = _Exchange()
+    async def test_the_proposal_put_to_the_reporter_carries_its_evidence(self) -> None:
+        intake = _intake(prior_art=_gate(opened=[_resolver_issue()]), filer=_Filer())
+        exchange = _Exchange(recognises=False)
         await intake.handle(exchange, _submission())
-        self.assertIn("#712", exchange.messages[0])
-        self.assertIn("match on", exchange.messages[0])
+        # The evidence travels with the question, not after it: a proposal a reporter is asked to
+        # accept without seeing why it was made is the silencing this sweep exists to avoid.
+        self.assertIn("#712", exchange.proposals[0])
+        self.assertIn("match on", exchange.proposals[0])
 
 
 class TestWhatTheReporterIsTold(unittest.IsolatedAsyncioTestCase):
@@ -453,7 +495,7 @@ class TestTheseTestsDetectABrokenWiring(unittest.TestCase):
 
         original = module.BugIntake._sweep
 
-        async def _no_sweep(self, report, lang):  # type: ignore[no-untyped-def]
+        async def _no_sweep(self, exchange, report, lang):  # type: ignore[no-untyped-def]
             return None, False
 
         module.BugIntake._sweep = _no_sweep  # type: ignore[method-assign]
@@ -469,8 +511,8 @@ class TestTheseTestsDetectABrokenWiring(unittest.TestCase):
 
         original = module.BugIntake._act_on
 
-        async def _file_regardless(self, sweep, report, lang, thread_url):  # type: ignore[no-untyped-def]
-            return await self._file(report, lang, thread_url)
+        async def _file_regardless(self, exchange, sweep, report, lang, thread_url):  # type: ignore[no-untyped-def]
+            return await self._file(exchange, report, lang, thread_url)
 
         module.BugIntake._act_on = _file_regardless  # type: ignore[method-assign]
         try:
@@ -485,14 +527,14 @@ class TestTheseTestsDetectABrokenWiring(unittest.TestCase):
 
         original = module.BugIntake._decide
 
-        async def _stop_on_any_match(self, report, lang, thread_url):  # type: ignore[no-untyped-def]
-            sweep, _ = await self._sweep(report, lang)
+        async def _stop_on_any_match(self, exchange, report, lang, thread_url):  # type: ignore[no-untyped-def]
+            sweep, _ = await self._sweep(exchange, report, lang)
             from dataclasses import replace
 
             report = replace(report, prior_art=sweep)
             if sweep is not None and sweep.found:
                 return report, render_match(sweep, lang)
-            return report, await self._file(report, lang, thread_url)
+            return report, await self._file(exchange, report, lang, thread_url)
 
         module.BugIntake._decide = _stop_on_any_match  # type: ignore[method-assign]
         try:
@@ -526,7 +568,7 @@ class TestTheseTestsDetectABrokenWiring(unittest.TestCase):
         from veaf_support_bot import service as module
 
         original = module.PriorArtGate
-        module.PriorArtGate = lambda sweeper: None  # type: ignore[assignment,misc]
+        module.PriorArtGate = lambda sweeper: None  # type: ignore[assignment,misc,return-value]
         try:
             self.assertTrue(
                 self._fails("TestTheServiceBuildsIt.test_an_intake_without_an_app_still_sweeps_the_checkout")

--- a/services/support-bot/tests/test_priorart.py
+++ b/services/support-bot/tests/test_priorart.py
@@ -330,36 +330,36 @@ class TestTheRefusal(unittest.IsolatedAsyncioTestCase):
     """The guard: a proposal the reporter refuses must not end his report."""
 
     async def test_an_accepted_match_is_reported_as_accepted(self) -> None:
-        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])), _Answer(True))
-        sweep, accepted = await gate.run(RESOLVER_REPORT, "fr")
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])))
+        sweep, accepted = await gate.run(RESOLVER_REPORT, "fr", confirmation=_Answer(True))
         self.assertTrue(accepted)
         self.assertEqual(sweep.verdict, DUPLICATE)
 
     async def test_a_rejected_match_leaves_the_flow_running(self) -> None:
         answer = _Answer(False)
-        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])), answer)
-        sweep, accepted = await gate.run(RESOLVER_REPORT, "fr")
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])))
+        sweep, accepted = await gate.run(RESOLVER_REPORT, "fr", confirmation=answer)
         self.assertFalse(accepted)
         self.assertTrue(sweep.found, "the finding survives the refusal, so the issue can record it")
 
     async def test_the_reporter_is_shown_the_evidence_before_being_asked(self) -> None:
         answer = _Answer(False)
-        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])), answer)
-        await gate.run(RESOLVER_REPORT, "fr")
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])))
+        await gate.run(RESOLVER_REPORT, "fr", confirmation=answer)
         self.assertEqual(len(answer.shown), 1)
         assert answer.shown[0].best is not None
         self.assertTrue(answer.shown[0].best.shared, "a proposal with no shared word is an assertion")
 
     async def test_with_nobody_to_ask_the_gate_refuses_rather_than_silencing_the_report(self) -> None:
-        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])), None)
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])))
         sweep, accepted = await gate.run(RESOLVER_REPORT, "fr")
         self.assertTrue(sweep.found)
         self.assertFalse(accepted)
 
     async def test_nothing_found_is_never_offered_for_confirmation(self) -> None:
         answer = _Answer(True)
-        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues()), answer)
-        _, accepted = await gate.run("the radio menu shows Cyrillic on a Kola map at dusk", "fr")
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues()))
+        _, accepted = await gate.run("the radio menu shows Cyrillic on a Kola map at dusk", "fr", confirmation=answer)
         self.assertFalse(accepted)
         self.assertEqual(answer.shown, [])
 
@@ -390,7 +390,7 @@ class TestTheseTestsDetectABrokenSweep(unittest.TestCase):
 
         original = priorart.PriorArtGate.run
 
-        async def _always_accept(self, query: str, lang: str):  # type: ignore[no-untyped-def]
+        async def _always_accept(self, query: str, lang: str, *, confirmation=None):  # type: ignore[no-untyped-def]
             return await self.sweeper.sweep(query), True
 
         priorart.PriorArtGate.run = _always_accept  # type: ignore[method-assign]

--- a/services/support-bot/veaf_support_bot/ask.py
+++ b/services/support-bot/veaf_support_bot/ask.py
@@ -98,6 +98,20 @@ class Exchange(Protocol):
             content: The new content.
         """
 
+    async def offer_escalation(self, question: str, answer: str, lang: str) -> None:
+        """Offer to turn an unsatisfying answer into a bug report.
+
+        An answer that did not help is the moment the asker is most likely to give up, and the
+        documentation bot is where a real bug most often shows up first. The offer carries the
+        question and the answer into the report form, so escalating costs a click rather than a
+        retype.
+
+        Args:
+            question: What was asked.
+            answer: What the bot replied.
+            lang: ``"fr"`` or ``"en"``.
+        """
+
 
 @dataclass
 class AskContext:
@@ -279,6 +293,7 @@ class AskHandler:
         body, titles = answer_module.split_sources(collected)
         links = answer_module.source_links(titles, lang)
         await exchange.edit(answer_module.render(body, links, lang))
+        await exchange.offer_escalation(context.question, body, lang)
         self._logger.info(
             "question answered",
             extra={

--- a/services/support-bot/veaf_support_bot/bugreport.py
+++ b/services/support-bot/veaf_support_bot/bugreport.py
@@ -137,7 +137,7 @@ class MaterialNote:
 
 @dataclass(frozen=True)
 class BugReport:
-    """A filled report, ready for the issue body ticket 04 renders and ticket 05 files.
+    """A filled report, ready for the issue body :mod:`veaf_support_bot.issue_body` renders.
 
     Attributes:
         form: The raw form, kept whole.

--- a/services/support-bot/veaf_support_bot/discord_bot.py
+++ b/services/support-bot/veaf_support_bot/discord_bot.py
@@ -22,6 +22,7 @@ serves the VEAF Discord rather than one invitable anywhere.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from logging import Logger
 from typing import Any
 
@@ -32,6 +33,14 @@ from veaf_support_bot.ask import AskContext, AskHandler
 from veaf_support_bot.attachments import Incoming
 from veaf_support_bot.bugreport import BugForm
 from veaf_support_bot.config import SupportBotConfig
+from veaf_support_bot.draft import (
+    CANCEL,
+    DRAFT_EXPIRY_SECONDS,
+    EDIT,
+    EXPIRED,
+    FILE,
+    MATCH_EXPIRY_SECONDS,
+)
 from veaf_support_bot.health import ServiceState
 from veaf_support_bot.intake import (
     DOCTOR_MAX_CHARS,
@@ -39,9 +48,11 @@ from veaf_support_bot.intake import (
     SUMMARY_MAX_CHARS,
     BugIntake,
     BugSubmission,
+    escalation_form,
 )
 from veaf_support_bot.logging_setup import get_logger
 from veaf_support_bot.service import InFlightTasks
+from veaf_support_bot.texts import text
 
 #: Gateway intents. The default set minus every privileged one: the bot reads slash-command options,
 #: never message content or member lists, so asking for more would be permission it does not need.
@@ -59,19 +70,42 @@ QUESTION_MAX_LENGTH = 1000
 #: Everyone*: it removes the question entirely, at the call site, for every message.
 NO_MENTIONS = discord.AllowedMentions.none()
 
+#: The two answers to a prior-art proposal. Local to this module: the protocol they implement
+#: speaks in booleans, so nothing outside needs to name them.
+_SAME = "same"
+_DIFFERENT = "different"
+
+#: How long the escalation button stays on an answer. It sits on a public message that nobody is
+#: waiting on, so it is measured in "while the thread is still being read" rather than in the
+#: interaction budget the draft's buttons live inside.
+ESCALATION_EXPIRY_SECONDS = 3600
+
 
 class InteractionExchange:
     """The :class:`~veaf_support_bot.ask.Exchange` protocol over a real Discord interaction."""
 
-    def __init__(self, interaction: discord.Interaction, logger: Logger | None = None) -> None:
+    def __init__(
+        self,
+        interaction: discord.Interaction,
+        logger: Logger | None = None,
+        *,
+        intake: BugIntake | None = None,
+        tasks: InFlightTasks | None = None,
+    ) -> None:
         """Initialize the exchange.
 
         Args:
             interaction: The interaction the command was invoked with.
             logger: Logger to use; defaults to the service's ``discord`` logger.
+            intake: What an escalation hands its form to. ``None`` — a deployment with no checkout,
+                where ``/bug`` is not published either — leaves the offer out rather than showing a
+                button that leads nowhere.
+            tasks: Registry a shutdown drains, passed on to the escalated report's own modal.
         """
         self._interaction = interaction
         self._logger = logger or get_logger("discord")
+        self._intake = intake
+        self._tasks = tasks
         self._thread: discord.Thread | None = None
         self._message: discord.Message | None = None
 
@@ -143,6 +177,65 @@ class InteractionExchange:
                 extra={"event": "ask.edit_failed", "error": f"{type(error).__name__}: {error}"},
             )
 
+    async def offer_escalation(self, question: str, answer: str, lang: str) -> None:
+        """Attach a *Report a bug* button to the answer, carrying the exchange into the form.
+
+        Never raises: the answer is already posted by the time this runs, and losing it to a failure
+        while adding a button would trade the thing that worked for the thing that did not.
+
+        Args:
+            question: What was asked.
+            answer: What the bot replied.
+            lang: ``"fr"`` or ``"en"``.
+        """
+        if self._intake is None or self._message is None:
+            return
+        view = _EscalationView(
+            label=text("escalate.button", lang),
+            open_form=self._escalation_opener(self._intake, question, answer, lang),
+            logger=self._logger,
+        )
+        try:
+            view.message = await self._message.edit(view=view, allowed_mentions=NO_MENTIONS)
+        except discord.HTTPException as error:
+            self._logger.warning(
+                "could not offer the escalation button",
+                extra={"event": "ask.escalation_failed", "error": type(error).__name__},
+            )
+
+    def _escalation_opener(
+        self, intake: BugIntake, question: str, answer: str, lang: str
+    ) -> Callable[[discord.Interaction], Awaitable[None]]:
+        """Build what the escalation button does when pressed.
+
+        Args:
+            intake: What the escalated report is handed to, passed in rather than read back off
+                the exchange so the closure cannot outlive the check that it exists.
+            question: What was asked.
+            answer: What the bot replied.
+            lang: ``"fr"`` or ``"en"``.
+
+        Returns:
+            A coroutine function opening the report form, pre-filled with the exchange.
+        """
+
+        async def open_form(click: discord.Interaction) -> None:
+            """Open the report form on the asker's own click.
+
+            Args:
+                click: The click, which is the interaction the modal must answer.
+            """
+            prefill = escalation_form(
+                question,
+                answer,
+                reporter=click.user.display_name,
+                reporter_id=str(click.user.id),
+                language=lang,
+            )
+            await click.response.send_modal(BugModal(intake, [], self._logger, prefill=prefill, tasks=self._tasks))
+
+        return open_form
+
 
 class SupportBotClient(discord.Client):
     """The gateway connection, and the readiness it publishes."""
@@ -175,7 +268,7 @@ class SupportBotClient(discord.Client):
         self._handler = handler
         self._logger = get_logger("discord")
         self.tree = app_commands.CommandTree(self)
-        register_commands(self.tree, handler, self._logger, tasks)
+        register_commands(self.tree, handler, self._logger, tasks, intake)
         if intake is not None:
             register_bug_command(self.tree, intake, self._logger, tasks)
 
@@ -251,6 +344,7 @@ def register_commands(
     handler: AskHandler,
     logger: Logger,
     tasks: InFlightTasks | None = None,
+    intake: BugIntake | None = None,
 ) -> None:
     """Attach ``/ask`` to a command tree.
 
@@ -262,6 +356,8 @@ def register_commands(
         handler: The handler the command delegates to.
         logger: Logger for failures that escape the handler.
         tasks: Registry a shutdown drains; the exchange is run as a tracked task when given.
+        intake: What an unsatisfying answer escalates to. ``None`` leaves the offer out — the same
+            deployment where ``/bug`` is not published at all.
     """
 
     @tree.command(name="ask", description="Ask a question about the VEAF Mission Creation Tools documentation")
@@ -279,7 +375,7 @@ def register_commands(
             question=question,
             locale=str(interaction.locale) if interaction.locale else None,
         )
-        exchange = InteractionExchange(interaction, logger)
+        exchange = InteractionExchange(interaction, logger, intake=intake, tasks=tasks)
         try:
             if tasks is None:
                 await handler.handle(exchange, context)
@@ -302,19 +398,33 @@ def register_commands(
 class ModalExchange:
     """The :class:`~veaf_support_bot.intake.BugExchange` protocol over a modal submission.
 
-    Ephemeral throughout. The deterministic pass is a *preparation* step: it says what the service
-    read and what it could not, which concerns the reporter and nobody else. What becomes public is
-    the issue, and opening it is ticket 04's click.
+    Ephemeral throughout. The preparation is a private step: it says what the service read and what
+    it could not, which concerns the reporter and nobody else. What becomes public is the issue, and
+    it is opened only when the button below is pressed.
+
+    The two questions — *is this your bug already reported?* and *does this go?* — are asked on the
+    reporter's own message, one after the other, and both are bounded in time. Their timeouts add up
+    to less than the fifteen minutes Discord keeps the interaction token alive, because the last
+    thing this exchange does is write the answer onto that same message.
     """
 
-    def __init__(self, interaction: discord.Interaction, logger: Logger | None = None) -> None:
+    def __init__(
+        self,
+        interaction: discord.Interaction,
+        reopen: Callable[[discord.Interaction], Awaitable[None]] | None = None,
+        logger: Logger | None = None,
+    ) -> None:
         """Initialize the exchange.
 
         Args:
             interaction: The modal submission interaction.
+            reopen: What the *Edit* button does — opens the form again, on the button's own
+                interaction. ``None`` leaves the button out, which is what an escalation with no
+                form behind it needs.
             logger: Logger to use; defaults to the service's ``discord`` logger.
         """
         self._interaction = interaction
+        self._reopen = reopen
         self._logger = logger or get_logger("discord")
 
     async def defer(self) -> None:
@@ -324,10 +434,229 @@ class ModalExchange:
     async def post(self, content: str) -> None:
         """Replace the acknowledgement with what the service made of the report.
 
+        The buttons are cleared with it: a message that still offers *File the issue* after the
+        issue was filed is an invitation to file it twice.
+
         Args:
             content: The message content.
         """
-        await self._interaction.edit_original_response(content=content, allowed_mentions=NO_MENTIONS)
+        await self._interaction.edit_original_response(content=content, view=None, allowed_mentions=NO_MENTIONS)
+
+    async def decide(self, content: str, lang: str) -> str:
+        """Show the draft with its buttons and wait for one to be pressed.
+
+        Args:
+            content: The draft, rendered and bounded.
+            lang: ``"fr"`` or ``"en"``.
+
+        Returns:
+            One of :data:`~veaf_support_bot.draft.CHOICES`. A silence returns
+            :data:`~veaf_support_bot.draft.EXPIRED` and a Discord failure returns
+            :data:`~veaf_support_bot.draft.CANCEL` — both leave the tracker untouched, which is the
+            only safe way for this step to fail.
+        """
+        view = _ChoiceView(default=EXPIRED, timeout=DRAFT_EXPIRY_SECONDS)
+        view.add_item(_ChoiceButton(FILE, text("draft.button.file", lang), discord.ButtonStyle.success))
+        if self._reopen is not None:
+            view.add_item(_EditButton(text("draft.button.edit", lang), self._reopen))
+        view.add_item(_ChoiceButton(CANCEL, text("draft.button.cancel", lang), discord.ButtonStyle.secondary))
+        return await self._ask(content, view, on_failure=CANCEL, event="bug.draft_failed")
+
+    async def confirm(self, content: str, lang: str) -> bool:
+        """Show a prior-art match with its evidence and wait for the reporter's answer.
+
+        Args:
+            content: The proposal, with its evidence.
+            lang: ``"fr"`` or ``"en"``.
+
+        Returns:
+            ``True`` only when he pressed *yes, that is it*. A silence, a refusal and a Discord
+            failure all answer ``False``, and the report carries on being filed: a machine's
+            unanswered guess must never silence a real bug.
+        """
+        view = _ChoiceView(default=_DIFFERENT, timeout=MATCH_EXPIRY_SECONDS)
+        view.add_item(_ChoiceButton(_SAME, text("match.button.same", lang), discord.ButtonStyle.primary))
+        view.add_item(_ChoiceButton(_DIFFERENT, text("match.button.different", lang), discord.ButtonStyle.secondary))
+        answer = await self._ask(content, view, on_failure=_DIFFERENT, event="bug.match_failed")
+        return answer == _SAME
+
+    async def _ask(self, content: str, view: _ChoiceView, *, on_failure: str, event: str) -> str:
+        """Put one question on the reporter's message and wait for it to be answered.
+
+        Args:
+            content: What the question says.
+            view: The buttons, and what a silence means.
+            on_failure: The answer to return when Discord refuses to show the question at all.
+            event: Log event for that refusal.
+
+        Returns:
+            The answer.
+        """
+        try:
+            await self._interaction.edit_original_response(content=content, view=view, allowed_mentions=NO_MENTIONS)
+        except discord.HTTPException as error:
+            self._logger.warning(
+                "the question could not be shown, so its safe answer is used",
+                extra={"event": event, "error": type(error).__name__, "answer": on_failure},
+            )
+            return on_failure
+        await view.wait()
+        return view.choice
+
+
+class _ChoiceButton(discord.ui.Button["_ChoiceView"]):
+    """A button that records one answer and ends the wait.
+
+    Args:
+        choice: What clicking it means.
+        label: What it says.
+        style: How it looks.
+    """
+
+    def __init__(self, choice: str, label: str, style: discord.ButtonStyle) -> None:
+        super().__init__(label=label, style=style)
+        self.choice = choice
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        """Record the answer, acknowledge the click, and release the waiter.
+
+        The acknowledgement is a deferred update rather than a message: what the reporter is told
+        next is written by the intake onto the *original* response, and a second message here would
+        say it twice.
+
+        Args:
+            interaction: The click.
+        """
+        view = self.view
+        if view is not None:
+            view.choose(self.choice)
+        await interaction.response.defer()
+
+
+class _ChoiceView(discord.ui.View):
+    """One question, its buttons, and the answer nobody gave.
+
+    The message these hang off is **ephemeral**, so only the reporter can see it and only he can
+    click: there is no second person to guard against. What has to be guarded is time — a view whose
+    timeout fires without a click leaves :attr:`choice` at whatever the caller decided a silence
+    means, which is never "publish".
+
+    Attributes:
+        choice: The answer, or the default the caller built it with.
+    """
+
+    def __init__(self, *, default: str, timeout: float) -> None:
+        """Initialize the view.
+
+        Args:
+            default: The answer a silence produces.
+            timeout: Seconds before the silence is final.
+        """
+        super().__init__(timeout=timeout)
+        self.choice = default
+
+    def choose(self, choice: str) -> None:
+        """Record an answer and stop waiting.
+
+        Args:
+            choice: The answer.
+        """
+        self.choice = choice
+        self.stop()
+
+
+class _EditButton(discord.ui.Button["_ChoiceView"]):
+    """The button that reopens the form instead of answering with a message.
+
+    Opening a modal has to be the *first* response to the interaction that opened it, so this button
+    cannot defer first the way the others do.
+
+    Args:
+        label: What it says.
+        reopen: What actually opens the form.
+    """
+
+    def __init__(self, label: str, reopen: Callable[[discord.Interaction], Awaitable[None]]) -> None:
+        super().__init__(label=label, style=discord.ButtonStyle.primary)
+        self._reopen = reopen
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        """Reopen the form, then end the wait.
+
+        Args:
+            interaction: The click.
+        """
+        await self._reopen(interaction)
+        view = self.view
+        if view is not None:
+            view.choose(EDIT)
+
+
+class _EscalationView(discord.ui.View):
+    """The *Report a bug* button that hangs off an answer, until it stops being offered.
+
+    Unlike the draft's buttons, this one sits on a **public** message that outlives the exchange, so
+    it has to clean up after itself: when the view expires the button is removed rather than left
+    to answer a click with *this interaction failed*.
+
+    Attributes:
+        message: The message the button is attached to, so the timeout can take it off.
+    """
+
+    def __init__(
+        self,
+        *,
+        label: str,
+        open_form: Callable[[discord.Interaction], Awaitable[None]],
+        logger: Logger,
+    ) -> None:
+        """Initialize the view.
+
+        Args:
+            label: What the button says.
+            open_form: What pressing it does.
+            logger: Logger for a failed clean-up.
+        """
+        super().__init__(timeout=ESCALATION_EXPIRY_SECONDS)
+        self.message: discord.Message | None = None
+        self._logger = logger
+        self.add_item(_EscalateButton(label, open_form))
+
+    async def on_timeout(self) -> None:
+        """Take the button off the answer once it is no longer live."""
+        if self.message is None:
+            return
+        try:
+            await self.message.edit(view=None)
+        except discord.HTTPException as error:
+            self._logger.warning(
+                "could not remove the escalation button",
+                extra={"event": "ask.escalation_cleanup_failed", "error": type(error).__name__},
+            )
+
+
+class _EscalateButton(discord.ui.Button["_EscalationView"]):
+    """The button that opens the report form on the asker's own click.
+
+    Args:
+        label: What it says.
+        open_form: What pressing it does.
+    """
+
+    def __init__(self, label: str, open_form: Callable[[discord.Interaction], Awaitable[None]]) -> None:
+        super().__init__(label=label, style=discord.ButtonStyle.secondary, emoji="🐞")
+        self._open_form = open_form
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        """Open the form.
+
+        The button stays on the message: a second reader of the same thread may want it too, and
+        the answer is public.
+
+        Args:
+            interaction: The click.
+        """
+        await self._open_form(interaction)
 
 
 class BugModal(discord.ui.Modal):
@@ -337,47 +666,66 @@ class BugModal(discord.ui.Modal):
     they are missing — asking a reporter for a version is how a report ends up saying "latest".
     """
 
-    def __init__(self, intake: BugIntake, attachments: list[Incoming], logger: Logger) -> None:
+    def __init__(
+        self,
+        intake: BugIntake,
+        attachments: list[Incoming],
+        logger: Logger,
+        *,
+        prefill: BugForm | None = None,
+        tasks: InFlightTasks | None = None,
+    ) -> None:
         """Build the modal.
 
         Args:
             intake: What the submission is handed to.
             attachments: The files the command carried, already flattened.
             logger: Logger for a failure that escapes the handler.
+            prefill: Answers to open the form with — what *Edit* gives back to the reporter, and
+                what an escalation from ``/ask`` carries in. A reporter who has to retype four
+                fields to fix a typo in one does not fix the typo.
+            tasks: Registry a shutdown drains. The submission is its own interaction, living for
+                fifteen minutes across two questions, so it is the one that has to be tracked.
         """
         super().__init__(title="Report a bug", timeout=None)
         self._intake = intake
         self._attachments = attachments
         self._logger = logger
+        self._tasks = tasks
         self.summary: discord.ui.TextInput[BugModal] = discord.ui.TextInput(
             label="In one line, what is wrong?",
             style=discord.TextStyle.short,
             max_length=SUMMARY_MAX_CHARS,
             required=True,
+            default=prefill.summary if prefill else None,
         )
         self.happened: discord.ui.TextInput[BugModal] = discord.ui.TextInput(
             label="What happened?",
             style=discord.TextStyle.paragraph,
             max_length=PARAGRAPH_MAX_CHARS,
             required=True,
+            default=prefill.happened if prefill else None,
         )
         self.expected: discord.ui.TextInput[BugModal] = discord.ui.TextInput(
             label="What did you expect?",
             style=discord.TextStyle.paragraph,
             max_length=PARAGRAPH_MAX_CHARS,
             required=True,
+            default=prefill.expected if prefill else None,
         )
         self.steps: discord.ui.TextInput[BugModal] = discord.ui.TextInput(
             label="Steps to reproduce",
             style=discord.TextStyle.paragraph,
             max_length=PARAGRAPH_MAX_CHARS,
             required=True,
+            default=prefill.steps if prefill else None,
         )
         self.doctor: discord.ui.TextInput[BugModal] = discord.ui.TextInput(
             label="Paste the output of: veaf-tools doctor",
             style=discord.TextStyle.paragraph,
             max_length=DOCTOR_MAX_CHARS,
             required=False,
+            default=prefill.doctor if prefill else None,
         )
         for item in (self.summary, self.happened, self.expected, self.steps, self.doctor):
             self.add_item(item)
@@ -406,12 +754,37 @@ class BugModal(discord.ui.Modal):
         )
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
-        """Run the deterministic pass over the submitted form.
+        """Run the deterministic pass, then ask the reporter what to do with what it produced.
 
         Args:
             interaction: The submission interaction.
         """
-        await self._intake.handle(ModalExchange(interaction, self._logger), self.submission(interaction))
+        submission = self.submission(interaction)
+
+        async def reopen(click: discord.Interaction) -> None:
+            """Give the form back, with his answers still in it.
+
+            Args:
+                click: The *Edit* click, which is the interaction the modal must answer.
+            """
+            await click.response.send_modal(
+                BugModal(
+                    self._intake,
+                    self._attachments,
+                    self._logger,
+                    prefill=submission.form,
+                    tasks=self._tasks,
+                )
+            )
+
+        exchange = ModalExchange(interaction, reopen, self._logger)
+        running = self._intake.handle(exchange, submission)
+        if self._tasks is None:
+            await running
+        else:
+            # Awaited, not fired and forgotten: a shutdown must wait for the last message rather
+            # than leave the reporter on a draft whose buttons answer nobody.
+            await self._tasks.track(running, name=f"bug:{submission.form.reporter_id}")
 
     # discord.py's `Modal.on_error` takes `(interaction, error)`; the `BaseView` it inherits from
     # takes a third `Item` argument, and that is the signature mypy resolves. Matching the base would
@@ -472,9 +845,10 @@ def register_bug_command(
         tree: The command tree to attach to.
         intake: The handler the command delegates to.
         logger: Logger for failures that escape the modal.
-        tasks: Registry a shutdown drains. Unused by the command itself, which returns as soon as
-            the modal is open; the modal's own submission is a separate interaction with its own
-            fifteen-minute token, which ticket 04 tracks when it adds the click that files.
+        tasks: Registry a shutdown drains. The command itself returns as soon as the modal is
+            open and has nothing to track; what is tracked is the modal's **submission**, a separate
+            interaction with its own fifteen-minute token that now spans two questions and a
+            filing — so the modal is handed the registry rather than the command.
     """
 
     @tree.command(name="bug", description="Report a bug — a short form, and the files you have")
@@ -500,5 +874,5 @@ def register_bug_command(
             mission: An optional mission archive.
             extra: One more optional file.
         """
-        modal = BugModal(intake, incoming_from(log, mission, extra), logger)
+        modal = BugModal(intake, incoming_from(log, mission, extra), logger, tasks=tasks)
         await interaction.response.send_modal(modal)

--- a/services/support-bot/veaf_support_bot/draft.py
+++ b/services/support-bot/veaf_support_bot/draft.py
@@ -1,0 +1,135 @@
+"""The issue as it will be filed, shown to the reporter, and the answer he gives.
+
+Ticket 04. Everything before this module is preparation: the form, the ``doctor`` block, the log
+excerpt, the located ``file:line``, the prior-art sweep. This is where the reporter sees what all of
+that became **before** it reaches a public tracker, and says whether it goes.
+
+## Why the draft is the issue and not a summary
+
+The reporter typed three fields; twenty lines get published. The log excerpt, the extracted code and
+the environment are material he never wrote, filed under a machine account that does not carry his
+name. So what he is shown is the body :mod:`~veaf_support_bot.filing` will send — the same string,
+built once — rather than a friendly recap of it. A recap would be a second implementation, and the
+one thing it could never prove is that the issue says what the preview said.
+
+## Truncation is announced, never silent
+
+Discord accepts 2000 characters and a GitHub issue accepts 60 000, so a real report does not fit.
+Cutting it quietly would make the preview a lie precisely where it matters — the long parts are the
+ones he did not write. :func:`fold` cuts on a line boundary, closes a fenced block it had to cut
+through, and returns what it left out so the message can say so.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from veaf_support_bot.texts import text
+from veaf_support_bot.untrusted import one_line
+
+#: The reporter files the issue.
+FILE: Final = "file"
+
+#: The reporter reopens the form: nothing is filed, and the modal comes back with his answers.
+EDIT: Final = "edit"
+
+#: The reporter drops the report. Nothing is filed, and nothing is kept.
+CANCEL: Final = "cancel"
+
+#: Nobody answered in time. Same effect as :data:`CANCEL`, and the reporter is told which it was —
+#: an abandoned draft turning into an issue days later is the failure this value exists to prevent.
+EXPIRED: Final = "expired"
+
+#: Every answer :meth:`~veaf_support_bot.intake.BugExchange.decide` may return.
+CHOICES: Final = (FILE, EDIT, CANCEL, EXPIRED)
+
+#: Longest draft message posted back. Discord's own ceiling is 2000 characters; the margin carries
+#: the truncation notice, which must fit *after* the cut has been decided.
+DRAFT_MAX_CHARS: Final = 1900
+
+#: How long a draft waits for a click, and how long the prior-art proposal waits before it. Both
+#: fit inside **one** interaction token, which Discord expires after fifteen minutes: an expiry the
+#: service can no longer announce is an expiry nobody learns about, and the reporter would be left
+#: on a preview that never resolves. Five plus eight leaves two minutes to write the last message.
+MATCH_EXPIRY_SECONDS: Final = 300
+DRAFT_EXPIRY_SECONDS: Final = 480
+
+#: Longest title shown in the draft header. The issue keeps its own; this is the preview line.
+TITLE_MAX_CHARS: Final = 200
+
+#: The fence a Markdown code block opens and closes with.
+_FENCE: Final = "```"
+
+
+@dataclass(frozen=True)
+class Draft:
+    """One issue, rendered and waiting for a click.
+
+    Attributes:
+        title: The issue title, exactly as it will be created.
+        body: The issue body, exactly as it will be sent — not a summary of it.
+    """
+
+    title: str
+    body: str
+
+    def render(self, lang: str, *, limit: int = DRAFT_MAX_CHARS, header: str = "draft.header") -> str:
+        """Render the draft as one Discord message, saying what it had to leave out.
+
+        Args:
+            lang: ``"fr"`` or ``"en"``.
+            limit: Longest message to produce.
+            header: Catalogue key of the opening line. A comment added to an existing issue is a
+                different act from opening one, and a preview calling it "the issue as it will be
+                filed" would misdescribe what the reporter is agreeing to.
+
+        Returns:
+            The message.
+        """
+        opening = text(header, lang) + "\n" + text("draft.title", lang, title=one_line(self.title, TITLE_MAX_CHARS))
+        # The notice is measured before the cut rather than after: a body folded to exactly the
+        # remaining room, then given a notice, would overshoot the ceiling by the notice's length.
+        notice = text("draft.truncated", lang, lines=9999, chars=999999)
+        budget = limit - len(opening) - len("\n\n") - len(notice) - len("\n\n")
+        kept, lines, chars = fold(self.body, max(budget, 0))
+        parts = [opening, kept]
+        if chars:
+            parts.append(text("draft.truncated", lang, lines=lines, chars=chars))
+        return "\n\n".join(parts)
+
+
+def fold(body: str, budget: int) -> tuple[str, int, int]:
+    """Cut a body down to *budget* characters on a line boundary, and say what was left.
+
+    Args:
+        body: The issue body.
+        budget: The room available.
+
+    Returns:
+        A triple of what is kept, how many lines were dropped, and how many characters.
+    """
+    if len(body) <= budget:
+        return body, 0, 0
+    cut = body[:budget]
+    # Prefer a whole line: a body cut mid-sentence reads as corruption rather than as an excerpt,
+    # and the reader cannot tell which of the two he is looking at.
+    boundary = cut.rfind("\n")
+    if boundary > 0:
+        cut = cut[:boundary]
+    dropped = body[len(cut) :]
+    return _close_fence(cut), dropped.count("\n"), len(dropped)
+
+
+def _close_fence(chunk: str) -> str:
+    """Close a fenced code block the cut opened, so the rest of the message still renders.
+
+    Args:
+        chunk: The kept part of the body.
+
+    Returns:
+        The chunk, with a closing fence appended when it needs one.
+    """
+    if chunk.count(_FENCE) % 2 == 0:
+        return chunk
+    return chunk.rstrip("\n") + "\n" + _FENCE

--- a/services/support-bot/veaf_support_bot/filing.py
+++ b/services/support-bot/veaf_support_bot/filing.py
@@ -49,6 +49,7 @@ from typing import Any
 
 from veaf_support_bot.attachments import Prepared
 from veaf_support_bot.bugreport import BASE_LABEL, BugReport
+from veaf_support_bot.draft import Draft
 from veaf_support_bot.github_app import GitHubApp, GitHubError
 from veaf_support_bot.issue_body import (
     Carried,
@@ -113,6 +114,18 @@ class Outcome:
             ``True`` for every action but ``"failed"``.
         """
         return self.action != "failed"
+
+
+def _language_of(report: BugReport) -> str:
+    """Return the language the issue is written in.
+
+    Args:
+        report: The assembled report.
+
+    Returns:
+        ``"fr"`` or ``"en"`` — an unrecognised locale is written in English rather than refused.
+    """
+    return report.form.language if report.form.language in ("fr", "en") else "en"
 
 
 def report_key(report: BugReport) -> str:
@@ -375,6 +388,53 @@ class IssueFiler:
         self._machine_label = machine_label
         self._locks: dict[str, _Serialiser] = {}
 
+    def _carried(self, report: BugReport) -> list[Carried]:
+        """Prepare the text attachments this report carries whole.
+
+        Args:
+            report: The assembled report.
+
+        Returns:
+            One :class:`~veaf_support_bot.issue_body.Carried` per prepared attachment.
+        """
+        return [carry(item, redactor=self._redactor) for item in report.attachments if isinstance(item, Prepared)]
+
+    def draft_of(self, report: BugReport, *, thread_url: str = "") -> Draft:
+        """Render the issue exactly as :meth:`file` would create it.
+
+        This is what ticket 04 shows the reporter before anything is published. It is the *same*
+        string builder the filing path uses, called with the same arguments — a preview rendered by
+        a second implementation could only ever prove that two functions disagree, which is the one
+        thing a consent step must not do.
+
+        Args:
+            report: The assembled report.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            The title and body that would be sent.
+        """
+        return Draft(
+            title=report.title,
+            body=render_body(report, report_key(report), thread_url=thread_url, carried=self._carried(report)),
+        )
+
+    def comment_draft_of(self, report: BugReport, *, thread_url: str = "") -> Draft:
+        """Render what :meth:`comment_on` would add to an existing issue.
+
+        A comment on a public tracker publishes the same material an issue does — the reporter's
+        words, his environment, what was extracted on his behalf. So it goes through the same click,
+        and through the same renderer, for the same reason :meth:`draft_of` does.
+
+        Args:
+            report: The assembled report.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            The comment as it would be posted. The title is the report's, for the preview header.
+        """
+        return Draft(title=report.title, body=render_duplicate_comment(report, _language_of(report), thread_url))
+
     @asynccontextmanager
     async def _serialised(self, key: str) -> AsyncIterator[None]:
         """Hold one report's lock, and forget the lock once nobody wants it.
@@ -433,12 +493,11 @@ class IssueFiler:
         Returns:
             The outcome.
         """
-        lang = report.form.language if report.form.language in ("fr", "en") else "en"
         try:
             response = await self._app.request(
                 "POST",
                 f"/repos/{self._app.repository}/issues/{number}/comments",
-                {"body": render_duplicate_comment(report, lang, thread_url)},
+                {"body": self.comment_draft_of(report, thread_url=thread_url).body},
             )
         except GitHubError as error:
             self._logger.error(
@@ -476,7 +535,7 @@ class IssueFiler:
             self._remember(key, existing)
             return Outcome(action="reused", number=existing.number, url=existing.url)
 
-        carried = [carry(item, redactor=self._redactor) for item in report.attachments if isinstance(item, Prepared)]
+        carried = self._carried(report)
         body = render_body(report, key, thread_url=thread_url, carried=carried)
         labels = self._labels_for(report)
 

--- a/services/support-bot/veaf_support_bot/intake.py
+++ b/services/support-bot/veaf_support_bot/intake.py
@@ -14,10 +14,11 @@ order needs the order to be observable without a Discord connection.
    operation, and neither is walking a checkout for callers.
 3. **Attachments first, then assembly.** A trace often appears only in the attached log, never in
    the form, so the log excerpt is scanned for locations along with the typed fields.
-4. **The report goes to a sink.** Filing it is ticket 05's GitHub App and previewing it is
-   ticket 04; this lot ends at a complete :class:`~veaf_support_bot.bugreport.BugReport` and a seam
-   to hand it through. The default sink renders it back to the reporter, so the deterministic path
-   is observable end to end before either of those exists.
+4. **Sweep, show, then file — in that order.** The prior-art sweep runs before anything is opened;
+   the issue is then rendered *as it will be filed* and put to the reporter with three buttons; and
+   only a press of *File the issue* reaches GitHub. Every other answer — edit, cancel, a silence —
+   leaves the tracker untouched and says which one it was. A deployment with no GitHub App at all
+   still shows the deterministic pass, so the pipeline stays observable end to end.
 
 ## Attachments arrive on the command, not in the thread
 
@@ -52,6 +53,7 @@ from typing import Protocol
 from veaf_support_bot.attachments import AttachmentCollector, Harvest, Incoming
 from veaf_support_bot.bugreport import BugForm, BugReport, MaterialNote, assemble, safe_redact
 from veaf_support_bot.checkout import Checkout
+from veaf_support_bot.draft import CANCEL, EDIT, EXPIRED, FILE, Draft
 from veaf_support_bot.filing import Outcome
 from veaf_support_bot.logging_setup import get_logger
 from veaf_support_bot.priorart import DUPLICATE, FIXED, IN_PROGRESS, PriorArtGate, Sweep
@@ -70,6 +72,13 @@ REPOSITORY_URL = "https://github.com/VEAF/VEAF-Mission-Creation-Tools"
 SUMMARY_MAX_CHARS = 200
 PARAGRAPH_MAX_CHARS = 1200
 DOCTOR_MAX_CHARS = 4000
+
+#: How much of an escalated ``/ask`` exchange is carried into the form. Discord **refuses** a modal
+#: whose pre-filled value is longer than the field, so an unsatisfying answer of two thousand
+#: characters would not produce a truncated form — it would produce no form at all. The two bounds
+#: leave room for the sentence that introduces them.
+ESCALATED_QUESTION_CHARS = 300
+ESCALATED_ANSWER_CHARS = 700
 
 
 @dataclass
@@ -101,9 +110,81 @@ class BugExchange(Protocol):
             content: The message content.
         """
 
+    async def decide(self, content: str, lang: str) -> str:
+        """Show the draft and return what the reporter chose to do with it.
+
+        This is the step that publishes, or does not. It lives on the exchange rather than on the
+        service because the buttons hang off *this* reporter's own message: a consent object built
+        once at start-up would have nowhere to draw them.
+
+        Args:
+            content: The draft, rendered and bounded.
+            lang: ``"fr"`` or ``"en"``, for the button labels.
+
+        Returns:
+            One of :data:`~veaf_support_bot.draft.CHOICES`. Anything that is not
+            :data:`~veaf_support_bot.draft.FILE` leaves the tracker untouched, so a silence, a
+            refusal and a Discord failure are all safe answers.
+        """
+
+    async def confirm(self, content: str, lang: str) -> bool:
+        """Show a prior-art match with its evidence and return whether the reporter recognised it.
+
+        Args:
+            content: The proposal, with the evidence it was computed from.
+            lang: ``"fr"`` or ``"en"``, for the button labels.
+
+        Returns:
+            ``True`` only when he says it is the same subject. Everything else — *mine is
+            different*, a silence, a failure — answers ``False`` and the report carries on, because
+            a machine's unanswered guess must never silence a real bug.
+        """
+
+
+class _AskTheReporter:
+    """The :class:`~veaf_support_bot.priorart.MatchConfirmation` protocol, over the exchange.
+
+    The sweep speaks in :class:`~veaf_support_bot.priorart.Sweep` objects and the exchange speaks in
+    strings, so the rendering — which is where the *evidence* is put in front of the reporter —
+    happens here, on this side of the seam. Discord never sees a sweep, and the intake never draws a
+    button.
+
+    Attributes:
+        exchange: Who gets asked.
+    """
+
+    def __init__(self, exchange: BugExchange) -> None:
+        """Initialize the adapter.
+
+        Args:
+            exchange: The Discord side.
+        """
+        self._exchange = exchange
+
+    async def confirm(self, sweep: Sweep, lang: str) -> bool:
+        """Put the match, with its evidence, to the reporter.
+
+        Args:
+            sweep: The finding.
+            lang: ``"fr"`` or ``"en"``.
+
+        Returns:
+            Whether he recognised it as the same subject.
+        """
+        return await self._exchange.confirm(render_match(sweep, lang), lang)
+
 
 #: What a finished report is handed to. Returns the sentence the reporter reads.
 ReportSink = Callable[[BugReport], Awaitable[str]]
+
+#: What the reporter is told for each answer that is not "file it". Written as a table rather than
+#: as branches so a new answer cannot be added without a sentence to go with it — a decision the
+#: reporter makes and the bot does not acknowledge reads exactly like a bot that crashed.
+DECLINED: dict[str, str] = {
+    EDIT: "draft.editing",
+    CANCEL: "draft.cancelled",
+    EXPIRED: "draft.expired",
+}
 
 
 class ReportFiler(Protocol):
@@ -134,6 +215,28 @@ class ReportFiler(Protocol):
 
         Returns:
             What became of it.
+        """
+
+    def draft_of(self, report: BugReport, *, thread_url: str = "") -> Draft:
+        """Render the issue exactly as :meth:`file` would create it.
+
+        Args:
+            report: The assembled report.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            The title and body that would be sent.
+        """
+
+    def comment_draft_of(self, report: BugReport, *, thread_url: str = "") -> Draft:
+        """Render what :meth:`comment_on` would add to an existing issue.
+
+        Args:
+            report: The assembled report.
+            thread_url: Link back to the Discord thread.
+
+        Returns:
+            The comment as it would be posted.
         """
 
 
@@ -207,7 +310,7 @@ class BugIntake:
                 await self._say(exchange, text("bug.error.unexpected", lang))
                 return None
 
-            report, message = await self._decide(report, lang, submission.thread_url)
+            report, message = await self._decide(exchange, report, lang, submission.thread_url)
             await self._say(exchange, message)
         finally:
             rmtree(workdir, ignore_errors=True)
@@ -228,7 +331,9 @@ class BugIntake:
         )
         return report
 
-    async def _decide(self, report: BugReport, lang: str, thread_url: str) -> tuple[BugReport, str]:
+    async def _decide(
+        self, exchange: BugExchange, report: BugReport, lang: str, thread_url: str
+    ) -> tuple[BugReport, str]:
         """Run the prior-art step, then either act on it or file the report.
 
         The order is the whole of ticket 03: the sweep happens **before** anything is opened, and
@@ -243,15 +348,15 @@ class BugIntake:
         Returns:
             A pair of the report, now carrying the finding, and what the reporter is told.
         """
-        sweep, accepted = await self._sweep(report, lang)
+        sweep, accepted = await self._sweep(exchange, report, lang)
         report = replace(report, prior_art=sweep)
         if accepted and sweep is not None:
-            return report, await self._act_on(sweep, report, lang, thread_url)
+            return report, await self._act_on(exchange, sweep, report, lang, thread_url)
         if self._sink is not None:
             return report, await self._sink(report)
-        return report, await self._file(report, lang, thread_url)
+        return report, await self._file(exchange, report, lang, thread_url)
 
-    async def _sweep(self, report: BugReport, lang: str) -> tuple[Sweep | None, bool]:
+    async def _sweep(self, exchange: BugExchange, report: BugReport, lang: str) -> tuple[Sweep | None, bool]:
         """Compare the report against everything already recorded.
 
         Args:
@@ -264,7 +369,7 @@ class BugIntake:
         """
         if self._prior_art is None:
             return None, False
-        sweep, accepted = await self._prior_art.run(sweep_query(report), lang)
+        sweep, accepted = await self._prior_art.run(sweep_query(report), lang, confirmation=_AskTheReporter(exchange))
         self._logger.info(
             "prior art swept",
             extra={
@@ -278,10 +383,16 @@ class BugIntake:
         )
         return sweep, accepted
 
-    async def _act_on(self, sweep: Sweep, report: BugReport, lang: str, thread_url: str) -> str:
+    async def _act_on(self, exchange: BugExchange, sweep: Sweep, report: BugReport, lang: str, thread_url: str) -> str:
         """Do what an accepted match asks for, which for three of the four verdicts is nothing.
 
+        The fourth — a duplicate — writes a **comment on a public tracker**, carrying the same
+        material an issue would: his words, his environment, what was extracted on his behalf.
+        Recognising an issue as his is not the same act as agreeing to publish twenty lines under
+        it, so this goes through the same click as the issue does.
+
         Args:
+            exchange: The Discord side, which is who gets asked.
             sweep: The accepted finding.
             report: The assembled report.
             lang: ``"fr"`` or ``"en"``.
@@ -296,11 +407,24 @@ class BugIntake:
         number = _issue_number(sweep)
         if number == 0:
             return proposal
+        draft = self._filer.comment_draft_of(report, thread_url=thread_url)
+        choice = await exchange.decide(draft.render(lang, header="draft.header_comment"), lang)
+        self._logger.info(
+            "the reporter decided what to do with his observation",
+            extra={"event": "intake.decided_comment", "user": report.form.reporter_id, "choice": choice},
+        )
+        if choice != FILE:
+            return text(DECLINED.get(choice, "draft.cancelled"), lang)
         outcome = await self._filer.comment_on(number, report, thread_url=thread_url)
         return proposal + "\n\n" + _render_outcome(outcome, lang, report)
 
-    async def _file(self, report: BugReport, lang: str, thread_url: str) -> str:
-        """File the report, or say why nothing was filed.
+    async def _file(self, exchange: BugExchange, report: BugReport, lang: str, thread_url: str) -> str:
+        """Show the issue, wait for the click, and file it — or say why nothing was filed.
+
+        The order is ticket 04's whole point: the reporter sees the body that will be published,
+        under a machine account that does not carry his name, and nothing reaches GitHub until he
+        says so. Every path that is not a click leaves the tracker untouched and says which one it
+        was, because a draft nobody acted on must never become an issue later.
 
         Args:
             report: The assembled report.
@@ -308,13 +432,20 @@ class BugIntake:
             thread_url: Link back to the Discord thread.
 
         Returns:
-            What the reporter is told: the preview, plus what became of the issue.
+            What the reporter is told.
         """
-        preview = render_preview(report, lang)
         if self._filer is None:
-            return preview + "\n\n" + text("filed.disabled", lang)
+            return render_preview(report, lang) + "\n\n" + text("filed.disabled", lang)
+        draft = self._filer.draft_of(report, thread_url=thread_url)
+        choice = await exchange.decide(draft.render(lang), lang)
+        self._logger.info(
+            "the reporter decided what to do with his draft",
+            extra={"event": "intake.decided", "user": report.form.reporter_id, "choice": choice},
+        )
+        if choice != FILE:
+            return text(DECLINED.get(choice, "draft.cancelled"), lang)
         outcome = await self._filer.file(report, thread_url=thread_url)
-        return preview + "\n\n" + _render_outcome(outcome, lang, report)
+        return _render_outcome(outcome, lang, report)
 
     async def build(self, submission: BugSubmission, workdir: Path) -> BugReport:
         """Do the deterministic pass, attachments included.
@@ -464,6 +595,48 @@ def _split_fields(form: BugForm, redacted_text: str) -> tuple[str, str, str, str
     return out[0], out[1], out[2], out[3], out[4]
 
 
+def escalation_form(
+    question: str,
+    answer: str,
+    *,
+    reporter: str,
+    reporter_id: str,
+    language: str,
+) -> BugForm:
+    """Turn an unsatisfying ``/ask`` exchange into the start of a report.
+
+    What it fills is *what happened*: the question and the answer are the observation, not the
+    diagnosis. *What was expected* and *the steps* are deliberately left empty — the form still
+    requires them, so escalating remains a report somebody wrote rather than a transcript nobody
+    read.
+
+    Args:
+        question: What was asked.
+        answer: What the bot replied.
+        reporter: The asker's display name.
+        reporter_id: The asker's Discord id.
+        language: The language of the exchange.
+
+    Returns:
+        The pre-filled form.
+    """
+    return BugForm(
+        summary=one_line(question, SUMMARY_MAX_CHARS),
+        happened=text(
+            "escalate.happened",
+            normalize_language(language),
+            question=one_line(question, ESCALATED_QUESTION_CHARS),
+            answer=one_line(answer, ESCALATED_ANSWER_CHARS),
+        )[:PARAGRAPH_MAX_CHARS],
+        expected="",
+        steps="",
+        doctor="",
+        reporter=reporter,
+        reporter_id=reporter_id,
+        language=language,
+    )
+
+
 def render_location(location: Location, lang: str) -> str:
     """Render one resolved location for the preview.
 
@@ -578,11 +751,12 @@ def _render_outcome(outcome: Outcome, lang: str, report: BugReport) -> str:
 
 
 def render_preview(report: BugReport, lang: str) -> str:
-    """Render what the deterministic pass produced, for the reporter to see.
+    """Render what the deterministic pass produced, for a deployment that files nothing.
 
-    This is a **preview**, not the issue body: ticket 04 owns the body and the click that files it.
-    What it proves today is that the pass ran and what it found — which is what makes the pipeline
-    observable before a GitHub App exists.
+    This is a **summary of the pass**, not the issue body — the body, and the click that publishes
+    it, are :class:`~veaf_support_bot.draft.Draft`. It is what a service with no GitHub App shows:
+    proof that the pass ran and what it found, so the pipeline stays observable without a tracker
+    to write to.
 
     Args:
         report: The assembled report.

--- a/services/support-bot/veaf_support_bot/priorart.py
+++ b/services/support-bot/veaf_support_bot/priorart.py
@@ -658,27 +658,29 @@ class PriorArtGate:
 
     Attributes:
         sweeper: What runs the sweep.
-        confirmation: Who is asked. ``None`` means **nobody can be asked**, and the gate then always
-            returns "rejected": with no way to obtain consent, silencing a report on a machine's
-            unverified guess is the one outcome this ticket exists to prevent. The finding is still
-            attached to the report and printed with its evidence.
     """
 
     sweeper: PriorArtSweeper
-    confirmation: MatchConfirmation | None = None
 
-    async def run(self, query: str, lang: str) -> tuple[Sweep, bool]:
+    async def run(self, query: str, lang: str, *, confirmation: MatchConfirmation | None = None) -> tuple[Sweep, bool]:
         """Sweep, and find out whether the match is accepted.
 
         Args:
             query: The report's own words.
             lang: ``"fr"`` or ``"en"``.
+            confirmation: Who is asked, **for this report**. It is an argument and not a field
+                because the buttons hang off the reporter's own message: there is no reporter to ask
+                at start-up, which is why ticket 03 could only ever answer "rejected". ``None``
+                means nobody can be asked and the gate answers "rejected" — with no way to obtain
+                consent, silencing a report on a machine's unverified guess is the one outcome this
+                step exists to prevent. The finding is still attached to the report and printed with
+                its evidence.
 
         Returns:
             A pair of the finding and whether it was **accepted** — ``True`` stops the flow, and the
             caller acts on :attr:`Sweep.verdict` instead of filing.
         """
         sweep = await self.sweeper.sweep(query)
-        if not sweep.found or self.confirmation is None:
+        if not sweep.found or confirmation is None:
             return sweep, False
-        return sweep, bool(await self.confirmation.confirm(sweep, lang))
+        return sweep, bool(await confirmation.confirm(sweep, lang))

--- a/services/support-bot/veaf_support_bot/texts.py
+++ b/services/support-bot/veaf_support_bot/texts.py
@@ -155,6 +155,42 @@ _TEXTS: Final[dict[str, dict[str, str]]] = {
             "-# 📝 Aucun ticket n'a été ouvert : ce bot n'a pas encore d'identité GitHub configurée. "
             "Le rapport ci-dessus est complet et peut être copié tel quel dans un ticket."
         ),
+        # --- ticket 04, l'aperçu et le clic qui dépose ----------------------------------------
+        "draft.header": (
+            "📋 **Voici le ticket tel qu'il sera déposé**, au nom du bot et pas au tien. "
+            "Rien n'est publié tant que tu n'as pas cliqué."
+        ),
+        "draft.header_comment": (
+            "📋 **Voici ce qui sera ajouté au ticket existant**, au nom du bot et pas au tien. "
+            "Rien n'est publié tant que tu n'as pas cliqué."
+        ),
+        "draft.title": "**Titre :** {title}",
+        "draft.truncated": (
+            "-# ✂️ Aperçu coupé ici : {lines} lignes de plus ({chars} caractères) partiront dans "
+            "le ticket. Rien n'est retiré du ticket lui-même."
+        ),
+        "draft.button.file": "Déposer le ticket",
+        "draft.button.edit": "Corriger",
+        "draft.button.cancel": "Annuler",
+        "draft.cancelled": "🗑️ Annulé : rien n'a été déposé, et rien n'est conservé.",
+        "draft.expired": (
+            "⏳ **Cet aperçu a expiré** et rien n'a été déposé. Relance `/bug` quand tu veux — un "
+            "brouillon abandonné ne devient jamais un ticket tout seul."
+        ),
+        "draft.editing": (
+            "✏️ Le formulaire s'est rouvert avec tes réponses. Rien n'a été déposé : le nouvel "
+            "aperçu remplacera celui-ci."
+        ),
+        "draft.no_consent": (
+            "-# 📝 Aucun ticket n'a été ouvert : je n'ai personne à qui demander le clic. Un ticket "
+            "n'est jamais déposé sans que son auteur l'ait vu — signale-le sur le canal support."
+        ),
+        "match.button.same": "Oui, c'est ça",
+        "match.button.different": "Non, le mien est différent",
+        "escalate.button": "Signaler un bug",
+        "escalate.happened": (
+            "J'ai posé cette question au bot :\n{question}\n\nSa réponse ne règle pas mon problème :\n{answer}"
+        ),
     },
     "en": {
         # --- the exchange -------------------------------------------------------------------
@@ -281,6 +317,41 @@ _TEXTS: Final[dict[str, dict[str, str]]] = {
         "filed.disabled": (
             "-# 📝 No issue was opened: this bot has no GitHub identity configured yet. The report "
             "above is complete and can be copied into an issue as it stands."
+        ),
+        # --- ticket 04, the preview and the click that files ----------------------------------
+        "draft.header": (
+            "📋 **This is the issue as it will be filed**, under the bot's name and not yours. "
+            "Nothing is published until you click."
+        ),
+        "draft.header_comment": (
+            "📋 **This is what will be added to the existing issue**, under the bot's name and not "
+            "yours. Nothing is published until you click."
+        ),
+        "draft.title": "**Title:** {title}",
+        "draft.truncated": (
+            "-# ✂️ Preview cut here: {lines} more lines ({chars} characters) go into the issue. "
+            "Nothing is removed from the issue itself."
+        ),
+        "draft.button.file": "File the issue",
+        "draft.button.edit": "Edit",
+        "draft.button.cancel": "Cancel",
+        "draft.cancelled": "🗑️ Cancelled: nothing was filed, and nothing is kept.",
+        "draft.expired": (
+            "⏳ **This preview expired** and nothing was filed. Run `/bug` again whenever you want "
+            "— an abandoned draft never turns into an issue on its own."
+        ),
+        "draft.editing": (
+            "✏️ The form reopened with your answers. Nothing was filed: the new preview replaces this one."
+        ),
+        "draft.no_consent": (
+            "-# 📝 No issue was opened: there is nobody I can ask for the click. An issue is never "
+            "filed without its author having seen it — report this on the support channel."
+        ),
+        "match.button.same": "Yes, that is it",
+        "match.button.different": "No, mine is different",
+        "escalate.button": "Report a bug",
+        "escalate.happened": (
+            "I asked the bot this question:\n{question}\n\nIts answer does not solve my problem:\n{answer}"
         ),
     },
 }


### PR DESCRIPTION
Ticket 04 of `FEAT-SUPPORT-BUG-INTAKE`: the preview, and the click that files it.

## What changes

`/bug` used to file as soon as the deterministic pass finished. It now shows the issue **itself** —
the exact title and body that would be created — and waits for a button.

| Button | What it does |
|---|---|
| **File the issue** | the only path that reaches GitHub |
| **Edit** | reopens the form with his answers still in it, and re-runs the whole pass |
| **Cancel** | nothing is filed, and nothing is kept |

He types three fields; twenty lines get published, under a machine account that does not carry his
name. The log excerpt, the extracted code and the environment are material he never wrote — the
click is where he can see the difference and say *not that*.

## The decisions worth reviewing

**The preview is the issue, not a rendering of it.** `IssueFiler.draft_of` calls the same
`render_body` the filing path calls, with the same arguments. A second renderer could only ever
prove that two functions disagree, which is the one thing a consent step must not do.

**The two questions moved onto `BugExchange`.** `decide` and `confirm` are protocol members rather
than objects built at start-up, because the buttons hang off *this* reporter's own message — there
is no reporter to ask when the service boots. That is also what finally answers ticket 03's open
point: `PriorArtGate.run` takes the confirmation as an argument, the gate's own field is gone, and
the prior-art match is genuinely put to the reporter with its evidence instead of always answering
*rejected*.

**The comment goes through the same click.** The ticket names the issue; the flow also writes a
comment when a duplicate is accepted, carrying the same material onto the same public tracker. So it
is previewed and confirmed exactly like the issue, under its own heading.

**Every failure leans the same way.** A silence expires, a Discord error cancels, an answer nobody
wrote a case for is a refusal. Both waits — five minutes for the proposal, eight for the draft — fit
inside Discord's fifteen-minute interaction token, so the expiry can still be announced on the
message it happened to.

**Truncation states its counts.** `fold` cuts on a line boundary, closes a fenced block it ran
through, and returns what it dropped so the notice can name it. The long parts are exactly the ones
the reporter did not write.

**Escalation from `/ask`.** An answer that did not help carries a *Report a bug* button for an hour,
opening the same form pre-filled with the question and the answer. What was expected and the steps
stay empty: the exchange is the observation, the report is still his to make.

## Checks

- `poetry run pytest` — 732 passed, coverage 96% (gate 95%)
- `poetry run ruff check` / `ruff format --check` / `mypy` — clean

## What ticket 06 still has to pick up

`BugSubmission.thread_url` is still empty, so an issue says the thread was not recorded. Ticket 06
owns that link — and it is the same link the relay needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Require reporters to review and explicitly approve generated bug issues and duplicate comments before publishing them, while enabling escalation from unsatisfying `/ask` answers.

New Features:
- Add a consent-based `/bug` workflow that previews the exact issue or duplicate comment before publication, with File, Edit, and Cancel actions.
- Add `/ask` escalation through a Report a bug button that opens a pre-filled bug form.

Bug Fixes:
- Prevent prior-art matches, Discord failures, unknown responses, cancellations, and timeouts from silently filing or suppressing reports.
- Ensure prior-art evidence is shown to the reporter and that accepted duplicate comments require the same publication consent as issues.

Enhancements:
- Centralize issue and comment draft generation with explicit, bounded truncation notices and safe Markdown fence handling.
- Keep modal submissions tracked through the consent workflow and remove stale interaction controls after completion or expiry.

Documentation:
- Document the preview-and-consent workflow, escalation behavior, expiry handling, and truncation semantics for support-bot users.

Tests:
- Add comprehensive tests covering Discord controls, consent outcomes, expiry, prior-art confirmation, truncation, modal prefilling, end-to-end submission wiring, and `/ask` escalation.

Chores:
- Mark support bug-intake ticket 04 as complete.