### PR TITLE
fix(support-bot): three answers where there were two, and a question /bug can afford

### DIFF
--- a/.backlog/FIX-SUPPORT-BOT-DEBTS/PRD.md
+++ b/.backlog/FIX-SUPPORT-BOT-DEBTS/PRD.md
@@ -1,6 +1,6 @@
 # FIX-SUPPORT-BOT-DEBTS — four things the support bot owes
 
-Status: 🔄 in-progress — tickets 03 and 08 are done; 01, 02, 04, 05, 06 and 07 remain
+Status: 🔄 in-progress — 02, 03, 04 and 08 are done; 01, 05, 06 and 07 remain
 
 Origin: three debts recorded across lots 4 and 5 of the support programme, plus one found by David
 on **2026-09-07, the first time the bot ran in front of a human**. Grouped because none of them is

--- a/.backlog/FIX-SUPPORT-BOT-DEBTS/tickets/02-tri-state-confirm.md
+++ b/.backlog/FIX-SUPPORT-BOT-DEBTS/tickets/02-tri-state-confirm.md
@@ -1,6 +1,6 @@
 # 02 — *He said no* and *he said nothing* are not the same answer
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: fix
 

--- a/.backlog/FIX-SUPPORT-BOT-DEBTS/tickets/04-bug-token-budget.md
+++ b/.backlog/FIX-SUPPORT-BOT-DEBTS/tickets/04-bug-token-budget.md
@@ -1,6 +1,6 @@
 # 04 — `/bug` runs on the same tight token budget `/suggest` was fixed for
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -660,6 +660,19 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the association's decision and it may well answer with two — with every entry validated exactly as
   the single id was.
 
+- **The bot stops recording an opinion nobody expressed, and `/bug` stops asking a question its
+  token cannot outlive.** A prior-art proposal had three possible endings — *yes it is mine*, *no
+  mine is different*, and nobody answering (a silence, or a Discord that never displayed the
+  question) — and the protocol returned a boolean, so the last two arrived as the same `False`. The
+  safe direction was right: only a *yes* ever stopped a report. What was wrong is what the issue
+  then said, which was *the reporter said his is different* under a silence. Three states now travel
+  from the buttons to the issue body, in both languages, and every caller was read rather than
+  adapted — the duplicate comment, which publishes on a public tracker, still requires an explicit
+  yes. Alongside it, `/bug` gained the bound `/suggest` already had: its two waits spend 780 of a
+  token's 900 seconds, before the preparation that precedes them, so when a question would no longer
+  leave room for the consent click it is **skipped** — the sweep still runs and the issue still
+  records what it found. The numbers live in one place both flows read.
+
 ## [6.19.0] — 2026-09-02
 
 ### Fixed

--- a/services/support-bot/tests/test_discord_consent.py
+++ b/services/support-bot/tests/test_discord_consent.py
@@ -29,7 +29,17 @@ from veaf_support_bot.discord_bot import (
     _EscalationView,
     role_ids_of,
 )
-from veaf_support_bot.draft import CANCEL, DRAFT_EXPIRY_SECONDS, EDIT, EXPIRED, FILE, MATCH_EXPIRY_SECONDS
+from veaf_support_bot.draft import (
+    CANCEL,
+    DIFFERENT,
+    DRAFT_EXPIRY_SECONDS,
+    EDIT,
+    EXPIRED,
+    FILE,
+    MATCH_EXPIRY_SECONDS,
+    SAME,
+    UNANSWERED,
+)
 from veaf_support_bot.intake import BugIntake
 from veaf_support_bot.logging_setup import get_logger
 from veaf_support_bot.service import InFlightTasks
@@ -239,20 +249,36 @@ class TestWhatASilenceMeans(unittest.IsolatedAsyncioTestCase):
 
 
 class TestTheProposalIsPutToTheReporter(unittest.IsolatedAsyncioTestCase):
-    async def test_recognising_the_match_answers_yes(self) -> None:
+    """Three things can happen, and the exchange now reports which — ticket 02.
+
+    They lead to the same action for two of them: only a *yes* may stop a report. What changes is
+    what the issue is able to say afterwards, and *he said his is different* was being written under
+    a silence.
+    """
+
+    async def test_recognising_the_match_answers_same(self) -> None:
         interaction = _Interaction(press="Yes, that is it")
 
-        self.assertTrue(await _modal_exchange(interaction).confirm("#712 looks like yours", "en"))
+        self.assertEqual(await _modal_exchange(interaction).confirm("#712 looks like yours", "en"), SAME)
 
-    async def test_saying_it_is_different_answers_no(self) -> None:
+    async def test_saying_it_is_different_answers_different(self) -> None:
         interaction = _Interaction(press="No, mine is different")
 
-        self.assertFalse(await _modal_exchange(interaction).confirm("#712 looks like yours", "en"))
+        self.assertEqual(await _modal_exchange(interaction).confirm("#712 looks like yours", "en"), DIFFERENT)
 
-    async def test_a_discord_failure_answers_no_rather_than_silencing_the_report(self) -> None:
+    async def test_a_discord_failure_answers_unanswered_rather_than_a_refusal(self) -> None:
+        """The question was never shown, so nobody refused anything."""
         interaction = _Interaction(edit_error=discord.HTTPException(cast(Any, _Stub()), "gone"))
 
-        self.assertFalse(await _modal_exchange(interaction).confirm("#712", "en"))
+        self.assertEqual(await _modal_exchange(interaction).confirm("#712", "en"), UNANSWERED)
+
+    def test_a_silence_answers_unanswered(self) -> None:
+        """A silence is not an opinion, and it used to arrive as *he said his is different*.
+
+        Asserted on the view's own default rather than by waiting: the real wait is five minutes,
+        and a test that sleeps through it would be a test nobody runs.
+        """
+        self.assertEqual(_ChoiceView(default=UNANSWERED, timeout=1).choice, UNANSWERED)
 
 
 class TestTheButtonsAreTakenAwayWithTheAnswer(unittest.IsolatedAsyncioTestCase):

--- a/services/support-bot/tests/test_intake.py
+++ b/services/support-bot/tests/test_intake.py
@@ -20,7 +20,7 @@ from tests.test_toolkit import SYNTHETIC_LOG
 from veaf_support_bot.attachments import AttachmentCollector, Incoming, Prepared
 from veaf_support_bot.bugreport import BugForm
 from veaf_support_bot.checkout import Checkout, Freshness
