### PR TITLE
feat(support-bot): ask the documentation whether an idea exists, and share the seam

### DIFF
--- a/services/support-bot/tests/test_existing.py
+++ b/services/support-bot/tests/test_existing.py
@@ -1,0 +1,206 @@
+"""Asking the documentation whether a suggestion already exists, and reading the answer.
+
+The three verdicts are asserted one per test, and so are the two cases the module is shaped around:
+an answer that merely *contains* the absence keyword is still an answer, and a documentation that
+could not be consulted must never read as a documentation that said nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from tests.fakes import FakeWorker
+from veaf_support_bot.answer import SOURCES_MARKER
+from veaf_support_bot.doc_pages_data import PAGES_BY_TITLE
+from veaf_support_bot.existing import (
+    ABSENT,
+    ANSWER_MAX_CHARS,
+    EXISTS,
+    NOTHING_KEYWORD,
+    UNKNOWN,
+    AskTheDocumentation,
+    DocumentationCheck,
+    says_nothing,
+)
+from veaf_support_bot.worker import FailureKind, WorkerFailure
+
+#: A request phrased the way a mission maker phrases one.
+REQUEST = "Je voudrais pouvoir faire apparaitre un convoi qui suit une route que je dessine."
+
+
+def a_real_title() -> str:
+    """Return a documentation title the corpus really has.
+
+    Returns:
+        The first French title, so the link the check produces is a real page rather than a shape.
+    """
+    return sorted(PAGES_BY_TITLE["fr"])[0]
+
+
+def check(worker: FakeWorker, request: str = REQUEST, lang: str = "fr") -> DocumentationCheck:
+    """Run one check against a scripted Worker.
+
+    Args:
+        worker: The scripted Worker.
+        request: What the user would like.
+        lang: The language asked for.
+
+    Returns:
+        The finding.
+    """
+    return asyncio.run(AskTheDocumentation(worker).check(request, lang, "user-1"))
+
+
+class TestTheDocumentationAnswers(unittest.TestCase):
+    """The documentation describes a way to do it."""
+
+    def test_the_answer_and_its_pages_are_kept(self) -> None:
+        title = a_real_title()
+        worker = FakeWorker(["Oui : la commande `_convoy` ", f"suit une route.\n{SOURCES_MARKER} {title}"])
+
+        found = check(worker)
+
+        self.assertEqual(found.verdict, EXISTS)
+        self.assertTrue(found.found)
+        self.assertIn("_convoy", found.answer)
+        self.assertNotIn(SOURCES_MARKER, found.answer)
+        self.assertEqual(len(found.links), 1)
+        self.assertIn(title, found.links[0])
+
+    def test_an_invented_page_is_not_linked(self) -> None:
+        """A title the corpus does not have is dropped rather than turned into a dead link."""
+        worker = FakeWorker([f"Oui, c'est possible.\n{SOURCES_MARKER} Une page qui n'existe pas"])
+
+        found = check(worker)
+
+        self.assertEqual(found.verdict, EXISTS)
+        self.assertEqual(found.links, ())
+
+    def test_a_long_answer_is_bounded(self) -> None:
+        worker = FakeWorker(["o" * (ANSWER_MAX_CHARS * 3)])
+
+        self.assertEqual(len(check(worker).answer), ANSWER_MAX_CHARS)
+
+    def test_it_says_what_was_asked_and_what_came_back(self) -> None:
+        title = a_real_title()
+        worker = FakeWorker([f"Oui.\n{SOURCES_MARKER} {title}"])
+
+        described = check(worker).describe()
+
+        self.assertIn("answered", described)
+        self.assertIn(title, described)
+
+
+class TestTheDocumentationIsSilent(unittest.TestCase):
+    """The documentation says nothing about it, which is a finding of its own."""
+
+    def test_the_keyword_alone_is_an_absence(self) -> None:
+        worker = FakeWorker([NOTHING_KEYWORD])
+
+        found = check(worker)
+
+        self.assertEqual(found.verdict, ABSENT)
+        self.assertFalse(found.found)
+        self.assertEqual(found.answer, "")
+
+    def test_the_keyword_survives_the_decoration_a_model_adds(self) -> None:
+        for body in (f"**{NOTHING_KEYWORD}**", f"`{NOTHING_KEYWORD}`.", f" {NOTHING_KEYWORD} "):
+            with self.subTest(body=body):
+                self.assertEqual(check(FakeWorker([body])).verdict, ABSENT)
+
+    def test_the_keyword_with_its_empty_trailer_is_still_an_absence(self) -> None:
+        self.assertEqual(check(FakeWorker([f"{NOTHING_KEYWORD}\n{SOURCES_MARKER}"])).verdict, ABSENT)
+
+    def test_a_short_sentence_beginning_with_the_keyword_is_still_an_answer(self) -> None:
+        """The prefix match this used to do discarded it as silence."""
+        found = check(FakeWorker([f"{NOTHING_KEYWORD} is documented about the radio menu."]), lang="en")
+
+        self.assertEqual(found.verdict, EXISTS)
+
+    def test_prose_containing_the_word_is_an_answer_not_an_absence(self) -> None:
+        """The failure this bound exists for: a real answer thrown away for using the word."""
+        worker = FakeWorker(["There is nothing stopping you: the `_convoy` command already does this."])
+
+        found = check(worker, lang="en")
+
+        self.assertEqual(found.verdict, EXISTS)
+        self.assertIn("_convoy", found.answer)
+
+    def test_it_says_the_documentation_was_asked(self) -> None:
+        self.assertIn("says nothing", check(FakeWorker([NOTHING_KEYWORD])).describe())
+
+
+class TestTheDocumentationCannotBeAsked(unittest.TestCase):
+    """Nobody could ask is not the same as nothing was found, and must not read as it."""
+
+    def test_an_upstream_failure_is_a_finding_not_an_exception(self) -> None:
+        worker = FakeWorker(failure=WorkerFailure(FailureKind.UNAVAILABLE, "connection refused"))
+
+        found = check(worker)
+
+        self.assertEqual(found.verdict, UNKNOWN)
+        self.assertEqual(found.problem, FailureKind.UNAVAILABLE.value)
+
+    def test_an_empty_answer_is_unknown_rather_than_absent(self) -> None:
+        found = check(FakeWorker(["   "]))
+
+        self.assertEqual(found.verdict, UNKNOWN)
+        self.assertEqual(found.problem, "empty")
+
+    def test_it_says_the_documentation_was_not_consulted(self) -> None:
+        worker = FakeWorker(failure=WorkerFailure(FailureKind.TIMEOUT, "too slow"))
+
+        described = check(worker).describe()
+
+        self.assertIn("could not be asked", described)
+        self.assertIn(FailureKind.TIMEOUT.value, described)
+
+    def test_nothing_consulted_is_the_default(self) -> None:
+        self.assertEqual(DocumentationCheck().verdict, UNKNOWN)
+
+
+class TestWhatTheWorkerIsSent(unittest.TestCase):
+    """The retrieval query is the request itself, and the instruction rides in an earlier turn."""
+
+    def test_the_request_is_the_last_turn_and_is_untouched(self) -> None:
+        worker = FakeWorker([NOTHING_KEYWORD])
+
+        check(worker)
+
+        turns = worker.seen[0]["messages"]
+        self.assertEqual(turns[-1], {"role": "user", "content": REQUEST})
+
+    def test_the_instruction_never_reaches_the_retrieval_query(self) -> None:
+        """Appending it to the request would poison the search with the instruction's own words."""
+        worker = FakeWorker([NOTHING_KEYWORD])
+
+        check(worker)
+
+        turns = worker.seen[0]["messages"]
+        self.assertIn(NOTHING_KEYWORD, turns[0]["content"])
+        self.assertNotIn(NOTHING_KEYWORD, turns[-1]["content"])
+        self.assertIn(SOURCES_MARKER, turns[0]["content"])
+
+    def test_the_language_and_the_subject_are_carried(self) -> None:
+        worker = FakeWorker([NOTHING_KEYWORD])
+
+        asyncio.run(AskTheDocumentation(worker).check(REQUEST, "en", "user-42"))
+
+        self.assertEqual(worker.seen[0]["lang"], "en")
+        self.assertEqual(worker.seen[0]["subject"], "user-42")
+
+
+class TestSaysNothing(unittest.TestCase):
+    """The bound between the keyword and prose that merely starts with it."""
+
+    def test_a_long_body_is_never_the_keyword(self) -> None:
+        self.assertFalse(says_nothing(f"{NOTHING_KEYWORD} " + "x" * 100))
+
+    def test_an_empty_body_is_not_the_keyword(self) -> None:
+        self.assertFalse(says_nothing(""))
+
+    def test_a_sentence_starting_with_the_keyword_is_an_answer(self) -> None:
+        """Reported by review: a prefix match throws away a real, short answer."""
+        self.assertFalse(says_nothing(f"{NOTHING_KEYWORD} is documented about it"))
+        self.assertFalse(says_nothing(f"{NOTHING_KEYWORD}NESS"))

--- a/services/support-bot/tests/test_intake_github_wiring.py
+++ b/services/support-bot/tests/test_intake_github_wiring.py
@@ -32,13 +32,13 @@ from veaf_support_bot.config import ConfigurationError, SupportBotConfig
 from veaf_support_bot.draft import CANCEL, EXPIRED, FILE, Draft
 from veaf_support_bot.filing import Outcome
 from veaf_support_bot.github_app import GitHubError
