### PR TITLE
feat(support-bot): a duplicate recognised by meaning, a claim that needs a page, and the second voice

### DIFF
--- a/.backlog/FIX-SUPPORT-BOT-DEBTS/PRD.md
+++ b/.backlog/FIX-SUPPORT-BOT-DEBTS/PRD.md
@@ -1,6 +1,6 @@
 # FIX-SUPPORT-BOT-DEBTS — four things the support bot owes
 
-Status: 🔄 in-progress — 02, 03, 04 and 08 are done; 01, 05, 06 and 07 remain
+Status: 🔄 in-progress — seven of eight are done; only 01 (the modal and command translation) remains
 
 Origin: three debts recorded across lots 4 and 5 of the support programme, plus one found by David
 on **2026-09-07, the first time the bot ran in front of a human**. Grouped because none of them is

--- a/.backlog/FIX-SUPPORT-BOT-DEBTS/tickets/05-duplicate-by-meaning.md
+++ b/.backlog/FIX-SUPPORT-BOT-DEBTS/tickets/05-duplicate-by-meaning.md
@@ -1,6 +1,6 @@
 # 05 — A request already made in other words
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: feat
 

--- a/.backlog/FIX-SUPPORT-BOT-DEBTS/tickets/06-exists-needs-a-source.md
+++ b/.backlog/FIX-SUPPORT-BOT-DEBTS/tickets/06-exists-needs-a-source.md
@@ -1,6 +1,6 @@
 # 06 — *It already exists* needs a page to point at
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: fix
 

--- a/.backlog/FIX-SUPPORT-BOT-DEBTS/tickets/07-observation-on-the-existing-issue.md
+++ b/.backlog/FIX-SUPPORT-BOT-DEBTS/tickets/07-observation-on-the-existing-issue.md
@@ -1,6 +1,6 @@
 # 07 — Do what the message promised: record the second voice
 
-Status: ⬜ ready
+Status: ✅ done
 
 Type: feat
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,6 +673,23 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   leave room for the consent click it is **skipped** — the sweep still runs and the issue still
   records what it found. The numbers live in one place both flows read.
 
+- **`/suggest` recognises a request already made in other words, needs a page before saying
+  something exists, and records the second voice on it.** Three things the first real run showed.
+  A duplicate was found by comparing words, and no two humans write the same request the same way —
+  the tracker holds `#240 -cap un peu plus selectif`, `#187 Modifications du watchdog de CAP` and
+  `#178 Gérer la destruction du -cap`, one subject in three vocabularies. The open issues' titles now
+  travel **inside the call the flow already makes**, so one request answers both questions at no
+  extra spend, and what the model recognises is proposed with the issue it names and refused with a
+  click, like every other match. Second: the bot announced *"la documentation semble déjà répondre à
+  ta demande"* over an answer that said the opposite — the model had answered in prose where a
+  keyword was asked for. Saying *it already exists* now requires **at least one cited page**, which
+  does not depend on guessing what a sentence means and matches the rule the service already runs
+  on: a link the asker can open is what lets him contradict the machine. Third, and the one that was
+  a promise the flow did not keep: an accepted duplicate now offers to **add the asker's observation
+  to the existing issue**, drafted, shown, and posted only on a second click. A suggestion is wanted
+  or not, and a second person asking for the same thing is the only signal of priority it will ever
+  carry.
+
 ## [6.19.0] — 2026-09-02
 
 ### Fixed

--- a/doc/SUPPORT.en.md
+++ b/doc/SUPPORT.en.md
@@ -155,14 +155,30 @@ issue that will wait for months.
 So the bot checks, in this order:
 
 1. **the documentation** — it puts your request to the assistant, which answers with the matching
-   pages. If that answers your need, you say so and **nothing is opened**;
-2. **the open issues** — somebody may have asked already;
+   pages. If that answers your need, you say so and **nothing is opened**. It only says *this
+   already exists* when it can show you **at least one page**: a claim with no page to open is not
+   an answer;
+2. **the open issues, by meaning and not only by words** — in the same question, it compares your
+   request against the titles of the open issues. No two people describe the same need with the same
+   vocabulary, so word matching walks straight past a duplicate a human reader would see at once;
 3. **the lots under way and the roadmap** — it may be planned already, or deliberately turned down,
    with the reasons.
 
 Every time, the bot shows you **what it found and why**, and you can answer *no, that is not it*:
 your request carries on. A machine does not get to decide on your behalf that your idea already
-exists.
+exists — and **neither does its silence**: if you do not answer, your request carries on as though
+nothing had been proposed.
+
+### If it really is the same need, your voice is added to the issue {#second-voice}
+
+When you recognise an issue as yours, the bot offers to **add your observation** to it: who you are
+and the need in your own words, and nothing else — the issue already holds a request.
+
+As everywhere else, it **shows you first** and publishes only after your click. Recognising an issue
+as your own is not the same act as agreeing to write under it.
+
+It matters: a feature request is wanted or not, and **a second person asking for the same thing is
+the only signal of priority it will ever carry**.
 
 If the documentation says nothing about the subject, the issue records that. It is useful: if the
 feature does exist, this is not a feature request, it is a **page to write** — and the cheapest fix

--- a/doc/SUPPORT.md
+++ b/doc/SUPPORT.md
@@ -158,14 +158,32 @@ tout de suite, plutôt qu'un ticket qui attendra des mois.
 Le bot vérifie donc, dans cet ordre :
 
 1. **la documentation** — il pose votre demande à l'assistant, qui répond avec les pages
-   correspondantes. Si ça répond à votre besoin, vous le dites et **rien n'est ouvert** ;
-2. **les tickets ouverts** — quelqu'un l'a peut-être déjà demandé ;
+   correspondantes. Si ça répond à votre besoin, vous le dites et **rien n'est ouvert**. Il ne dit
+   « ça existe déjà » que s'il peut vous montrer **au moins une page** : une affirmation sans page à
+   ouvrir n'est pas une réponse ;
+2. **les tickets ouverts, sur le sens et pas seulement sur les mots** — dans la même question, il
+   compare votre demande aux titres des tickets ouverts. Deux personnes ne décrivent jamais le même
+   besoin avec le même vocabulaire, et une comparaison de mots passe donc à côté d'un doublon
+   évident pour un lecteur humain ;
 3. **les chantiers en cours et la feuille de route** — c'est peut-être déjà prévu, ou explicitement
    écarté, avec les raisons.
 
 À chaque fois, le bot vous montre **ce qu'il a trouvé et pourquoi**, et vous pouvez répondre *non,
 ce n'est pas ça* : votre demande continue son chemin. Une machine ne décide pas à votre place que