-from veaf_support_bot.draft import CANCEL
+from veaf_support_bot.draft import DIFFERENT, CANCEL
 from veaf_support_bot.intake import (
     PREVIEW_MAX_CHARS,
     BugIntake,
@@ -54,9 +54,9 @@ class RecordingExchange:
         self.calls.append("decide")
         return CANCEL
 
-    async def confirm(self, content: str, lang: str) -> bool:
+    async def confirm(self, content: str, lang: str) -> str:
         self.calls.append("confirm")
-        return False
+        return DIFFERENT
 
     async def open_followup_thread(self, name: str) -> ThreadHandle:
         self.calls.append("open_followup_thread")

--- a/services/support-bot/tests/test_intake_github_wiring.py
+++ b/services/support-bot/tests/test_intake_github_wiring.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import tempfile
 import unittest
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -29,7 +29,17 @@ from tests.test_priorart import RESOLVER_REPORT, _Issues, _resolver_issue
 from veaf_support_bot.attachments import AttachmentCollector
 from veaf_support_bot.bugreport import BugForm
 from veaf_support_bot.config import ConfigurationError, SupportBotConfig
-from veaf_support_bot.draft import CANCEL, EXPIRED, FILE, Draft
+from veaf_support_bot.draft import (
+    CANCEL,
+    DIFFERENT,
+    EXPIRED,
+    FILE,
+    MATCH_EXPIRY_SECONDS,
+    SAME,
+    TOKEN_LIFETIME_SECONDS,
+    UNANSWERED,
+    Draft,
+)
 from veaf_support_bot.filing import Outcome
 from veaf_support_bot.github_app import GitHubError
 from veaf_support_bot.intake import BugIntake, BugSubmission, ThreadHandle, sweep_query
@@ -74,9 +84,9 @@ class _Exchange:
         self.drafts.append(content)
         return self.decision
 
-    async def confirm(self, content: str, lang: str) -> bool:
+    async def confirm(self, content: str, lang: str) -> str:
         self.proposals.append(content)
-        return self.recognises
+        return SAME if self.recognises else DIFFERENT
 
     async def open_followup_thread(self, name: str) -> ThreadHandle:
         self.threads.append(name)
@@ -123,9 +133,9 @@ class _Answer:
         self.answer = answer
         self.asked = 0
 
-    async def confirm(self, sweep: Sweep, lang: str) -> bool:
+    async def confirm(self, sweep: Sweep, lang: str) -> str:
         self.asked += 1
-        return self.answer
+        return SAME if self.answer else DIFFERENT
 
 
 def _intake(**kwargs: Any) -> BugIntake:
@@ -220,6 +230,63 @@ class TestTheSweepRunsBeforeAnythingOpens(unittest.IsolatedAsyncioTestCase):
         report = await _intake(filer=_Filer()).handle(_Exchange(), _submission())
         assert report is not None
         self.assertIsNone(report.prior_art, "an absent sweep must not read as a sweep that found nothing")
+
+
+def _late_clock(elapsed: float) -> Callable[[], float]:
+    """Return a clock that reports *elapsed* seconds between the first call and the next.
+
+    Args:
+        elapsed: How far into the interaction token the exchange should appear to be.
+
+    Returns:
+        The clock.
+    """
+    calls = iter([0.0, elapsed, elapsed, elapsed, elapsed, elapsed])
+    return lambda: next(calls, elapsed)
+
+
+class TestTheTokenOutlivesTheConsent(unittest.IsolatedAsyncioTestCase):
+    """Ticket 04: `/bug` spends 780 of a token's 900 seconds on two waits.
+
+    The failure this prevents is the worst kind the service has. Somebody lets the first question
+    expire, takes his time over the draft, presses *File the issue* — and the token is dead. He has
+    consented to something that will never happen, and he cannot be told, because telling him needs
+    the same token.
+    """
+
+    async def test_a_late_exchange_skips_the_question_and_still_files(self) -> None:
+        filer = _Filer()
+        exchange = _Exchange(decision=FILE)
+        # Far enough in that the two waits plus the closing margin no longer fit.
+        clock = _late_clock(TOKEN_LIFETIME_SECONDS - MATCH_EXPIRY_SECONDS)
+
+        await _intake(prior_art=_gate(opened=[_resolver_issue()]), filer=filer, clock=clock).handle(
+            exchange, _submission()
+        )
+
+        self.assertEqual(exchange.proposals, [], "the check gave way")
+        self.assertEqual(len(filer.filed), 1, "the consent did not")
+
+    async def test_the_finding_is_still_recorded_when_nobody_was_asked(self) -> None:
+        """A skipped question is not a skipped sweep: the issue still says what was found."""
+        filer = _Filer()
+        clock = _late_clock(TOKEN_LIFETIME_SECONDS - MATCH_EXPIRY_SECONDS)
+
+        report = await _intake(prior_art=_gate(opened=[_resolver_issue()]), filer=filer, clock=clock).handle(
+            _Exchange(decision=FILE), _submission()
+        )
+
+        assert report is not None and report.prior_art is not None
+        self.assertTrue(report.prior_art.found)
+        self.assertEqual(report.prior_art_answer, UNANSWERED, "nobody was asked, and the issue says so")
+
+    async def test_an_exchange_that_starts_on_time_still_asks(self) -> None:
+        """The bound must not be a switch that turns the check off for everybody."""
+        exchange = _Exchange(decision=FILE)
+
+        await _intake(prior_art=_gate(opened=[_resolver_issue()]), filer=_Filer()).handle(exchange, _submission())
+
+        self.assertEqual(len(exchange.proposals), 1)
 
 
 class TestWhatAnAcceptedMatchDoes(unittest.IsolatedAsyncioTestCase):
@@ -514,8 +581,8 @@ class TestTheseTestsDetectABrokenWiring(unittest.TestCase):
 
         original = module.BugIntake._sweep
 
-        async def _no_sweep(self, exchange, report, lang):  # type: ignore[no-untyped-def]
-            return None, False
+        async def _no_sweep(self, exchange, report, lang, started=0.0):  # type: ignore[no-untyped-def]
+            return None, UNANSWERED
 
         module.BugIntake._sweep = _no_sweep  # type: ignore[method-assign]
         try:
@@ -546,8 +613,8 @@ class TestTheseTestsDetectABrokenWiring(unittest.TestCase):
 
         original = module.BugIntake._decide
 
-        async def _stop_on_any_match(self, exchange, report, lang, thread_url):  # type: ignore[no-untyped-def]
-            sweep, _ = await self._sweep(exchange, report, lang)
+        async def _stop_on_any_match(self, exchange, report, lang, thread_url, started=0.0):  # type: ignore[no-untyped-def]
+            sweep, _ = await self._sweep(exchange, report, lang, started)
             from dataclasses import replace
 
             report = replace(report, prior_art=sweep)

--- a/services/support-bot/tests/test_issue_body.py
+++ b/services/support-bot/tests/test_issue_body.py
@@ -16,6 +16,7 @@ from typing import Any
 from tests.intake_fixtures import fixture_checkout, fixture_root
 from veaf_support_bot.attachments import Prepared
 from veaf_support_bot.bugreport import BugForm, BugReport, MaterialNote, assemble
+from veaf_support_bot.draft import DIFFERENT, SAME, UNANSWERED
 from veaf_support_bot.issue_body import (
     INLINE_MAX_CHARS,
     Carried,
@@ -212,10 +213,31 @@ class TestThePriorArtSection(unittest.TestCase):
         return Sweep(verdict=DUPLICATE, best=match, checked=("9 open issue(s)",))
 
     def test_a_rejected_match_is_recorded_with_its_evidence(self) -> None:
-        rendered = render_prior_art(self._sweep(), "en")
+        rendered = render_prior_art(self._sweep(), "en", DIFFERENT)
         self.assertIn("#712", rendered)
         self.assertIn("veafsample.resolve", rendered)
-        self.assertIn("rejected by the reporter", rendered)
+        self.assertIn("said his is different", rendered)
+
+    def test_a_silence_is_not_written_up_as_a_refusal(self) -> None:
+        """Ticket 02, where it is finally visible: the issue says which of the three happened."""
+        rendered = render_prior_art(self._sweep(), "en", UNANSWERED)
+
+        self.assertIn("nobody answered", rendered)
+        self.assertNotIn("said his is different", rendered)
+
+    def test_the_three_answers_read_differently(self) -> None:
+        """A distinction nothing can see is a distinction that was not made."""
+        sweep = self._sweep()
+        rendered = {answer: render_prior_art(sweep, "fr", answer) for answer in (SAME, DIFFERENT, UNANSWERED)}
+
+        self.assertEqual(len(set(rendered.values())), 3)
+
+    def test_the_section_is_written_in_the_reporters_language(self) -> None:
+        """It sat in English under French headings, like the manifest of ticket 08."""
+        self.assertNotEqual(
+            render_prior_art(self._sweep(), "fr", DIFFERENT),
+            render_prior_art(self._sweep(), "en", DIFFERENT),
+        )
 
     def test_what_was_checked_is_recorded_even_when_nothing_matched(self) -> None:
         rendered = render_prior_art(Sweep(verdict=NONE, checked=("9 open issue(s)",)), "en")

--- a/services/support-bot/tests/test_priorart.py
+++ b/services/support-bot/tests/test_priorart.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from tests.intake_fixtures import fixture_root
+from veaf_support_bot.draft import DIFFERENT, SAME, UNANSWERED
 from veaf_support_bot.priorart import (
     DUPLICATE,
     FIXED,
@@ -72,11 +73,11 @@ class _BrokenIssues:
 class _Answer:
     """A confirmation that always gives the same answer, and remembers what it was shown."""
 
-    def __init__(self, answer: bool) -> None:
+    def __init__(self, answer: str) -> None:
         self.answer = answer
         self.shown: list[Sweep] = []
 
-    async def confirm(self, sweep: Sweep, lang: str) -> bool:
+    async def confirm(self, sweep: Sweep, lang: str) -> str:
         self.shown.append(sweep)
         return self.answer
 
@@ -331,19 +332,34 @@ class TestTheRefusal(unittest.IsolatedAsyncioTestCase):
 
     async def test_an_accepted_match_is_reported_as_accepted(self) -> None:
         gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])))