-from veaf_support_bot.intake import BugIntake, BugSubmission, ThreadHandle, render_match, sweep_query
-from veaf_support_bot.priorart import DUPLICATE, FIXED, IN_PROGRESS, PriorArtGate, PriorArtSweeper, Sweep
+from veaf_support_bot.intake import BugIntake, BugSubmission, ThreadHandle, sweep_query
+from veaf_support_bot.priorart import DUPLICATE, FIXED, IN_PROGRESS, PriorArtGate, PriorArtSweeper, Sweep, render_match
 from veaf_support_bot.service import build_github_app, build_intake
 
 
 class _Exchange:
-    """A :class:`~veaf_support_bot.intake.BugExchange` that records what the reporter was told.
+    """A :class:`~veaf_support_bot.exchange.ThreadExchange` that records what the reporter was told.
 
     It is also who answers the two questions, because ticket 04 put them on the exchange: what the
     reporter is *shown* and what he *answers* are the same conversation, and a double that split

--- a/services/support-bot/tests/test_suggestion.py
+++ b/services/support-bot/tests/test_suggestion.py
@@ -1,0 +1,206 @@
+"""What a submitted idea becomes, and the one thing that can rot silently.
+
+The component list writes the options of ``.github/ISSUE_TEMPLATE/feature_request.yml`` into a filed
+issue, so a renamed option there would leave the bot writing a component nobody can filter on — with
+every other test in this file still green, since they only compare strings to themselves.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from veaf_support_bot.existing import ABSENT, EXISTS, UNKNOWN, DocumentationCheck
+from veaf_support_bot.issue_body import marker_for
+from veaf_support_bot.priorart import SOURCE_BACKLOG, Candidate, Match, Sweep
+from veaf_support_bot.suggestion import (
+    COMPONENTS,
+    TITLE_MAX_CHARS,
+    SuggestionForm,
+    build_title,
+    language_of,
+    render_suggestion_body,
+    suggestion_key,
+)
+
+#: The repository's own issue template, read for real.
+TEMPLATE = Path(__file__).resolve().parents[3] / ".github" / "ISSUE_TEMPLATE" / "feature_request.yml"
+
+
+def a_form(**overrides: str) -> SuggestionForm:
+    """Build a complete form.
+
+    Args:
+        **overrides: Fields to replace.
+
+    Returns:
+        The form.
+    """
+    base = {
+        "summary": "Convoys along a drawn route",
+        "problem": "Placing a convoy by hand takes ten minutes per mission.",
+        "solution": "Let me draw a route and have the convoy follow it.",
+        "asker": "Someone",
+        "asker_id": "42",
+        "language": "en",
+    }
+    base.update(overrides)
+    return SuggestionForm(**base)
+
+
+def a_body(form: SuggestionForm | None = None, **kwargs: object) -> str:
+    """Render an issue body with sensible defaults.
+
+    Args:
+        form: The form; a default one when omitted.
+        **kwargs: Passed through to the renderer.
+
+    Returns:
+        The Markdown body.
+    """
+    form = form or a_form()
+    check = kwargs.pop("check", DocumentationCheck(verdict=ABSENT))
+    return render_suggestion_body(form, "key123", check=check, **kwargs)  # type: ignore[arg-type]
+
+
+class TestTheComponentListIsReal(unittest.TestCase):
+    """The list is only useful if it is the template's."""
+
+    def test_every_component_exists_in_the_template(self) -> None:
+        template = TEMPLATE.read_text(encoding="utf-8")
+
+        for component in COMPONENTS:
+            with self.subTest(component=component):
+                self.assertIn(component, template)
+
+    def test_the_template_is_where_it_is_expected(self) -> None:
+        self.assertTrue(TEMPLATE.is_file(), TEMPLATE)
+
+
+class TestTheRequiredFields(unittest.TestCase):
+    """A solution with no problem cannot be weighed against anything."""
+
+    def test_a_blank_problem_is_missing(self) -> None:
+        self.assertEqual(a_form(problem="   ").missing_fields(), ("problem",))
+
+    def test_a_complete_form_is_missing_nothing(self) -> None:
+        self.assertEqual(a_form().missing_fields(), ())
+
+    def test_the_optional_fields_are_optional(self) -> None:
+        self.assertEqual(a_form(alternatives="", context="").missing_fields(), ())
+
+
+class TestTheIdentity(unittest.TestCase):
+    """The same suggestion twice is one issue, so the key comes from the content alone."""
+
+    def test_the_same_form_gives_the_same_key(self) -> None:
+        self.assertEqual(suggestion_key(a_form()), suggestion_key(a_form()))
+
+    def test_a_different_asker_gives_a_different_key(self) -> None:
+        self.assertNotEqual(suggestion_key(a_form()), suggestion_key(a_form(asker_id="43")))
+
+    def test_a_changed_word_gives_a_different_key(self) -> None:
+        self.assertNotEqual(suggestion_key(a_form()), suggestion_key(a_form(solution="something else")))
+
+    def test_the_key_is_in_the_body_as_a_hidden_marker(self) -> None:
+        self.assertIn(marker_for("key123"), a_body())
+
+
+class TestTheTitle(unittest.TestCase):
+    """The title is the asker's own summary, bounded."""
+
+    def test_it_is_the_summary(self) -> None:
+        self.assertEqual(build_title(a_form(summary="Add a thing")), "Add a thing")
+
+    def test_it_is_bounded(self) -> None:
+        self.assertLessEqual(len(build_title(a_form(summary="x" * 400))), TITLE_MAX_CHARS)
+
+    def test_an_empty_summary_still_gives_a_title(self) -> None:
+        self.assertNotEqual(build_title(a_form(summary="  ")), "")
+
+
+class TestTheBody(unittest.TestCase):
+    """It reads like a hand-filled feature request, in the asker's language."""
+
+    def test_it_carries_the_template_sections(self) -> None:
+        body = a_body()
+
+        for expected in ("Component", "What problem does this solve?", "Proposed solution"):
+            with self.subTest(section=expected):
+                self.assertIn(expected, body)
+
+    def test_it_is_written_in_the_askers_language(self) -> None:
+        self.assertIn("Quel problème cela résout-il ?", a_body(a_form(language="fr")))
+
+    def test_an_unknown_locale_falls_back_to_english(self) -> None:
+        self.assertEqual(language_of(a_form(language="de")), "en")
+
+    def test_an_empty_optional_section_is_omitted(self) -> None:
+        self.assertNotIn("Alternatives considered", a_body(a_form(alternatives="")))
+
+    def test_a_filled_optional_section_is_kept(self) -> None:
+        self.assertIn("Alternatives considered", a_body(a_form(alternatives="a trigger")))
+
+    def test_the_askers_text_is_quoted_so_it_cannot_escape(self) -> None:
+        body = a_body(a_form(problem="### Not a heading\n@everyone"))
+
+        self.assertIn("```", body)
+        self.assertNotIn("@everyone", body)
+
+    def test_it_says_no_sketch_was_made(self) -> None:
+        self.assertIn("No technical sketch", a_body())
+
+    def test_it_credits_the_asker_and_the_bot(self) -> None:
+        body = a_body()
+
+        self.assertIn("Someone", body)
+        self.assertIn("support bot", body)
+
+    def test_a_thread_is_linked_when_there_is_one(self) -> None:
+        self.assertIn("https://discord.test/1", a_body(thread_url="https://discord.test/1"))
+
+    def test_no_thread_says_so_rather_than_inventing_one(self) -> None:
+        self.assertIn("not recorded", a_body())
+
+
+class TestWhatWasChecked(unittest.TestCase):
+    """A reader three months later must not have to redo the search."""
+
+    def test_an_answered_documentation_is_recorded_with_its_pages(self) -> None:
+        check = DocumentationCheck(verdict=EXISTS, answer="The `_convoy` command does this.", links=("[page](u)",))
+
+        body = a_body(check=check)
+
+        self.assertIn("_convoy", body)
+        self.assertIn("[page](u)", body)
+        self.assertIn("the request was maintained regardless", body)
+
+    def test_a_silent_documentation_is_flagged_as_a_possible_gap(self) -> None:
+        body = a_body(check=DocumentationCheck(verdict=ABSENT))
+
+        self.assertIn("documentation gap", body)
+
+    def test_an_unreachable_documentation_never_reads_as_a_silent_one(self) -> None:
+        """The distinction the whole verdict exists for."""
+        unreachable = a_body(check=DocumentationCheck(verdict=UNKNOWN, problem="timeout"))
+        silent = a_body(check=DocumentationCheck(verdict=ABSENT))
+
+        self.assertIn("could not be asked", unreachable)
+        self.assertNotIn("documentation gap", unreachable)
+        self.assertNotIn("could not be asked", silent)
+
+    def test_the_sweep_is_recorded_with_its_evidence(self) -> None:
+        sweep = Sweep(
+            verdict="in-progress",
+            best=Match(Candidate(SOURCE_BACKLOG, "FEAT-X", "a lot", url=".backlog/FEAT-X/PRD.md"), 0.5, ("convoy",)),
+            checked=("28 open backlog lot(s)",),
+        )
+
+        body = a_body(sweep=sweep)
+
+        self.assertIn("FEAT-X", body)
+        self.assertIn("convoy", body)
+        self.assertIn("28 open backlog lot(s)", body)
+
+    def test_no_sweep_records_only_the_documentation(self) -> None:
+        self.assertNotIn("Prior art checked", a_body(sweep=None))