-votre idée existe déjà.
+votre idée existe déjà — et **son silence non plus** : si vous ne répondez pas, votre demande suit
+son cours comme si de rien n'était.
+
+### Si c'est bien le même besoin, votre voix est ajoutée au ticket {#second-voice}
+
+Quand vous reconnaissez un ticket comme le vôtre, le bot vous propose d'y **ajouter votre
+observation** : qui vous êtes et le besoin dans vos mots, rien de plus — le ticket contient déjà une
+demande.
+
+Comme partout ailleurs, il vous le **montre d'abord** et ne publie qu'après votre clic. Reconnaître
+un ticket comme le sien n'est pas la même chose qu'accepter d'écrire dessous.
+
+Ça compte : une demande d'évolution est souhaitée ou non, et **une deuxième personne qui demande la
+même chose est le seul signal de priorité qu'elle portera jamais**.
 
 Si la documentation ne dit rien du sujet, le ticket le note. C'est utile : si la fonctionnalité
 existe en réalité, ce n'est pas une demande d'évolution, c'est une **page à écrire** — et c'est le

--- a/services/support-bot/tests/test_existing.py
+++ b/services/support-bot/tests/test_existing.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import unittest
+from collections.abc import Sequence
 
 from tests.fakes import FakeWorker
 from veaf_support_bot.answer import SOURCES_MARKER
@@ -29,27 +30,41 @@ from veaf_support_bot.worker import FailureKind, WorkerFailure
 REQUEST = "Je voudrais pouvoir faire apparaitre un convoi qui suit une route que je dessine."
 
 
-def a_real_title() -> str:
-    """Return a documentation title the corpus really has.
+def a_real_title(lang: str = "fr") -> str:
+    """Return a documentation title the corpus really has, in the language being asked.
+
+    Args:
+        lang: ``"fr"`` or ``"en"``. A French title cited in an English answer resolves to nothing,
+            and since ticket 06 an answer that cites nothing is read as silence — so a test that
+            means to exercise *it exists* has to cite a page of the language it is checking.
 
     Returns:
-        The first French title, so the link the check produces is a real page rather than a shape.
+        The first title of that corpus, so the link the check produces is a real page.
     """
-    return sorted(PAGES_BY_TITLE["fr"])[0]
+    # A short, plain title: some real ones carry quotation marks and parentheses, which a
+    # `Sources:` line renders but a test reads as noise when the match then fails for a reason that
+    # has nothing to do with what it is asserting.
+    return min((title for title in PAGES_BY_TITLE[lang] if title.isascii() and '"' not in title), key=len)
 
 
-def check(worker: FakeWorker, request: str = REQUEST, lang: str = "fr") -> DocumentationCheck:
+def check(
+    worker: FakeWorker,
+    request: str = REQUEST,
+    lang: str = "fr",
+    issues: Sequence[tuple[int, str]] = (),
+) -> DocumentationCheck:
     """Run one check against a scripted Worker.
 
     Args:
         worker: The scripted Worker.
         request: What the user would like.
         lang: The language asked for.
+        issues: The open issues offered for the second question.
 
     Returns:
         The finding.
     """
-    return asyncio.run(AskTheDocumentation(worker).check(request, lang, "user-1"))
+    return asyncio.run(AskTheDocumentation(worker).check(request, lang, "user-1", issues))
 
 
 class TestTheDocumentationAnswers(unittest.TestCase):
@@ -68,17 +83,22 @@ class TestTheDocumentationAnswers(unittest.TestCase):
         self.assertEqual(len(found.links), 1)
         self.assertIn(title, found.links[0])
 
-    def test_an_invented_page_is_not_linked(self) -> None:
-        """A title the corpus does not have is dropped rather than turned into a dead link."""
+    def test_an_invented_page_leaves_the_answer_without_a_source(self) -> None:
+        """A title the corpus does not have is dropped — and dropping it drops the claim with it.
+
+        This case used to be *EXISTS with no link*, on the grounds that the title was unverifiable.
+        Ticket 06 reads it the honest way instead: the model named a page that does not exist, so
+        there is nothing for the asker to open and nothing that says his idea already exists.
+        """
         worker = FakeWorker([f"Oui, c'est possible.\n{SOURCES_MARKER} Une page qui n'existe pas"])
 
         found = check(worker)
 
-        self.assertEqual(found.verdict, EXISTS)
+        self.assertEqual(found.verdict, ABSENT)
         self.assertEqual(found.links, ())
 
     def test_a_long_answer_is_bounded(self) -> None:
-        worker = FakeWorker(["o" * (ANSWER_MAX_CHARS * 3)])
+        worker = FakeWorker(["o" * (ANSWER_MAX_CHARS * 3) + f"\n{SOURCES_MARKER} {a_real_title()}"])
 
         self.assertEqual(len(check(worker).answer), ANSWER_MAX_CHARS)
 
@@ -90,6 +110,90 @@ class TestTheDocumentationAnswers(unittest.TestCase):
 
         self.assertIn("answered", described)
         self.assertIn(title, described)
+
+
+class TestSayingItExistsNeedsAPageToOpen(unittest.TestCase):
+    """Ticket 06, from the first real `/suggest` in front of a human.
+
+    The bot announced *"la documentation semble déjà répondre à ta demande"* and displayed, as that
+    answer, *"la documentation ne décrit pas de moyen de dessiner une route pour qu'un convoi la
+    suive"* — the exact opposite of what it concluded. The model was told to answer a keyword when
+    the documentation does not cover a subject and answered in prose instead, so the code saw no
+    keyword and inferred presence.
+    """
+
+    def test_prose_with_no_citation_is_read_as_silence(self) -> None:
+        found = check(FakeWorker(["La documentation ne décrit pas de moyen de faire cela."]))
+
+        self.assertEqual(found.verdict, ABSENT)
+        self.assertFalse(found.found)
+
+    def test_prose_with_a_citation_still_says_it_exists(self) -> None:
+        """The rule must not silence the answers it exists to keep."""
+        found = check(FakeWorker([f"Oui, avec `_convoy`.\n{SOURCES_MARKER} {a_real_title()}"]))
+
+        self.assertEqual(found.verdict, EXISTS)
+        self.assertTrue(found.links)
+
+    def test_the_keyword_still_works_decoration_and_all(self) -> None:
+        found = check(FakeWorker([f"**{NOTHING_KEYWORD}**."]))
+
+        self.assertEqual(found.verdict, ABSENT)
+
+
+class TestARequestAlreadyMadeInOtherWords(unittest.TestCase):
+    """Ticket 05. A duplicate was recognised by comparing words, and no two humans use the same ones.
+
+    The tracker proves it: `#240 -cap un peu plus selectif`, `#187 Modifications du watchdog de CAP`
+    and `#178 Gérer la destruction du -cap` are one subject in three vocabularies.
+    """
+
+    OPEN = ((240, "-cap un peu plus selectif"), (187, "Modifications du watchdog de CAP"))
+
+    def test_the_open_issues_travel_in_the_call_the_flow_already_makes(self) -> None:
+        """One call, two answers: joining the titles costs no extra model request."""
+        worker = FakeWorker([f"**{NOTHING_KEYWORD}**."])
+
+        check(worker, issues=self.OPEN)
+
+        sent = "".join(turn["content"] for turn in worker.seen[0]["messages"])
+        self.assertIn("#240", sent)
+        self.assertIn("watchdog", sent)
+        self.assertEqual(len(worker.seen), 1, "a second call would spend a second request")
+
+    def test_a_reformulation_is_recognised(self) -> None:
+        found = check(FakeWorker([f"**{NOTHING_KEYWORD}**.\nISSUE #240"]), issues=self.OPEN)
+
+        self.assertEqual(found.issue, 240)
+
+    def test_an_issue_it_was_not_offered_is_refused(self) -> None:
+        """A model naming #999 would send the asker to an issue nobody wrote."""
+        found = check(FakeWorker([f"**{NOTHING_KEYWORD}**.\nISSUE #999"]), issues=self.OPEN)
+
+        self.assertEqual(found.issue, 0)
+
+    def test_no_line_means_no_match(self) -> None:
+        found = check(FakeWorker([f"**{NOTHING_KEYWORD}**."]), issues=self.OPEN)
+
+        self.assertEqual(found.issue, 0)
+
+    def test_the_marker_line_is_not_shown_to_the_asker(self) -> None:
+        """It is an instruction to this code, like the idempotency marker in a Discord preview."""
+        found = check(
+            FakeWorker([f"Oui, avec `_convoy`.\n{SOURCES_MARKER} {a_real_title()}\nISSUE #240"]),
+            issues=self.OPEN,
+        )
+
+        self.assertEqual(found.issue, 240)
+        self.assertNotIn("ISSUE #240", found.answer)
+
+    def test_with_no_issues_offered_the_question_is_not_asked_at_all(self) -> None:
+        worker = FakeWorker([f"**{NOTHING_KEYWORD}**."])
+
+        check(worker)
+
+        sent = "".join(turn["content"] for turn in worker.seen[0]["messages"])
+        self.assertNotIn("ISSUE", sent)
 
 
 class TestTheDocumentationIsSilent(unittest.TestCase):