-        sweep, accepted = await gate.run(RESOLVER_REPORT, "fr", confirmation=_Answer(True))
-        self.assertTrue(accepted)
+        sweep, answer = await gate.run(RESOLVER_REPORT, "fr", confirmation=_Answer(SAME))
+        self.assertEqual(answer, SAME)
         self.assertEqual(sweep.verdict, DUPLICATE)
 
     async def test_a_rejected_match_leaves_the_flow_running(self) -> None:
-        answer = _Answer(False)
+        confirmation = _Answer(DIFFERENT)
         gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])))
-        sweep, accepted = await gate.run(RESOLVER_REPORT, "fr", confirmation=answer)
-        self.assertFalse(accepted)
+        sweep, answer = await gate.run(RESOLVER_REPORT, "fr", confirmation=confirmation)
+        self.assertEqual(answer, DIFFERENT)
         self.assertTrue(sweep.found, "the finding survives the refusal, so the issue can record it")
 
+    async def test_a_silence_is_not_reported_as_a_refusal(self) -> None:
+        """The whole of ticket 02: three things happen and two of them are not opinions.
+
+        Same action — the report carries on — and a different fact, which is what the issue records.
+        """
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])))
+        _, answer = await gate.run(RESOLVER_REPORT, "fr", confirmation=_Answer(UNANSWERED))
+        self.assertEqual(answer, UNANSWERED)
+
+    async def test_an_answer_outside_the_vocabulary_is_read_as_unanswered(self) -> None:
+        """Fail closed: an answer nobody wrote a case for must never mean agreement."""
+        gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])))
+        _, answer = await gate.run(RESOLVER_REPORT, "fr", confirmation=_Answer("yes please"))
+        self.assertEqual(answer, UNANSWERED)
+
     async def test_the_reporter_is_shown_the_evidence_before_being_asked(self) -> None:
-        answer = _Answer(False)
+        answer = _Answer(DIFFERENT)
         gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])))
         await gate.run(RESOLVER_REPORT, "fr", confirmation=answer)
         self.assertEqual(len(answer.shown), 1)
@@ -352,16 +368,18 @@ class TestTheRefusal(unittest.IsolatedAsyncioTestCase):
 
     async def test_with_nobody_to_ask_the_gate_refuses_rather_than_silencing_the_report(self) -> None:
         gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues(opened=[_resolver_issue()])))
-        sweep, accepted = await gate.run(RESOLVER_REPORT, "fr")
+        sweep, answer = await gate.run(RESOLVER_REPORT, "fr")
         self.assertTrue(sweep.found)
-        self.assertFalse(accepted)
+        self.assertEqual(answer, UNANSWERED, "nobody was asked, which is not the same as a refusal")
 
     async def test_nothing_found_is_never_offered_for_confirmation(self) -> None:
-        answer = _Answer(True)
+        confirmation = _Answer(SAME)
         gate = PriorArtGate(PriorArtSweeper(fixture_root(), _Issues()))
-        _, accepted = await gate.run("the radio menu shows Cyrillic on a Kola map at dusk", "fr", confirmation=answer)
-        self.assertFalse(accepted)
-        self.assertEqual(answer.shown, [])
+        _, answer = await gate.run(
+            "the radio menu shows Cyrillic on a Kola map at dusk", "fr", confirmation=confirmation
+        )
+        self.assertEqual(answer, UNANSWERED)
+        self.assertEqual(confirmation.shown, [])
 
 
 class TestTheseTestsDetectABrokenSweep(unittest.TestCase):

--- a/services/support-bot/tests/test_suggest.py
+++ b/services/support-bot/tests/test_suggest.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from tests.intake_fixtures import fixture_root
 from tests.test_priorart import RESOLVER_REPORT, _Issues, _resolver_issue
-from veaf_support_bot.draft import CANCEL, EXPIRED, FILE
+from veaf_support_bot.draft import CANCEL, DIFFERENT, EXPIRED, FILE, SAME
 from veaf_support_bot.exchange import ThreadHandle
 from veaf_support_bot.existing import ABSENT, EXISTS, UNKNOWN, DocumentationCheck
 from veaf_support_bot.filing import Outcome
@@ -81,10 +81,11 @@ class RecordingExchange:
         self.shown.append(content)
         return self._choice
 
-    async def confirm(self, content: str, lang: str) -> bool:
+    async def confirm(self, content: str, lang: str) -> str:
         self.calls.append("confirm")
         self.shown.append(content)
-        return self._confirms.pop(0) if self._confirms else False
+        answered = self._confirms.pop(0) if self._confirms else False
+        return SAME if answered else DIFFERENT
 
     async def open_followup_thread(self, name: str) -> ThreadHandle:
         self.calls.append("open_followup_thread")

--- a/services/support-bot/veaf_support_bot/bugreport.py
+++ b/services/support-bot/veaf_support_bot/bugreport.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 
 from veaf_support_bot.checkout import Checkout, Freshness
+from veaf_support_bot.draft import UNANSWERED
 from veaf_support_bot.priorart import Sweep
 from veaf_support_bot.toolkit import DoctorFacts, ToolkitUnavailable, parse_doctor_block, redact
 from veaf_support_bot.traces import Location, TraceReading, Unresolved, read_trace
@@ -162,6 +163,11 @@ class BugReport:
         prior_art: What the four-source sweep found, or ``None`` when no sweep ran. It is attached
             to the report rather than acted on here: the sweep informs the decision, the reporter
             takes it.