--- a/services/support-bot/veaf_support_bot/answer.py
+++ b/services/support-bot/veaf_support_bot/answer.py
@@ -96,18 +96,23 @@ _PROTOCOL: Final = (
 _PROTOCOL_ACK: Final = "Understood. I will end every answer with that line."
 
 
-def protocol_turns(question: str) -> list[dict[str, str]]:
+def protocol_turns(question: str, *, extra: str = "") -> list[dict[str, str]]:
     """Build the conversation sent to the Worker for one question.
 
     Args:
         question: The user's question, verbatim.
+        extra: A further instruction for callers asking something other than a plain question —
+            :mod:`veaf_support_bot.existing` asks whether a feature already exists. It joins the
+            instruction turn rather than the question, because the Worker embeds the last user turn
+            to retrieve passages and instructions in it would poison the retrieval.
 
     Returns:
         Three turns: the protocol instruction, the model's acknowledgement, and the question. The
         question is last and untouched, which is what keeps the Worker's retrieval query clean.
     """
+    instruction = f"{extra}\n\n{_PROTOCOL}" if extra else _PROTOCOL
     return [
-        {"role": "user", "content": _PROTOCOL},
+        {"role": "user", "content": instruction},
         {"role": "assistant", "content": _PROTOCOL_ACK},
         {"role": "user", "content": question},
     ]

--- a/services/support-bot/veaf_support_bot/draft.py
+++ b/services/support-bot/veaf_support_bot/draft.py
@@ -41,7 +41,7 @@ CANCEL: Final = "cancel"
 #: an abandoned draft turning into an issue days later is the failure this value exists to prevent.
 EXPIRED: Final = "expired"
 
-#: Every answer :meth:`~veaf_support_bot.intake.BugExchange.decide` may return.
+#: Every answer :meth:`~veaf_support_bot.exchange.ThreadExchange.decide` may return.
 CHOICES: Final = (FILE, EDIT, CANCEL, EXPIRED)
 
 #: Longest draft message posted back. Discord's own ceiling is 2000 characters; the margin carries

--- a/services/support-bot/veaf_support_bot/exchange.py
+++ b/services/support-bot/veaf_support_bot/exchange.py
@@ -1,0 +1,116 @@
+"""The seam between a flow and Discord: what a flow may ask of a conversation, and nothing more.
+
+Both flows — the ``/bug`` intake and the ``/suggest`` one — need the same six gestures: acknowledge,
+say something, put a draft to a vote, put a proposal to a yes-or-no, open a public thread and post
+into it. They are declared here rather than in either flow, so the second one to be written does not
+copy a protocol out of the first: two copies of a seam drift, and the drift shows up as a flow that
+silently stops asking for consent.
+
+Written as a narrow protocol on purpose. Asserting on the *order* of the steps — sweep, show, file —
+needs the order to be observable without a Discord connection, which is what
+``tests/test_intake.py`` and ``tests/test_suggest.py`` both do against a recording stand-in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class ThreadExchange(Protocol):
+    """What a flow needs from Discord, and nothing more."""
+
+    async def defer(self) -> None:
+        """Acknowledge the modal submission, inside Discord's three-second budget."""
+
+    async def post(self, content: str) -> None:
+        """Show the person what the service made of his report.
+
+        Args:
+            content: The message content.
+        """
+
+    async def decide(self, content: str, lang: str) -> str:
+        """Show the draft and return what the person chose to do with it.
+
+        This is the step that publishes, or does not. It lives on the exchange rather than on the
+        service because the buttons hang off *this* reporter's own message: a consent object built
+        once at start-up would have nowhere to draw them.
+
+        Args:
+            content: The draft, rendered and bounded.
+            lang: ``"fr"`` or ``"en"``, for the button labels.
+
+        Returns:
+            One of :data:`~veaf_support_bot.draft.CHOICES`. Anything that is not
+            :data:`~veaf_support_bot.draft.FILE` leaves the tracker untouched, so a silence, a
+            refusal and a Discord failure are all safe answers.
+        """
+
+    async def confirm(self, content: str, lang: str) -> bool:
+        """Show a prior-art match with its evidence and return whether the person recognised it.
+
+        Args:
+            content: The proposal, with the evidence it was computed from.
+            lang: ``"fr"`` or ``"en"``, for the button labels.
+
+        Returns:
+            ``True`` only when he says it is the same subject. Everything else — *mine is
+            different*, a silence, a failure — answers ``False`` and the report carries on, because
+            a machine's unanswered guess must never silence a real bug.
+        """
+
+    async def open_followup_thread(self, name: str) -> ThreadHandle:
+        """Open the public thread the issue's news will come back into.
+
+        The exchange itself is ephemeral: the preparation concerns the reporter and nobody else.
+        What is public is the report, once he has decided to file it — and it needs a room a
+        maintainer's answer can be carried into, because the issue is filed under a machine account
+        the reporter is subscribed to nothing on.
+
+        Args:
+            name: The thread name.
+
+        Returns:
+            Where it was opened. An empty handle means no thread could be opened — a missing
+            permission, a channel that holds none — and the report is filed anyway, saying the
+            thread was not recorded rather than inventing a link.
+        """
+
+    async def post_in_thread(self, handle: ThreadHandle, content: str) -> None:
+        """Post the opening message once the issue exists and can be linked to.
+
+        Args:
+            handle: The thread opened by :meth:`open_followup_thread`.
+            content: What to post.
+        """
+
+
+@dataclass(frozen=True)
+class ThreadHandle:
+    """Where a report's follow-up thread lives, or nothing.
+
+    Attributes:
+        channel_id: The channel it belongs to. Kept alongside the thread id so a restart can reach
+            it without a warm Discord cache.
+        thread_id: The thread.
+        url: Its address, which is what the issue links back to.
+        handle: The library object the thread was opened from, kept so posting into it needs no
+            cache lookup. The bot runs on ``Intents.none()``, so a freshly created thread is
+            routinely absent from the cache: resolving it by id right after creating it is a
+            silent way to lose the message that carries the issue's address.
+    """
+
+    channel_id: int = 0
+    thread_id: int = 0
+    url: str = ""
+    handle: object | None = None
+
+    @property
+    def opened(self) -> bool:
+        """Say whether there is a thread to answer in.
+
+        Returns:
+            ``True`` when one was opened.
+        """
+        return self.thread_id > 0

--- a/services/support-bot/veaf_support_bot/existing.py
+++ b/services/support-bot/veaf_support_bot/existing.py
@@ -1,0 +1,270 @@
+"""Does the product already do this? The documentation is **asked**, not searched.
+
+A large share of feature requests are documentation gaps wearing a costume: the thing exists, the
+user did not find it. Answering *"it is there, here is the page"* serves him on the spot and keeps
+the tracker clean — so the check has to come before anything is drafted.
+
+## Why this is not the text matching :mod:`veaf_support_bot.priorart` does
+
+That module compares a bug report against prior bug reports: two texts of the same kind, whose
+discriminating words are identifiers the reporter pasted — ``veafSpawn.lua``, ``KeyError``,
+``FEAT-SUPPORT-BUG-INTAKE``. A suggestion written in ordinary language has none of those, and the
+corpus it would be compared against is the whole documentation, where the words naming a feature are
+everywhere. Measured on the real tree, 144 pages:
+
+| word | pages containing it | pages with it in a heading |
+|---|---|---|
+| ``csar`` | 24 (17%) | 6 |
+| ``combat`` | 69 (48%) | 20 |
+| ``zone`` | 87 (60%) | 20 |
+
+No threshold separates *the page describing CSAR* from *the twenty-four pages mentioning CSAR*,
+because the documentation cross-references itself: that is what makes it good documentation. Three
+successive attempts at scoring it were measured and thrown away — rarity weighting still matched a
+request for SMS alerts against the support page, on ``bot`` and ``serveur``, at 57%. A wrong *"it
+already exists"* silences a real idea, and the user will not argue with a bot.
+
+## What is asked instead
+
+The question *"does the documentation describe a way to do this?"* is the question ``/ask`` already
+answers, from the same corpus, with its sources and under its quota. So this module asks it — one
+exchange with the Worker, the request itself as the retrieval query, an answer that either explains
+how to do the thing or says the documentation is silent.
+
+Two consequences worth stating plainly:
+
+* the check **costs a model call**, which the lot's PRD said it would not. That constraint was
+  written before the corpus was measured, and it is incompatible with the goal stated beside it;
+* the machine never concludes on its own. It shows the answer and its pages, and the person who
+  asked says whether that is what he meant. What he answers is recorded either way — a *"no, that
+  is not it"* on an answer the documentation gave is worth reading later.
+
+Everything the Worker returns is data. Nothing in it selects a code path; the body is shown and the
+declared titles are looked up in the real tree, so a title the corpus does not have is dropped
+rather than linked. See :mod:`veaf_support_bot.untrusted`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping, Sequence
+from dataclasses import dataclass
+from logging import Logger
+from typing import Protocol
+
+from veaf_support_bot import answer as answer_module
+from veaf_support_bot.ask import MAX_QUESTION_CHARS
+from veaf_support_bot.logging_setup import get_logger
+from veaf_support_bot.worker import WorkerFailure
+
+#: The documentation describes a way to do it.
+EXISTS = "exists"
+
+#: The documentation says nothing about it.
+ABSENT = "absent"
+
+#: The documentation could not be consulted at all — the Worker was down, the quota was spent, the
+#: answer came back empty. Deliberately not the same as :data:`ABSENT`: *"the documentation does not
+#: mention it"* is a finding, *"nobody could ask"* is a missing step, and an issue that confuses the
+#: two tells its reader the documentation was checked when it was not.
+UNKNOWN = "unknown"
+
+#: What the model is told to answer when the documentation does not cover the request. Uppercase
+#: ASCII in both languages, for the reason :data:`~veaf_support_bot.answer.SOURCES_KEYWORD` is: a
+#: localized keyword would have to be matched in two spellings, and the model translates the
+#: keyword of a French instruction often enough to matter.
+NOTHING_KEYWORD = "NOTHING"
+
+#: Decoration to strip before comparing a body to the keyword.
+_NOTHING_TRIM = " \t\n`*_\"'«»“”.,;:!?()[]"
+
+#: Longest answer carried into the thread and into the issue. Discord's own ceiling is 2000
+#: characters for a whole message, and this one shares it with the question and the links.
+ANSWER_MAX_CHARS = 1200
+
+#: The task the model is given, sent as a *prior* turn so the request itself stays the retrieval
+#: query — appending instructions to the request would poison the search with them, see
+#: :func:`veaf_support_bot.answer.protocol_turns`.
+#:
+#: Deliberately **not** named ``_PROTOCOL``: :mod:`veaf_support_bot.answer` has a constant of that
+#: name carrying a different instruction — the one asking for the sources trailer — and this is
+#: passed to it as ``extra``. A reviewer reading two identically named constants concluded the
+#: protocol was being sent twice, which it is not: the two texts are joined, and dropping either
+#: would cost this check its task or its citations.
+_TASK = (
+    "The user is about to describe a feature he would like to see. Your only task is to say whether "
+    "the documentation already describes a way to do it. If it does, answer by explaining how, "
+    "briefly, for a reader who looked and did not find it. If the documentation does not describe a "
+    f"way to do it, answer with exactly `{NOTHING_KEYWORD}` and nothing else. Never describe a "
+    "feature the documentation does not describe, and never guess at one that might exist."
+)
+
+
+@dataclass(frozen=True)
+class DocumentationCheck:
+    """What the documentation answered about one request.
+
+    Nothing here has been acted on: :attr:`verdict` is a finding, and whether it settles the request
+    is the asker's to say.
+
+    Attributes:
+        verdict: :data:`EXISTS`, :data:`ABSENT` or :data:`UNKNOWN`.
+        answer: What the documentation assistant answered, bounded. Empty unless the verdict is
+            :data:`EXISTS`.
+        links: The documentation pages it cited, as Markdown links, already validated against the
+            real tree.
+        problem: Why the documentation could not be consulted. Empty unless the verdict is
+            :data:`UNKNOWN`.
+    """
+
+    verdict: str = UNKNOWN
+    answer: str = ""
+    links: tuple[str, ...] = ()
+    problem: str = ""
+
+    @property
+    def found(self) -> bool:
+        """Say whether there is an answer to put to the asker.
+
+        Returns:
+            ``True`` when the documentation described a way to do it.
+        """
+        return self.verdict == EXISTS
+
+    def describe(self) -> str:
+        """Render one line saying what the documentation was asked and what it said.
+
+        Recorded in the issue, so a reader three months later does not redo the search — and so the
+        difference between *the documentation is silent* and *the documentation was not consulted*
+        survives into the tracker.
+
+        Returns:
+            A sentence, never empty.
+        """
+        if self.verdict == EXISTS:
+            pages = f" It cited: {', '.join(self.links)}." if self.links else " It cited no page."
+            return f"The documentation was asked whether this already exists, and it answered.{pages}"
+        if self.verdict == ABSENT:
+            return "The documentation was asked whether this already exists; it says nothing about it."
+        reason = f" ({self.problem})" if self.problem else ""
+        return f"The documentation could not be asked whether this already exists{reason}."
+
+
+class DocumentationWorker(Protocol):
+    """What this check needs from the Worker client, and nothing more.
+
+    A protocol rather than :class:`~veaf_support_bot.worker.WorkerClient` itself, for the reason
+    every other seam in this service is one: the tests drive it with a scripted stand-in, and a
+    stand-in that has to *be* the client is a stand-in that carries a session factory and a timeout
+    to say one sentence.
+    """
+
+    def stream(self, messages: Sequence[Mapping[str, str]], lang: str, subject: str) -> AsyncIterator[str]:
+        """Stream the answer to a conversation, one text fragment at a time.
+
+        Args:
+            messages: The conversation turns, oldest first.
+            lang: ``"fr"`` or ``"en"``.
+            subject: Per-user rate-limit subject.
+
+        Returns:
+            The fragments, in order.
+        """
+
+
+class DocumentationSource(Protocol):
+    """Who answers *does this already exist?*, as a flow sees it.
+
+    :class:`AskTheDocumentation` is the one implementation; the protocol exists so a flow can be
+    driven, in a test, by a scripted answer rather than by an HTTP client.
+    """
+
+    async def check(self, request: str, lang: str, subject: str) -> DocumentationCheck:
+        """Ask whether the documentation already describes a way to do this.
+
+        Args:
+            request: What the user would like, in his own words.
+            lang: ``"fr"`` or ``"en"``.
+            subject: Per-user rate-limit subject.
+
+        Returns:
+            The finding.
+        """
+
+
+class AskTheDocumentation:
+    """Puts one request to the documentation assistant and reads what came back."""
+
+    def __init__(self, worker: DocumentationWorker, *, logger: Logger | None = None) -> None:
+        """Initialize the check.
+
+        Args:
+            worker: The documentation chatbot client, the same one ``/ask`` uses.
+            logger: Logger to use; defaults to the service's ``suggest`` logger.
+        """
+        self._worker = worker
+        self._logger = logger or get_logger("suggest")
+
+    async def check(self, request: str, lang: str, subject: str) -> DocumentationCheck:
+        """Ask whether the documentation already describes a way to do this.
+
+        Args:
+            request: What the user would like, in his own words. Sent as the last turn and
+                untouched, because it is what the Worker embeds to retrieve passages.
+            lang: ``"fr"`` or ``"en"``.
+            subject: Per-user rate-limit subject, as the Worker counts them.
+
+        Returns:
+            The finding. Never raises: every failure becomes :data:`UNKNOWN` with its reason, since
+            losing a suggestion because the documentation could not be reached is the one outcome
+            this step must not produce.
+        """
+        # Bounded here, not only where the form is: the whole submission is five modal fields, up
+        # to 5000 characters, and it is the *last user turn* the Worker embeds to retrieve passages.
+        # ``/ask`` trims at the same number for the same reason — past it, retrieval is being handed
+        # a paste and does nothing useful with it.
+        turns = answer_module.protocol_turns(" ".join(request.split())[:MAX_QUESTION_CHARS], extra=_TASK)
+        try:
+            collected = "".join([fragment async for fragment in self._worker.stream(turns, lang, subject)])
+        except WorkerFailure as failure:
+            self._logger.warning(
+                "the documentation could not be asked whether this already exists",
+                extra={"event": "suggest.check_failed", "kind": failure.kind.value, "detail": failure.detail},
+            )
+            return DocumentationCheck(verdict=UNKNOWN, problem=failure.kind.value)
+
+        body, titles = answer_module.split_sources(collected)
+        if not body.strip():
+            self._logger.warning(
+                "the documentation assistant answered nothing at all",
+                extra={"event": "suggest.check_empty"},
+            )
+            return DocumentationCheck(verdict=UNKNOWN, problem="empty")
+        if says_nothing(body):
+            self._logger.info(
+                "the documentation says nothing about this request",
+                extra={"event": "suggest.checked", "verdict": ABSENT},
+            )
+            return DocumentationCheck(verdict=ABSENT)
+        links = answer_module.source_links(titles, lang)
+        self._logger.info(
+            "the documentation describes a way to do this",
+            extra={"event": "suggest.checked", "verdict": EXISTS, "pages": len(links)},
+        )
+        return DocumentationCheck(verdict=EXISTS, answer=body[:ANSWER_MAX_CHARS], links=tuple(links))
+
+
+def says_nothing(body: str) -> bool:
+    """Decide whether an answer is the *"the documentation does not cover this"* keyword.
+
+    The comparison is an equality, not a prefix: *"NOTHING is documented about the radio menu"* is
+    an answer, and reading it as an absence would throw it away — the failure this whole module is
+    shaped around, one step earlier. What the decoration bound above still buys is the punctuation
+    and emphasis a model puts around the word: ``**NOTHING**.`` strips down to the keyword itself.
+
+    Args:
+        body: The answer body, trailer already removed.
+
+    Returns:
+        ``True`` when the model answered the keyword and nothing else.
+    """
+    return body.strip(_NOTHING_TRIM).strip().upper() == NOTHING_KEYWORD

--- a/services/support-bot/veaf_support_bot/filing.py
+++ b/services/support-bot/veaf_support_bot/filing.py
@@ -388,6 +388,31 @@ class IssueFiler:
         self._machine_label = machine_label
         self._locks: dict[str, _Serialiser] = {}
 
+    @property
+    def app(self) -> GitHubApp:
+        """Return the authenticated client this filer publishes through.
+
+        Read by the assembly, which builds the prior-art sweep's issue source from the same client
+        rather than authenticating a second one: two clients would mean two installation tokens
+        refreshed on two schedules for one App.
+
+        Returns:
+            The client.
+        """
+        return self._app
+
+    @property
+    def machine_label(self) -> str:
+        """Return the label marking an issue as machine-filed.
+
+        Read by a caller that renders its own labels — the suggestion flow does, since ``enhancement``
+        is not a label this filer would ever add to a bug report.
+
+        Returns:
+            The label.
+        """
+        return self._machine_label
+
     def _carried(self, report: BugReport) -> list[Carried]:
         """Prepare the text attachments this report carries whole.
 
@@ -469,18 +494,37 @@ class IssueFiler:
             because an exception here loses a report he has already spent five minutes on.
         """
         key = report_key(report)
-        async with self._serialised(key):
-            recorded = self._ledger.load().get(key) or {}
-            if recorded.get("number"):
-                return Outcome(action="reused", number=int(recorded["number"]), url=str(recorded.get("url") or ""))
-            try:
-                return await self._file_once(report, key, thread_url)
-            except GitHubError as error:
-                self._logger.error(
-                    "the issue could not be filed",
-                    extra={"event": "filing.failed", "key": key, "status": error.status, "error": str(error)},
-                )
-                return Outcome(action="failed", error=str(error))
+
+        def prepare() -> tuple[str, str, tuple[str, ...], list[Carried]]:
+            # Inside the closure, so a report the ledger already knows about costs neither the
+            # attachment reads nor the redaction pass they go through.
+            carried = self._carried(report)
+            body = render_body(report, key, thread_url=thread_url, carried=carried)
+            return report.title, body, self._labels_for(report), carried
+
+        return await self._file(key, prepare)
+
+    async def file_prepared(self, key: str, title: str, body: str, labels: Sequence[str]) -> Outcome:
+        """File an issue somebody else rendered, under the same guarantees a report gets.
+
+        The suggestion flow files through here: it has no attachments, no checkout pass and no
+        component table, but it needs the *whole* of what makes filing safe — one issue per key
+        however many times it is asked, a recovery search when the ledger lost the answer, and a
+        failure that comes back as an outcome rather than an exception. Rewriting that for the
+        second issue shape would be two mechanisms drifting apart on a public tracker.
+
+        Args:
+            key: The idempotency key. The body **must** carry
+                :func:`~veaf_support_bot.issue_body.marker_for` of this key, which is what the
+                recovery search greps for.
+            title: The issue title.
+            body: The issue body, already rendered.
+            labels: The labels to ask for, in order.
+
+        Returns:
+            The outcome. Never raises, for the reason :meth:`file` does not.
+        """
+        return await self._file(key, lambda: (title, body, tuple(labels), []))
 
     async def comment_on(self, number: int, report: BugReport, *, thread_url: str = "") -> Outcome:
         """Add the new observation to an existing issue instead of opening a second one.
@@ -536,7 +580,34 @@ class IssueFiler:
         url = str(response.body.get("html_url") or "") if isinstance(response.body, dict) else ""
         return Outcome(action="commented", number=number, url=url)
 
-    async def _file_once(self, report: BugReport, key: str, thread_url: str) -> Outcome:
+    async def _file(self, key: str, prepare: Callable[[], tuple[str, str, tuple[str, ...], list[Carried]]]) -> Outcome:
+        """File one issue for one key, whatever happens twice.
+
+        Args:
+            key: The idempotency key.
+            prepare: Renders the issue — title, body, labels and the attachments to post after it.
+                Called only when there is something to file, since preparing a report reads and
+                redacts every file it carries.
+
+        Returns:
+            The outcome. Never raises.
+        """
+        async with self._serialised(key):
+            recorded = self._ledger.load().get(key) or {}
+            if recorded.get("number"):
+                return Outcome(action="reused", number=int(recorded["number"]), url=str(recorded.get("url") or ""))
+            try:
+                return await self._file_once(key, prepare)
+            except GitHubError as error:
+                self._logger.error(
+                    "the issue could not be filed",
+                    extra={"event": "filing.failed", "key": key, "status": error.status, "error": str(error)},
+                )
+                return Outcome(action="failed", error=str(error))
+
+    async def _file_once(
+        self, key: str, prepare: Callable[[], tuple[str, str, tuple[str, ...], list[Carried]]]
+    ) -> Outcome:
         """Create the issue, having first made sure no earlier attempt already did.
 
         The marker search runs on **every** report that has no recorded number, not only on one the
@@ -548,9 +619,8 @@ class IssueFiler:
         public tracker, which is the outcome the ticket calls hardest to undo.
 
         Args:
-            report: The assembled report.
-            key: The report's idempotency key.
-            thread_url: Link back to the Discord thread.
+            key: The idempotency key.
+            prepare: Renders what is to be filed.
 
         Returns:
             The outcome.
@@ -563,13 +633,21 @@ class IssueFiler:
             self._remember(key, existing)
             return Outcome(action="reused", number=existing.number, url=existing.url)
 
-        carried = self._carried(report)
-        body = render_body(report, key, thread_url=thread_url, carried=carried)
-        labels = self._labels_for(report)
+        title, body, labels, carried = prepare()
 
         self._ledger.record(key, {"state": "filing", "started": time.time()})
-        response, notes = await self._create(report.title, body, labels)
+        response, notes = await self._create(title, body, labels)
         item = _record_of(response if isinstance(response, dict) else {})
+        if not item.number:
+            # A 2xx whose body is not an issue object. Reporting this as *created* hands the
+            # reporter `#0` as his issue address, records a zero in the ledger, and leaves the
+            # follow-up thread pointing at nothing. A success message is the one thing that must not
+            # be sent when there is no issue.
+            self._logger.error(
+                "GitHub accepted the issue but returned no number",
+                extra={"event": "filing.no_number", "key": key},
+            )
+            return Outcome(action="failed", error="GitHub returned no issue number")
         self._remember(key, item)
         notes += await self._attach(item.number, carried)
         self._logger.info(

--- a/services/support-bot/veaf_support_bot/intake.py
+++ b/services/support-bot/veaf_support_bot/intake.py
@@ -55,19 +55,16 @@ from veaf_support_bot.bugreport import BugForm, BugReport, MaterialNote, assembl
 from veaf_support_bot.checkout import Checkout
 from veaf_support_bot.draft import CANCEL, EDIT, EXPIRED, FILE, Draft
 from veaf_support_bot.enrichment import DISABLED, Enricher
+from veaf_support_bot.exchange import ThreadExchange, ThreadHandle
 from veaf_support_bot.filing import Outcome
 from veaf_support_bot.logging_setup import get_logger
-from veaf_support_bot.priorart import DUPLICATE, FIXED, IN_PROGRESS, PriorArtGate, Sweep
-from veaf_support_bot.texts import normalize_language, text
+from veaf_support_bot.priorart import DUPLICATE, PriorArtGate, Sweep, render_match
+from veaf_support_bot.texts import REPOSITORY_URL, normalize_language, text
 from veaf_support_bot.traces import Location
 from veaf_support_bot.untrusted import one_line, quote
 
 #: Longest preview posted back to the reporter. Discord's own message ceiling is 2000 characters.
 PREVIEW_MAX_CHARS = 1900
-
-#: Where a reporter is sent when the bot could not file for him. Never a dead end: the report is
-#: already rendered above the link, so it can be pasted straight into the form.
-REPOSITORY_URL = "https://github.com/VEAF/VEAF-Mission-Creation-Tools"
 
 #: Field lengths the modal enforces, mirrored here so the handler's bounds hold whatever calls it.
 SUMMARY_MAX_CHARS = 200
@@ -108,105 +105,6 @@ class BugSubmission:
     roles: tuple[str, ...] = ()
 
 
-class BugExchange(Protocol):
-    """What :meth:`BugIntake.handle` needs from Discord, and nothing more."""
-
-    async def defer(self) -> None:
-        """Acknowledge the modal submission, inside Discord's three-second budget."""
-
-    async def post(self, content: str) -> None:
-        """Show the reporter what the service made of his report.
-
-        Args:
-            content: The message content.
-        """
-
-    async def decide(self, content: str, lang: str) -> str:
-        """Show the draft and return what the reporter chose to do with it.
-
-        This is the step that publishes, or does not. It lives on the exchange rather than on the
-        service because the buttons hang off *this* reporter's own message: a consent object built
-        once at start-up would have nowhere to draw them.
-
-        Args:
-            content: The draft, rendered and bounded.
-            lang: ``"fr"`` or ``"en"``, for the button labels.
-
-        Returns:
-            One of :data:`~veaf_support_bot.draft.CHOICES`. Anything that is not
-            :data:`~veaf_support_bot.draft.FILE` leaves the tracker untouched, so a silence, a
-            refusal and a Discord failure are all safe answers.
-        """
-
-    async def confirm(self, content: str, lang: str) -> bool:
-        """Show a prior-art match with its evidence and return whether the reporter recognised it.
-
-        Args:
-            content: The proposal, with the evidence it was computed from.
-            lang: ``"fr"`` or ``"en"``, for the button labels.
-
-        Returns:
-            ``True`` only when he says it is the same subject. Everything else — *mine is
-            different*, a silence, a failure — answers ``False`` and the report carries on, because
-            a machine's unanswered guess must never silence a real bug.
-        """
-
-    async def open_followup_thread(self, name: str) -> ThreadHandle:
-        """Open the public thread the issue's news will come back into.
-
-        The exchange itself is ephemeral: the preparation concerns the reporter and nobody else.
-        What is public is the report, once he has decided to file it — and it needs a room a
-        maintainer's answer can be carried into, because the issue is filed under a machine account
-        the reporter is subscribed to nothing on.
-
-        Args:
-            name: The thread name.
-
-        Returns:
-            Where it was opened. An empty handle means no thread could be opened — a missing
-            permission, a channel that holds none — and the report is filed anyway, saying the
-            thread was not recorded rather than inventing a link.
-        """
-
-    async def post_in_thread(self, handle: ThreadHandle, content: str) -> None:
-        """Post the opening message once the issue exists and can be linked to.
-
-        Args:
-            handle: The thread opened by :meth:`open_followup_thread`.
-            content: What to post.
-        """
-
-
-@dataclass(frozen=True)
-class ThreadHandle:
-    """Where a report's follow-up thread lives, or nothing.
-
-    Attributes:
-        channel_id: The channel it belongs to. Kept alongside the thread id so a restart can reach
-            it without a warm Discord cache.
-        thread_id: The thread.
-        url: Its address, which is what the issue links back to.
-        handle: The library object the thread was opened from, kept so posting into it needs no
-            cache lookup. The bot runs on ``Intents.none()``, so a freshly created thread is
-            routinely absent from the cache: resolving it by id right after creating it is a
-            silent way to lose the message that carries the issue's address.
-    """
-
-    channel_id: int = 0
-    thread_id: int = 0
-    url: str = ""
-    handle: object | None = None
-
-    @property
-    def opened(self) -> bool:
-        """Say whether there is a thread to answer in.
-
-        Returns:
-            ``True`` when one was opened.
-        """
-        return self.thread_id > 0
-
-
 class ReportTracker(Protocol):
     """What the intake needs from :mod:`veaf_support_bot.relay`, and nothing more."""
 
@@ -233,7 +131,7 @@ class _AskTheReporter:
         exchange: Who gets asked.
     """
 
-    def __init__(self, exchange: BugExchange) -> None:
+    def __init__(self, exchange: ThreadExchange) -> None:
         """Initialize the adapter.
 
         Args:
@@ -378,7 +276,7 @@ class BugIntake:
         self._enricher = enricher
         self._tracker = tracker
 
-    async def handle(self, exchange: BugExchange, submission: BugSubmission) -> BugReport | None:
+    async def handle(self, exchange: ThreadExchange, submission: BugSubmission) -> BugReport | None:
         """Run one report end to end.
 
         Args:
@@ -432,7 +330,7 @@ class BugIntake:
         return report
 
     async def _decide(
-        self, exchange: BugExchange, report: BugReport, lang: str, submission: BugSubmission
+        self, exchange: ThreadExchange, report: BugReport, lang: str, submission: BugSubmission
     ) -> tuple[BugReport, str]:
         """Run the prior-art step, then either act on it or file the report.
 
@@ -457,7 +355,7 @@ class BugIntake:
             return report, await self._sink(report)
         return report, await self._file(exchange, report, lang, submission)
 
-    async def _sweep(self, exchange: BugExchange, report: BugReport, lang: str) -> tuple[Sweep | None, bool]:
+    async def _sweep(self, exchange: ThreadExchange, report: BugReport, lang: str) -> tuple[Sweep | None, bool]:
         """Compare the report against everything already recorded.
 
         Args:
@@ -485,7 +383,7 @@ class BugIntake:
         return sweep, accepted
 
     async def _act_on(
-        self, exchange: BugExchange, sweep: Sweep, report: BugReport, lang: str, submission: BugSubmission
+        self, exchange: ThreadExchange, sweep: Sweep, report: BugReport, lang: str, submission: BugSubmission
     ) -> str:
         """Do what an accepted match asks for, which for three of the four verdicts is nothing.
 
@@ -521,7 +419,7 @@ class BugIntake:
         outcome = await self._filer.comment_on(number, report, thread_url=submission.thread_url)
         return proposal + "\n\n" + _render_outcome(outcome, lang, report)
 
-    async def _file(self, exchange: BugExchange, report: BugReport, lang: str, submission: BugSubmission) -> str:
+    async def _file(self, exchange: ThreadExchange, report: BugReport, lang: str, submission: BugSubmission) -> str:
         """Show the issue, wait for the click, and file it — or say why nothing was filed.
 
         The order is ticket 04's whole point: the reporter sees the body that will be published,
@@ -577,7 +475,7 @@ class BugIntake:
             message += await self._add_hypothesis(report, draft.body, outcome.number, lang, submission.roles)
         return message
 
-    async def _open_thread(self, exchange: BugExchange, report: BugReport, lang: str) -> ThreadHandle:
+    async def _open_thread(self, exchange: ThreadExchange, report: BugReport, lang: str) -> ThreadHandle:
         """Open the public thread this report's answers come back into.
 
         Args:
@@ -736,7 +634,7 @@ class BugIntake:
             attachments=tuple(harvest.prepared),
         )
 