@@ -114,13 +218,23 @@ class TestTheDocumentationIsSilent(unittest.TestCase):
 
     def test_a_short_sentence_beginning_with_the_keyword_is_still_an_answer(self) -> None:
         """The prefix match this used to do discarded it as silence."""
-        found = check(FakeWorker([f"{NOTHING_KEYWORD} is documented about the radio menu."]), lang="en")
+        found = check(
+            FakeWorker(
+                [f"{NOTHING_KEYWORD} is documented about the radio menu.\n{SOURCES_MARKER} {a_real_title('en')}"]
+            ),
+            lang="en",
+        )
 
         self.assertEqual(found.verdict, EXISTS)
 
     def test_prose_containing_the_word_is_an_answer_not_an_absence(self) -> None:
         """The failure this bound exists for: a real answer thrown away for using the word."""
-        worker = FakeWorker(["There is nothing stopping you: the `_convoy` command already does this."])
+        worker = FakeWorker(
+            [
+                "There is nothing stopping you: the `_convoy` command already does this."
+                f"\n{SOURCES_MARKER} {a_real_title('en')}"
+            ]
+        )
 
         found = check(worker, lang="en")
 

--- a/services/support-bot/tests/test_intake.py
+++ b/services/support-bot/tests/test_intake.py
@@ -20,7 +20,7 @@ from tests.test_toolkit import SYNTHETIC_LOG
 from veaf_support_bot.attachments import AttachmentCollector, Incoming, Prepared
 from veaf_support_bot.bugreport import BugForm
 from veaf_support_bot.checkout import Checkout, Freshness