+        prior_art_answer: What the reporter answered about the proposed match —
+            :data:`~veaf_support_bot.draft.SAME`, :data:`~veaf_support_bot.draft.DIFFERENT` or
+            :data:`~veaf_support_bot.draft.UNANSWERED`. Kept because the three are different facts
+            and the issue says which: *he said his is different* and *nobody answered* used to
+            arrive here as the same ``False``.
     """
 
     form: BugForm
@@ -178,6 +184,7 @@ class BugReport:
     log_digests: tuple[str, ...] = ()
     quoted_files: tuple[str, ...] = ()
     prior_art: Sweep | None = None
+    prior_art_answer: str = UNANSWERED
 
     @property
     def located(self) -> tuple[Location, ...]:

--- a/services/support-bot/veaf_support_bot/discord_bot.py
+++ b/services/support-bot/veaf_support_bot/discord_bot.py
@@ -35,11 +35,14 @@ from veaf_support_bot.bugreport import BugForm
 from veaf_support_bot.config import SupportBotConfig
 from veaf_support_bot.draft import (
     CANCEL,
+    DIFFERENT,
     DRAFT_EXPIRY_SECONDS,
     EDIT,
     EXPIRED,
     FILE,
     MATCH_EXPIRY_SECONDS,
+    SAME,
+    UNANSWERED,
 )
 from veaf_support_bot.followup import strip_mentions
 from veaf_support_bot.health import ServiceState
@@ -96,11 +99,6 @@ QUESTION_MAX_LENGTH = 1000
 #: messages by permission, so this does not merely rely on the bot never being granted *Mention
 #: Everyone*: it removes the question entirely, at the call site, for every message.
 NO_MENTIONS = discord.AllowedMentions.none()
-
-#: The two answers to a prior-art proposal. Local to this module: the protocol they implement
-#: speaks in booleans, so nothing outside needs to name them.
-_SAME = "same"
-_DIFFERENT = "different"
 
 #: How long the escalation button stays on an answer. It sits on a public message that nobody is
 #: waiting on, so it is measured in "while the thread is still being read" rather than in the
@@ -818,7 +816,7 @@ class ModalExchange:
         view.add_item(_ChoiceButton(CANCEL, text("draft.button.cancel", lang), discord.ButtonStyle.secondary))
         return await self._ask(content, view, on_failure=CANCEL, event="bug.draft_failed")
 
-    async def confirm(self, content: str, lang: str) -> bool:
+    async def confirm(self, content: str, lang: str) -> str:
         """Show a prior-art match with its evidence and wait for the reporter's answer.
 
         Args:
@@ -826,15 +824,17 @@ class ModalExchange:
             lang: ``"fr"`` or ``"en"``.
 
         Returns:
-            ``True`` only when he pressed *yes, that is it*. A silence, a refusal and a Discord
-            failure all answer ``False``, and the report carries on being filed: a machine's
-            unanswered guess must never silence a real bug.
+            :data:`~veaf_support_bot.draft.SAME` when he pressed *yes, that is it*;
+            :data:`~veaf_support_bot.draft.DIFFERENT` when he said his is different; and
+            :data:`~veaf_support_bot.draft.UNANSWERED` for a silence **and** for a Discord that
+            refused to display the question. Both of the last two used to be reported as *he said
+            his is different*, which put an opinion in the issue that nobody had expressed. What
+            they share is that only the first may stop a report.
         """
-        view = _ChoiceView(default=_DIFFERENT, timeout=MATCH_EXPIRY_SECONDS)
-        view.add_item(_ChoiceButton(_SAME, text("match.button.same", lang), discord.ButtonStyle.primary))
-        view.add_item(_ChoiceButton(_DIFFERENT, text("match.button.different", lang), discord.ButtonStyle.secondary))
-        answer = await self._ask(content, view, on_failure=_DIFFERENT, event="bug.match_failed")
-        return answer == _SAME
+        view = _ChoiceView(default=UNANSWERED, timeout=MATCH_EXPIRY_SECONDS)
+        view.add_item(_ChoiceButton(SAME, text("match.button.same", lang), discord.ButtonStyle.primary))
+        view.add_item(_ChoiceButton(DIFFERENT, text("match.button.different", lang), discord.ButtonStyle.secondary))
+        return await self._ask(content, view, on_failure=UNANSWERED, event="bug.match_failed")
 
     async def _ask(self, content: str, view: _ChoiceView, *, on_failure: str, event: str) -> str:
         """Put one question on the reporter's message and wait for it to be answered.

--- a/services/support-bot/veaf_support_bot/draft.py
+++ b/services/support-bot/veaf_support_bot/draft.py
@@ -76,6 +76,41 @@ DRAFT_EXPIRY_SECONDS: Final = 480
 #: Longest title shown in the draft header. The issue keeps its own; this is the preview line.
 TITLE_MAX_CHARS: Final = 200
 
+#: How long Discord keeps a deferred interaction token alive. Every wait of a flow — the prior-art
+#: proposal, the documentation check, the draft itself — spends the **same** one.
+TOKEN_LIFETIME_SECONDS: Final = 900
+
+#: Kept aside for the last message: writing the outcome onto the message the buttons hang off. A
+#: budget that fits exactly is a budget that does not, once Discord has a slow second.
+CLOSING_MARGIN_SECONDS: Final = 30
+
+
+def room_for_a_question(spent: float) -> bool:
+    """Say whether one more timed question still leaves room for the consent click.
+
+    The rule both flows run on, in the module that owns the two waits it measures. `/suggest` had
+    it and `/bug` did not, though `/bug` is where the arithmetic is tightest: 300 + 480 of 900
+    seconds on two waits, before counting the preparation that precedes them — downloading an 11 MB
+    log, summarising a mission, walking a checkout for callers.
+
+    The failure it prevents is the worst kind this service has: somebody lets the first question
+    expire, takes his time over the draft, presses **File the issue** — and the token is dead. He
+    has consented to something that will never happen, and he cannot even be told, because telling
+    him needs the same token.
+
+    So the *checks* give way and the consent never does.
+
+    Args:
+        spent: Seconds elapsed since the interaction was acknowledged.
+
+    Returns:
+        Whether asking one more question still leaves the draft its full wait plus the closing
+        margin.
+    """
+    needed = MATCH_EXPIRY_SECONDS + DRAFT_EXPIRY_SECONDS + CLOSING_MARGIN_SECONDS
+    return spent + needed <= TOKEN_LIFETIME_SECONDS
+
+
 #: A line that is nothing but **this service's own** marker comment.
 #:
 #: Narrow on purpose, and the narrowness is the point. Hiding every HTML comment would also hide one

--- a/services/support-bot/veaf_support_bot/draft.py
+++ b/services/support-bot/veaf_support_bot/draft.py
@@ -45,6 +45,23 @@ EXPIRED: Final = "expired"
 #: Every answer :meth:`~veaf_support_bot.exchange.ThreadExchange.decide` may return.
 CHOICES: Final = (FILE, EDIT, CANCEL, EXPIRED)
 
+#: He recognised the proposed match as his own subject.
+SAME: Final = "same"
+
+#: He said his is different. An opinion, and the report carries on.
+DIFFERENT: Final = "different"
+
+#: Nobody answered — a silence, or a Discord that never showed the question.
+#:
+#: Kept apart from :data:`DIFFERENT` because the two are not the same fact and the issue says which.
+#: They lead to the same **action**, deliberately: an unanswered guess must never silence a real
+#: report. What they must never lead to is agreement, which is why the vocabulary is three values
+#: rather than a boolean nobody could widen later.
+UNANSWERED: Final = "unanswered"
+
+#: Every answer :meth:`~veaf_support_bot.exchange.ThreadExchange.confirm` may return.
+ANSWERS: Final = (SAME, DIFFERENT, UNANSWERED)
+
 #: Longest draft message posted back. Discord's own ceiling is 2000 characters; the margin carries
 #: the truncation notice, which must fit *after* the cut has been decided.
 DRAFT_MAX_CHARS: Final = 1900