-    async def _say(self, exchange: BugExchange, message: str) -> None:
+    async def _say(self, exchange: ThreadExchange, message: str) -> None:
         """Post to the reporter, best effort.
 
         Args:
@@ -901,39 +799,6 @@ def _issue_number(sweep: Sweep) -> int:
         return 0
     reference = sweep.best.candidate.reference
     return int(reference[1:]) if reference.startswith("#") and reference[1:].isdigit() else 0
-
-
-def render_match(sweep: Sweep, lang: str) -> str:
-    """Render a proposed match **with its evidence**, so it can be disagreed with.
-
-    A proposal with no evidence is an assertion, and an assertion is what silences a real bug: the
-    reporter has no way to tell a good match from a bad one, concludes the desk already knows, and
-    goes away. So the shared words, the score and the reference are all printed.
-
-    Args:
-        sweep: The finding.
-        lang: ``"fr"`` or ``"en"``.
-
-    Returns:
-        The message, or an empty string when there is nothing to propose.
-    """
-    if sweep.best is None:
-        return ""
-    match = sweep.best
-    key = {
-        DUPLICATE: "priorart.duplicate",
-        FIXED: "priorart.fixed" if match.candidate.detail else "priorart.fixed_no_version",
-        IN_PROGRESS: "priorart.in_progress",
-    }[sweep.verdict]
-    values = {
-        "reference": match.candidate.reference,
-        "title": one_line(match.candidate.title, 140),
-        "evidence": "-# " + match.evidence(),
-        "url": match.candidate.url,
-    }
-    if key == "priorart.fixed":
-        values["version"] = match.candidate.detail
-    return text(key, lang, **values)
 
 
 def _render_outcome(outcome: Outcome, lang: str, report: BugReport) -> str:

--- a/services/support-bot/veaf_support_bot/priorart.py
+++ b/services/support-bot/veaf_support_bot/priorart.py
@@ -48,6 +48,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
+from veaf_support_bot.texts import text as localized
+from veaf_support_bot.untrusted import one_line
+
 #: No source found anything worth proposing.
 NONE = "none"
 
@@ -521,10 +524,16 @@ class PriorArtSweeper:
         root: The checkout root the two file sources are read from.
         issues: Where the issue halves come from; ``None`` sweeps the checkout only, which is what a
             deployment with no GitHub credentials does.
+        closed_issues: Whether a recently closed issue may be proposed. True for a bug report, where
+            *this was fixed in 6.19, update* is the outcome that unblocks the reporter on the spot.
+            **False for a suggestion**: the same sentence told to somebody asking for a feature that
+            does not exist sends him to install a version that has nothing to do with his idea, and
+            he does not argue with a bot.
     """
 
     root: Path
     issues: IssueSource | None = None