-from veaf_support_bot.draft import DIFFERENT, CANCEL
+from veaf_support_bot.draft import CANCEL, DIFFERENT
 from veaf_support_bot.intake import (
     PREVIEW_MAX_CHARS,
     BugIntake,

--- a/services/support-bot/tests/test_suggest.py
+++ b/services/support-bot/tests/test_suggest.py
@@ -103,8 +103,11 @@ class ScriptedDocumentation:
         self.finding = finding
         self.asked: list[tuple[str, str, str]] = []
 
-    async def check(self, request: str, lang: str, subject: str) -> DocumentationCheck:
+    async def check(
+        self, request: str, lang: str, subject: str, issues: Sequence[tuple[int, str]] = ()
+    ) -> DocumentationCheck:
         self.asked.append((request, lang, subject))
+        self.offered = tuple(issues)
         return self.finding
 
 
@@ -115,11 +118,16 @@ class RecordingFiler:
 
     def __init__(self, outcome: Outcome | None = None) -> None:
         self.filed: list[dict[str, object]] = []
+        self.comments: list[tuple[int, str]] = []
         self._outcome = outcome or Outcome(action="created", number=7, url="https://github.test/issues/7")
 
     async def file_prepared(self, key: str, title: str, body: str, labels: Sequence[str]) -> Outcome:
         self.filed.append({"key": key, "title": title, "body": body, "labels": tuple(labels)})
         return self._outcome
+
+    async def add_comment(self, number: int, body: str) -> Outcome:
+        self.comments.append((number, body))
+        return Outcome(action="commented", number=number, url=f"https://github.test/issues/{number}#c1")
 
 
 class RecordingTracker:
@@ -304,6 +312,95 @@ def a_matching_form(**overrides: str) -> SuggestionForm:
     return a_form(summary=summary, problem=RESOLVER_REPORT, solution=rest, **overrides)
 
 
+class TestARequestAlreadyMadeInOtherWords(unittest.TestCase):
+    """Ticket 05, at the flow level: what the model recognises is a proposal like any other."""
+
+    def test_a_recognised_issue_is_put_to_the_asker(self) -> None:
+        documentation = ScriptedDocumentation(DocumentationCheck(verdict=ABSENT, issue=240))
+        exchange = RecordingExchange(confirms=[False])
+
+        run(SuggestIntake(documentation=documentation, filer=RecordingFiler()), exchange)
+
+        self.assertTrue(any("#240" in shown for shown in exchange.shown))
+
+    def test_a_refusal_carries_the_request_on(self) -> None:
+        """A model saying *this is #240* is a proposal, and a wrong one must not silence anybody."""
+        documentation = ScriptedDocumentation(DocumentationCheck(verdict=ABSENT, issue=240))
+        filer = RecordingFiler()
+
+        run(SuggestIntake(documentation=documentation, filer=filer), RecordingExchange(confirms=[False], choice=FILE))
+
+        self.assertEqual(len(filer.filed), 1, "his request was still filed")
+
+    def test_a_silence_carries_the_request_on_too(self) -> None:
+        """Neither is an agreement, and only an agreement may stop somebody's request."""
+        documentation = ScriptedDocumentation(DocumentationCheck(verdict=ABSENT, issue=240))
+        filer = RecordingFiler()
+
+        run(SuggestIntake(documentation=documentation, filer=filer), RecordingExchange(choice=FILE))
+
+        self.assertEqual(len(filer.filed), 1)
+
+    def test_an_accepted_recognition_opens_nothing(self) -> None:
+        documentation = ScriptedDocumentation(DocumentationCheck(verdict=ABSENT, issue=240))
+        filer = RecordingFiler()
+
+        run(
+            SuggestIntake(documentation=documentation, filer=filer),
+            RecordingExchange(confirms=[True], choice=CANCEL),
+        )
+
+        self.assertEqual(filer.filed, [])
+
+
+class TestTheSecondVoiceIsRecorded(unittest.TestCase):
+    """Ticket 07: the message used to promise this, and the flow dropped it.
+
+    *A second person asking for the same thing* is the only signal of priority a suggestion carries,
+    and it was thrown away: the asker was told the subject is tracked elsewhere, and nothing
+    anywhere recorded that one more person needed it.
+    """
+
+    def test_an_accepted_duplicate_offers_to_add_the_observation(self) -> None:
+        documentation = ScriptedDocumentation(DocumentationCheck(verdict=ABSENT, issue=240))
+        filer = RecordingFiler()
+
+        run(
+            SuggestIntake(documentation=documentation, filer=filer),
+            RecordingExchange(confirms=[True], choice=FILE),
+        )
+
+        self.assertEqual(len(filer.comments), 1)
+        number, body = filer.comments[0]
+        self.assertEqual(number, 240)
+        self.assertIn(a_form().asker, body, "a maintainer needs to know who else asked")
+
+    def test_it_posts_nothing_without_the_second_click(self) -> None:
+        """Recognising an issue as one's own is not agreeing to publish under it."""
+        documentation = ScriptedDocumentation(DocumentationCheck(verdict=ABSENT, issue=240))
+        filer = RecordingFiler()
+
+        run(
+            SuggestIntake(documentation=documentation, filer=filer),
+            RecordingExchange(confirms=[True], choice=CANCEL),
+        )
+
+        self.assertEqual(filer.comments, [])
+
+    def test_it_carries_the_problem_and_not_the_whole_template(self) -> None:
+        """The issue already holds a feature request; a second copy buries the one useful line."""
+        documentation = ScriptedDocumentation(DocumentationCheck(verdict=ABSENT, issue=240))
+        filer = RecordingFiler()
+
+        run(
+            SuggestIntake(documentation=documentation, filer=filer),
+            RecordingExchange(confirms=[True], choice=FILE),
+        )
+
+        body = filer.comments[0][1]
+        self.assertNotIn("### ", body, "no headings: this is an observation, not a second request")
+
+
 class TestThePriorArtSweep(unittest.TestCase):
     """The issues, the lots and the roadmap, swept the way the bug flow sweeps them."""
 
@@ -460,7 +557,9 @@ class TestWhenItGoesWrong(unittest.TestCase):
 
     def test_a_crash_after_the_acknowledgement_is_told_to_the_asker(self) -> None:
         class Exploding(ScriptedDocumentation):
-            async def check(self, request: str, lang: str, subject: str) -> DocumentationCheck:
+            async def check(
+                self, request: str, lang: str, subject: str, issues: Sequence[tuple[int, str]] = ()
+            ) -> DocumentationCheck:
                 raise RuntimeError("boom")
 
         exchange = RecordingExchange()

--- a/services/support-bot/veaf_support_bot/existing.py
+++ b/services/support-bot/veaf_support_bot/existing.py
@@ -46,6 +46,7 @@ rather than linked. See :mod:`veaf_support_bot.untrusted`.
 
 from __future__ import annotations
 
+import re
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass
 from logging import Logger
@@ -54,6 +55,7 @@ from typing import Protocol
 from veaf_support_bot import answer as answer_module
 from veaf_support_bot.ask import MAX_QUESTION_CHARS
 from veaf_support_bot.logging_setup import get_logger
+from veaf_support_bot.untrusted import one_line
 from veaf_support_bot.worker import WorkerFailure
 
 #: The documentation describes a way to do it.
@@ -98,6 +100,41 @@ _TASK = (
     "feature the documentation does not describe, and never guess at one that might exist."
 )
 
+#: The second question, asked in the **same** call — measured 2026-09-07: ten open issues, short
+#: titles, the whole list under 600 characters, so joining them costs on the order of 200 tokens and
+#: no second model call at all.
+#:
+#: Why a model is asked this when a word matcher already sweeps the tracker: two people writing the
+#: same request share no identifier, only ordinary words. The tracker proves it — ``#240 -cap un peu
+#: plus selectif``, ``#187 Modifications du watchdog de CAP``, ``#178 Gérer la destruction du -cap``
+#: are one subject in three vocabularies, and somebody writing *"je voudrais que la CAP arrête de
+#: tirer sur les pilotes en parachute"* may share no word with any of them while a human reader sees
+#: the connection instantly.
+#:
+#: The answer is a **line**, not prose to interpret: an unparsable answer is simply no match, and a
+#: number that is not one of the numbers offered is discarded rather than trusted.
+_ISSUE_TASK = (
+    "\n\nSecond, and separately: here are the issues currently open on the tracker. If the user's "
+    "request is one of them — the same need, however differently worded — end your whole answer "
+    "with a final line reading exactly `{marker} #<number>`, using one of the numbers below. If it "
+    "is none of them, do not write that line at all. Never invent a number, and never name an issue "
+    "that is not in this list.\n\n{issues}"
+)
+
+#: Longest issue title carried into the prompt. A title is a line, not a paragraph.
+ISSUE_TITLE_MAX_CHARS = 120
+
+#: The marker that final line carries. Uppercase and unpunctuated, like the absence keyword above.
+ISSUE_KEYWORD = "ISSUE"
+
+#: How many open issues travel with the request. The tracker held ten when this was measured; the
+#: bound is here so a tracker that grows to two hundred does not quietly turn one prompt into a
+#: paste the retrieval cannot carry.
+MAX_ISSUES_OFFERED = 40
+
+#: A final line naming one issue, with the decoration a model puts around it.
+_ISSUE_LINE = re.compile(rf"^[\s>*_`-]*{ISSUE_KEYWORD}[\s:]*#(\d+)[\s.`*_]*$", re.MULTILINE | re.IGNORECASE)
+
 
 @dataclass(frozen=True)
 class DocumentationCheck:
@@ -114,12 +151,16 @@ class DocumentationCheck:
             real tree.
         problem: Why the documentation could not be consulted. Empty unless the verdict is
             :data:`UNKNOWN`.
+        issue: An open issue the model recognised as the same request, or ``0``. Independent of
+            :attr:`verdict`: the documentation being silent and the tracker already holding the
+            request are different facts, and a request can be both undocumented and already asked.
     """
 
     verdict: str = UNKNOWN
     answer: str = ""
     links: tuple[str, ...] = ()
     problem: str = ""
+    issue: int = 0
 
     @property
     def found(self) -> bool:
@@ -178,13 +219,18 @@ class DocumentationSource(Protocol):
     driven, in a test, by a scripted answer rather than by an HTTP client.
     """
 
-    async def check(self, request: str, lang: str, subject: str) -> DocumentationCheck:
-        """Ask whether the documentation already describes a way to do this.
+    async def check(
+        self, request: str, lang: str, subject: str, issues: Sequence[tuple[int, str]] = ()
+    ) -> DocumentationCheck:
+        """Ask whether the documentation already describes a way to do this, and whether the request
+        is one of the open issues.
 
         Args:
             request: What the user would like, in his own words.
             lang: ``"fr"`` or ``"en"``.
             subject: Per-user rate-limit subject.
+            issues: The open issues, as ``(number, title)``, for the second question of the same
+                call. Empty asks the documentation question alone.
 
         Returns:
             The finding.
@@ -204,14 +250,22 @@ class AskTheDocumentation:
         self._worker = worker
         self._logger = logger or get_logger("suggest")
 
-    async def check(self, request: str, lang: str, subject: str) -> DocumentationCheck:
-        """Ask whether the documentation already describes a way to do this.
+    async def check(
+        self, request: str, lang: str, subject: str, issues: Sequence[tuple[int, str]] = ()
+    ) -> DocumentationCheck:
+        """Ask whether the documentation already describes a way to do this — and whether it is one
+        of the open issues.
+
+        Two answers from one call. The second question is ticket 05: a duplicate is recognised today
+        by comparing words, and no two humans write the same request in the same words.
 
         Args:
             request: What the user would like, in his own words. Sent as the last turn and
                 untouched, because it is what the Worker embeds to retrieve passages.
             lang: ``"fr"`` or ``"en"``.
             subject: Per-user rate-limit subject, as the Worker counts them.
+            issues: The open issues, as ``(number, title)``. Empty asks the documentation question
+                alone, which is what a deployment with no tracker access does.
 
         Returns:
             The finding. Never raises: every failure becomes :data:`UNKNOWN` with its reason, since
@@ -222,7 +276,8 @@ class AskTheDocumentation:
         # to 5000 characters, and it is the *last user turn* the Worker embeds to retrieve passages.
         # ``/ask`` trims at the same number for the same reason — past it, retrieval is being handed
         # a paste and does nothing useful with it.
-        turns = answer_module.protocol_turns(" ".join(request.split())[:MAX_QUESTION_CHARS], extra=_TASK)
+        task = _TASK + _issue_task(issues)
+        turns = answer_module.protocol_turns(" ".join(request.split())[:MAX_QUESTION_CHARS], extra=task)
         try:
             collected = "".join([fragment async for fragment in self._worker.stream(turns, lang, subject)])
         except WorkerFailure as failure:
@@ -233,6 +288,11 @@ class AskTheDocumentation:
             return DocumentationCheck(verdict=UNKNOWN, problem=failure.kind.value)
 
         body, titles = answer_module.split_sources(collected)
+        named = _named_issue(body, issues)
+        # Read off the body, then removed from it: the line is an instruction to this code, and
+        # leaving `ISSUE #240` at the end of a paragraph shown to a human is the same defect the
+        # idempotency marker had in the Discord preview.
+        body = _ISSUE_LINE.sub("", body).strip()
         if not body.strip():
             self._logger.warning(
                 "the documentation assistant answered nothing at all",
@@ -244,13 +304,67 @@ class AskTheDocumentation:
                 "the documentation says nothing about this request",
                 extra={"event": "suggest.checked", "verdict": ABSENT},
             )
-            return DocumentationCheck(verdict=ABSENT)
+            return DocumentationCheck(verdict=ABSENT, issue=named)
         links = answer_module.source_links(titles, lang)
+        if not links:
+            # Measured in front of a human, 2026-09-07: the first real `/suggest` announced *"la
+            # documentation semble déjà répondre à ta demande"* and displayed, as that answer, *"la
+            # documentation ne décrit pas de moyen de dessiner une route pour qu'un convoi la
+            # suive"* — the exact opposite of what it concluded. The model is told to answer the
+            # keyword when the documentation does not cover a subject; it answered in prose, so the
+            # keyword check saw nothing and the absence of a keyword was read as presence.
+            #
+            # Requiring a **citation** does not depend on guessing what a sentence means, and it is
+            # the rule the whole service already runs on: a link the asker can open is what lets him
+            # contradict the machine. An answer with no page to open is not an answer that something
+            # exists. It also covers the case the log line below names: a model that cited a page
+            # the corpus does not have, whose title was dropped as unverifiable.
+            self._logger.info(
+                "the documentation answered without citing a page, so it is read as silence",
+                extra={"event": "suggest.checked", "verdict": ABSENT, "reason": "no-citation"},
+            )
+            return DocumentationCheck(verdict=ABSENT, issue=named)
         self._logger.info(
             "the documentation describes a way to do this",
             extra={"event": "suggest.checked", "verdict": EXISTS, "pages": len(links)},
         )
-        return DocumentationCheck(verdict=EXISTS, answer=body[:ANSWER_MAX_CHARS], links=tuple(links))
+        return DocumentationCheck(verdict=EXISTS, answer=body[:ANSWER_MAX_CHARS], links=tuple(links), issue=named)
+
+
+def _issue_task(issues: Sequence[tuple[int, str]]) -> str:
+    """Render the second question, or nothing when there is no tracker to compare against.
+
+    Args:
+        issues: The open issues, as ``(number, title)``.
+
+    Returns:
+        The instruction to append, empty when *issues* is.
+    """
+    if not issues:
+        return ""
+    listed = "\n".join(
+        f"- #{number} {one_line(title, ISSUE_TITLE_MAX_CHARS)}" for number, title in issues[:MAX_ISSUES_OFFERED]
+    )
+    return _ISSUE_TASK.format(marker=ISSUE_KEYWORD, issues=listed)
+
+
+def _named_issue(body: str, issues: Sequence[tuple[int, str]]) -> int:
+    """Read back which issue the model named, if any, and refuse one it invented.
+
+    Args:
+        body: The answer body, trailer already removed.
+        issues: The issues that were offered.
+
+    Returns:
+        The issue number, or ``0``. A number outside the offered list is dropped: a model naming
+        ``#999`` would otherwise send an asker to an issue nobody wrote, which is worse than not
+        recognising his request at all.
+    """
+    found = _ISSUE_LINE.search(body)
+    if found is None:
+        return 0
+    number = int(found.group(1))
+    return number if any(number == offered for offered, _ in issues) else 0
 
 
 def says_nothing(body: str) -> bool:

--- a/services/support-bot/veaf_support_bot/suggest.py
+++ b/services/support-bot/veaf_support_bot/suggest.py
@@ -39,6 +39,7 @@ component comes from a Discord choice bound to :data:`~veaf_support_bot.suggesti
 
 from __future__ import annotations
 
+import re
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -59,7 +60,7 @@ from veaf_support_bot.exchange import ThreadExchange, ThreadHandle
 from veaf_support_bot.existing import DocumentationCheck, DocumentationSource
 from veaf_support_bot.filing import Outcome
 from veaf_support_bot.logging_setup import get_logger
-from veaf_support_bot.priorart import PriorArtGate, Sweep, render_match
+from veaf_support_bot.priorart import DUPLICATE, SOURCE_OPEN_ISSUE, Candidate, Match, PriorArtGate, Sweep, render_match
 from veaf_support_bot.quota import QuotaKeeper
 from veaf_support_bot.suggestion import (
     BASE_LABEL,
@@ -69,7 +70,7 @@ from veaf_support_bot.suggestion import (
     suggestion_key,
 )
 from veaf_support_bot.texts import REPOSITORY_URL, normalize_language, text
-from veaf_support_bot.untrusted import one_line
+from veaf_support_bot.untrusted import one_line, quote
 
 #: The family of prior-art sentences this flow speaks from. Not the bug flow's: that one tells the
 #: reporter his observation will be added to the existing issue, and then adds it. This flow opens
@@ -143,6 +144,21 @@ class PreparedFiler(Protocol):
             What became of it.
         """
 
+    async def add_comment(self, number: int, body: str) -> Outcome:
+        """Add one comment to an existing issue.
+
+        The same call the enrichment uses, which is what ticket 07 means by *one mechanism*: the
+        bug flow's own duplicate comment and this one both end here rather than each growing a
+        renderer-shaped method of their own.
+
+        Args:
+            number: The issue to comment on.
+            body: The comment body, already rendered.
+
+        Returns:
+            What became of it.
+        """
+
 
 class SuggestionTracker(Protocol):
     """What this flow needs from :mod:`veaf_support_bot.relay`, and nothing more."""
@@ -188,6 +204,54 @@ class _AskTheAsker:
             What he answered: ``SAME``, ``DIFFERENT`` or ``UNANSWERED``.
         """
         return await self._exchange.confirm(render_match(sweep, lang, family=PRIOR_ART_FAMILY), lang)
+
+
+def _issue_number(sweep: Sweep) -> int | None:
+    """Read the issue number out of a finding, when the finding is a GitHub issue at all.
+
+    Args:
+        sweep: The finding the asker recognised.
+
+    Returns:
+        The number, or ``None`` when the match is a lot or a roadmap section — which are not places
+        a comment can be added.
+    """
+    if sweep.best is None:
+        return None
+    matched = re.fullmatch(r"#(\d+)", sweep.best.candidate.reference.strip())
+    return int(matched.group(1)) if matched else None
+
+
+def render_observation(form: SuggestionForm, lang: str) -> str:
+    """Render what gets added to the existing issue.
+
+    Args:
+        form: The submitted form.
+        lang: ``"fr"`` or ``"en"``.
+
+    Returns:
+        The comment body: who asked, and the problem in his own words. Quoted rather than pasted,
+        for the same reason every other published field is.
+    """
+    return text(
+        "suggest.observation.body",
+        lang,
+        asker=one_line(form.asker, 80),
+        problem=quote(form.problem),
+    )
+
+
+def _match_for(number: int) -> Match:
+    """Wrap an issue the model named in the shape the rest of the flow already speaks.
+
+    Args:
+        number: The issue number.
+
+    Returns:
+        A match carrying that reference. The score is 0: this one was not measured by word overlap,
+        and printing a number it did not earn would be evidence the sweep never produced.
+    """
+    return Match(candidate=Candidate(source=SOURCE_OPEN_ISSUE, reference=f"#{number}", title=""), score=0.0)
 
 
 class SuggestIntake:
@@ -306,6 +370,11 @@ class SuggestIntake:
             await self._say(exchange, text("suggest.settled.documentation", lang))
             return None
 
+        if check.issue and self._may_ask(started, "a request already made in other words"):
+            settled = await self._propose_the_named_issue(exchange, form, check.issue, lang, started)
+            if settled:
+                return None
+
         sweep, answer = await self._sweep(exchange, form, lang, started)
         # Only an explicit *yes* settles a request. A silence means the asker never saw the
         # proposal or never answered it, and dropping his request on that would be the machine
@@ -319,9 +388,93 @@ class SuggestIntake:
                 exchange,
                 render_match(sweep, lang, family=PRIOR_ART_FAMILY) + "\n\n" + text("suggest.settled.prior_art", lang),
             )
+            await self._record_the_second_voice(exchange, form, sweep, lang)
             return None
 
         return await self._file(exchange, submission, check, sweep, lang, asked=asked, progress=progress)
+
+    async def _propose_the_named_issue(
+        self, exchange: ThreadExchange, form: SuggestionForm, number: int, lang: str, started: float
+    ) -> bool:
+        """Put the issue the model recognised to the asker, with what it is, and take his answer.
+
+        A model saying *this is #240* is a proposal like any other: it is shown with the issue it
+        names and a way to refuse it, and a refusal carries the request on untouched. What it is not
+        is a decision — the whole reason the deterministic sweep proposes rather than applies.
+
+        Args:
+            exchange: The Discord side.
+            form: The submitted form.
+            number: The issue the model named, already validated against the ones it was offered.
+            lang: ``"fr"`` or ``"en"``.
+            started: When the interaction was acknowledged.
+
+        Returns:
+            Whether the request is settled. ``False`` for a refusal **and** for a silence: neither
+            is an agreement, and only an agreement may stop somebody's request.
+        """
+        answer = await exchange.confirm(text("suggest.named_issue", lang, issue=number), lang)
+        self._logger.info(
+            "a request already made in other words was proposed",
+            extra={"event": "suggest.named_issue", "issue": number, "answer": answer},
+        )
+        if answer != SAME:
+            return False
+        await self._say(exchange, text("suggest.settled.named_issue", lang, issue=number))
+        await self._record_the_second_voice(exchange, form, Sweep(verdict=DUPLICATE, best=_match_for(number)), lang)
+        return True
+
+    async def _record_the_second_voice(
+        self, exchange: ThreadExchange, form: SuggestionForm, sweep: Sweep, lang: str
+    ) -> None:
+        """Offer to add the asker's observation to the issue he just recognised as his own.
+
+        Why it is worth doing at all: a suggestion is only wanted or not, and one person deciding.
+        *A second person asking for the same thing* is the only signal of priority a suggestion will
+        ever carry — and until this existed it was thrown away entirely. The asker was told the
+        subject is tracked elsewhere, and nothing anywhere recorded that one more person needed it.
+
+        Two guards, both deliberate:
+
+        * it is **drafted and shown**, and posted only on a second click. Recognising an issue as
+          one's own is not the same act as agreeing to publish under it, and this publishes words on
+          a public tracker;
+        * it carries the problem as the asker stated it and who asked, and nothing else. The issue
+          already holds a feature request; a second copy of the template would bury the one line a
+          maintainer actually needs.
+
+        Args:
+            exchange: The Discord side.
+            form: The submitted form.
+            sweep: The finding the asker recognised, which carries the issue's reference.
+            lang: ``"fr"`` or ``"en"``.
+        """
+        number = _issue_number(sweep)
+        if self._filer is None or number is None:
+            return
+        body = render_observation(form, lang)
+        decision = await exchange.decide(
+            Draft(title=text("suggest.observation.title", lang, issue=number), body=body).render(
+                lang, header="suggest.observation.header"
+            ),
+            lang,
+        )
+        if decision != FILE:
+            # Every other answer posts nothing, expiry included. The request was already settled by
+            # his own *yes*; what he declined here is publishing under his name.
+            await self._say(exchange, text("suggest.observation.declined", lang))
+            return
+        outcome = await self._filer.add_comment(number, body)
+        self._logger.info(
+            "a second voice was recorded on an existing issue",
+            extra={"event": "suggest.observed", "issue": number, "action": outcome.action},
+        )
+        await self._say(
+            exchange,
+            text("suggest.observation.recorded", lang, issue=number)
+            if outcome.action == "commented"
+            else text("suggest.observation.failed", lang, issue=number),
+        )
 
     def _may_ask(self, started: float, what: str) -> bool:
         """Say whether one more timed question still leaves room for the consent click.
@@ -350,6 +503,32 @@ class SuggestIntake:
         )
         return False
 
+    async def _open_issues(self) -> tuple[tuple[int, str], ...]:
+        """Read the open issues' numbers and titles, for the second question of the same call.
+
+        Ticket 05: a duplicate is recognised today by comparing words, and no two humans write the
+        same request in the same words. The titles ride along with the documentation question rather
+        than costing a call of their own — measured 2026-09-07, ten open issues and under 600
+        characters of titles.
+
+        Returns:
+            The issues, or an empty tuple when there is no gate, no source, or the tracker could not
+            be read. A tracker that cannot be reached costs the *recognition*, never the suggestion:
+            the deterministic sweep still runs afterwards and the issue still records what happened.
+        """
+        source = self._prior_art.sweeper.issues if self._prior_art is not None else None
+        if source is None:
+            return ()
+        try:
+            records = await source.open_issues()
+        except Exception as error:  # noqa: BLE001 - a courtesy check must not cost a suggestion
+            self._logger.warning(
+                "the open issues could not be read, so the request is not compared against them",
+                extra={"event": "suggest.issues_unavailable", "error": type(error).__name__},
+            )
+            return ()
+        return tuple((record.number, record.title) for record in records)
+
     async def _ask_documentation(self, form: SuggestionForm, lang: str) -> DocumentationCheck:
         """Ask the documentation whether this already exists, if there is an allowance for it.
 
@@ -366,6 +545,7 @@ class SuggestIntake:
         """
         if self._documentation is None:
             return DocumentationCheck(problem="not configured")
+        issues = await self._open_issues()
         if self._quota is not None:
             decision = self._quota.check_and_consume(form.asker_id)
             if not decision.allowed:
@@ -374,7 +554,7 @@ class SuggestIntake:
                     extra={"event": "suggest.check_refused", "user": form.asker_id, "reason": decision.reason},
                 )
                 return DocumentationCheck(problem=f"quota: {decision.reason}")
-        return await self._documentation.check(form.all_text(), lang, form.asker_id)
+        return await self._documentation.check(form.all_text(), lang, form.asker_id, issues)
 
     async def _sweep(
         self, exchange: ThreadExchange, form: SuggestionForm, lang: str, started: float

--- a/services/support-bot/veaf_support_bot/texts.py
+++ b/services/support-bot/veaf_support_bot/texts.py
@@ -111,6 +111,36 @@ _TEXTS: Final[dict[str, dict[str, str]]] = {
             "questions pour aujourd'hui, par sécurité. Ça se remet à zéro {reset_relative} (à "
             "{reset_time}) — et signale-le sur le canal support, ça ne se répare pas tout seul."
         ),
+        "suggest.named_issue": (
+            "🔎 **Ta demande ressemble à un ticket déjà ouvert : #{issue}.**\n"
+            "Ce rapprochement vient d'une lecture du sens, pas d'une comparaison de mots — deux "
+            "personnes ne décrivent jamais le même besoin avec le même vocabulaire. Ouvre-le et "
+            "dis-moi : c'est bien la même chose, ou pas ?"
+        ),
+        "suggest.settled.named_issue": (
+            "Entendu, rien de nouveau n'est ouvert : le ticket #{issue} porte déjà ce besoin."
+        ),
+        # --- ticket 07 : la seconde voix, consignée sur le ticket existant --------------------
+        # Une demande est souhaitée ou non, et une seule personne tranche. *Quelqu'un d'autre qui
+        # demande la même chose* est le seul signal de priorité qu'une demande portera jamais, et il
+        # était jeté : on disait à l'auteur que le sujet est suivi ailleurs, et rien nulle part
+        # n'enregistrait qu'une personne de plus en avait besoin.
+        "suggest.observation.header": (
+            "💬 **Voici ce qui serait ajouté au ticket**, sous ton nom Discord. Rien n'est publié "
+            "tant que tu n'as pas cliqué."
+        ),
+        "suggest.observation.title": "Observation à ajouter au ticket #{issue}",
+        "suggest.observation.body": (
+            "**{asker}** a demandé la même chose sur le Discord VEAF. Le besoin, dans ses mots :\n\n"
+            "{problem}\n\n"
+            "-# Ajouté automatiquement par le bot de support VEAF, avec son accord explicite."
+        ),
+        "suggest.observation.recorded": "✅ C'est ajouté au ticket #{issue} : une voix de plus y est consignée.",
+        "suggest.observation.declined": "D'accord, rien n'a été publié sur le ticket.",
+        "suggest.observation.failed": (
+            "Je n'ai pas réussi à écrire sur le ticket #{issue}. Rien n'est perdu de ton côté — tu "
+            "peux commenter toi-même si tu as un compte GitHub."
+        ),
         # --- ce qu'une pièce jointe devient dans le ticket ------------------------------------
         # Écrit dans le ticket, donc dans la langue du rapporteur. Les deux comptes ci-dessous
         # portent sur des choses différentes — les enregistrements que le profil garde, et les
@@ -407,6 +437,30 @@ _TEXTS: Final[dict[str, dict[str, str]]] = {
             "The bot can no longer keep its counters, so it has held itself to {limit} questions for "
             "today as a precaution. It resets {reset_relative} (at {reset_time}) — and please report "
             "it on the support channel, this one does not fix itself."
+        ),
+        "suggest.named_issue": (
+            "🔎 **Your request looks like an issue that is already open: #{issue}.**\n"
+            "That match comes from reading the meaning, not from comparing words — no two people "
+            "describe the same need with the same vocabulary. Open it and tell me: is it the same "
+            "thing, or not?"
+        ),
+        "suggest.settled.named_issue": ("Understood, nothing new is opened: issue #{issue} already carries this need."),
+        # --- ticket 07: the second voice, recorded on the existing issue ---------------------
+        "suggest.observation.header": (
+            "💬 **This is what would be added to the issue**, under your Discord name. Nothing is "
+            "published until you click."
+        ),
+        "suggest.observation.title": "Observation to add to issue #{issue}",
+        "suggest.observation.body": (
+            "**{asker}** asked for the same thing on the VEAF Discord. The need, in his words:\n\n"
+            "{problem}\n\n"
+            "-# Added automatically by the VEAF support bot, with his explicit consent."
+        ),
+        "suggest.observation.recorded": "✅ Added to issue #{issue}: one more voice is recorded there.",
+        "suggest.observation.declined": "All right, nothing was published on the issue.",
+        "suggest.observation.failed": (
+            "I could not write to issue #{issue}. Nothing is lost on your side — you can comment "
+            "yourself if you have a GitHub account."
         ),
         # --- what an attachment becomes in the issue ------------------------------------------
         "attachment.log_digest": (


### PR DESCRIPTION
## Tickets 05, 06 and 07 — what `/suggest` learned from its first real run

Third of the three PRs the lot ships as. One of these is a design correction rather than a defect.

## 05 — a request already made in other words

> *« jamais un humain ne va taper exactement les mêmes mots ; il faut analyser le texte et en comprendre le sens »*

The tracker proves the point: `#240 -cap un peu plus selectif`, `#187 Modifications du watchdog de CAP` and `#178 Gérer la destruction du -cap` are **one subject in three vocabularies**, and somebody writing *"je voudrais que la CAP arrête de tirer sur les pilotes en parachute"* shares no word with any of them while a human reader sees the connection instantly.

So the open issues' titles now travel **inside the call the flow already makes** — one request, two answers, on the order of 200 extra tokens and no second model call. Measured 2026-09-07: ten open issues, whole list under 600 characters.

What comes back is a **proposal like any other**: shown with the issue it names, refused with a click, and — the guard that matters — a number the model was *not offered* is discarded rather than trusted. A model naming `#999` would otherwise send an asker to an issue nobody wrote.

The idempotency key is untouched: it answers a different question and has to stay reproducible after a restart.

## 06 — *it already exists* needs a page to point at

The first real `/suggest` announced **« la documentation semble déjà répondre à ta demande »** and displayed, as that answer:

> *« La documentation ne décrit pas de moyen de dessiner une route pour qu'un convoi la suive. »*

The exact opposite of what it concluded. The model is instructed to answer a keyword when the documentation does not cover a subject; it answered in prose, the code saw no keyword and inferred presence.

Saying *it exists* now requires **at least one cited page**. That criterion does not depend on guessing what a sentence means, and it is the rule the whole service runs on: a link the asker can open is what lets him contradict the machine.

It also reads one existing case the honest way: an answer citing a page the corpus does not have used to be *EXISTS with no link*; it is now silence, because the model named a page that does not exist.

## 07 — do what the message promised

The prior-art sentences said an accepted match would carry the asker's observation to the existing issue. `/bug` did exactly that; `/suggest` opened nothing and commented nothing. The wording was fixed on the day — this is the other half.

An accepted duplicate now offers to **add the observation**: drafted, shown, posted only on a **second click**, carrying who asked and the need in his own words, and not a second copy of the template. Both flows end on the same `add_comment`.

Why it is worth doing: a suggestion is only wanted or not, and **a second person asking for the same thing is the only signal of priority it will ever carry** — until now it was thrown away entirely.

## Verification

1020 tests green, mypy clean, ruff clean, coverage 95.17 % (gate 95), `docs-check` clean. Both documentation pages updated, in both languages.

## The lot after this

Seven of eight are done. Only **ticket 01** remains — the modal labels and the command descriptions, which needs `app_commands.Translator` and is a surface of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve `/suggest` duplicate handling by recognizing requests by meaning, requiring verifiable documentation sources, and recording additional user observations on confirmed existing issues.

New Features:
- Detect semantically matching open issues during `/suggest` and let users confirm the match before abandoning a new request.
- Record a consenting user's observation and identity as a comment on an existing matching issue.

Bug Fixes:
- Require at least one valid documentation citation before treating a suggestion as already covered, preventing contradictory or unverifiable answers from being classified as existing.

Enhancements:
- Keep issue matching within the existing documentation check and validate model-reported issue numbers against the offered open issues.
- Preserve the normal suggestion flow when a proposed duplicate is rejected or unanswered.

Documentation:
- Update English and French support documentation to describe citation requirements, meaning-based duplicate detection, and recording a second voice.

Tests:
- Add coverage for citation-gated documentation results, semantic issue matching, invalid issue references, user confirmation behavior, and observation comments.

Chores:
- Mark support-bot debt tickets 05, 06, and 07 as completed and update the backlog status.
- Document the changes in the changelog.