--- a/services/support-bot/veaf_support_bot/exchange.py
+++ b/services/support-bot/veaf_support_bot/exchange.py
@@ -47,17 +47,18 @@ class ThreadExchange(Protocol):
             refusal and a Discord failure are all safe answers.
         """
 
-    async def confirm(self, content: str, lang: str) -> bool:
-        """Show a prior-art match with its evidence and return whether the person recognised it.
+    async def confirm(self, content: str, lang: str) -> str:
+        """Show a prior-art match with its evidence and return what the person answered.
 
         Args:
             content: The proposal, with the evidence it was computed from.
             lang: ``"fr"`` or ``"en"``, for the button labels.
 
         Returns:
-            ``True`` only when he says it is the same subject. Everything else — *mine is
-            different*, a silence, a failure — answers ``False`` and the report carries on, because
-            a machine's unanswered guess must never silence a real bug.
+            One of :data:`~veaf_support_bot.draft.SAME`, :data:`~veaf_support_bot.draft.DIFFERENT`
+            or :data:`~veaf_support_bot.draft.UNANSWERED`. Only ``SAME`` may stop a report: a
+            silence and a Discord that never showed the question are not opinions, and until this
+            returned three values the issue could not say which of the three had happened.
         """
 
     async def open_followup_thread(self, name: str) -> ThreadHandle:

--- a/services/support-bot/veaf_support_bot/intake.py
+++ b/services/support-bot/veaf_support_bot/intake.py
@@ -53,7 +53,7 @@ from typing import Protocol
 from veaf_support_bot.attachments import AttachmentCollector, Harvest, Incoming
 from veaf_support_bot.bugreport import BugForm, BugReport, MaterialNote, assemble, safe_redact
 from veaf_support_bot.checkout import Checkout
-from veaf_support_bot.draft import CANCEL, EDIT, EXPIRED, FILE, Draft
+from veaf_support_bot.draft import CANCEL, EDIT, EXPIRED, FILE, SAME, UNANSWERED, Draft
 from veaf_support_bot.enrichment import DISABLED, Enricher
 from veaf_support_bot.exchange import ThreadExchange, ThreadHandle
 from veaf_support_bot.filing import Outcome
@@ -139,7 +139,7 @@ class _AskTheReporter:
         """
         self._exchange = exchange
 
-    async def confirm(self, sweep: Sweep, lang: str) -> bool:
+    async def confirm(self, sweep: Sweep, lang: str) -> str:
         """Put the match, with its evidence, to the reporter.
 
         Args:
@@ -147,7 +147,7 @@ class _AskTheReporter:
             lang: ``"fr"`` or ``"en"``.
 
         Returns:
-            Whether he recognised it as the same subject.
+            What he answered: ``SAME``, ``DIFFERENT`` or ``UNANSWERED``.
         """
         return await self._exchange.confirm(render_match(sweep, lang), lang)
 
@@ -347,15 +347,17 @@ class BugIntake:
         Returns:
             A pair of the report, now carrying the finding, and what the reporter is told.
         """
-        sweep, accepted = await self._sweep(exchange, report, lang)
-        report = replace(report, prior_art=sweep)
-        if accepted and sweep is not None:
+        sweep, answer = await self._sweep(exchange, report, lang)
+        report = replace(report, prior_art=sweep, prior_art_answer=answer)
+        # Only an explicit *yes* may stop a report. A silence and a Discord that never showed the
+        # question are not opinions, and this branch is the one that comments on a public tracker.
+        if answer == SAME and sweep is not None:
             return report, await self._act_on(exchange, sweep, report, lang, submission)
         if self._sink is not None:
             return report, await self._sink(report)
         return report, await self._file(exchange, report, lang, submission)
 
-    async def _sweep(self, exchange: ThreadExchange, report: BugReport, lang: str) -> tuple[Sweep | None, bool]:
+    async def _sweep(self, exchange: ThreadExchange, report: BugReport, lang: str) -> tuple[Sweep | None, str]:
         """Compare the report against everything already recorded.
 
         Args:
@@ -363,24 +365,25 @@ class BugIntake:
             lang: ``"fr"`` or ``"en"``.
 
         Returns:
-            A pair of the finding — ``None`` when no sweep is configured — and whether the reporter
-            accepted the proposed match.
+            A pair of the finding — ``None`` when no sweep is configured — and what the reporter
+            answered about the proposed match.
         """
         if self._prior_art is None:
-            return None, False
-        sweep, accepted = await self._prior_art.run(sweep_query(report), lang, confirmation=_AskTheReporter(exchange))
+            return None, UNANSWERED
+        answer: str
+        sweep, answer = await self._prior_art.run(sweep_query(report), lang, confirmation=_AskTheReporter(exchange))
         self._logger.info(
             "prior art swept",
             extra={
                 "event": "intake.prior_art",
                 "verdict": sweep.verdict,
-                "accepted": accepted,
+                "answer": answer,
                 "reference": sweep.best.candidate.reference if sweep.best else "",
                 "score": sweep.best.score if sweep.best else 0.0,
                 "problems": list(sweep.problems),
             },
         )
-        return sweep, accepted
+        return sweep, answer
 
     async def _act_on(
         self, exchange: ThreadExchange, sweep: Sweep, report: BugReport, lang: str, submission: BugSubmission

--- a/services/support-bot/veaf_support_bot/intake.py
+++ b/services/support-bot/veaf_support_bot/intake.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from logging import Logger
@@ -53,7 +54,7 @@ from typing import Protocol
 from veaf_support_bot.attachments import AttachmentCollector, Harvest, Incoming
 from veaf_support_bot.bugreport import BugForm, BugReport, MaterialNote, assemble, safe_redact
 from veaf_support_bot.checkout import Checkout
-from veaf_support_bot.draft import CANCEL, EDIT, EXPIRED, FILE, SAME, UNANSWERED, Draft
+from veaf_support_bot.draft import CANCEL, EDIT, EXPIRED, FILE, SAME, UNANSWERED, Draft, room_for_a_question
 from veaf_support_bot.enrichment import DISABLED, Enricher
 from veaf_support_bot.exchange import ThreadExchange, ThreadHandle
 from veaf_support_bot.filing import Outcome
@@ -244,6 +245,7 @@ class BugIntake:
         filer: ReportFiler | None = None,
         enricher: Enricher | None = None,
         tracker: ReportTracker | None = None,
+        clock: Callable[[], float] | None = None,
     ) -> None:
         """Initialize the intake.
 
@@ -265,6 +267,8 @@ class BugIntake:
                 looks like — not a degraded one.
             tracker: What remembers which thread an issue must answer in. ``None`` files the report
                 and opens the thread all the same; what is lost is the follow-up, not the report.
+            clock: Source of monotonic timestamps, so a test can place an exchange near the end of
+                its interaction token without waiting a quarter of an hour for one.
         """
         self._checkout = checkout
         self._collector = collector
@@ -275,6 +279,7 @@ class BugIntake:
         self._filer = filer
         self._enricher = enricher
         self._tracker = tracker