+    closed_issues: bool = True
     _problems: list[str] = field(default_factory=list, init=False, repr=False)
 
     async def sweep(self, query: str) -> Sweep:
@@ -547,10 +556,12 @@ class PriorArtSweeper:
 
         open_records, closed_records, tracker_read = await self._issue_records()
         candidates += [_from_issue(record, SOURCE_OPEN_ISSUE) for record in open_records]
-        candidates += [_from_issue(record, SOURCE_CLOSED_ISSUE, self.root) for record in closed_records]
+        if self.closed_issues:
+            candidates += [_from_issue(record, SOURCE_CLOSED_ISSUE, self.root) for record in closed_records]
         if tracker_read:
             checked.append(f"{len(open_records)} open issue(s)")
-            checked.append(f"{len(closed_records)} recently closed issue(s)")
+            if self.closed_issues:
+                checked.append(f"{len(closed_records)} recently closed issue(s)")
 
         lots, problem, unreadable = read_backlog(self.root)
         self._note(problem, "`.backlog/`")
@@ -684,3 +695,36 @@ class PriorArtGate:
         if not sweep.found or confirmation is None:
             return sweep, False
         return sweep, bool(await confirmation.confirm(sweep, lang))
+
+
+def render_match(sweep: Sweep, lang: str) -> str:
+    """Render a proposed match **with its evidence**, so it can be disagreed with.
+
+    A proposal with no evidence is an assertion, and an assertion is what silences a real bug: the
+    reporter has no way to tell a good match from a bad one, concludes the desk already knows, and
+    goes away. So the shared words, the score and the reference are all printed.
+
+    Args:
+        sweep: The finding.
+        lang: ``"fr"`` or ``"en"``.
+
+    Returns:
+        The message, or an empty string when there is nothing to propose.
+    """
+    if sweep.best is None:
+        return ""
+    match = sweep.best
+    key = {
+        DUPLICATE: "priorart.duplicate",
+        FIXED: "priorart.fixed" if match.candidate.detail else "priorart.fixed_no_version",
+        IN_PROGRESS: "priorart.in_progress",
+    }[sweep.verdict]
+    values = {
+        "reference": match.candidate.reference,
+        "title": one_line(match.candidate.title, 140),
+        "evidence": "-# " + match.evidence(),
+        "url": match.candidate.url,
+    }
+    if key == "priorart.fixed":
+        values["version"] = match.candidate.detail
+    return localized(key, lang, **values)