+        self._clock: Callable[[], float] = clock or time.monotonic
 
     async def handle(self, exchange: ThreadExchange, submission: BugSubmission) -> BugReport | None:
         """Run one report end to end.
@@ -288,6 +293,7 @@ class BugIntake:
             in which case the reporter has been told so rather than left on a placeholder.
         """
         lang = normalize_language(submission.form.language)
+        started = self._clock()
         await exchange.defer()
         # The downloaded files live until the sink has had them. Ticket 05 uploads them to the
         # issue, and a cleanup inside `build` would hand it paths that no longer exist — the exact
@@ -308,7 +314,7 @@ class BugIntake:
                 await self._say(exchange, text("bug.error.unexpected", lang))
                 return None
 
-            report, message = await self._decide(exchange, report, lang, submission)
+            report, message = await self._decide(exchange, report, lang, submission, started)
             await self._say(exchange, message)
         finally:
             rmtree(workdir, ignore_errors=True)
@@ -330,7 +336,7 @@ class BugIntake:
         return report
 
     async def _decide(
-        self, exchange: ThreadExchange, report: BugReport, lang: str, submission: BugSubmission
+        self, exchange: ThreadExchange, report: BugReport, lang: str, submission: BugSubmission, started: float
     ) -> tuple[BugReport, str]:
         """Run the prior-art step, then either act on it or file the report.
 
@@ -343,11 +349,13 @@ class BugIntake:
             lang: ``"fr"`` or ``"en"``.
             submission: The form, its attachments, the thread it came from and the reporter's
                 roles — everything the steps below need that the report itself does not carry.
+            started: When the interaction was acknowledged, which is what bounds the questions
+                asked before the consent click.
 
         Returns:
             A pair of the report, now carrying the finding, and what the reporter is told.
         """
-        sweep, answer = await self._sweep(exchange, report, lang)
+        sweep, answer = await self._sweep(exchange, report, lang, started)
         report = replace(report, prior_art=sweep, prior_art_answer=answer)
         # Only an explicit *yes* may stop a report. A silence and a Discord that never showed the
         # question are not opinions, and this branch is the one that comments on a public tracker.
@@ -357,7 +365,9 @@ class BugIntake:
             return report, await self._sink(report)
         return report, await self._file(exchange, report, lang, submission)
 
-    async def _sweep(self, exchange: ThreadExchange, report: BugReport, lang: str) -> tuple[Sweep | None, str]:
+    async def _sweep(
+        self, exchange: ThreadExchange, report: BugReport, lang: str, started: float
+    ) -> tuple[Sweep | None, str]:
         """Compare the report against everything already recorded.
 
         Args:
@@ -370,8 +380,27 @@ class BugIntake:
         """
         if self._prior_art is None:
             return None, UNANSWERED
+        # The preparation that precedes this can be slow — an 11 MB log downloaded, a mission
+        # summarised, a checkout walked for callers — and the two waits that follow spend 780 of
+        # the token's 900 seconds. When they no longer fit, the *check* is skipped rather than the
+        # consent: a reporter who presses `File the issue` on a dead token has agreed to something
+        # that will never happen, and telling him needs the token that just died.
+        #
+        # The sweep still runs, and the issue still records it: what is dropped is the question,
+        # not the finding.
+        spent = self._clock() - started
+        may_ask = room_for_a_question(spent)
+        if not may_ask:
+            self._logger.info(
+                "the prior-art match was not put to the reporter: the token would not outlive it",
+                extra={"event": "intake.check_skipped", "spent": round(spent)},
+            )
         answer: str