--- a/services/support-bot/veaf_support_bot/suggestion.py
+++ b/services/support-bot/veaf_support_bot/suggestion.py
@@ -1,0 +1,308 @@
+"""What a submitted idea becomes: a feature request shaped like the repository's own template.
+
+``.github/ISSUE_TEMPLATE/feature_request.yml`` exists — component, problem, solution, alternatives,
+context — and has never been filled in by a human. The machine fills it every time, in the asker's
+language, so a maintainer reads the same shape whether the request came through GitHub or through
+Discord.
+
+## The field that makes a request decidable
+
+The template asks *what problem does this solve?* first, and that is the field people skip: someone
+who wants a feature describes the solution he imagined, not the pain behind it. A solution with no
+problem cannot be weighed against anything, cannot be met a different way, and cannot be declined
+for a reason anyone can state. So the form asks for it, and the issue prints it first.
+
+## What is not here
+
+No design sketch. The session that specified this weighed it and turned it down: a wrong sketch in a
+public issue steers the discussion into a wall, durably, and it is expensive to unwind. The issue
+states the problem, the request, and what was checked before opening it. Where it would fit is the
+work of whoever opens the lot.
+
+Every field is the asker's own text and is quoted as such — see :mod:`veaf_support_bot.untrusted`.
+Nothing in it selects a code path here: the component comes from a Discord choice bound to the list
+below, never from free text.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from veaf_support_bot.existing import ABSENT, EXISTS, DocumentationCheck
+from veaf_support_bot.issue_body import BODY_MAX_CHARS, marker_for
+from veaf_support_bot.priorart import Sweep
+from veaf_support_bot.untrusted import one_line, quote
+
+#: Label the repository's own template puts on a feature request.
+BASE_LABEL = "enhancement"
+
+#: Longest issue title. The bug flow's bound, for the same reason: GitHub allows 256 and nobody
+#: reads that far.
+TITLE_MAX_CHARS = 110
+
+#: Field lengths the modal enforces, mirrored here so the handler's bounds hold whatever calls it.
+SUMMARY_MAX_CHARS = 200
+PARAGRAPH_MAX_CHARS = 1200
+
+#: The component options of ``.github/ISSUE_TEMPLATE/feature_request.yml``, in its order.
+#: ``tests/test_suggestion.py`` asserts they still exist in that file: a renamed option would leave
+#: the bot writing a component nobody can filter on, and nothing else would notice.
+COMPONENTS: tuple[str, ...] = (
+    "Lua runtime scripts (in-mission)",
+    "veaf-tools.exe (Python CLI)",
+    "veaf-build (build pipeline)",
+    "Documentation",
+    "DevContainer / tooling",
+    "Other",
+)
+
+#: The option chosen when none was, which is the template's own catch-all.
+UNKNOWN_COMPONENT = "Other"
+
+#: Section headings, per language. The English ones are the template's field labels, word for word.
+_HEADINGS: dict[str, dict[str, str]] = {
+    "fr": {
+        "component": "Composant",
+        "problem": "Quel problème cela résout-il ?",
+        "solution": "Solution proposée",
+        "alternatives": "Alternatives envisagées",
+        "context": "Contexte supplémentaire",
+        "checked": "Ce qui a été vérifié avant d'ouvrir",
+        "documentation_answered": (
+            "La documentation a été interrogée et a répondu ; la demande a été maintenue malgré cette "
+            "réponse — soit qu'elle ne réglait pas le besoin, soit qu'elle soit restée sans réponse. "
+            "Ce que la documentation a répondu :"
+        ),
+        "documentation_unasked": (
+            "La documentation a été interrogée et a répondu, mais la question n'a **pas** pu lui "
+            "être posée : le temps imparti à l'échange ne le permettait plus. Personne n'a donc dit "
+            "que ce n'était pas ça. Ce que la documentation a répondu :"
+        ),
+        "documentation_silent": (
+            "La documentation a été interrogée : elle ne dit rien à ce sujet. **Si la fonctionnalité "
+            "existe déjà**, c'est une lacune de documentation, pas une demande de fonctionnalité — "
+            "et c'est le correctif le moins cher qui soit."
+        ),
+        "documentation_unknown": "La documentation n'a pas pu être interrogée, donc elle n'a pas été vérifiée.",
+        "pages": "Pages citées :",
+        "filed_by": "Proposé sur Discord par **{asker}** · déposé automatiquement par le bot de support VEAF.",
+        "thread": "Fil d'origine : {url}",
+        "no_thread": "Fil d'origine : (non enregistré)",
+        "verbatim": "_Cité tel quel, ni traduit ni reformulé._",
+        "no_sketch": (
+            "_Aucune ébauche technique : le bot énonce le besoin et ce qui a été vérifié, pas la façon de le réaliser._"
+        ),
+    },
+    "en": {
+        "component": "Component",
+        "problem": "What problem does this solve?",
+        "solution": "Proposed solution",
+        "alternatives": "Alternatives considered",
+        "context": "Additional context",
+        "checked": "What was checked before opening this",
+        "documentation_answered": (
+            "The documentation was asked and it answered; the request was maintained regardless — "
+            "either the answer did not settle the need, or it went unanswered. What the "
+            "documentation answered:"
+        ),
+        "documentation_unasked": (
+            "The documentation was asked and it answered, but the question could **not** be put to "
+            "the person who made the request: the exchange had no time left for it. So nobody said "
+            "this was not it. What the documentation answered:"
+        ),
+        "documentation_silent": (
+            "The documentation was asked: it says nothing about this. **If the feature already "
+            "exists**, this is a documentation gap rather than a feature request — and the cheapest "
+            "fix there is."
+        ),
+        "documentation_unknown": "The documentation could not be asked, so it was not checked.",
+        "pages": "Pages cited:",
+        "filed_by": "Suggested on Discord by **{asker}** · filed automatically by the VEAF support bot.",
+        "thread": "Original thread: {url}",
+        "no_thread": "Original thread: (not recorded)",
+        "verbatim": "_Quoted verbatim, neither translated nor reworded._",
+        "no_sketch": ("_No technical sketch: the bot states the need and what was checked, not how to build it._"),
+    },
+}
+
+
+@dataclass(frozen=True)
+class SuggestionForm:
+    """What the asker typed, plus the component he picked from the command's own list.
+
+    Attributes:
+        summary: One line — becomes the issue title.
+        problem: The pain behind the request. Required, and the reason the exchange exists.
+        solution: What he would like to happen. Required.
+        alternatives: Other approaches he considered.
+        context: Anything else — examples, links, a mission that shows the need.
+        component: One of :data:`COMPONENTS`.
+        asker: How to credit him in the issue, already a display name.
+        asker_id: His Discord id, for the relay and for the idempotency key.
+        language: ``"fr"`` or ``"en"`` — the issue is written in his language.
+    """
+
+    summary: str
+    problem: str
+    solution: str
+    alternatives: str = ""
+    context: str = ""
+    component: str = UNKNOWN_COMPONENT
+    asker: str = ""
+    asker_id: str = ""
+    language: str = "fr"
+
+    def all_text(self) -> str:
+        """Return every free-text field joined.
+
+        Returns:
+            The fields in form order, newline-separated. This is what the documentation is asked
+            about and what the sweep is run against.
+        """
+        return "\n".join((self.summary, self.problem, self.solution, self.alternatives, self.context))
+
+    def missing_fields(self) -> tuple[str, ...]:
+        """Name the required fields left empty.
+
+        Discord enforces its own ``required`` flag, but a modal submitted through the API — or a
+        field holding only spaces — reaches here empty all the same.
+
+        Returns:
+            The field names, in form order.
+        """
+        named = (("summary", self.summary), ("problem", self.problem), ("solution", self.solution))
+        return tuple(name for name, value in named if not value.strip())
+
+
+def heading(key: str, lang: str) -> str:
+    """Return one section heading in the asker's language.
+
+    Args:
+        key: Heading key.
+        lang: ``"fr"`` or ``"en"``.
+
+    Returns:
+        The heading text.
+    """
+    return _HEADINGS.get(lang, _HEADINGS["en"])[key]
+
+
+def language_of(form: SuggestionForm) -> str:
+    """Return the language the issue is written in.
+
+    Args:
+        form: The submitted form.
+
+    Returns:
+        ``"fr"`` or ``"en"`` — an unrecognised locale is written in English rather than refused.
+    """
+    return form.language if form.language in _HEADINGS else "en"
+
+
+def suggestion_key(form: SuggestionForm) -> str:
+    """Derive the stable identity of one suggestion.
+
+    Built from what the asker supplied and nothing else — not from a timestamp, not from a random
+    value — so the same suggestion submitted twice produces the same key and a restart can recompute
+    it. It is what :meth:`~veaf_support_bot.filing.IssueFiler.file_prepared` deduplicates on.
+
+    Args:
+        form: The submitted form.
+
+    Returns:
+        A 32-character hex digest.
+    """
+    material = (form.asker_id, form.summary, form.problem, form.solution, form.alternatives, form.context)
+    return hashlib.sha256("\x1f".join(material).encode("utf-8", errors="replace")).hexdigest()[:32]
+
+
+def build_title(form: SuggestionForm) -> str:
+    """Compose the issue title.
+
+    Args:
+        form: The submitted form.
+
+    Returns:
+        A single bounded line, the asker's own summary.
+    """
+    return one_line(form.summary, TITLE_MAX_CHARS) or "feature request with no summary"
+
+
+def render_checked(check: DocumentationCheck, sweep: Sweep | None, lang: str, *, asked: bool = True) -> str:
+    """Render what was consulted before the issue was opened.
+
+    A reader three months later should not have to redo the search — and the difference between
+    *the documentation is silent* and *the documentation was never reached* has to survive into the
+    tracker, because only the first of the two is a finding.
+
+    Args:
+        check: What the documentation answered.
+        sweep: What the issues, backlog and roadmap sweep found; ``None`` when no sweep ran.
+        lang: ``"fr"`` or ``"en"``.
+        asked: Whether the answer was actually put to the person who made the request. When it was
+            not — the exchange ran out of token — the section says so instead of reporting a
+            disagreement nobody expressed.
+
+    Returns:
+        The section body.
+    """
+    lines: list[str] = []
+    if check.verdict == EXISTS:
+        lines.append(heading("documentation_answered" if asked else "documentation_unasked", lang))
+        lines.append(quote(check.answer))
+        if check.links:
+            lines.append(f"{heading('pages', lang)} " + ", ".join(check.links))
+    elif check.verdict == ABSENT:
+        lines.append(heading("documentation_silent", lang))
+    else:
+        lines.append(heading("documentation_unknown", lang))
+        if check.problem:
+            lines.append(f"- {check.problem}")
+    if sweep is not None:
+        lines.append(sweep.describe())
+        if sweep.best is not None:
+            lines.append(f"- {sweep.best.evidence()}")
+            lines.extend(f"- {other.evidence()}" for other in sweep.alternatives)
+    return "\n\n".join(line for line in lines if line)
+
+
+def render_suggestion_body(
+    form: SuggestionForm,
+    key: str,
+    *,
+    check: DocumentationCheck,
+    sweep: Sweep | None = None,
+    thread_url: str = "",
+    asked: bool = True,
+) -> str:
+    """Render the whole issue body, in the shape of the repository's feature request template.
+
+    Args:
+        form: The submitted form.
+        key: The idempotency key, embedded as the hidden marker the recovery search greps for.
+        check: What the documentation answered about the request.
+        sweep: What the issues, backlog and roadmap sweep found.
+        thread_url: Link back to the Discord thread, when there is one.
+        asked: Whether the documentation's answer was put to the person who made the request.
+
+    Returns:
+        The Markdown body, bounded to what GitHub accepts.
+    """
+    lang = language_of(form)
+    parts: list[str] = [marker_for(key)]
+    parts.append(f"### {heading('component', lang)}\n\n{form.component}")
+    parts.append(f"### {heading('problem', lang)}\n\n{quote(form.problem)}")
+    parts.append(f"### {heading('solution', lang)}\n\n{quote(form.solution)}")
+    if form.alternatives.strip():
+        parts.append(f"### {heading('alternatives', lang)}\n\n{quote(form.alternatives)}")
+    context = [heading("verbatim", lang)]
+    if form.context.strip():
+        context.insert(0, quote(form.context))
+    parts.append(f"### {heading('context', lang)}\n\n" + "\n\n".join(context))
+    parts.append(f"### {heading('checked', lang)}\n\n{render_checked(check, sweep, lang, asked=asked)}")
+    parts.append(heading("no_sketch", lang))
+    parts.append("---")
+    parts.append(heading("filed_by", lang).format(asker=one_line(form.asker or "?", 80)))
+    parts.append(heading("thread", lang).format(url=thread_url) if thread_url else heading("no_thread", lang))
+    return "\n\n".join(parts)[:BODY_MAX_CHARS]

--- a/services/support-bot/veaf_support_bot/texts.py
+++ b/services/support-bot/veaf_support_bot/texts.py
@@ -27,6 +27,11 @@ DEFAULT_LANGUAGE: Final = "fr"
 #: (``mission_builder/v5_converter.py``). English lives under ``/en/``, French at the root.
 DOC_SITE_BASE: Final = "https://veaf.github.io/documentation/dev"
 
+#: The repository itself. Here rather than beside one of its callers: both flows link it — the
+#: bug intake to its issue form, the suggestion flow to the feature request one — and neither of
+#: those two modules can import the other.
+REPOSITORY_URL: Final = "https://github.com/VEAF/VEAF-Mission-Creation-Tools"
+
 _TEXTS: Final[dict[str, dict[str, str]]] = {
     "fr": {
         # --- the exchange -------------------------------------------------------------------


### PR DESCRIPTION
Groundwork for `/suggest` (lot 5 of the support programme). Split out of #924 because the whole lot measures **219 000** diff characters, over the 150 000 above which Sourcery declines to review — `CLAUDE.md` §10 asks for sequenced PRs with the shared groundwork first. #924 is stacked on this branch and carries the flow. **Nothing here has a caller yet**, so nothing changes behaviour.

## 1. Asking the documentation whether an idea already exists

`existing.py`: one exchange with the Worker, the request itself as the retrieval query, and three outcomes that must stay distinguishable — *it exists*, *the documentation is silent*, *the documentation could not be asked*. Only the first two are findings; folding the third into "nothing was found" would tell a reader the documentation was checked when it was not.

**Why it is asked and not searched.** The lot specified text matching over `doc/`, at no model cost. Measured on the real tree, that does not work: the words naming a feature are everywhere, because good documentation cross-references itself.

| word | pages containing it | pages with it in a heading |
|---|---|---|
| `csar` | 24 / 144 (17%) | 6 |
| `combat` | 69 / 144 (48%) | 20 |
| `zone` | 87 / 144 (60%) | 20 |

No threshold separates *the page describing CSAR* from *the twenty-four pages mentioning CSAR*. Three scorings were written, measured and thrown away; the last still matched a request for SMS alerts against the support page at 57%. The duplicate sweep works because two reports of the same bug share identifiers a reporter pasted — a suggestion written in ordinary language has none.

## 2. What a submitted idea becomes

`suggestion.py` renders the repository's own `feature_request.yml`, filled, in the asker's language: component, problem, solution, alternatives, context, plus a section recording what was checked before opening. The problem comes first because it is the field people skip and the one that makes a request decidable. The component list is asserted against the real template, so a renamed option cannot leave the bot writing a component nobody can filter on.

## 3. Two pieces of the bug lot become shareable

Both were written against `BugReport` and could not serve a second issue shape without being copied:

- the **exchange protocol** every flow needs from Discord moves to `exchange.py` as `ThreadExchange` — same six gestures, no flow of its own;
- the **filer** keeps one mechanism and gains `file_prepared`, the door an already-rendered issue comes through: one issue per key however many times it is asked, the recovery search when the ledger lost the answer, failures as outcomes. Preparing a bug report stays lazy, so a report the ledger already knows costs neither the attachment reads nor the redaction pass.

`render_match` moves next to the `Sweep` it renders, and `REPOSITORY_URL` to the leaf module both flows can import.

## Two defects fixed on the way, both in code `/bug` already runs

- a **2xx carrying no issue number** was reported as *created*, handing the reporter `#0` as his issue address, recording a zero in the ledger and leaving the follow-up thread pointing at nothing;
- the sweeper can now leave the **closed issues** out. *This was fixed in 6.19, update* unblocks a bug reporter on the spot; told to somebody asking for a feature that does not exist, it sends him to install a version that has nothing to do with his idea. `/bug` keeps them, `/suggest` does not.

## Checks

- 877 tests green, coverage 95.42% against a 95% gate
- `ruff check`, `ruff format --check`, `mypy` clean over the whole service, tests included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