-        sweep, answer = await self._prior_art.run(sweep_query(report), lang, confirmation=_AskTheReporter(exchange))
+        sweep, answer = await self._prior_art.run(
+            sweep_query(report),
+            lang,
+            confirmation=_AskTheReporter(exchange) if may_ask else None,
+        )
         self._logger.info(
             "prior art swept",
             extra={

--- a/services/support-bot/veaf_support_bot/issue_body.py
+++ b/services/support-bot/veaf_support_bot/issue_body.py
@@ -43,6 +43,7 @@ from pathlib import Path
 
 from veaf_support_bot.attachments import Prepared
 from veaf_support_bot.bugreport import NOT_STATED, BugReport
+from veaf_support_bot.draft import DIFFERENT, SAME, UNANSWERED
 from veaf_support_bot.logging_setup import get_logger
 from veaf_support_bot.priorart import DUPLICATE, FIXED, IN_PROGRESS, Sweep
 from veaf_support_bot.texts import DEFAULT_LANGUAGE, text
@@ -305,8 +306,25 @@ def carry(
     return Carried(prepared, text=redacted, digest=digest)
 
 
-def render_prior_art(sweep: Sweep, lang: str) -> str:
-    """Render what the sweep checked and what it proposed.
+#: What was proposed, per verdict — the noun the sentence below is built on.
+_PROPOSED: dict[str, str] = {
+    DUPLICATE: "priorart.proposed.duplicate",
+    FIXED: "priorart.proposed.fixed",
+    IN_PROGRESS: "priorart.proposed.in_progress",
+}
+
+#: What became of the proposal. Three keys, because three things can happen and a reader deciding
+#: what to do with this issue needs to know which: a refusal is an opinion he can weigh, a silence
+#: is not — and until the exchange returned three values, the issue could not tell them apart.
+_ANSWERED: dict[str, str] = {
+    DIFFERENT: "priorart.answer.different",
+    UNANSWERED: "priorart.answer.unanswered",
+    SAME: "priorart.answer.same",
+}
+
+
+def render_prior_art(sweep: Sweep, lang: str, answer: str = UNANSWERED) -> str:
+    """Render what the sweep checked, what it proposed, and what the reporter answered.
 
     Recorded even when nothing matched: a reader who cannot see that the sweep ran has to run it
     again himself.
@@ -314,23 +332,23 @@ def render_prior_art(sweep: Sweep, lang: str) -> str:
     Args:
         sweep: The finding.
         lang: ``"fr"`` or ``"en"``.
+        answer: What the reporter said about the proposal — ``SAME``, ``DIFFERENT`` or
+            ``UNANSWERED``. The last one covers both a silence and a Discord that never displayed
+            the question; neither is an opinion, and the sentence says so rather than claiming he
+            disagreed.
 
     Returns:
         The section body.
     """
     lines = [sweep.describe()]
     if sweep.best is not None:
-        outcome = {
-            DUPLICATE: "a similar open issue was proposed and the reporter said his is different",
-            FIXED: "a closed issue was proposed and the reporter said his is different",
-            IN_PROGRESS: "existing work was proposed and the reporter said his is different",
-        }[sweep.verdict]
-        lines.append(f"Closest match, **rejected by the reporter** ({outcome}):")
+        proposed = text(_PROPOSED[sweep.verdict], lang)
+        became = text(_ANSWERED.get(answer, "priorart.answer.unanswered"), lang)
+        lines.append(text("priorart.closest", lang, proposed=proposed, answer=became))
         lines.append(f"- {sweep.best.evidence()}")
         for other in sweep.alternatives:
-            lines.append(f"- also considered: {other.evidence()}")
-    if lang == "fr":
-        lines.append("_Balayage déterministe : appariement de mots, aucun modèle._")
+            lines.append(f"- {text('priorart.also_considered', lang)} {other.evidence()}")
+    lines.append(text("priorart.deterministic", lang))
     return "\n".join(lines)
 
 
@@ -382,7 +400,9 @@ def render_body(report: BugReport, key: str, *, thread_url: str = "", carried: I
     if files:
         parts.append(f"### {heading('files', lang)}\n\n{files}")
     if report.prior_art is not None:
-        parts.append(f"### {heading('priorart', lang)}\n\n{render_prior_art(report.prior_art, lang)}")
+        parts.append(
+            f"### {heading('priorart', lang)}\n\n{render_prior_art(report.prior_art, lang, report.prior_art_answer)}"
+        )
     if report.notes:
         listed = "\n".join(f"- **{note.subject}** — {note.reason}" for note in report.notes)
         parts.append(f"### {heading('missing', lang)}\n\n{listed}")

--- a/services/support-bot/veaf_support_bot/priorart.py
+++ b/services/support-bot/veaf_support_bot/priorart.py
@@ -48,6 +48,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
+from veaf_support_bot.draft import ANSWERS, UNANSWERED
 from veaf_support_bot.texts import text as localized
 from veaf_support_bot.untrusted import one_line
 
@@ -650,7 +651,7 @@ def _from_issue(record: IssueRecord, source: str, root: Path | None = None) -> C
 class MatchConfirmation(Protocol):
     """Asks the reporter whether a proposed match really is his bug."""
 
-    async def confirm(self, sweep: Sweep, lang: str) -> bool:
+    async def confirm(self, sweep: Sweep, lang: str) -> str:
         """Show the match with its evidence and return the reporter's answer.
 
         Args:
@@ -658,8 +659,8 @@ class MatchConfirmation(Protocol):
             lang: ``"fr"`` or ``"en"``.
 
         Returns:
-            ``True`` when the reporter agrees it is the same subject — nothing is opened. ``False``
-            when he says his is different, and the report goes on being filed.
+            :data:`~veaf_support_bot.draft.SAME`, :data:`~veaf_support_bot.draft.DIFFERENT` or
+            :data:`~veaf_support_bot.draft.UNANSWERED`.
         """
 
 
@@ -673,7 +674,7 @@ class PriorArtGate:
 
     sweeper: PriorArtSweeper
 
-    async def run(self, query: str, lang: str, *, confirmation: MatchConfirmation | None = None) -> tuple[Sweep, bool]:
+    async def run(self, query: str, lang: str, *, confirmation: MatchConfirmation | None = None) -> tuple[Sweep, str]:
         """Sweep, and find out whether the match is accepted.
 
         Args:
@@ -688,13 +689,18 @@ class PriorArtGate:
                 its evidence.
 
         Returns:
-            A pair of the finding and whether it was **accepted** — ``True`` stops the flow, and the
-            caller acts on :attr:`Sweep.verdict` instead of filing.
+            A pair of the finding and what the reporter answered. Only
+            :data:`~veaf_support_bot.draft.SAME` stops the flow; a sweep that found nothing, and one
+            nobody could be asked about, both answer :data:`~veaf_support_bot.draft.UNANSWERED` —
+            which is what they are, and is not the same fact as a refusal.
         """
         sweep = await self.sweeper.sweep(query)
         if not sweep.found or confirmation is None:
-            return sweep, False
-        return sweep, bool(await confirmation.confirm(sweep, lang))
+            return sweep, UNANSWERED
+        answered = await confirmation.confirm(sweep, lang)
+        # An answer outside the vocabulary is read as *nobody answered*, never as agreement: the
+        # safe direction is the one that leaves the tracker untouched.
+        return sweep, answered if answered in ANSWERS else UNANSWERED
 
 
 def render_match(sweep: Sweep, lang: str, *, family: str = "priorart") -> str:

--- a/services/support-bot/veaf_support_bot/suggest.py
+++ b/services/support-bot/veaf_support_bot/suggest.py
@@ -52,6 +52,8 @@ from veaf_support_bot.draft import (
     EXPIRED,
     FILE,
     MATCH_EXPIRY_SECONDS,
+    SAME,
+    UNANSWERED,
     Draft,
 )
 from veaf_support_bot.exchange import ThreadExchange, ThreadHandle
@@ -176,7 +178,7 @@ class _AskTheAsker:
         """
         self._exchange = exchange
 
-    async def confirm(self, sweep: Sweep, lang: str) -> bool:
+    async def confirm(self, sweep: Sweep, lang: str) -> str:
         """Put the match, with its evidence, to the asker.
 
         Args:
@@ -184,7 +186,7 @@ class _AskTheAsker:
             lang: ``"fr"`` or ``"en"``.
 
         Returns:
-            Whether he recognised it as the same subject.
+            What he answered: ``SAME``, ``DIFFERENT`` or ``UNANSWERED``.
         """
         return await self._exchange.confirm(render_match(sweep, lang, family=PRIOR_ART_FAMILY), lang)
 
@@ -295,7 +297,9 @@ class SuggestIntake:
 
         check = await self._ask_documentation(form, lang)
         asked = check.found and self._may_ask(started, "documentation")
-        if asked and await exchange.confirm(render_documentation(check, lang), lang):
+        # `== SAME`, not truthiness: every non-empty string was true, so a future value — or a
+        # stand-in returning something else — would have settled the request without a yes.
+        if asked and await exchange.confirm(render_documentation(check, lang), lang) == SAME:
             self._logger.info(
                 "the documentation already answered the request",
                 extra={"event": "suggest.settled", "user": form.asker_id, "by": "documentation"},
@@ -303,8 +307,11 @@ class SuggestIntake:
             await self._say(exchange, text("suggest.settled.documentation", lang))
             return None
 
-        sweep, accepted = await self._sweep(exchange, form, lang, started)
-        if accepted and sweep is not None:
+        sweep, answer = await self._sweep(exchange, form, lang, started)
+        # Only an explicit *yes* settles a request. A silence means the asker never saw the
+        # proposal or never answered it, and dropping his request on that would be the machine
+        # deciding his idea already exists.
+        if answer == SAME and sweep is not None:
             self._logger.info(
                 "existing work already covers the request",
                 extra={"event": "suggest.settled", "user": form.asker_id, "by": sweep.verdict},
@@ -373,7 +380,7 @@ class SuggestIntake:
 
     async def _sweep(
         self, exchange: ThreadExchange, form: SuggestionForm, lang: str, started: float
-    ) -> tuple[Sweep | None, bool]:
+    ) -> tuple[Sweep | None, str]:
         """Compare the request against what is already reported, scheduled or declined.
 
         Args:
@@ -386,23 +393,26 @@ class SuggestIntake:
 
         Returns:
             A pair of the finding — ``None`` when no sweep is configured — and whether the asker
-            accepted the proposed match.
+            answered about the proposed match. A sweep nobody could be asked about — no gate,
+            or no room left in the token for one more question — answers ``UNANSWERED``,
+            which is what it is: not a refusal, and never an agreement.
         """
         if self._prior_art is None:
-            return None, False
+            return None, UNANSWERED
         confirmation = _AskTheAsker(exchange) if self._may_ask(started, "prior art") else None
-        sweep, accepted = await self._prior_art.run(form.all_text(), lang, confirmation=confirmation)
+        answer: str
+        sweep, answer = await self._prior_art.run(form.all_text(), lang, confirmation=confirmation)
         self._logger.info(
             "prior art swept",
             extra={
                 "event": "suggest.prior_art",
                 "verdict": sweep.verdict,
-                "accepted": accepted,
+                "answer": answer,
                 "reference": sweep.best.candidate.reference if sweep.best else "",
                 "problems": list(sweep.problems),
             },
         )
-        return sweep, accepted
+        return sweep, answer
 
     async def _file(
         self,

--- a/services/support-bot/veaf_support_bot/suggest.py
+++ b/services/support-bot/veaf_support_bot/suggest.py
@@ -47,14 +47,13 @@ from typing import Protocol
 
 from veaf_support_bot.draft import (
     CANCEL,
-    DRAFT_EXPIRY_SECONDS,
     EDIT,
     EXPIRED,
     FILE,
-    MATCH_EXPIRY_SECONDS,
     SAME,
     UNANSWERED,
     Draft,
+    room_for_a_question,
 )
 from veaf_support_bot.exchange import ThreadExchange, ThreadHandle
 from veaf_support_bot.existing import DocumentationCheck, DocumentationSource
@@ -343,8 +342,7 @@ class SuggestIntake:
             still recorded in the issue, it is simply not put to the asker.
         """
         spent = self._clock() - started
-        needed = MATCH_EXPIRY_SECONDS + DRAFT_EXPIRY_SECONDS + CLOSING_MARGIN_SECONDS
-        if spent + needed <= TOKEN_LIFETIME_SECONDS:
+        if room_for_a_question(spent):
             return True
         self._logger.info(
             "a check was not put to the asker: the interaction token would not outlive it",

--- a/services/support-bot/veaf_support_bot/texts.py
+++ b/services/support-bot/veaf_support_bot/texts.py
@@ -135,6 +135,19 @@ _TEXTS: Final[dict[str, dict[str, str]]] = {
         "attachment.download_failed": "n'a pas pu être téléchargé ({error})",
         "attachment.not_summarised": "joint, mais non résumé : {error}",
         "attachment.file_unreadable": "joint, mais illisible : {error}",
+        # --- l'antériorité telle qu'elle est consignée dans le ticket ------------------------
+        # Trois réponses possibles et non deux : « il a dit que ce n'est pas pareil » est un avis
+        # qu'un lecteur peut peser, « personne n'a répondu » n'en est pas un. Le protocole ne
+        # renvoyait qu'un booléen, et les deux arrivaient ici comme la même chose.
+        "priorart.proposed.duplicate": "un ticket ouvert proche a été proposé",
+        "priorart.proposed.fixed": "un ticket déjà fermé a été proposé",
+        "priorart.proposed.in_progress": "un chantier en cours a été proposé",
+        "priorart.answer.same": "et le rapporteur l'a reconnu comme le sien",
+        "priorart.answer.different": "et le rapporteur a dit que le sien est différent",
+        "priorart.answer.unanswered": "et personne n'a répondu — ni accord, ni refus",
+        "priorart.closest": "Correspondance la plus proche : {proposed}, {answer}.",
+        "priorart.also_considered": "également envisagé :",
+        "priorart.deterministic": "_Balayage déterministe : appariement de mots, aucun modèle._",
         # --- /bug, the deterministic intake --------------------------------------------------
         "bug.received": "📥 Rapport reçu : **{title}**",
         "bug.facts": ("-# Version déclarée : {version} · Composant : {component}\n-# Dépôt consulté : {revision}"),
@@ -411,6 +424,16 @@ _TEXTS: Final[dict[str, dict[str, str]]] = {
         "attachment.download_failed": "could not be downloaded ({error})",
         "attachment.not_summarised": "attached, but not summarised: {error}",
         "attachment.file_unreadable": "attached, but unreadable: {error}",
+        # --- prior art, as the issue records it ----------------------------------------------
+        "priorart.proposed.duplicate": "a similar open issue was proposed",
+        "priorart.proposed.fixed": "a closed issue was proposed",
+        "priorart.proposed.in_progress": "existing work was proposed",
+        "priorart.answer.same": "and the reporter recognised it as his own",
+        "priorart.answer.different": "and the reporter said his is different",
+        "priorart.answer.unanswered": "and nobody answered — neither agreement nor refusal",
+        "priorart.closest": "Closest match: {proposed}, {answer}.",
+        "priorart.also_considered": "also considered:",
+        "priorart.deterministic": "_Deterministic sweep: word matching, no model._",
         # --- /bug, the deterministic intake --------------------------------------------------
         "bug.received": "📥 Report received: **{title}**",
         "bug.facts": ("-# Claimed version: {version} · Component: {component}\n-# Repository consulted: {revision}"),


### PR DESCRIPTION
## Tickets 02 and 04 — the protocol both flows sit on

Second of the three PRs the lot ships as. This is the one the PRD called *the one to be careful with*.

## *He said no* and *he said nothing* were the same answer

A prior-art proposal has three endings, and `confirm` returned a **boolean**:

| What happened | What the code knew |
|---|---|
| *Yes, that is it* | `True` |
| *No, mine is different* | `False` |
| Nobody answered, or Discord never displayed the question | `False` |

The safe direction was already right — only a *yes* ever stopped a report. What was wrong is what the issue **recorded**: *the reporter said his is different*, written under a silence nobody had broken.

Three states now travel from the buttons to the issue body, in both languages, and a reader can tell a refusal (an opinion he can weigh) from a silence (which is not one).

**Every caller was read**, which is exactly why this was kept out of lot 5:

- `/bug`'s duplicate comment publishes on a public tracker — it still requires an explicit yes;
- `/suggest`'s documentation check compared by truthiness, where *every* non-empty string was true; it now compares with `== SAME`;
- the gate answers `UNANSWERED` when there is nobody to ask, and reads an answer outside the vocabulary as `UNANSWERED` rather than as agreement.

The prior-art section of the issue was also English under French headings, like the manifest of the previous PR; it now comes from the catalogue.

## `/bug` ran on a budget it could not afford

Its two waits spend **780 of a token's 900 seconds**, before the preparation that precedes them — an 11 MB log downloaded, a mission summarised, a checkout walked for callers. The failure that produces is the worst kind this service has: somebody lets the first question expire, takes his time over the draft, presses **File the issue** — and the token is dead. He has consented to something that will never happen, and he cannot be told, because telling him needs the token that just died.

So `/bug` gained the bound `/suggest` already had: when a question would no longer leave room for the consent click, **the question gives way**. The sweep still runs, and the issue still records what it found and that nobody was asked. The numbers now live in `draft.py`, which owns the two waits they measure, and both flows read them rather than each keeping a copy.

## Verification

1004 tests green, mypy clean, ruff clean, coverage 95.25 % (gate 95). One test per state per flow, as the ticket asks — plus the two that matter most: an answer outside the vocabulary is not agreement, and a late exchange skips the check while still filing.

One test of mine was replaced before it ever ran in CI: it waited on the real five-minute timeout to observe a silence. The view's own default carries the same fact and does not sleep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make support-bot prior-art decisions three-state and ensure `/bug` preserves filing consent when interaction time is nearly exhausted.

Bug Fixes:
- Distinguish explicit prior-art rejection from unanswered or unavailable confirmation, preserving all three outcomes through issue reporting in English and French.
- Prevent `/bug` from asking a confirmation question when the interaction token cannot outlive the remaining waits, while still recording the sweep and filing the report safely.
- Treat unknown confirmation values and non-explicit answers as non-agreement, and require an explicit match response before suppressing bug or suggestion reports.

Enhancements:
- Centralize interaction token budgeting for `/bug` and `/suggest`.

Documentation:
- Update the changelog and backlog statuses for the completed support-bot fixes.

Tests:
- Add coverage for all prior-art answer states, fail-closed handling of unknown answers, localized issue rendering, and late-token filing behavior.